### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add Debug trait to generated Clients
 - Add `rusoto_ec2::filter!` macro
 - Improve `InstanceMetadataProvider` to avoid cloning unnecessarily
+- Remove deprecated `Error::description` implementations
 
 ## [0.42.0] - 2019-11-18
 

--- a/rusoto/core/src/error.rs
+++ b/rusoto/core/src/error.rs
@@ -60,22 +60,18 @@ impl<E> From<io::Error> for RusotoError<E> {
 
 impl<E: Error + 'static> fmt::Display for RusotoError<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        match *self {
+            RusotoError::Service(ref err) => write!(f, "{}", err),
+            RusotoError::Validation(ref cause) => write!(f, "{}", cause),
+            RusotoError::Credentials(ref err) => write!(f, "{}", err),
+            RusotoError::HttpDispatch(ref dispatch_error) => write!(f, "{}", dispatch_error),
+            RusotoError::ParseError(ref cause) => write!(f, "{}", cause),
+            RusotoError::Unknown(ref cause) => write!(f, "{}", cause.body_as_str()),
+        }
     }
 }
 
 impl<E: Error + 'static> Error for RusotoError<E> {
-    fn description(&self) -> &str {
-        match *self {
-            RusotoError::Service(ref err) => err.description(),
-            RusotoError::Validation(ref cause) => cause,
-            RusotoError::Credentials(ref err) => err.description(),
-            RusotoError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
-            RusotoError::ParseError(ref cause) => cause,
-            RusotoError::Unknown(ref cause) => cause.body_as_str(),
-        }
-    }
-
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             RusotoError::Service(ref err) => Some(err),

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -165,11 +165,7 @@ impl HttpDispatchError {
     }
 }
 
-impl Error for HttpDispatchError {
-    fn description(&self) -> &str {
-        &self.message
-    }
-}
+impl Error for HttpDispatchError {}
 
 impl fmt::Display for HttpDispatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -406,11 +402,7 @@ pub struct TlsError {
     message: String,
 }
 
-impl Error for TlsError {
-    fn description(&self) -> &str {
-        &self.message
-    }
-}
+impl Error for TlsError {}
 
 impl fmt::Display for TlsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/rusoto/core/src/serialization.rs
+++ b/rusoto/core/src/serialization.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::fmt::{Formatter, Result as FmtResult};
 
 use base64;
@@ -32,7 +31,7 @@ impl<'de> Visitor<'de> for BlobVisitor {
     {
         base64::decode(v)
             .map(Bytes::from)
-            .map_err(|err| SerdeError::custom(err.description()))
+            .map_err(|err| SerdeError::custom(err.to_string()))
     }
 }
 

--- a/rusoto/credential/src/container.rs
+++ b/rusoto/credential/src/container.rs
@@ -1,6 +1,5 @@
 //! The Credentials provider to read from a task's IAM Role.
 
-use std::error::Error;
 use std::time::Duration;
 
 use futures::future::{err, FutureResult};

--- a/rusoto/credential/src/container.rs
+++ b/rusoto/credential/src/container.rs
@@ -160,9 +160,7 @@ fn new_request(uri: &str, env_var_name: &str) -> Result<Request<Body>, Credentia
     Request::get(uri).body(Body::empty()).map_err(|error| {
         CredentialsError::new(format!(
             "Error while parsing URI '{}' derived from environment variable '{}': {}",
-            uri,
-            env_var_name,
-            error.description()
+            uri, env_var_name, error
         ))
     })
 }

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -211,25 +211,21 @@ impl CredentialsError {
 
 impl fmt::Display for CredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", self)
     }
 }
 
-impl Error for CredentialsError {
-    fn description(&self) -> &str {
-        &self.message
-    }
-}
+impl Error for CredentialsError {}
 
 impl From<ParseError> for CredentialsError {
     fn from(err: ParseError) -> CredentialsError {
-        CredentialsError::new(err.description())
+        CredentialsError::new(err.to_string())
     }
 }
 
 impl From<IoError> for CredentialsError {
     fn from(err: IoError) -> CredentialsError {
-        CredentialsError::new(err.description())
+        CredentialsError::new(err.to_string())
     }
 }
 
@@ -241,19 +237,19 @@ impl From<HyperError> for CredentialsError {
 
 impl From<serde_json::Error> for CredentialsError {
     fn from(err: serde_json::Error) -> CredentialsError {
-        CredentialsError::new(err.description())
+        CredentialsError::new(err.to_string())
     }
 }
 
 impl From<VarError> for CredentialsError {
     fn from(err: VarError) -> CredentialsError {
-        CredentialsError::new(err.description())
+        CredentialsError::new(err.to_string())
     }
 }
 
 impl From<FromUtf8Error> for CredentialsError {
     fn from(err: FromUtf8Error) -> CredentialsError {
-        CredentialsError::new(err.description())
+        CredentialsError::new(err.to_string())
     }
 }
 

--- a/rusoto/services/acm-pca/src/generated.rs
+++ b/rusoto/services/acm-pca/src/generated.rs
@@ -685,19 +685,15 @@ impl CreateCertificateAuthorityError {
 }
 impl fmt::Display for CreateCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCertificateAuthorityError::InvalidArgs(ref cause) => cause,
-            CreateCertificateAuthorityError::InvalidPolicy(ref cause) => cause,
-            CreateCertificateAuthorityError::InvalidTag(ref cause) => cause,
-            CreateCertificateAuthorityError::LimitExceeded(ref cause) => cause,
+            CreateCertificateAuthorityError::InvalidArgs(ref cause) => write!(f, "{}", cause),
+            CreateCertificateAuthorityError::InvalidPolicy(ref cause) => write!(f, "{}", cause),
+            CreateCertificateAuthorityError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            CreateCertificateAuthorityError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCertificateAuthorityError {}
 /// Errors returned by CreateCertificateAuthorityAuditReport
 #[derive(Debug, PartialEq)]
 pub enum CreateCertificateAuthorityAuditReportError {
@@ -760,21 +756,29 @@ impl CreateCertificateAuthorityAuditReportError {
 }
 impl fmt::Display for CreateCertificateAuthorityAuditReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCertificateAuthorityAuditReportError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCertificateAuthorityAuditReportError::InvalidArgs(ref cause) => cause,
-            CreateCertificateAuthorityAuditReportError::InvalidArn(ref cause) => cause,
-            CreateCertificateAuthorityAuditReportError::InvalidState(ref cause) => cause,
-            CreateCertificateAuthorityAuditReportError::RequestFailed(ref cause) => cause,
-            CreateCertificateAuthorityAuditReportError::RequestInProgress(ref cause) => cause,
-            CreateCertificateAuthorityAuditReportError::ResourceNotFound(ref cause) => cause,
+            CreateCertificateAuthorityAuditReportError::InvalidArgs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCertificateAuthorityAuditReportError::InvalidArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCertificateAuthorityAuditReportError::InvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCertificateAuthorityAuditReportError::RequestFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCertificateAuthorityAuditReportError::RequestInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCertificateAuthorityAuditReportError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCertificateAuthorityAuditReportError {}
 /// Errors returned by CreatePermission
 #[derive(Debug, PartialEq)]
 pub enum CreatePermissionError {
@@ -825,21 +829,17 @@ impl CreatePermissionError {
 }
 impl fmt::Display for CreatePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePermissionError::InvalidArn(ref cause) => cause,
-            CreatePermissionError::InvalidState(ref cause) => cause,
-            CreatePermissionError::LimitExceeded(ref cause) => cause,
-            CreatePermissionError::PermissionAlreadyExists(ref cause) => cause,
-            CreatePermissionError::RequestFailed(ref cause) => cause,
-            CreatePermissionError::ResourceNotFound(ref cause) => cause,
+            CreatePermissionError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreatePermissionError::InvalidState(ref cause) => write!(f, "{}", cause),
+            CreatePermissionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePermissionError::PermissionAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreatePermissionError::RequestFailed(ref cause) => write!(f, "{}", cause),
+            CreatePermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePermissionError {}
 /// Errors returned by DeleteCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum DeleteCertificateAuthorityError {
@@ -888,19 +888,17 @@ impl DeleteCertificateAuthorityError {
 }
 impl fmt::Display for DeleteCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCertificateAuthorityError::ConcurrentModification(ref cause) => cause,
-            DeleteCertificateAuthorityError::InvalidArn(ref cause) => cause,
-            DeleteCertificateAuthorityError::InvalidState(ref cause) => cause,
-            DeleteCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
+            DeleteCertificateAuthorityError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCertificateAuthorityError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateAuthorityError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateAuthorityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCertificateAuthorityError {}
 /// Errors returned by DeletePermission
 #[derive(Debug, PartialEq)]
 pub enum DeletePermissionError {
@@ -939,19 +937,15 @@ impl DeletePermissionError {
 }
 impl fmt::Display for DeletePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePermissionError::InvalidArn(ref cause) => cause,
-            DeletePermissionError::InvalidState(ref cause) => cause,
-            DeletePermissionError::RequestFailed(ref cause) => cause,
-            DeletePermissionError::ResourceNotFound(ref cause) => cause,
+            DeletePermissionError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeletePermissionError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DeletePermissionError::RequestFailed(ref cause) => write!(f, "{}", cause),
+            DeletePermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePermissionError {}
 /// Errors returned by DescribeCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificateAuthorityError {
@@ -986,17 +980,15 @@ impl DescribeCertificateAuthorityError {
 }
 impl fmt::Display for DescribeCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificateAuthorityError::InvalidArn(ref cause) => cause,
-            DescribeCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
+            DescribeCertificateAuthorityError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateAuthorityError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCertificateAuthorityError {}
 /// Errors returned by DescribeCertificateAuthorityAuditReport
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificateAuthorityAuditReportError {
@@ -1038,18 +1030,20 @@ impl DescribeCertificateAuthorityAuditReportError {
 }
 impl fmt::Display for DescribeCertificateAuthorityAuditReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificateAuthorityAuditReportError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificateAuthorityAuditReportError::InvalidArgs(ref cause) => cause,
-            DescribeCertificateAuthorityAuditReportError::InvalidArn(ref cause) => cause,
-            DescribeCertificateAuthorityAuditReportError::ResourceNotFound(ref cause) => cause,
+            DescribeCertificateAuthorityAuditReportError::InvalidArgs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCertificateAuthorityAuditReportError::InvalidArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCertificateAuthorityAuditReportError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCertificateAuthorityAuditReportError {}
 /// Errors returned by GetCertificate
 #[derive(Debug, PartialEq)]
 pub enum GetCertificateError {
@@ -1093,20 +1087,16 @@ impl GetCertificateError {
 }
 impl fmt::Display for GetCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            GetCertificateError::InvalidArn(ref cause) => cause,
-            GetCertificateError::InvalidState(ref cause) => cause,
-            GetCertificateError::RequestFailed(ref cause) => cause,
-            GetCertificateError::RequestInProgress(ref cause) => cause,
-            GetCertificateError::ResourceNotFound(ref cause) => cause,
+            GetCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetCertificateError::InvalidState(ref cause) => write!(f, "{}", cause),
+            GetCertificateError::RequestFailed(ref cause) => write!(f, "{}", cause),
+            GetCertificateError::RequestInProgress(ref cause) => write!(f, "{}", cause),
+            GetCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCertificateError {}
 /// Errors returned by GetCertificateAuthorityCertificate
 #[derive(Debug, PartialEq)]
 pub enum GetCertificateAuthorityCertificateError {
@@ -1148,18 +1138,20 @@ impl GetCertificateAuthorityCertificateError {
 }
 impl fmt::Display for GetCertificateAuthorityCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCertificateAuthorityCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            GetCertificateAuthorityCertificateError::InvalidArn(ref cause) => cause,
-            GetCertificateAuthorityCertificateError::InvalidState(ref cause) => cause,
-            GetCertificateAuthorityCertificateError::ResourceNotFound(ref cause) => cause,
+            GetCertificateAuthorityCertificateError::InvalidArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCertificateAuthorityCertificateError::InvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCertificateAuthorityCertificateError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetCertificateAuthorityCertificateError {}
 /// Errors returned by GetCertificateAuthorityCsr
 #[derive(Debug, PartialEq)]
 pub enum GetCertificateAuthorityCsrError {
@@ -1215,20 +1207,16 @@ impl GetCertificateAuthorityCsrError {
 }
 impl fmt::Display for GetCertificateAuthorityCsrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCertificateAuthorityCsrError {
-    fn description(&self) -> &str {
         match *self {
-            GetCertificateAuthorityCsrError::InvalidArn(ref cause) => cause,
-            GetCertificateAuthorityCsrError::InvalidState(ref cause) => cause,
-            GetCertificateAuthorityCsrError::RequestFailed(ref cause) => cause,
-            GetCertificateAuthorityCsrError::RequestInProgress(ref cause) => cause,
-            GetCertificateAuthorityCsrError::ResourceNotFound(ref cause) => cause,
+            GetCertificateAuthorityCsrError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetCertificateAuthorityCsrError::InvalidState(ref cause) => write!(f, "{}", cause),
+            GetCertificateAuthorityCsrError::RequestFailed(ref cause) => write!(f, "{}", cause),
+            GetCertificateAuthorityCsrError::RequestInProgress(ref cause) => write!(f, "{}", cause),
+            GetCertificateAuthorityCsrError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCertificateAuthorityCsrError {}
 /// Errors returned by ImportCertificateAuthorityCertificate
 #[derive(Debug, PartialEq)]
 pub enum ImportCertificateAuthorityCertificateError {
@@ -1312,24 +1300,38 @@ impl ImportCertificateAuthorityCertificateError {
 }
 impl fmt::Display for ImportCertificateAuthorityCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportCertificateAuthorityCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            ImportCertificateAuthorityCertificateError::CertificateMismatch(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::ConcurrentModification(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::InvalidArn(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::InvalidRequest(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::InvalidState(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::MalformedCertificate(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::RequestFailed(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::RequestInProgress(ref cause) => cause,
-            ImportCertificateAuthorityCertificateError::ResourceNotFound(ref cause) => cause,
+            ImportCertificateAuthorityCertificateError::CertificateMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::InvalidArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::InvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::MalformedCertificate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::RequestFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::RequestInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportCertificateAuthorityCertificateError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ImportCertificateAuthorityCertificateError {}
 /// Errors returned by IssueCertificate
 #[derive(Debug, PartialEq)]
 pub enum IssueCertificateError {
@@ -1378,21 +1380,17 @@ impl IssueCertificateError {
 }
 impl fmt::Display for IssueCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for IssueCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            IssueCertificateError::InvalidArgs(ref cause) => cause,
-            IssueCertificateError::InvalidArn(ref cause) => cause,
-            IssueCertificateError::InvalidState(ref cause) => cause,
-            IssueCertificateError::LimitExceeded(ref cause) => cause,
-            IssueCertificateError::MalformedCSR(ref cause) => cause,
-            IssueCertificateError::ResourceNotFound(ref cause) => cause,
+            IssueCertificateError::InvalidArgs(ref cause) => write!(f, "{}", cause),
+            IssueCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            IssueCertificateError::InvalidState(ref cause) => write!(f, "{}", cause),
+            IssueCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            IssueCertificateError::MalformedCSR(ref cause) => write!(f, "{}", cause),
+            IssueCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for IssueCertificateError {}
 /// Errors returned by ListCertificateAuthorities
 #[derive(Debug, PartialEq)]
 pub enum ListCertificateAuthoritiesError {
@@ -1420,16 +1418,12 @@ impl ListCertificateAuthoritiesError {
 }
 impl fmt::Display for ListCertificateAuthoritiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCertificateAuthoritiesError {
-    fn description(&self) -> &str {
         match *self {
-            ListCertificateAuthoritiesError::InvalidNextToken(ref cause) => cause,
+            ListCertificateAuthoritiesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCertificateAuthoritiesError {}
 /// Errors returned by ListPermissions
 #[derive(Debug, PartialEq)]
 pub enum ListPermissionsError {
@@ -1473,20 +1467,16 @@ impl ListPermissionsError {
 }
 impl fmt::Display for ListPermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPermissionsError::InvalidArn(ref cause) => cause,
-            ListPermissionsError::InvalidNextToken(ref cause) => cause,
-            ListPermissionsError::InvalidState(ref cause) => cause,
-            ListPermissionsError::RequestFailed(ref cause) => cause,
-            ListPermissionsError::ResourceNotFound(ref cause) => cause,
+            ListPermissionsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::InvalidState(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::RequestFailed(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPermissionsError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -1520,18 +1510,14 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::InvalidArn(ref cause) => cause,
-            ListTagsError::InvalidState(ref cause) => cause,
-            ListTagsError::ResourceNotFound(ref cause) => cause,
+            ListTagsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InvalidState(ref cause) => write!(f, "{}", cause),
+            ListTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by RestoreCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum RestoreCertificateAuthorityError {
@@ -1573,18 +1559,14 @@ impl RestoreCertificateAuthorityError {
 }
 impl fmt::Display for RestoreCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreCertificateAuthorityError::InvalidArn(ref cause) => cause,
-            RestoreCertificateAuthorityError::InvalidState(ref cause) => cause,
-            RestoreCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
+            RestoreCertificateAuthorityError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RestoreCertificateAuthorityError::InvalidState(ref cause) => write!(f, "{}", cause),
+            RestoreCertificateAuthorityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreCertificateAuthorityError {}
 /// Errors returned by RevokeCertificate
 #[derive(Debug, PartialEq)]
 pub enum RevokeCertificateError {
@@ -1652,24 +1634,20 @@ impl RevokeCertificateError {
 }
 impl fmt::Display for RevokeCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeCertificateError::ConcurrentModification(ref cause) => cause,
-            RevokeCertificateError::InvalidArn(ref cause) => cause,
-            RevokeCertificateError::InvalidRequest(ref cause) => cause,
-            RevokeCertificateError::InvalidState(ref cause) => cause,
-            RevokeCertificateError::LimitExceeded(ref cause) => cause,
-            RevokeCertificateError::RequestAlreadyProcessed(ref cause) => cause,
-            RevokeCertificateError::RequestFailed(ref cause) => cause,
-            RevokeCertificateError::RequestInProgress(ref cause) => cause,
-            RevokeCertificateError::ResourceNotFound(ref cause) => cause,
+            RevokeCertificateError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::InvalidState(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::RequestAlreadyProcessed(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::RequestFailed(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::RequestInProgress(ref cause) => write!(f, "{}", cause),
+            RevokeCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RevokeCertificateError {}
 /// Errors returned by TagCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum TagCertificateAuthorityError {
@@ -1717,20 +1695,16 @@ impl TagCertificateAuthorityError {
 }
 impl fmt::Display for TagCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            TagCertificateAuthorityError::InvalidArn(ref cause) => cause,
-            TagCertificateAuthorityError::InvalidState(ref cause) => cause,
-            TagCertificateAuthorityError::InvalidTag(ref cause) => cause,
-            TagCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
-            TagCertificateAuthorityError::TooManyTags(ref cause) => cause,
+            TagCertificateAuthorityError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            TagCertificateAuthorityError::InvalidState(ref cause) => write!(f, "{}", cause),
+            TagCertificateAuthorityError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            TagCertificateAuthorityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagCertificateAuthorityError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagCertificateAuthorityError {}
 /// Errors returned by UntagCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum UntagCertificateAuthorityError {
@@ -1777,19 +1751,15 @@ impl UntagCertificateAuthorityError {
 }
 impl fmt::Display for UntagCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            UntagCertificateAuthorityError::InvalidArn(ref cause) => cause,
-            UntagCertificateAuthorityError::InvalidState(ref cause) => cause,
-            UntagCertificateAuthorityError::InvalidTag(ref cause) => cause,
-            UntagCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
+            UntagCertificateAuthorityError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UntagCertificateAuthorityError::InvalidState(ref cause) => write!(f, "{}", cause),
+            UntagCertificateAuthorityError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            UntagCertificateAuthorityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagCertificateAuthorityError {}
 /// Errors returned by UpdateCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum UpdateCertificateAuthorityError {
@@ -1852,21 +1822,19 @@ impl UpdateCertificateAuthorityError {
 }
 impl fmt::Display for UpdateCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCertificateAuthorityError::ConcurrentModification(ref cause) => cause,
-            UpdateCertificateAuthorityError::InvalidArgs(ref cause) => cause,
-            UpdateCertificateAuthorityError::InvalidArn(ref cause) => cause,
-            UpdateCertificateAuthorityError::InvalidPolicy(ref cause) => cause,
-            UpdateCertificateAuthorityError::InvalidState(ref cause) => cause,
-            UpdateCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
+            UpdateCertificateAuthorityError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCertificateAuthorityError::InvalidArgs(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateAuthorityError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateAuthorityError::InvalidPolicy(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateAuthorityError::InvalidState(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateAuthorityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCertificateAuthorityError {}
 /// Trait representing the capabilities of the ACM-PCA API. ACM-PCA clients implement this trait.
 pub trait AcmPca {
     /// <p>Creates a root or subordinate private certificate authority (CA). You must specify the CA configuration, the certificate revocation list (CRL) configuration, the CA type, and an optional idempotency token to avoid accidental creation of multiple CAs. The CA configuration specifies the name of the algorithm and key size to be used to create the CA private key, the type of signing algorithm that the CA uses, and X.500 subject information. The CRL configuration specifies the CRL expiration period in days (the validity period of the CRL), the Amazon S3 bucket that will contain the CRL, and a CNAME alias for the S3 bucket that is included in certificates issued by the CA. If successful, this action returns the Amazon Resource Name (ARN) of the CA.</p>

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -599,21 +599,17 @@ impl AddTagsToCertificateError {
 }
 impl fmt::Display for AddTagsToCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToCertificateError::InvalidArn(ref cause) => cause,
-            AddTagsToCertificateError::InvalidParameter(ref cause) => cause,
-            AddTagsToCertificateError::InvalidTag(ref cause) => cause,
-            AddTagsToCertificateError::ResourceNotFound(ref cause) => cause,
-            AddTagsToCertificateError::TagPolicy(ref cause) => cause,
-            AddTagsToCertificateError::TooManyTags(ref cause) => cause,
+            AddTagsToCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            AddTagsToCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AddTagsToCertificateError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            AddTagsToCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddTagsToCertificateError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            AddTagsToCertificateError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToCertificateError {}
 /// Errors returned by DeleteCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteCertificateError {
@@ -647,18 +643,14 @@ impl DeleteCertificateError {
 }
 impl fmt::Display for DeleteCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCertificateError::InvalidArn(ref cause) => cause,
-            DeleteCertificateError::ResourceInUse(ref cause) => cause,
-            DeleteCertificateError::ResourceNotFound(ref cause) => cause,
+            DeleteCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCertificateError {}
 /// Errors returned by DescribeCertificate
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificateError {
@@ -689,17 +681,13 @@ impl DescribeCertificateError {
 }
 impl fmt::Display for DescribeCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificateError::InvalidArn(ref cause) => cause,
-            DescribeCertificateError::ResourceNotFound(ref cause) => cause,
+            DescribeCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCertificateError {}
 /// Errors returned by ExportCertificate
 #[derive(Debug, PartialEq)]
 pub enum ExportCertificateError {
@@ -733,18 +721,14 @@ impl ExportCertificateError {
 }
 impl fmt::Display for ExportCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExportCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            ExportCertificateError::InvalidArn(ref cause) => cause,
-            ExportCertificateError::RequestInProgress(ref cause) => cause,
-            ExportCertificateError::ResourceNotFound(ref cause) => cause,
+            ExportCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ExportCertificateError::RequestInProgress(ref cause) => write!(f, "{}", cause),
+            ExportCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExportCertificateError {}
 /// Errors returned by GetCertificate
 #[derive(Debug, PartialEq)]
 pub enum GetCertificateError {
@@ -778,18 +762,14 @@ impl GetCertificateError {
 }
 impl fmt::Display for GetCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            GetCertificateError::InvalidArn(ref cause) => cause,
-            GetCertificateError::RequestInProgress(ref cause) => cause,
-            GetCertificateError::ResourceNotFound(ref cause) => cause,
+            GetCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetCertificateError::RequestInProgress(ref cause) => write!(f, "{}", cause),
+            GetCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCertificateError {}
 /// Errors returned by ImportCertificate
 #[derive(Debug, PartialEq)]
 pub enum ImportCertificateError {
@@ -838,21 +818,17 @@ impl ImportCertificateError {
 }
 impl fmt::Display for ImportCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            ImportCertificateError::InvalidParameter(ref cause) => cause,
-            ImportCertificateError::InvalidTag(ref cause) => cause,
-            ImportCertificateError::LimitExceeded(ref cause) => cause,
-            ImportCertificateError::ResourceNotFound(ref cause) => cause,
-            ImportCertificateError::TagPolicy(ref cause) => cause,
-            ImportCertificateError::TooManyTags(ref cause) => cause,
+            ImportCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ImportCertificateError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            ImportCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ImportCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ImportCertificateError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            ImportCertificateError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportCertificateError {}
 /// Errors returned by ListCertificates
 #[derive(Debug, PartialEq)]
 pub enum ListCertificatesError {
@@ -876,16 +852,12 @@ impl ListCertificatesError {
 }
 impl fmt::Display for ListCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListCertificatesError::InvalidArgs(ref cause) => cause,
+            ListCertificatesError::InvalidArgs(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCertificatesError {}
 /// Errors returned by ListTagsForCertificate
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForCertificateError {
@@ -916,17 +888,13 @@ impl ListTagsForCertificateError {
 }
 impl fmt::Display for ListTagsForCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForCertificateError::InvalidArn(ref cause) => cause,
-            ListTagsForCertificateError::ResourceNotFound(ref cause) => cause,
+            ListTagsForCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTagsForCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForCertificateError {}
 /// Errors returned by RemoveTagsFromCertificate
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromCertificateError {
@@ -978,20 +946,16 @@ impl RemoveTagsFromCertificateError {
 }
 impl fmt::Display for RemoveTagsFromCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromCertificateError::InvalidArn(ref cause) => cause,
-            RemoveTagsFromCertificateError::InvalidParameter(ref cause) => cause,
-            RemoveTagsFromCertificateError::InvalidTag(ref cause) => cause,
-            RemoveTagsFromCertificateError::ResourceNotFound(ref cause) => cause,
-            RemoveTagsFromCertificateError::TagPolicy(ref cause) => cause,
+            RemoveTagsFromCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromCertificateError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromCertificateError::TagPolicy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromCertificateError {}
 /// Errors returned by RenewCertificate
 #[derive(Debug, PartialEq)]
 pub enum RenewCertificateError {
@@ -1020,17 +984,13 @@ impl RenewCertificateError {
 }
 impl fmt::Display for RenewCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RenewCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            RenewCertificateError::InvalidArn(ref cause) => cause,
-            RenewCertificateError::ResourceNotFound(ref cause) => cause,
+            RenewCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RenewCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RenewCertificateError {}
 /// Errors returned by RequestCertificate
 #[derive(Debug, PartialEq)]
 pub enum RequestCertificateError {
@@ -1086,22 +1046,20 @@ impl RequestCertificateError {
 }
 impl fmt::Display for RequestCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RequestCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            RequestCertificateError::InvalidArn(ref cause) => cause,
-            RequestCertificateError::InvalidDomainValidationOptions(ref cause) => cause,
-            RequestCertificateError::InvalidParameter(ref cause) => cause,
-            RequestCertificateError::InvalidTag(ref cause) => cause,
-            RequestCertificateError::LimitExceeded(ref cause) => cause,
-            RequestCertificateError::TagPolicy(ref cause) => cause,
-            RequestCertificateError::TooManyTags(ref cause) => cause,
+            RequestCertificateError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RequestCertificateError::InvalidDomainValidationOptions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RequestCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RequestCertificateError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            RequestCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RequestCertificateError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            RequestCertificateError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RequestCertificateError {}
 /// Errors returned by ResendValidationEmail
 #[derive(Debug, PartialEq)]
 pub enum ResendValidationEmailError {
@@ -1144,19 +1102,17 @@ impl ResendValidationEmailError {
 }
 impl fmt::Display for ResendValidationEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResendValidationEmailError {
-    fn description(&self) -> &str {
         match *self {
-            ResendValidationEmailError::InvalidArn(ref cause) => cause,
-            ResendValidationEmailError::InvalidDomainValidationOptions(ref cause) => cause,
-            ResendValidationEmailError::InvalidState(ref cause) => cause,
-            ResendValidationEmailError::ResourceNotFound(ref cause) => cause,
+            ResendValidationEmailError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ResendValidationEmailError::InvalidDomainValidationOptions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResendValidationEmailError::InvalidState(ref cause) => write!(f, "{}", cause),
+            ResendValidationEmailError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResendValidationEmailError {}
 /// Errors returned by UpdateCertificateOptions
 #[derive(Debug, PartialEq)]
 pub enum UpdateCertificateOptionsError {
@@ -1201,19 +1157,15 @@ impl UpdateCertificateOptionsError {
 }
 impl fmt::Display for UpdateCertificateOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCertificateOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCertificateOptionsError::InvalidArn(ref cause) => cause,
-            UpdateCertificateOptionsError::InvalidState(ref cause) => cause,
-            UpdateCertificateOptionsError::LimitExceeded(ref cause) => cause,
-            UpdateCertificateOptionsError::ResourceNotFound(ref cause) => cause,
+            UpdateCertificateOptionsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateOptionsError::InvalidState(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateOptionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateOptionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCertificateOptionsError {}
 /// Trait representing the capabilities of the ACM API. ACM clients implement this trait.
 pub trait Acm {
     /// <p>Adds one or more tags to an ACM certificate. Tags are labels that you can use to identify and organize your AWS resources. Each tag consists of a <code>key</code> and an optional <code>value</code>. You specify the certificate on input by its Amazon Resource Name (ARN). You specify the tag by using a key-value pair. </p> <p>You can apply a tag to just one certificate if you want to identify a specific characteristic of that certificate, or you can apply the same tag to multiple certificates if you want to filter for a common relationship among those certificates. Similarly, you can apply the same tag to multiple resources if you want to specify a relationship among those resources. For example, you can add the same tag to an ACM certificate and an Elastic Load Balancing load balancer to indicate that they are both used by the same website. For more information, see <a href="https://docs.aws.amazon.com/acm/latest/userguide/tags.html">Tagging ACM certificates</a>. </p> <p>To remove one or more tags, use the <a>RemoveTagsFromCertificate</a> action. To view all of the tags that have been applied to the certificate, use the <a>ListTagsForCertificate</a> action. </p>

--- a/rusoto/services/alexaforbusiness/src/generated.rs
+++ b/rusoto/services/alexaforbusiness/src/generated.rs
@@ -3414,18 +3414,14 @@ impl ApproveSkillError {
 }
 impl fmt::Display for ApproveSkillError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApproveSkillError {
-    fn description(&self) -> &str {
         match *self {
-            ApproveSkillError::ConcurrentModification(ref cause) => cause,
-            ApproveSkillError::LimitExceeded(ref cause) => cause,
-            ApproveSkillError::NotFound(ref cause) => cause,
+            ApproveSkillError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            ApproveSkillError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ApproveSkillError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ApproveSkillError {}
 /// Errors returned by AssociateContactWithAddressBook
 #[derive(Debug, PartialEq)]
 pub enum AssociateContactWithAddressBookError {
@@ -3453,16 +3449,14 @@ impl AssociateContactWithAddressBookError {
 }
 impl fmt::Display for AssociateContactWithAddressBookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateContactWithAddressBookError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateContactWithAddressBookError::LimitExceeded(ref cause) => cause,
+            AssociateContactWithAddressBookError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateContactWithAddressBookError {}
 /// Errors returned by AssociateDeviceWithNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum AssociateDeviceWithNetworkProfileError {
@@ -3504,18 +3498,18 @@ impl AssociateDeviceWithNetworkProfileError {
 }
 impl fmt::Display for AssociateDeviceWithNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDeviceWithNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDeviceWithNetworkProfileError::ConcurrentModification(ref cause) => cause,
-            AssociateDeviceWithNetworkProfileError::DeviceNotRegistered(ref cause) => cause,
-            AssociateDeviceWithNetworkProfileError::NotFound(ref cause) => cause,
+            AssociateDeviceWithNetworkProfileError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDeviceWithNetworkProfileError::DeviceNotRegistered(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDeviceWithNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateDeviceWithNetworkProfileError {}
 /// Errors returned by AssociateDeviceWithRoom
 #[derive(Debug, PartialEq)]
 pub enum AssociateDeviceWithRoomError {
@@ -3555,18 +3549,16 @@ impl AssociateDeviceWithRoomError {
 }
 impl fmt::Display for AssociateDeviceWithRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDeviceWithRoomError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDeviceWithRoomError::ConcurrentModification(ref cause) => cause,
-            AssociateDeviceWithRoomError::DeviceNotRegistered(ref cause) => cause,
-            AssociateDeviceWithRoomError::LimitExceeded(ref cause) => cause,
+            AssociateDeviceWithRoomError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDeviceWithRoomError::DeviceNotRegistered(ref cause) => write!(f, "{}", cause),
+            AssociateDeviceWithRoomError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateDeviceWithRoomError {}
 /// Errors returned by AssociateSkillGroupWithRoom
 #[derive(Debug, PartialEq)]
 pub enum AssociateSkillGroupWithRoomError {
@@ -3594,16 +3586,14 @@ impl AssociateSkillGroupWithRoomError {
 }
 impl fmt::Display for AssociateSkillGroupWithRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateSkillGroupWithRoomError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateSkillGroupWithRoomError::ConcurrentModification(ref cause) => cause,
+            AssociateSkillGroupWithRoomError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateSkillGroupWithRoomError {}
 /// Errors returned by AssociateSkillWithSkillGroup
 #[derive(Debug, PartialEq)]
 pub enum AssociateSkillWithSkillGroupError {
@@ -3645,18 +3635,16 @@ impl AssociateSkillWithSkillGroupError {
 }
 impl fmt::Display for AssociateSkillWithSkillGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateSkillWithSkillGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateSkillWithSkillGroupError::ConcurrentModification(ref cause) => cause,
-            AssociateSkillWithSkillGroupError::NotFound(ref cause) => cause,
-            AssociateSkillWithSkillGroupError::SkillNotLinked(ref cause) => cause,
+            AssociateSkillWithSkillGroupError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateSkillWithSkillGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            AssociateSkillWithSkillGroupError::SkillNotLinked(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateSkillWithSkillGroupError {}
 /// Errors returned by AssociateSkillWithUsers
 #[derive(Debug, PartialEq)]
 pub enum AssociateSkillWithUsersError {
@@ -3687,17 +3675,15 @@ impl AssociateSkillWithUsersError {
 }
 impl fmt::Display for AssociateSkillWithUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateSkillWithUsersError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateSkillWithUsersError::ConcurrentModification(ref cause) => cause,
-            AssociateSkillWithUsersError::NotFound(ref cause) => cause,
+            AssociateSkillWithUsersError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateSkillWithUsersError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateSkillWithUsersError {}
 /// Errors returned by CreateAddressBook
 #[derive(Debug, PartialEq)]
 pub enum CreateAddressBookError {
@@ -3726,17 +3712,13 @@ impl CreateAddressBookError {
 }
 impl fmt::Display for CreateAddressBookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAddressBookError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAddressBookError::AlreadyExists(ref cause) => cause,
-            CreateAddressBookError::LimitExceeded(ref cause) => cause,
+            CreateAddressBookError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateAddressBookError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAddressBookError {}
 /// Errors returned by CreateBusinessReportSchedule
 #[derive(Debug, PartialEq)]
 pub enum CreateBusinessReportScheduleError {
@@ -3764,16 +3746,12 @@ impl CreateBusinessReportScheduleError {
 }
 impl fmt::Display for CreateBusinessReportScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBusinessReportScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBusinessReportScheduleError::AlreadyExists(ref cause) => cause,
+            CreateBusinessReportScheduleError::AlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBusinessReportScheduleError {}
 /// Errors returned by CreateConferenceProvider
 #[derive(Debug, PartialEq)]
 pub enum CreateConferenceProviderError {
@@ -3799,16 +3777,12 @@ impl CreateConferenceProviderError {
 }
 impl fmt::Display for CreateConferenceProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConferenceProviderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConferenceProviderError::AlreadyExists(ref cause) => cause,
+            CreateConferenceProviderError::AlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConferenceProviderError {}
 /// Errors returned by CreateContact
 #[derive(Debug, PartialEq)]
 pub enum CreateContactError {
@@ -3837,17 +3811,13 @@ impl CreateContactError {
 }
 impl fmt::Display for CreateContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateContactError {
-    fn description(&self) -> &str {
         match *self {
-            CreateContactError::AlreadyExists(ref cause) => cause,
-            CreateContactError::LimitExceeded(ref cause) => cause,
+            CreateContactError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateContactError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateContactError {}
 /// Errors returned by CreateGatewayGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateGatewayGroupError {
@@ -3876,17 +3846,13 @@ impl CreateGatewayGroupError {
 }
 impl fmt::Display for CreateGatewayGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGatewayGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGatewayGroupError::AlreadyExists(ref cause) => cause,
-            CreateGatewayGroupError::LimitExceeded(ref cause) => cause,
+            CreateGatewayGroupError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateGatewayGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGatewayGroupError {}
 /// Errors returned by CreateNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateNetworkProfileError {
@@ -3936,20 +3902,20 @@ impl CreateNetworkProfileError {
 }
 impl fmt::Display for CreateNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNetworkProfileError::AlreadyExists(ref cause) => cause,
-            CreateNetworkProfileError::ConcurrentModification(ref cause) => cause,
-            CreateNetworkProfileError::InvalidCertificateAuthority(ref cause) => cause,
-            CreateNetworkProfileError::InvalidServiceLinkedRoleState(ref cause) => cause,
-            CreateNetworkProfileError::LimitExceeded(ref cause) => cause,
+            CreateNetworkProfileError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateNetworkProfileError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateNetworkProfileError::InvalidCertificateAuthority(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateNetworkProfileError::InvalidServiceLinkedRoleState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateNetworkProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateNetworkProfileError {}
 /// Errors returned by CreateProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateProfileError {
@@ -3985,18 +3951,14 @@ impl CreateProfileError {
 }
 impl fmt::Display for CreateProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProfileError::AlreadyExists(ref cause) => cause,
-            CreateProfileError::ConcurrentModification(ref cause) => cause,
-            CreateProfileError::LimitExceeded(ref cause) => cause,
+            CreateProfileError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateProfileError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProfileError {}
 /// Errors returned by CreateRoom
 #[derive(Debug, PartialEq)]
 pub enum CreateRoomError {
@@ -4025,17 +3987,13 @@ impl CreateRoomError {
 }
 impl fmt::Display for CreateRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRoomError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRoomError::AlreadyExists(ref cause) => cause,
-            CreateRoomError::LimitExceeded(ref cause) => cause,
+            CreateRoomError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateRoomError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRoomError {}
 /// Errors returned by CreateSkillGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateSkillGroupError {
@@ -4071,18 +4029,14 @@ impl CreateSkillGroupError {
 }
 impl fmt::Display for CreateSkillGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSkillGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSkillGroupError::AlreadyExists(ref cause) => cause,
-            CreateSkillGroupError::ConcurrentModification(ref cause) => cause,
-            CreateSkillGroupError::LimitExceeded(ref cause) => cause,
+            CreateSkillGroupError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateSkillGroupError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateSkillGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSkillGroupError {}
 /// Errors returned by CreateUser
 #[derive(Debug, PartialEq)]
 pub enum CreateUserError {
@@ -4116,18 +4070,14 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::ConcurrentModification(ref cause) => cause,
-            CreateUserError::LimitExceeded(ref cause) => cause,
-            CreateUserError::ResourceInUse(ref cause) => cause,
+            CreateUserError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateUserError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by DeleteAddressBook
 #[derive(Debug, PartialEq)]
 pub enum DeleteAddressBookError {
@@ -4158,17 +4108,13 @@ impl DeleteAddressBookError {
 }
 impl fmt::Display for DeleteAddressBookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAddressBookError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAddressBookError::ConcurrentModification(ref cause) => cause,
-            DeleteAddressBookError::NotFound(ref cause) => cause,
+            DeleteAddressBookError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteAddressBookError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAddressBookError {}
 /// Errors returned by DeleteBusinessReportSchedule
 #[derive(Debug, PartialEq)]
 pub enum DeleteBusinessReportScheduleError {
@@ -4203,17 +4149,15 @@ impl DeleteBusinessReportScheduleError {
 }
 impl fmt::Display for DeleteBusinessReportScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBusinessReportScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBusinessReportScheduleError::ConcurrentModification(ref cause) => cause,
-            DeleteBusinessReportScheduleError::NotFound(ref cause) => cause,
+            DeleteBusinessReportScheduleError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteBusinessReportScheduleError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBusinessReportScheduleError {}
 /// Errors returned by DeleteConferenceProvider
 #[derive(Debug, PartialEq)]
 pub enum DeleteConferenceProviderError {
@@ -4237,16 +4181,12 @@ impl DeleteConferenceProviderError {
 }
 impl fmt::Display for DeleteConferenceProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConferenceProviderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConferenceProviderError::NotFound(ref cause) => cause,
+            DeleteConferenceProviderError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConferenceProviderError {}
 /// Errors returned by DeleteContact
 #[derive(Debug, PartialEq)]
 pub enum DeleteContactError {
@@ -4277,17 +4217,13 @@ impl DeleteContactError {
 }
 impl fmt::Display for DeleteContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteContactError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteContactError::ConcurrentModification(ref cause) => cause,
-            DeleteContactError::NotFound(ref cause) => cause,
+            DeleteContactError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteContactError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteContactError {}
 /// Errors returned by DeleteDevice
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeviceError {
@@ -4323,18 +4259,14 @@ impl DeleteDeviceError {
 }
 impl fmt::Display for DeleteDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeviceError::ConcurrentModification(ref cause) => cause,
-            DeleteDeviceError::InvalidCertificateAuthority(ref cause) => cause,
-            DeleteDeviceError::NotFound(ref cause) => cause,
+            DeleteDeviceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteDeviceError::InvalidCertificateAuthority(ref cause) => write!(f, "{}", cause),
+            DeleteDeviceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeviceError {}
 /// Errors returned by DeleteDeviceUsageData
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeviceUsageDataError {
@@ -4370,18 +4302,14 @@ impl DeleteDeviceUsageDataError {
 }
 impl fmt::Display for DeleteDeviceUsageDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeviceUsageDataError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeviceUsageDataError::DeviceNotRegistered(ref cause) => cause,
-            DeleteDeviceUsageDataError::LimitExceeded(ref cause) => cause,
-            DeleteDeviceUsageDataError::NotFound(ref cause) => cause,
+            DeleteDeviceUsageDataError::DeviceNotRegistered(ref cause) => write!(f, "{}", cause),
+            DeleteDeviceUsageDataError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteDeviceUsageDataError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeviceUsageDataError {}
 /// Errors returned by DeleteGatewayGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteGatewayGroupError {
@@ -4407,16 +4335,12 @@ impl DeleteGatewayGroupError {
 }
 impl fmt::Display for DeleteGatewayGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGatewayGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGatewayGroupError::ResourceAssociated(ref cause) => cause,
+            DeleteGatewayGroupError::ResourceAssociated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGatewayGroupError {}
 /// Errors returned by DeleteNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteNetworkProfileError {
@@ -4452,18 +4376,14 @@ impl DeleteNetworkProfileError {
 }
 impl fmt::Display for DeleteNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNetworkProfileError::ConcurrentModification(ref cause) => cause,
-            DeleteNetworkProfileError::NotFound(ref cause) => cause,
-            DeleteNetworkProfileError::ResourceInUse(ref cause) => cause,
+            DeleteNetworkProfileError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteNetworkProfileError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteNetworkProfileError {}
 /// Errors returned by DeleteProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteProfileError {
@@ -4494,17 +4414,13 @@ impl DeleteProfileError {
 }
 impl fmt::Display for DeleteProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProfileError::ConcurrentModification(ref cause) => cause,
-            DeleteProfileError::NotFound(ref cause) => cause,
+            DeleteProfileError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteProfileError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProfileError {}
 /// Errors returned by DeleteRoom
 #[derive(Debug, PartialEq)]
 pub enum DeleteRoomError {
@@ -4533,17 +4449,13 @@ impl DeleteRoomError {
 }
 impl fmt::Display for DeleteRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRoomError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRoomError::ConcurrentModification(ref cause) => cause,
-            DeleteRoomError::NotFound(ref cause) => cause,
+            DeleteRoomError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteRoomError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRoomError {}
 /// Errors returned by DeleteRoomSkillParameter
 #[derive(Debug, PartialEq)]
 pub enum DeleteRoomSkillParameterError {
@@ -4569,16 +4481,14 @@ impl DeleteRoomSkillParameterError {
 }
 impl fmt::Display for DeleteRoomSkillParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRoomSkillParameterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRoomSkillParameterError::ConcurrentModification(ref cause) => cause,
+            DeleteRoomSkillParameterError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRoomSkillParameterError {}
 /// Errors returned by DeleteSkillAuthorization
 #[derive(Debug, PartialEq)]
 pub enum DeleteSkillAuthorizationError {
@@ -4609,17 +4519,15 @@ impl DeleteSkillAuthorizationError {
 }
 impl fmt::Display for DeleteSkillAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSkillAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSkillAuthorizationError::ConcurrentModification(ref cause) => cause,
-            DeleteSkillAuthorizationError::NotFound(ref cause) => cause,
+            DeleteSkillAuthorizationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteSkillAuthorizationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSkillAuthorizationError {}
 /// Errors returned by DeleteSkillGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteSkillGroupError {
@@ -4650,17 +4558,13 @@ impl DeleteSkillGroupError {
 }
 impl fmt::Display for DeleteSkillGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSkillGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSkillGroupError::ConcurrentModification(ref cause) => cause,
-            DeleteSkillGroupError::NotFound(ref cause) => cause,
+            DeleteSkillGroupError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteSkillGroupError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSkillGroupError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -4689,17 +4593,13 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::ConcurrentModification(ref cause) => cause,
-            DeleteUserError::NotFound(ref cause) => cause,
+            DeleteUserError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DisassociateContactFromAddressBook
 #[derive(Debug, PartialEq)]
 pub enum DisassociateContactFromAddressBookError {}
@@ -4719,14 +4619,10 @@ impl DisassociateContactFromAddressBookError {
 }
 impl fmt::Display for DisassociateContactFromAddressBookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateContactFromAddressBookError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DisassociateContactFromAddressBookError {}
 /// Errors returned by DisassociateDeviceFromRoom
 #[derive(Debug, PartialEq)]
 pub enum DisassociateDeviceFromRoomError {
@@ -4761,17 +4657,17 @@ impl DisassociateDeviceFromRoomError {
 }
 impl fmt::Display for DisassociateDeviceFromRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateDeviceFromRoomError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateDeviceFromRoomError::ConcurrentModification(ref cause) => cause,
-            DisassociateDeviceFromRoomError::DeviceNotRegistered(ref cause) => cause,
+            DisassociateDeviceFromRoomError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDeviceFromRoomError::DeviceNotRegistered(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateDeviceFromRoomError {}
 /// Errors returned by DisassociateSkillFromSkillGroup
 #[derive(Debug, PartialEq)]
 pub enum DisassociateSkillFromSkillGroupError {
@@ -4806,17 +4702,15 @@ impl DisassociateSkillFromSkillGroupError {
 }
 impl fmt::Display for DisassociateSkillFromSkillGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateSkillFromSkillGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateSkillFromSkillGroupError::ConcurrentModification(ref cause) => cause,
-            DisassociateSkillFromSkillGroupError::NotFound(ref cause) => cause,
+            DisassociateSkillFromSkillGroupError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateSkillFromSkillGroupError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateSkillFromSkillGroupError {}
 /// Errors returned by DisassociateSkillFromUsers
 #[derive(Debug, PartialEq)]
 pub enum DisassociateSkillFromUsersError {
@@ -4849,17 +4743,15 @@ impl DisassociateSkillFromUsersError {
 }
 impl fmt::Display for DisassociateSkillFromUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateSkillFromUsersError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateSkillFromUsersError::ConcurrentModification(ref cause) => cause,
-            DisassociateSkillFromUsersError::NotFound(ref cause) => cause,
+            DisassociateSkillFromUsersError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateSkillFromUsersError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateSkillFromUsersError {}
 /// Errors returned by DisassociateSkillGroupFromRoom
 #[derive(Debug, PartialEq)]
 pub enum DisassociateSkillGroupFromRoomError {
@@ -4887,16 +4779,14 @@ impl DisassociateSkillGroupFromRoomError {
 }
 impl fmt::Display for DisassociateSkillGroupFromRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateSkillGroupFromRoomError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateSkillGroupFromRoomError::ConcurrentModification(ref cause) => cause,
+            DisassociateSkillGroupFromRoomError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateSkillGroupFromRoomError {}
 /// Errors returned by ForgetSmartHomeAppliances
 #[derive(Debug, PartialEq)]
 pub enum ForgetSmartHomeAppliancesError {
@@ -4920,16 +4810,12 @@ impl ForgetSmartHomeAppliancesError {
 }
 impl fmt::Display for ForgetSmartHomeAppliancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ForgetSmartHomeAppliancesError {
-    fn description(&self) -> &str {
         match *self {
-            ForgetSmartHomeAppliancesError::NotFound(ref cause) => cause,
+            ForgetSmartHomeAppliancesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ForgetSmartHomeAppliancesError {}
 /// Errors returned by GetAddressBook
 #[derive(Debug, PartialEq)]
 pub enum GetAddressBookError {
@@ -4953,16 +4839,12 @@ impl GetAddressBookError {
 }
 impl fmt::Display for GetAddressBookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAddressBookError {
-    fn description(&self) -> &str {
         match *self {
-            GetAddressBookError::NotFound(ref cause) => cause,
+            GetAddressBookError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAddressBookError {}
 /// Errors returned by GetConferencePreference
 #[derive(Debug, PartialEq)]
 pub enum GetConferencePreferenceError {
@@ -4986,16 +4868,12 @@ impl GetConferencePreferenceError {
 }
 impl fmt::Display for GetConferencePreferenceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConferencePreferenceError {
-    fn description(&self) -> &str {
         match *self {
-            GetConferencePreferenceError::NotFound(ref cause) => cause,
+            GetConferencePreferenceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConferencePreferenceError {}
 /// Errors returned by GetConferenceProvider
 #[derive(Debug, PartialEq)]
 pub enum GetConferenceProviderError {
@@ -5019,16 +4897,12 @@ impl GetConferenceProviderError {
 }
 impl fmt::Display for GetConferenceProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConferenceProviderError {
-    fn description(&self) -> &str {
         match *self {
-            GetConferenceProviderError::NotFound(ref cause) => cause,
+            GetConferenceProviderError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConferenceProviderError {}
 /// Errors returned by GetContact
 #[derive(Debug, PartialEq)]
 pub enum GetContactError {
@@ -5052,16 +4926,12 @@ impl GetContactError {
 }
 impl fmt::Display for GetContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetContactError {
-    fn description(&self) -> &str {
         match *self {
-            GetContactError::NotFound(ref cause) => cause,
+            GetContactError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetContactError {}
 /// Errors returned by GetDevice
 #[derive(Debug, PartialEq)]
 pub enum GetDeviceError {
@@ -5085,16 +4955,12 @@ impl GetDeviceError {
 }
 impl fmt::Display for GetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeviceError::NotFound(ref cause) => cause,
+            GetDeviceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeviceError {}
 /// Errors returned by GetGateway
 #[derive(Debug, PartialEq)]
 pub enum GetGatewayError {
@@ -5118,16 +4984,12 @@ impl GetGatewayError {
 }
 impl fmt::Display for GetGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            GetGatewayError::NotFound(ref cause) => cause,
+            GetGatewayError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGatewayError {}
 /// Errors returned by GetGatewayGroup
 #[derive(Debug, PartialEq)]
 pub enum GetGatewayGroupError {
@@ -5151,16 +5013,12 @@ impl GetGatewayGroupError {
 }
 impl fmt::Display for GetGatewayGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGatewayGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetGatewayGroupError::NotFound(ref cause) => cause,
+            GetGatewayGroupError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGatewayGroupError {}
 /// Errors returned by GetInvitationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetInvitationConfigurationError {
@@ -5186,16 +5044,12 @@ impl GetInvitationConfigurationError {
 }
 impl fmt::Display for GetInvitationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInvitationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetInvitationConfigurationError::NotFound(ref cause) => cause,
+            GetInvitationConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInvitationConfigurationError {}
 /// Errors returned by GetNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum GetNetworkProfileError {
@@ -5226,17 +5080,15 @@ impl GetNetworkProfileError {
 }
 impl fmt::Display for GetNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            GetNetworkProfileError::InvalidSecretsManagerResource(ref cause) => cause,
-            GetNetworkProfileError::NotFound(ref cause) => cause,
+            GetNetworkProfileError::InvalidSecretsManagerResource(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetNetworkProfileError {}
 /// Errors returned by GetProfile
 #[derive(Debug, PartialEq)]
 pub enum GetProfileError {
@@ -5260,16 +5112,12 @@ impl GetProfileError {
 }
 impl fmt::Display for GetProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetProfileError {
-    fn description(&self) -> &str {
         match *self {
-            GetProfileError::NotFound(ref cause) => cause,
+            GetProfileError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetProfileError {}
 /// Errors returned by GetRoom
 #[derive(Debug, PartialEq)]
 pub enum GetRoomError {
@@ -5293,16 +5141,12 @@ impl GetRoomError {
 }
 impl fmt::Display for GetRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRoomError {
-    fn description(&self) -> &str {
         match *self {
-            GetRoomError::NotFound(ref cause) => cause,
+            GetRoomError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRoomError {}
 /// Errors returned by GetRoomSkillParameter
 #[derive(Debug, PartialEq)]
 pub enum GetRoomSkillParameterError {
@@ -5326,16 +5170,12 @@ impl GetRoomSkillParameterError {
 }
 impl fmt::Display for GetRoomSkillParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRoomSkillParameterError {
-    fn description(&self) -> &str {
         match *self {
-            GetRoomSkillParameterError::NotFound(ref cause) => cause,
+            GetRoomSkillParameterError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRoomSkillParameterError {}
 /// Errors returned by GetSkillGroup
 #[derive(Debug, PartialEq)]
 pub enum GetSkillGroupError {
@@ -5359,16 +5199,12 @@ impl GetSkillGroupError {
 }
 impl fmt::Display for GetSkillGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSkillGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetSkillGroupError::NotFound(ref cause) => cause,
+            GetSkillGroupError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSkillGroupError {}
 /// Errors returned by ListBusinessReportSchedules
 #[derive(Debug, PartialEq)]
 pub enum ListBusinessReportSchedulesError {}
@@ -5388,14 +5224,10 @@ impl ListBusinessReportSchedulesError {
 }
 impl fmt::Display for ListBusinessReportSchedulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBusinessReportSchedulesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListBusinessReportSchedulesError {}
 /// Errors returned by ListConferenceProviders
 #[derive(Debug, PartialEq)]
 pub enum ListConferenceProvidersError {}
@@ -5413,14 +5245,10 @@ impl ListConferenceProvidersError {
 }
 impl fmt::Display for ListConferenceProvidersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConferenceProvidersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListConferenceProvidersError {}
 /// Errors returned by ListDeviceEvents
 #[derive(Debug, PartialEq)]
 pub enum ListDeviceEventsError {
@@ -5444,16 +5272,12 @@ impl ListDeviceEventsError {
 }
 impl fmt::Display for ListDeviceEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeviceEventsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeviceEventsError::NotFound(ref cause) => cause,
+            ListDeviceEventsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeviceEventsError {}
 /// Errors returned by ListGatewayGroups
 #[derive(Debug, PartialEq)]
 pub enum ListGatewayGroupsError {}
@@ -5471,14 +5295,10 @@ impl ListGatewayGroupsError {
 }
 impl fmt::Display for ListGatewayGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGatewayGroupsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListGatewayGroupsError {}
 /// Errors returned by ListGateways
 #[derive(Debug, PartialEq)]
 pub enum ListGatewaysError {}
@@ -5496,14 +5316,10 @@ impl ListGatewaysError {
 }
 impl fmt::Display for ListGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGatewaysError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListGatewaysError {}
 /// Errors returned by ListSkills
 #[derive(Debug, PartialEq)]
 pub enum ListSkillsError {}
@@ -5521,14 +5337,10 @@ impl ListSkillsError {
 }
 impl fmt::Display for ListSkillsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSkillsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListSkillsError {}
 /// Errors returned by ListSkillsStoreCategories
 #[derive(Debug, PartialEq)]
 pub enum ListSkillsStoreCategoriesError {}
@@ -5546,14 +5358,10 @@ impl ListSkillsStoreCategoriesError {
 }
 impl fmt::Display for ListSkillsStoreCategoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSkillsStoreCategoriesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListSkillsStoreCategoriesError {}
 /// Errors returned by ListSkillsStoreSkillsByCategory
 #[derive(Debug, PartialEq)]
 pub enum ListSkillsStoreSkillsByCategoryError {}
@@ -5573,14 +5381,10 @@ impl ListSkillsStoreSkillsByCategoryError {
 }
 impl fmt::Display for ListSkillsStoreSkillsByCategoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSkillsStoreSkillsByCategoryError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListSkillsStoreSkillsByCategoryError {}
 /// Errors returned by ListSmartHomeAppliances
 #[derive(Debug, PartialEq)]
 pub enum ListSmartHomeAppliancesError {
@@ -5604,16 +5408,12 @@ impl ListSmartHomeAppliancesError {
 }
 impl fmt::Display for ListSmartHomeAppliancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSmartHomeAppliancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListSmartHomeAppliancesError::NotFound(ref cause) => cause,
+            ListSmartHomeAppliancesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSmartHomeAppliancesError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -5637,16 +5437,12 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::NotFound(ref cause) => cause,
+            ListTagsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by PutConferencePreference
 #[derive(Debug, PartialEq)]
 pub enum PutConferencePreferenceError {
@@ -5670,16 +5466,12 @@ impl PutConferencePreferenceError {
 }
 impl fmt::Display for PutConferencePreferenceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutConferencePreferenceError {
-    fn description(&self) -> &str {
         match *self {
-            PutConferencePreferenceError::NotFound(ref cause) => cause,
+            PutConferencePreferenceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutConferencePreferenceError {}
 /// Errors returned by PutInvitationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutInvitationConfigurationError {
@@ -5712,17 +5504,15 @@ impl PutInvitationConfigurationError {
 }
 impl fmt::Display for PutInvitationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutInvitationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutInvitationConfigurationError::ConcurrentModification(ref cause) => cause,
-            PutInvitationConfigurationError::NotFound(ref cause) => cause,
+            PutInvitationConfigurationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutInvitationConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutInvitationConfigurationError {}
 /// Errors returned by PutRoomSkillParameter
 #[derive(Debug, PartialEq)]
 pub enum PutRoomSkillParameterError {
@@ -5748,16 +5538,12 @@ impl PutRoomSkillParameterError {
 }
 impl fmt::Display for PutRoomSkillParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRoomSkillParameterError {
-    fn description(&self) -> &str {
         match *self {
-            PutRoomSkillParameterError::ConcurrentModification(ref cause) => cause,
+            PutRoomSkillParameterError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRoomSkillParameterError {}
 /// Errors returned by PutSkillAuthorization
 #[derive(Debug, PartialEq)]
 pub enum PutSkillAuthorizationError {
@@ -5788,17 +5574,13 @@ impl PutSkillAuthorizationError {
 }
 impl fmt::Display for PutSkillAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutSkillAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            PutSkillAuthorizationError::ConcurrentModification(ref cause) => cause,
-            PutSkillAuthorizationError::Unauthorized(ref cause) => cause,
+            PutSkillAuthorizationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            PutSkillAuthorizationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutSkillAuthorizationError {}
 /// Errors returned by RegisterAVSDevice
 #[derive(Debug, PartialEq)]
 pub enum RegisterAVSDeviceError {
@@ -5834,18 +5616,14 @@ impl RegisterAVSDeviceError {
 }
 impl fmt::Display for RegisterAVSDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterAVSDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterAVSDeviceError::ConcurrentModification(ref cause) => cause,
-            RegisterAVSDeviceError::InvalidDevice(ref cause) => cause,
-            RegisterAVSDeviceError::LimitExceeded(ref cause) => cause,
+            RegisterAVSDeviceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            RegisterAVSDeviceError::InvalidDevice(ref cause) => write!(f, "{}", cause),
+            RegisterAVSDeviceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterAVSDeviceError {}
 /// Errors returned by RejectSkill
 #[derive(Debug, PartialEq)]
 pub enum RejectSkillError {
@@ -5874,17 +5652,13 @@ impl RejectSkillError {
 }
 impl fmt::Display for RejectSkillError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RejectSkillError {
-    fn description(&self) -> &str {
         match *self {
-            RejectSkillError::ConcurrentModification(ref cause) => cause,
-            RejectSkillError::NotFound(ref cause) => cause,
+            RejectSkillError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            RejectSkillError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RejectSkillError {}
 /// Errors returned by ResolveRoom
 #[derive(Debug, PartialEq)]
 pub enum ResolveRoomError {
@@ -5908,16 +5682,12 @@ impl ResolveRoomError {
 }
 impl fmt::Display for ResolveRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResolveRoomError {
-    fn description(&self) -> &str {
         match *self {
-            ResolveRoomError::NotFound(ref cause) => cause,
+            ResolveRoomError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResolveRoomError {}
 /// Errors returned by RevokeInvitation
 #[derive(Debug, PartialEq)]
 pub enum RevokeInvitationError {
@@ -5948,17 +5718,13 @@ impl RevokeInvitationError {
 }
 impl fmt::Display for RevokeInvitationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeInvitationError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeInvitationError::ConcurrentModification(ref cause) => cause,
-            RevokeInvitationError::NotFound(ref cause) => cause,
+            RevokeInvitationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            RevokeInvitationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RevokeInvitationError {}
 /// Errors returned by SearchAddressBooks
 #[derive(Debug, PartialEq)]
 pub enum SearchAddressBooksError {}
@@ -5976,14 +5742,10 @@ impl SearchAddressBooksError {
 }
 impl fmt::Display for SearchAddressBooksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchAddressBooksError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchAddressBooksError {}
 /// Errors returned by SearchContacts
 #[derive(Debug, PartialEq)]
 pub enum SearchContactsError {}
@@ -6001,14 +5763,10 @@ impl SearchContactsError {
 }
 impl fmt::Display for SearchContactsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchContactsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchContactsError {}
 /// Errors returned by SearchDevices
 #[derive(Debug, PartialEq)]
 pub enum SearchDevicesError {}
@@ -6026,14 +5784,10 @@ impl SearchDevicesError {
 }
 impl fmt::Display for SearchDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchDevicesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchDevicesError {}
 /// Errors returned by SearchNetworkProfiles
 #[derive(Debug, PartialEq)]
 pub enum SearchNetworkProfilesError {}
@@ -6051,14 +5805,10 @@ impl SearchNetworkProfilesError {
 }
 impl fmt::Display for SearchNetworkProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchNetworkProfilesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchNetworkProfilesError {}
 /// Errors returned by SearchProfiles
 #[derive(Debug, PartialEq)]
 pub enum SearchProfilesError {}
@@ -6076,14 +5826,10 @@ impl SearchProfilesError {
 }
 impl fmt::Display for SearchProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchProfilesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchProfilesError {}
 /// Errors returned by SearchRooms
 #[derive(Debug, PartialEq)]
 pub enum SearchRoomsError {}
@@ -6101,14 +5847,10 @@ impl SearchRoomsError {
 }
 impl fmt::Display for SearchRoomsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchRoomsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchRoomsError {}
 /// Errors returned by SearchSkillGroups
 #[derive(Debug, PartialEq)]
 pub enum SearchSkillGroupsError {}
@@ -6126,14 +5868,10 @@ impl SearchSkillGroupsError {
 }
 impl fmt::Display for SearchSkillGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchSkillGroupsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchSkillGroupsError {}
 /// Errors returned by SearchUsers
 #[derive(Debug, PartialEq)]
 pub enum SearchUsersError {}
@@ -6151,14 +5889,10 @@ impl SearchUsersError {
 }
 impl fmt::Display for SearchUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchUsersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchUsersError {}
 /// Errors returned by SendAnnouncement
 #[derive(Debug, PartialEq)]
 pub enum SendAnnouncementError {
@@ -6187,17 +5921,13 @@ impl SendAnnouncementError {
 }
 impl fmt::Display for SendAnnouncementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendAnnouncementError {
-    fn description(&self) -> &str {
         match *self {
-            SendAnnouncementError::AlreadyExists(ref cause) => cause,
-            SendAnnouncementError::LimitExceeded(ref cause) => cause,
+            SendAnnouncementError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            SendAnnouncementError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendAnnouncementError {}
 /// Errors returned by SendInvitation
 #[derive(Debug, PartialEq)]
 pub enum SendInvitationError {
@@ -6233,18 +5963,14 @@ impl SendInvitationError {
 }
 impl fmt::Display for SendInvitationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendInvitationError {
-    fn description(&self) -> &str {
         match *self {
-            SendInvitationError::ConcurrentModification(ref cause) => cause,
-            SendInvitationError::InvalidUserStatus(ref cause) => cause,
-            SendInvitationError::NotFound(ref cause) => cause,
+            SendInvitationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            SendInvitationError::InvalidUserStatus(ref cause) => write!(f, "{}", cause),
+            SendInvitationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendInvitationError {}
 /// Errors returned by StartDeviceSync
 #[derive(Debug, PartialEq)]
 pub enum StartDeviceSyncError {
@@ -6268,16 +5994,12 @@ impl StartDeviceSyncError {
 }
 impl fmt::Display for StartDeviceSyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDeviceSyncError {
-    fn description(&self) -> &str {
         match *self {
-            StartDeviceSyncError::DeviceNotRegistered(ref cause) => cause,
+            StartDeviceSyncError::DeviceNotRegistered(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartDeviceSyncError {}
 /// Errors returned by StartSmartHomeApplianceDiscovery
 #[derive(Debug, PartialEq)]
 pub enum StartSmartHomeApplianceDiscoveryError {
@@ -6305,16 +6027,12 @@ impl StartSmartHomeApplianceDiscoveryError {
 }
 impl fmt::Display for StartSmartHomeApplianceDiscoveryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartSmartHomeApplianceDiscoveryError {
-    fn description(&self) -> &str {
         match *self {
-            StartSmartHomeApplianceDiscoveryError::NotFound(ref cause) => cause,
+            StartSmartHomeApplianceDiscoveryError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartSmartHomeApplianceDiscoveryError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -6338,16 +6056,12 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::NotFound(ref cause) => cause,
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -6371,16 +6085,12 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::NotFound(ref cause) => cause,
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateAddressBook
 #[derive(Debug, PartialEq)]
 pub enum UpdateAddressBookError {
@@ -6416,18 +6126,14 @@ impl UpdateAddressBookError {
 }
 impl fmt::Display for UpdateAddressBookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAddressBookError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAddressBookError::ConcurrentModification(ref cause) => cause,
-            UpdateAddressBookError::NameInUse(ref cause) => cause,
-            UpdateAddressBookError::NotFound(ref cause) => cause,
+            UpdateAddressBookError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateAddressBookError::NameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateAddressBookError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAddressBookError {}
 /// Errors returned by UpdateBusinessReportSchedule
 #[derive(Debug, PartialEq)]
 pub enum UpdateBusinessReportScheduleError {
@@ -6462,17 +6168,15 @@ impl UpdateBusinessReportScheduleError {
 }
 impl fmt::Display for UpdateBusinessReportScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBusinessReportScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBusinessReportScheduleError::ConcurrentModification(ref cause) => cause,
-            UpdateBusinessReportScheduleError::NotFound(ref cause) => cause,
+            UpdateBusinessReportScheduleError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateBusinessReportScheduleError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBusinessReportScheduleError {}
 /// Errors returned by UpdateConferenceProvider
 #[derive(Debug, PartialEq)]
 pub enum UpdateConferenceProviderError {
@@ -6496,16 +6200,12 @@ impl UpdateConferenceProviderError {
 }
 impl fmt::Display for UpdateConferenceProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConferenceProviderError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConferenceProviderError::NotFound(ref cause) => cause,
+            UpdateConferenceProviderError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConferenceProviderError {}
 /// Errors returned by UpdateContact
 #[derive(Debug, PartialEq)]
 pub enum UpdateContactError {
@@ -6536,17 +6236,13 @@ impl UpdateContactError {
 }
 impl fmt::Display for UpdateContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateContactError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateContactError::ConcurrentModification(ref cause) => cause,
-            UpdateContactError::NotFound(ref cause) => cause,
+            UpdateContactError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateContactError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateContactError {}
 /// Errors returned by UpdateDevice
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeviceError {
@@ -6580,18 +6276,14 @@ impl UpdateDeviceError {
 }
 impl fmt::Display for UpdateDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeviceError::ConcurrentModification(ref cause) => cause,
-            UpdateDeviceError::DeviceNotRegistered(ref cause) => cause,
-            UpdateDeviceError::NotFound(ref cause) => cause,
+            UpdateDeviceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceError::DeviceNotRegistered(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDeviceError {}
 /// Errors returned by UpdateGateway
 #[derive(Debug, PartialEq)]
 pub enum UpdateGatewayError {
@@ -6620,17 +6312,13 @@ impl UpdateGatewayError {
 }
 impl fmt::Display for UpdateGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGatewayError::NameInUse(ref cause) => cause,
-            UpdateGatewayError::NotFound(ref cause) => cause,
+            UpdateGatewayError::NameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateGatewayError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGatewayError {}
 /// Errors returned by UpdateGatewayGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateGatewayGroupError {
@@ -6659,17 +6347,13 @@ impl UpdateGatewayGroupError {
 }
 impl fmt::Display for UpdateGatewayGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGatewayGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGatewayGroupError::NameInUse(ref cause) => cause,
-            UpdateGatewayGroupError::NotFound(ref cause) => cause,
+            UpdateGatewayGroupError::NameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateGatewayGroupError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGatewayGroupError {}
 /// Errors returned by UpdateNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateNetworkProfileError {
@@ -6719,20 +6403,20 @@ impl UpdateNetworkProfileError {
 }
 impl fmt::Display for UpdateNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNetworkProfileError::ConcurrentModification(ref cause) => cause,
-            UpdateNetworkProfileError::InvalidCertificateAuthority(ref cause) => cause,
-            UpdateNetworkProfileError::InvalidSecretsManagerResource(ref cause) => cause,
-            UpdateNetworkProfileError::NameInUse(ref cause) => cause,
-            UpdateNetworkProfileError::NotFound(ref cause) => cause,
+            UpdateNetworkProfileError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateNetworkProfileError::InvalidCertificateAuthority(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateNetworkProfileError::InvalidSecretsManagerResource(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateNetworkProfileError::NameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNetworkProfileError {}
 /// Errors returned by UpdateProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateProfileError {
@@ -6768,18 +6452,14 @@ impl UpdateProfileError {
 }
 impl fmt::Display for UpdateProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProfileError::ConcurrentModification(ref cause) => cause,
-            UpdateProfileError::NameInUse(ref cause) => cause,
-            UpdateProfileError::NotFound(ref cause) => cause,
+            UpdateProfileError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateProfileError::NameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateProfileError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProfileError {}
 /// Errors returned by UpdateRoom
 #[derive(Debug, PartialEq)]
 pub enum UpdateRoomError {
@@ -6808,17 +6488,13 @@ impl UpdateRoomError {
 }
 impl fmt::Display for UpdateRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRoomError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRoomError::NameInUse(ref cause) => cause,
-            UpdateRoomError::NotFound(ref cause) => cause,
+            UpdateRoomError::NameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateRoomError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRoomError {}
 /// Errors returned by UpdateSkillGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateSkillGroupError {
@@ -6854,18 +6530,14 @@ impl UpdateSkillGroupError {
 }
 impl fmt::Display for UpdateSkillGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSkillGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSkillGroupError::ConcurrentModification(ref cause) => cause,
-            UpdateSkillGroupError::NameInUse(ref cause) => cause,
-            UpdateSkillGroupError::NotFound(ref cause) => cause,
+            UpdateSkillGroupError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateSkillGroupError::NameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateSkillGroupError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSkillGroupError {}
 /// Trait representing the capabilities of the Alexa For Business API. Alexa For Business clients implement this trait.
 pub trait AlexaForBusiness {
     /// <p>Associates a skill with the organization under the customer's AWS account. If a skill is private, the user implicitly accepts access to this skill during enablement.</p>

--- a/rusoto/services/amplify/src/generated.rs
+++ b/rusoto/services/amplify/src/generated.rs
@@ -1639,20 +1639,16 @@ impl CreateAppError {
 }
 impl fmt::Display for CreateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAppError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAppError::BadRequest(ref cause) => cause,
-            CreateAppError::DependentServiceFailure(ref cause) => cause,
-            CreateAppError::InternalFailure(ref cause) => cause,
-            CreateAppError::LimitExceeded(ref cause) => cause,
-            CreateAppError::Unauthorized(ref cause) => cause,
+            CreateAppError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateAppError::DependentServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateAppError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateAppError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAppError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAppError {}
 /// Errors returned by CreateBackendEnvironment
 #[derive(Debug, PartialEq)]
 pub enum CreateBackendEnvironmentError {
@@ -1702,20 +1698,16 @@ impl CreateBackendEnvironmentError {
 }
 impl fmt::Display for CreateBackendEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBackendEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBackendEnvironmentError::BadRequest(ref cause) => cause,
-            CreateBackendEnvironmentError::InternalFailure(ref cause) => cause,
-            CreateBackendEnvironmentError::LimitExceeded(ref cause) => cause,
-            CreateBackendEnvironmentError::NotFound(ref cause) => cause,
-            CreateBackendEnvironmentError::Unauthorized(ref cause) => cause,
+            CreateBackendEnvironmentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateBackendEnvironmentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateBackendEnvironmentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBackendEnvironmentError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateBackendEnvironmentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBackendEnvironmentError {}
 /// Errors returned by CreateBranch
 #[derive(Debug, PartialEq)]
 pub enum CreateBranchError {
@@ -1766,21 +1758,17 @@ impl CreateBranchError {
 }
 impl fmt::Display for CreateBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBranchError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBranchError::BadRequest(ref cause) => cause,
-            CreateBranchError::DependentServiceFailure(ref cause) => cause,
-            CreateBranchError::InternalFailure(ref cause) => cause,
-            CreateBranchError::LimitExceeded(ref cause) => cause,
-            CreateBranchError::NotFound(ref cause) => cause,
-            CreateBranchError::Unauthorized(ref cause) => cause,
+            CreateBranchError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::DependentServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBranchError {}
 /// Errors returned by CreateDeployment
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentError {
@@ -1819,19 +1807,15 @@ impl CreateDeploymentError {
 }
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentError::BadRequest(ref cause) => cause,
-            CreateDeploymentError::InternalFailure(ref cause) => cause,
-            CreateDeploymentError::LimitExceeded(ref cause) => cause,
-            CreateDeploymentError::Unauthorized(ref cause) => cause,
+            CreateDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeploymentError {}
 /// Errors returned by CreateDomainAssociation
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainAssociationError {
@@ -1888,21 +1872,19 @@ impl CreateDomainAssociationError {
 }
 impl fmt::Display for CreateDomainAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainAssociationError::BadRequest(ref cause) => cause,
-            CreateDomainAssociationError::DependentServiceFailure(ref cause) => cause,
-            CreateDomainAssociationError::InternalFailure(ref cause) => cause,
-            CreateDomainAssociationError::LimitExceeded(ref cause) => cause,
-            CreateDomainAssociationError::NotFound(ref cause) => cause,
-            CreateDomainAssociationError::Unauthorized(ref cause) => cause,
+            CreateDomainAssociationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDomainAssociationError::DependentServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDomainAssociationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDomainAssociationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDomainAssociationError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDomainAssociationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainAssociationError {}
 /// Errors returned by CreateWebhook
 #[derive(Debug, PartialEq)]
 pub enum CreateWebhookError {
@@ -1953,21 +1935,17 @@ impl CreateWebhookError {
 }
 impl fmt::Display for CreateWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWebhookError::BadRequest(ref cause) => cause,
-            CreateWebhookError::DependentServiceFailure(ref cause) => cause,
-            CreateWebhookError::InternalFailure(ref cause) => cause,
-            CreateWebhookError::LimitExceeded(ref cause) => cause,
-            CreateWebhookError::NotFound(ref cause) => cause,
-            CreateWebhookError::Unauthorized(ref cause) => cause,
+            CreateWebhookError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::DependentServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWebhookError {}
 /// Errors returned by DeleteApp
 #[derive(Debug, PartialEq)]
 pub enum DeleteAppError {
@@ -2011,20 +1989,16 @@ impl DeleteAppError {
 }
 impl fmt::Display for DeleteAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAppError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAppError::BadRequest(ref cause) => cause,
-            DeleteAppError::DependentServiceFailure(ref cause) => cause,
-            DeleteAppError::InternalFailure(ref cause) => cause,
-            DeleteAppError::NotFound(ref cause) => cause,
-            DeleteAppError::Unauthorized(ref cause) => cause,
+            DeleteAppError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::DependentServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAppError {}
 /// Errors returned by DeleteBackendEnvironment
 #[derive(Debug, PartialEq)]
 pub enum DeleteBackendEnvironmentError {
@@ -2074,20 +2048,18 @@ impl DeleteBackendEnvironmentError {
 }
 impl fmt::Display for DeleteBackendEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBackendEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBackendEnvironmentError::BadRequest(ref cause) => cause,
-            DeleteBackendEnvironmentError::DependentServiceFailure(ref cause) => cause,
-            DeleteBackendEnvironmentError::InternalFailure(ref cause) => cause,
-            DeleteBackendEnvironmentError::NotFound(ref cause) => cause,
-            DeleteBackendEnvironmentError::Unauthorized(ref cause) => cause,
+            DeleteBackendEnvironmentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBackendEnvironmentError::DependentServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteBackendEnvironmentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBackendEnvironmentError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBackendEnvironmentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBackendEnvironmentError {}
 /// Errors returned by DeleteBranch
 #[derive(Debug, PartialEq)]
 pub enum DeleteBranchError {
@@ -2133,20 +2105,16 @@ impl DeleteBranchError {
 }
 impl fmt::Display for DeleteBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBranchError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBranchError::BadRequest(ref cause) => cause,
-            DeleteBranchError::DependentServiceFailure(ref cause) => cause,
-            DeleteBranchError::InternalFailure(ref cause) => cause,
-            DeleteBranchError::NotFound(ref cause) => cause,
-            DeleteBranchError::Unauthorized(ref cause) => cause,
+            DeleteBranchError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::DependentServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBranchError {}
 /// Errors returned by DeleteDomainAssociation
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainAssociationError {
@@ -2196,20 +2164,18 @@ impl DeleteDomainAssociationError {
 }
 impl fmt::Display for DeleteDomainAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainAssociationError::BadRequest(ref cause) => cause,
-            DeleteDomainAssociationError::DependentServiceFailure(ref cause) => cause,
-            DeleteDomainAssociationError::InternalFailure(ref cause) => cause,
-            DeleteDomainAssociationError::NotFound(ref cause) => cause,
-            DeleteDomainAssociationError::Unauthorized(ref cause) => cause,
+            DeleteDomainAssociationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDomainAssociationError::DependentServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDomainAssociationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDomainAssociationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDomainAssociationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainAssociationError {}
 /// Errors returned by DeleteJob
 #[derive(Debug, PartialEq)]
 pub enum DeleteJobError {
@@ -2253,20 +2219,16 @@ impl DeleteJobError {
 }
 impl fmt::Display for DeleteJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteJobError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteJobError::BadRequest(ref cause) => cause,
-            DeleteJobError::InternalFailure(ref cause) => cause,
-            DeleteJobError::LimitExceeded(ref cause) => cause,
-            DeleteJobError::NotFound(ref cause) => cause,
-            DeleteJobError::Unauthorized(ref cause) => cause,
+            DeleteJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteJobError {}
 /// Errors returned by DeleteWebhook
 #[derive(Debug, PartialEq)]
 pub enum DeleteWebhookError {
@@ -2310,20 +2272,16 @@ impl DeleteWebhookError {
 }
 impl fmt::Display for DeleteWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWebhookError::BadRequest(ref cause) => cause,
-            DeleteWebhookError::InternalFailure(ref cause) => cause,
-            DeleteWebhookError::LimitExceeded(ref cause) => cause,
-            DeleteWebhookError::NotFound(ref cause) => cause,
-            DeleteWebhookError::Unauthorized(ref cause) => cause,
+            DeleteWebhookError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteWebhookError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteWebhookError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteWebhookError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteWebhookError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWebhookError {}
 /// Errors returned by GenerateAccessLogs
 #[derive(Debug, PartialEq)]
 pub enum GenerateAccessLogsError {
@@ -2362,19 +2320,15 @@ impl GenerateAccessLogsError {
 }
 impl fmt::Display for GenerateAccessLogsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateAccessLogsError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateAccessLogsError::BadRequest(ref cause) => cause,
-            GenerateAccessLogsError::InternalFailure(ref cause) => cause,
-            GenerateAccessLogsError::NotFound(ref cause) => cause,
-            GenerateAccessLogsError::Unauthorized(ref cause) => cause,
+            GenerateAccessLogsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GenerateAccessLogsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GenerateAccessLogsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GenerateAccessLogsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateAccessLogsError {}
 /// Errors returned by GetApp
 #[derive(Debug, PartialEq)]
 pub enum GetAppError {
@@ -2411,19 +2365,15 @@ impl GetAppError {
 }
 impl fmt::Display for GetAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAppError {
-    fn description(&self) -> &str {
         match *self {
-            GetAppError::BadRequest(ref cause) => cause,
-            GetAppError::InternalFailure(ref cause) => cause,
-            GetAppError::NotFound(ref cause) => cause,
-            GetAppError::Unauthorized(ref cause) => cause,
+            GetAppError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetAppError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetAppError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAppError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAppError {}
 /// Errors returned by GetArtifactUrl
 #[derive(Debug, PartialEq)]
 pub enum GetArtifactUrlError {
@@ -2467,20 +2417,16 @@ impl GetArtifactUrlError {
 }
 impl fmt::Display for GetArtifactUrlError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetArtifactUrlError {
-    fn description(&self) -> &str {
         match *self {
-            GetArtifactUrlError::BadRequest(ref cause) => cause,
-            GetArtifactUrlError::InternalFailure(ref cause) => cause,
-            GetArtifactUrlError::LimitExceeded(ref cause) => cause,
-            GetArtifactUrlError::NotFound(ref cause) => cause,
-            GetArtifactUrlError::Unauthorized(ref cause) => cause,
+            GetArtifactUrlError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetArtifactUrlError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetArtifactUrlError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetArtifactUrlError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetArtifactUrlError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetArtifactUrlError {}
 /// Errors returned by GetBackendEnvironment
 #[derive(Debug, PartialEq)]
 pub enum GetBackendEnvironmentError {
@@ -2521,19 +2467,15 @@ impl GetBackendEnvironmentError {
 }
 impl fmt::Display for GetBackendEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBackendEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            GetBackendEnvironmentError::BadRequest(ref cause) => cause,
-            GetBackendEnvironmentError::InternalFailure(ref cause) => cause,
-            GetBackendEnvironmentError::NotFound(ref cause) => cause,
-            GetBackendEnvironmentError::Unauthorized(ref cause) => cause,
+            GetBackendEnvironmentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBackendEnvironmentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBackendEnvironmentError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetBackendEnvironmentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBackendEnvironmentError {}
 /// Errors returned by GetBranch
 #[derive(Debug, PartialEq)]
 pub enum GetBranchError {
@@ -2572,19 +2514,15 @@ impl GetBranchError {
 }
 impl fmt::Display for GetBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBranchError {
-    fn description(&self) -> &str {
         match *self {
-            GetBranchError::BadRequest(ref cause) => cause,
-            GetBranchError::InternalFailure(ref cause) => cause,
-            GetBranchError::NotFound(ref cause) => cause,
-            GetBranchError::Unauthorized(ref cause) => cause,
+            GetBranchError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBranchError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBranchError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetBranchError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBranchError {}
 /// Errors returned by GetDomainAssociation
 #[derive(Debug, PartialEq)]
 pub enum GetDomainAssociationError {
@@ -2625,19 +2563,15 @@ impl GetDomainAssociationError {
 }
 impl fmt::Display for GetDomainAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainAssociationError::BadRequest(ref cause) => cause,
-            GetDomainAssociationError::InternalFailure(ref cause) => cause,
-            GetDomainAssociationError::NotFound(ref cause) => cause,
-            GetDomainAssociationError::Unauthorized(ref cause) => cause,
+            GetDomainAssociationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDomainAssociationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetDomainAssociationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDomainAssociationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainAssociationError {}
 /// Errors returned by GetJob
 #[derive(Debug, PartialEq)]
 pub enum GetJobError {
@@ -2679,20 +2613,16 @@ impl GetJobError {
 }
 impl fmt::Display for GetJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobError::BadRequest(ref cause) => cause,
-            GetJobError::InternalFailure(ref cause) => cause,
-            GetJobError::LimitExceeded(ref cause) => cause,
-            GetJobError::NotFound(ref cause) => cause,
-            GetJobError::Unauthorized(ref cause) => cause,
+            GetJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetJobError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetJobError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobError {}
 /// Errors returned by GetWebhook
 #[derive(Debug, PartialEq)]
 pub enum GetWebhookError {
@@ -2736,20 +2666,16 @@ impl GetWebhookError {
 }
 impl fmt::Display for GetWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            GetWebhookError::BadRequest(ref cause) => cause,
-            GetWebhookError::InternalFailure(ref cause) => cause,
-            GetWebhookError::LimitExceeded(ref cause) => cause,
-            GetWebhookError::NotFound(ref cause) => cause,
-            GetWebhookError::Unauthorized(ref cause) => cause,
+            GetWebhookError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetWebhookError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetWebhookError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetWebhookError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetWebhookError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWebhookError {}
 /// Errors returned by ListApps
 #[derive(Debug, PartialEq)]
 pub enum ListAppsError {
@@ -2783,18 +2709,14 @@ impl ListAppsError {
 }
 impl fmt::Display for ListAppsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAppsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAppsError::BadRequest(ref cause) => cause,
-            ListAppsError::InternalFailure(ref cause) => cause,
-            ListAppsError::Unauthorized(ref cause) => cause,
+            ListAppsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListAppsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListAppsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAppsError {}
 /// Errors returned by ListArtifacts
 #[derive(Debug, PartialEq)]
 pub enum ListArtifactsError {
@@ -2833,19 +2755,15 @@ impl ListArtifactsError {
 }
 impl fmt::Display for ListArtifactsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListArtifactsError {
-    fn description(&self) -> &str {
         match *self {
-            ListArtifactsError::BadRequest(ref cause) => cause,
-            ListArtifactsError::InternalFailure(ref cause) => cause,
-            ListArtifactsError::LimitExceeded(ref cause) => cause,
-            ListArtifactsError::Unauthorized(ref cause) => cause,
+            ListArtifactsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListArtifactsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListArtifactsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListArtifactsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListArtifactsError {}
 /// Errors returned by ListBackendEnvironments
 #[derive(Debug, PartialEq)]
 pub enum ListBackendEnvironmentsError {
@@ -2883,18 +2801,14 @@ impl ListBackendEnvironmentsError {
 }
 impl fmt::Display for ListBackendEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBackendEnvironmentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBackendEnvironmentsError::BadRequest(ref cause) => cause,
-            ListBackendEnvironmentsError::InternalFailure(ref cause) => cause,
-            ListBackendEnvironmentsError::Unauthorized(ref cause) => cause,
+            ListBackendEnvironmentsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListBackendEnvironmentsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListBackendEnvironmentsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBackendEnvironmentsError {}
 /// Errors returned by ListBranches
 #[derive(Debug, PartialEq)]
 pub enum ListBranchesError {
@@ -2928,18 +2842,14 @@ impl ListBranchesError {
 }
 impl fmt::Display for ListBranchesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBranchesError {
-    fn description(&self) -> &str {
         match *self {
-            ListBranchesError::BadRequest(ref cause) => cause,
-            ListBranchesError::InternalFailure(ref cause) => cause,
-            ListBranchesError::Unauthorized(ref cause) => cause,
+            ListBranchesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBranchesError {}
 /// Errors returned by ListDomainAssociations
 #[derive(Debug, PartialEq)]
 pub enum ListDomainAssociationsError {
@@ -2975,18 +2885,14 @@ impl ListDomainAssociationsError {
 }
 impl fmt::Display for ListDomainAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainAssociationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDomainAssociationsError::BadRequest(ref cause) => cause,
-            ListDomainAssociationsError::InternalFailure(ref cause) => cause,
-            ListDomainAssociationsError::Unauthorized(ref cause) => cause,
+            ListDomainAssociationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListDomainAssociationsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDomainAssociationsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDomainAssociationsError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -3025,19 +2931,15 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::BadRequest(ref cause) => cause,
-            ListJobsError::InternalFailure(ref cause) => cause,
-            ListJobsError::LimitExceeded(ref cause) => cause,
-            ListJobsError::Unauthorized(ref cause) => cause,
+            ListJobsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListJobsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListJobsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListJobsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3073,18 +2975,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::InternalFailure(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListWebhooks
 #[derive(Debug, PartialEq)]
 pub enum ListWebhooksError {
@@ -3123,19 +3021,15 @@ impl ListWebhooksError {
 }
 impl fmt::Display for ListWebhooksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWebhooksError {
-    fn description(&self) -> &str {
         match *self {
-            ListWebhooksError::BadRequest(ref cause) => cause,
-            ListWebhooksError::InternalFailure(ref cause) => cause,
-            ListWebhooksError::LimitExceeded(ref cause) => cause,
-            ListWebhooksError::Unauthorized(ref cause) => cause,
+            ListWebhooksError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListWebhooksError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListWebhooksError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListWebhooksError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWebhooksError {}
 /// Errors returned by StartDeployment
 #[derive(Debug, PartialEq)]
 pub enum StartDeploymentError {
@@ -3179,20 +3073,16 @@ impl StartDeploymentError {
 }
 impl fmt::Display for StartDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            StartDeploymentError::BadRequest(ref cause) => cause,
-            StartDeploymentError::InternalFailure(ref cause) => cause,
-            StartDeploymentError::LimitExceeded(ref cause) => cause,
-            StartDeploymentError::NotFound(ref cause) => cause,
-            StartDeploymentError::Unauthorized(ref cause) => cause,
+            StartDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartDeploymentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartDeploymentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartDeploymentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartDeploymentError {}
 /// Errors returned by StartJob
 #[derive(Debug, PartialEq)]
 pub enum StartJobError {
@@ -3236,20 +3126,16 @@ impl StartJobError {
 }
 impl fmt::Display for StartJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartJobError::BadRequest(ref cause) => cause,
-            StartJobError::InternalFailure(ref cause) => cause,
-            StartJobError::LimitExceeded(ref cause) => cause,
-            StartJobError::NotFound(ref cause) => cause,
-            StartJobError::Unauthorized(ref cause) => cause,
+            StartJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartJobError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartJobError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartJobError {}
 /// Errors returned by StopJob
 #[derive(Debug, PartialEq)]
 pub enum StopJobError {
@@ -3293,20 +3179,16 @@ impl StopJobError {
 }
 impl fmt::Display for StopJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopJobError::BadRequest(ref cause) => cause,
-            StopJobError::InternalFailure(ref cause) => cause,
-            StopJobError::LimitExceeded(ref cause) => cause,
-            StopJobError::NotFound(ref cause) => cause,
-            StopJobError::Unauthorized(ref cause) => cause,
+            StopJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StopJobError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StopJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StopJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopJobError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopJobError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3340,18 +3222,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::InternalFailure(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3385,18 +3263,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::InternalFailure(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateApp
 #[derive(Debug, PartialEq)]
 pub enum UpdateAppError {
@@ -3435,19 +3309,15 @@ impl UpdateAppError {
 }
 impl fmt::Display for UpdateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAppError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAppError::BadRequest(ref cause) => cause,
-            UpdateAppError::InternalFailure(ref cause) => cause,
-            UpdateAppError::NotFound(ref cause) => cause,
-            UpdateAppError::Unauthorized(ref cause) => cause,
+            UpdateAppError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAppError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateAppError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAppError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAppError {}
 /// Errors returned by UpdateBranch
 #[derive(Debug, PartialEq)]
 pub enum UpdateBranchError {
@@ -3493,20 +3363,16 @@ impl UpdateBranchError {
 }
 impl fmt::Display for UpdateBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBranchError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBranchError::BadRequest(ref cause) => cause,
-            UpdateBranchError::DependentServiceFailure(ref cause) => cause,
-            UpdateBranchError::InternalFailure(ref cause) => cause,
-            UpdateBranchError::NotFound(ref cause) => cause,
-            UpdateBranchError::Unauthorized(ref cause) => cause,
+            UpdateBranchError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBranchError::DependentServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateBranchError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateBranchError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateBranchError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBranchError {}
 /// Errors returned by UpdateDomainAssociation
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainAssociationError {
@@ -3556,20 +3422,18 @@ impl UpdateDomainAssociationError {
 }
 impl fmt::Display for UpdateDomainAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainAssociationError::BadRequest(ref cause) => cause,
-            UpdateDomainAssociationError::DependentServiceFailure(ref cause) => cause,
-            UpdateDomainAssociationError::InternalFailure(ref cause) => cause,
-            UpdateDomainAssociationError::NotFound(ref cause) => cause,
-            UpdateDomainAssociationError::Unauthorized(ref cause) => cause,
+            UpdateDomainAssociationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainAssociationError::DependentServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDomainAssociationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDomainAssociationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDomainAssociationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainAssociationError {}
 /// Errors returned by UpdateWebhook
 #[derive(Debug, PartialEq)]
 pub enum UpdateWebhookError {
@@ -3615,20 +3479,16 @@ impl UpdateWebhookError {
 }
 impl fmt::Display for UpdateWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateWebhookError::BadRequest(ref cause) => cause,
-            UpdateWebhookError::DependentServiceFailure(ref cause) => cause,
-            UpdateWebhookError::InternalFailure(ref cause) => cause,
-            UpdateWebhookError::NotFound(ref cause) => cause,
-            UpdateWebhookError::Unauthorized(ref cause) => cause,
+            UpdateWebhookError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateWebhookError::DependentServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateWebhookError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateWebhookError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateWebhookError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateWebhookError {}
 /// Trait representing the capabilities of the Amplify API. Amplify clients implement this trait.
 pub trait Amplify {
     /// <p> Creates a new Amplify App. </p>

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -3559,21 +3559,17 @@ impl CreateApiKeyError {
 }
 impl fmt::Display for CreateApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApiKeyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApiKeyError::BadRequest(ref cause) => cause,
-            CreateApiKeyError::Conflict(ref cause) => cause,
-            CreateApiKeyError::LimitExceeded(ref cause) => cause,
-            CreateApiKeyError::NotFound(ref cause) => cause,
-            CreateApiKeyError::TooManyRequests(ref cause) => cause,
-            CreateApiKeyError::Unauthorized(ref cause) => cause,
+            CreateApiKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApiKeyError {}
 /// Errors returned by CreateAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum CreateAuthorizerError {
@@ -3617,20 +3613,16 @@ impl CreateAuthorizerError {
 }
 impl fmt::Display for CreateAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAuthorizerError::BadRequest(ref cause) => cause,
-            CreateAuthorizerError::LimitExceeded(ref cause) => cause,
-            CreateAuthorizerError::NotFound(ref cause) => cause,
-            CreateAuthorizerError::TooManyRequests(ref cause) => cause,
-            CreateAuthorizerError::Unauthorized(ref cause) => cause,
+            CreateAuthorizerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAuthorizerError {}
 /// Errors returned by CreateBasePathMapping
 #[derive(Debug, PartialEq)]
 pub enum CreateBasePathMappingError {
@@ -3676,20 +3668,16 @@ impl CreateBasePathMappingError {
 }
 impl fmt::Display for CreateBasePathMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBasePathMappingError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBasePathMappingError::BadRequest(ref cause) => cause,
-            CreateBasePathMappingError::Conflict(ref cause) => cause,
-            CreateBasePathMappingError::NotFound(ref cause) => cause,
-            CreateBasePathMappingError::TooManyRequests(ref cause) => cause,
-            CreateBasePathMappingError::Unauthorized(ref cause) => cause,
+            CreateBasePathMappingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateBasePathMappingError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateBasePathMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateBasePathMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateBasePathMappingError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBasePathMappingError {}
 /// Errors returned by CreateDeployment
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentError {
@@ -3743,22 +3731,18 @@ impl CreateDeploymentError {
 }
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentError::BadRequest(ref cause) => cause,
-            CreateDeploymentError::Conflict(ref cause) => cause,
-            CreateDeploymentError::LimitExceeded(ref cause) => cause,
-            CreateDeploymentError::NotFound(ref cause) => cause,
-            CreateDeploymentError::ServiceUnavailable(ref cause) => cause,
-            CreateDeploymentError::TooManyRequests(ref cause) => cause,
-            CreateDeploymentError::Unauthorized(ref cause) => cause,
+            CreateDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeploymentError {}
 /// Errors returned by CreateDocumentationPart
 #[derive(Debug, PartialEq)]
 pub enum CreateDocumentationPartError {
@@ -3813,21 +3797,17 @@ impl CreateDocumentationPartError {
 }
 impl fmt::Display for CreateDocumentationPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDocumentationPartError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDocumentationPartError::BadRequest(ref cause) => cause,
-            CreateDocumentationPartError::Conflict(ref cause) => cause,
-            CreateDocumentationPartError::LimitExceeded(ref cause) => cause,
-            CreateDocumentationPartError::NotFound(ref cause) => cause,
-            CreateDocumentationPartError::TooManyRequests(ref cause) => cause,
-            CreateDocumentationPartError::Unauthorized(ref cause) => cause,
+            CreateDocumentationPartError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationPartError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationPartError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationPartError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationPartError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationPartError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDocumentationPartError {}
 /// Errors returned by CreateDocumentationVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateDocumentationVersionError {
@@ -3886,21 +3866,17 @@ impl CreateDocumentationVersionError {
 }
 impl fmt::Display for CreateDocumentationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDocumentationVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDocumentationVersionError::BadRequest(ref cause) => cause,
-            CreateDocumentationVersionError::Conflict(ref cause) => cause,
-            CreateDocumentationVersionError::LimitExceeded(ref cause) => cause,
-            CreateDocumentationVersionError::NotFound(ref cause) => cause,
-            CreateDocumentationVersionError::TooManyRequests(ref cause) => cause,
-            CreateDocumentationVersionError::Unauthorized(ref cause) => cause,
+            CreateDocumentationVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateDocumentationVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDocumentationVersionError {}
 /// Errors returned by CreateDomainName
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainNameError {
@@ -3939,19 +3915,15 @@ impl CreateDomainNameError {
 }
 impl fmt::Display for CreateDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainNameError::BadRequest(ref cause) => cause,
-            CreateDomainNameError::Conflict(ref cause) => cause,
-            CreateDomainNameError::TooManyRequests(ref cause) => cause,
-            CreateDomainNameError::Unauthorized(ref cause) => cause,
+            CreateDomainNameError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDomainNameError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateDomainNameError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainNameError {}
 /// Errors returned by CreateModel
 #[derive(Debug, PartialEq)]
 pub enum CreateModelError {
@@ -4000,21 +3972,17 @@ impl CreateModelError {
 }
 impl fmt::Display for CreateModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateModelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateModelError::BadRequest(ref cause) => cause,
-            CreateModelError::Conflict(ref cause) => cause,
-            CreateModelError::LimitExceeded(ref cause) => cause,
-            CreateModelError::NotFound(ref cause) => cause,
-            CreateModelError::TooManyRequests(ref cause) => cause,
-            CreateModelError::Unauthorized(ref cause) => cause,
+            CreateModelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateModelError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateModelError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateModelError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateModelError {}
 /// Errors returned by CreateRequestValidator
 #[derive(Debug, PartialEq)]
 pub enum CreateRequestValidatorError {
@@ -4062,20 +4030,16 @@ impl CreateRequestValidatorError {
 }
 impl fmt::Display for CreateRequestValidatorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRequestValidatorError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRequestValidatorError::BadRequest(ref cause) => cause,
-            CreateRequestValidatorError::LimitExceeded(ref cause) => cause,
-            CreateRequestValidatorError::NotFound(ref cause) => cause,
-            CreateRequestValidatorError::TooManyRequests(ref cause) => cause,
-            CreateRequestValidatorError::Unauthorized(ref cause) => cause,
+            CreateRequestValidatorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRequestValidatorError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRequestValidatorError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRequestValidatorError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateRequestValidatorError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRequestValidatorError {}
 /// Errors returned by CreateResource
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceError {
@@ -4124,21 +4088,17 @@ impl CreateResourceError {
 }
 impl fmt::Display for CreateResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceError::BadRequest(ref cause) => cause,
-            CreateResourceError::Conflict(ref cause) => cause,
-            CreateResourceError::LimitExceeded(ref cause) => cause,
-            CreateResourceError::NotFound(ref cause) => cause,
-            CreateResourceError::TooManyRequests(ref cause) => cause,
-            CreateResourceError::Unauthorized(ref cause) => cause,
+            CreateResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateResourceError {}
 /// Errors returned by CreateRestApi
 #[derive(Debug, PartialEq)]
 pub enum CreateRestApiError {
@@ -4177,19 +4137,15 @@ impl CreateRestApiError {
 }
 impl fmt::Display for CreateRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRestApiError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRestApiError::BadRequest(ref cause) => cause,
-            CreateRestApiError::LimitExceeded(ref cause) => cause,
-            CreateRestApiError::TooManyRequests(ref cause) => cause,
-            CreateRestApiError::Unauthorized(ref cause) => cause,
+            CreateRestApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRestApiError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRestApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateRestApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRestApiError {}
 /// Errors returned by CreateStage
 #[derive(Debug, PartialEq)]
 pub enum CreateStageError {
@@ -4238,21 +4194,17 @@ impl CreateStageError {
 }
 impl fmt::Display for CreateStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStageError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStageError::BadRequest(ref cause) => cause,
-            CreateStageError::Conflict(ref cause) => cause,
-            CreateStageError::LimitExceeded(ref cause) => cause,
-            CreateStageError::NotFound(ref cause) => cause,
-            CreateStageError::TooManyRequests(ref cause) => cause,
-            CreateStageError::Unauthorized(ref cause) => cause,
+            CreateStageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateStageError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateStageError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateStageError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStageError {}
 /// Errors returned by CreateUsagePlan
 #[derive(Debug, PartialEq)]
 pub enum CreateUsagePlanError {
@@ -4301,21 +4253,17 @@ impl CreateUsagePlanError {
 }
 impl fmt::Display for CreateUsagePlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUsagePlanError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUsagePlanError::BadRequest(ref cause) => cause,
-            CreateUsagePlanError::Conflict(ref cause) => cause,
-            CreateUsagePlanError::LimitExceeded(ref cause) => cause,
-            CreateUsagePlanError::NotFound(ref cause) => cause,
-            CreateUsagePlanError::TooManyRequests(ref cause) => cause,
-            CreateUsagePlanError::Unauthorized(ref cause) => cause,
+            CreateUsagePlanError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUsagePlanError {}
 /// Errors returned by CreateUsagePlanKey
 #[derive(Debug, PartialEq)]
 pub enum CreateUsagePlanKeyError {
@@ -4359,20 +4307,16 @@ impl CreateUsagePlanKeyError {
 }
 impl fmt::Display for CreateUsagePlanKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUsagePlanKeyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUsagePlanKeyError::BadRequest(ref cause) => cause,
-            CreateUsagePlanKeyError::Conflict(ref cause) => cause,
-            CreateUsagePlanKeyError::NotFound(ref cause) => cause,
-            CreateUsagePlanKeyError::TooManyRequests(ref cause) => cause,
-            CreateUsagePlanKeyError::Unauthorized(ref cause) => cause,
+            CreateUsagePlanKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanKeyError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanKeyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateUsagePlanKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUsagePlanKeyError {}
 /// Errors returned by CreateVpcLink
 #[derive(Debug, PartialEq)]
 pub enum CreateVpcLinkError {
@@ -4406,18 +4350,14 @@ impl CreateVpcLinkError {
 }
 impl fmt::Display for CreateVpcLinkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVpcLinkError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVpcLinkError::BadRequest(ref cause) => cause,
-            CreateVpcLinkError::TooManyRequests(ref cause) => cause,
-            CreateVpcLinkError::Unauthorized(ref cause) => cause,
+            CreateVpcLinkError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateVpcLinkError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateVpcLinkError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVpcLinkError {}
 /// Errors returned by DeleteApiKey
 #[derive(Debug, PartialEq)]
 pub enum DeleteApiKeyError {
@@ -4451,18 +4391,14 @@ impl DeleteApiKeyError {
 }
 impl fmt::Display for DeleteApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApiKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApiKeyError::NotFound(ref cause) => cause,
-            DeleteApiKeyError::TooManyRequests(ref cause) => cause,
-            DeleteApiKeyError::Unauthorized(ref cause) => cause,
+            DeleteApiKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApiKeyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteApiKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApiKeyError {}
 /// Errors returned by DeleteAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum DeleteAuthorizerError {
@@ -4506,20 +4442,16 @@ impl DeleteAuthorizerError {
 }
 impl fmt::Display for DeleteAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAuthorizerError::BadRequest(ref cause) => cause,
-            DeleteAuthorizerError::Conflict(ref cause) => cause,
-            DeleteAuthorizerError::NotFound(ref cause) => cause,
-            DeleteAuthorizerError::TooManyRequests(ref cause) => cause,
-            DeleteAuthorizerError::Unauthorized(ref cause) => cause,
+            DeleteAuthorizerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAuthorizerError {}
 /// Errors returned by DeleteBasePathMapping
 #[derive(Debug, PartialEq)]
 pub enum DeleteBasePathMappingError {
@@ -4565,20 +4497,16 @@ impl DeleteBasePathMappingError {
 }
 impl fmt::Display for DeleteBasePathMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBasePathMappingError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBasePathMappingError::BadRequest(ref cause) => cause,
-            DeleteBasePathMappingError::Conflict(ref cause) => cause,
-            DeleteBasePathMappingError::NotFound(ref cause) => cause,
-            DeleteBasePathMappingError::TooManyRequests(ref cause) => cause,
-            DeleteBasePathMappingError::Unauthorized(ref cause) => cause,
+            DeleteBasePathMappingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBasePathMappingError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteBasePathMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBasePathMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteBasePathMappingError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBasePathMappingError {}
 /// Errors returned by DeleteClientCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteClientCertificateError {
@@ -4621,19 +4549,15 @@ impl DeleteClientCertificateError {
 }
 impl fmt::Display for DeleteClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClientCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClientCertificateError::BadRequest(ref cause) => cause,
-            DeleteClientCertificateError::NotFound(ref cause) => cause,
-            DeleteClientCertificateError::TooManyRequests(ref cause) => cause,
-            DeleteClientCertificateError::Unauthorized(ref cause) => cause,
+            DeleteClientCertificateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteClientCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteClientCertificateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteClientCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClientCertificateError {}
 /// Errors returned by DeleteDeployment
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeploymentError {
@@ -4672,19 +4596,15 @@ impl DeleteDeploymentError {
 }
 impl fmt::Display for DeleteDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeploymentError::BadRequest(ref cause) => cause,
-            DeleteDeploymentError::NotFound(ref cause) => cause,
-            DeleteDeploymentError::TooManyRequests(ref cause) => cause,
-            DeleteDeploymentError::Unauthorized(ref cause) => cause,
+            DeleteDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteDeploymentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeploymentError {}
 /// Errors returned by DeleteDocumentationPart
 #[derive(Debug, PartialEq)]
 pub enum DeleteDocumentationPartError {
@@ -4732,20 +4652,16 @@ impl DeleteDocumentationPartError {
 }
 impl fmt::Display for DeleteDocumentationPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDocumentationPartError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDocumentationPartError::BadRequest(ref cause) => cause,
-            DeleteDocumentationPartError::Conflict(ref cause) => cause,
-            DeleteDocumentationPartError::NotFound(ref cause) => cause,
-            DeleteDocumentationPartError::TooManyRequests(ref cause) => cause,
-            DeleteDocumentationPartError::Unauthorized(ref cause) => cause,
+            DeleteDocumentationPartError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationPartError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationPartError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationPartError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationPartError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDocumentationPartError {}
 /// Errors returned by DeleteDocumentationVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteDocumentationVersionError {
@@ -4797,20 +4713,16 @@ impl DeleteDocumentationVersionError {
 }
 impl fmt::Display for DeleteDocumentationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDocumentationVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDocumentationVersionError::BadRequest(ref cause) => cause,
-            DeleteDocumentationVersionError::Conflict(ref cause) => cause,
-            DeleteDocumentationVersionError::NotFound(ref cause) => cause,
-            DeleteDocumentationVersionError::TooManyRequests(ref cause) => cause,
-            DeleteDocumentationVersionError::Unauthorized(ref cause) => cause,
+            DeleteDocumentationVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentationVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDocumentationVersionError {}
 /// Errors returned by DeleteDomainName
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainNameError {
@@ -4849,19 +4761,15 @@ impl DeleteDomainNameError {
 }
 impl fmt::Display for DeleteDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainNameError::BadRequest(ref cause) => cause,
-            DeleteDomainNameError::NotFound(ref cause) => cause,
-            DeleteDomainNameError::TooManyRequests(ref cause) => cause,
-            DeleteDomainNameError::Unauthorized(ref cause) => cause,
+            DeleteDomainNameError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDomainNameError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteDomainNameError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainNameError {}
 /// Errors returned by DeleteGatewayResponse
 #[derive(Debug, PartialEq)]
 pub enum DeleteGatewayResponseError {
@@ -4907,20 +4815,16 @@ impl DeleteGatewayResponseError {
 }
 impl fmt::Display for DeleteGatewayResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGatewayResponseError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGatewayResponseError::BadRequest(ref cause) => cause,
-            DeleteGatewayResponseError::Conflict(ref cause) => cause,
-            DeleteGatewayResponseError::NotFound(ref cause) => cause,
-            DeleteGatewayResponseError::TooManyRequests(ref cause) => cause,
-            DeleteGatewayResponseError::Unauthorized(ref cause) => cause,
+            DeleteGatewayResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteGatewayResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteGatewayResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteGatewayResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteGatewayResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGatewayResponseError {}
 /// Errors returned by DeleteIntegration
 #[derive(Debug, PartialEq)]
 pub enum DeleteIntegrationError {
@@ -4959,19 +4863,15 @@ impl DeleteIntegrationError {
 }
 impl fmt::Display for DeleteIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIntegrationError::Conflict(ref cause) => cause,
-            DeleteIntegrationError::NotFound(ref cause) => cause,
-            DeleteIntegrationError::TooManyRequests(ref cause) => cause,
-            DeleteIntegrationError::Unauthorized(ref cause) => cause,
+            DeleteIntegrationError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIntegrationError {}
 /// Errors returned by DeleteIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum DeleteIntegrationResponseError {
@@ -5021,20 +4921,16 @@ impl DeleteIntegrationResponseError {
 }
 impl fmt::Display for DeleteIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIntegrationResponseError::BadRequest(ref cause) => cause,
-            DeleteIntegrationResponseError::Conflict(ref cause) => cause,
-            DeleteIntegrationResponseError::NotFound(ref cause) => cause,
-            DeleteIntegrationResponseError::TooManyRequests(ref cause) => cause,
-            DeleteIntegrationResponseError::Unauthorized(ref cause) => cause,
+            DeleteIntegrationResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIntegrationResponseError {}
 /// Errors returned by DeleteMethod
 #[derive(Debug, PartialEq)]
 pub enum DeleteMethodError {
@@ -5073,19 +4969,15 @@ impl DeleteMethodError {
 }
 impl fmt::Display for DeleteMethodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMethodError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMethodError::Conflict(ref cause) => cause,
-            DeleteMethodError::NotFound(ref cause) => cause,
-            DeleteMethodError::TooManyRequests(ref cause) => cause,
-            DeleteMethodError::Unauthorized(ref cause) => cause,
+            DeleteMethodError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteMethodError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMethodError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteMethodError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMethodError {}
 /// Errors returned by DeleteMethodResponse
 #[derive(Debug, PartialEq)]
 pub enum DeleteMethodResponseError {
@@ -5131,20 +5023,16 @@ impl DeleteMethodResponseError {
 }
 impl fmt::Display for DeleteMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMethodResponseError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMethodResponseError::BadRequest(ref cause) => cause,
-            DeleteMethodResponseError::Conflict(ref cause) => cause,
-            DeleteMethodResponseError::NotFound(ref cause) => cause,
-            DeleteMethodResponseError::TooManyRequests(ref cause) => cause,
-            DeleteMethodResponseError::Unauthorized(ref cause) => cause,
+            DeleteMethodResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMethodResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteMethodResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMethodResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteMethodResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMethodResponseError {}
 /// Errors returned by DeleteModel
 #[derive(Debug, PartialEq)]
 pub enum DeleteModelError {
@@ -5188,20 +5076,16 @@ impl DeleteModelError {
 }
 impl fmt::Display for DeleteModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteModelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteModelError::BadRequest(ref cause) => cause,
-            DeleteModelError::Conflict(ref cause) => cause,
-            DeleteModelError::NotFound(ref cause) => cause,
-            DeleteModelError::TooManyRequests(ref cause) => cause,
-            DeleteModelError::Unauthorized(ref cause) => cause,
+            DeleteModelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteModelError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteModelError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteModelError {}
 /// Errors returned by DeleteRequestValidator
 #[derive(Debug, PartialEq)]
 pub enum DeleteRequestValidatorError {
@@ -5247,20 +5131,16 @@ impl DeleteRequestValidatorError {
 }
 impl fmt::Display for DeleteRequestValidatorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRequestValidatorError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRequestValidatorError::BadRequest(ref cause) => cause,
-            DeleteRequestValidatorError::Conflict(ref cause) => cause,
-            DeleteRequestValidatorError::NotFound(ref cause) => cause,
-            DeleteRequestValidatorError::TooManyRequests(ref cause) => cause,
-            DeleteRequestValidatorError::Unauthorized(ref cause) => cause,
+            DeleteRequestValidatorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteRequestValidatorError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteRequestValidatorError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRequestValidatorError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteRequestValidatorError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRequestValidatorError {}
 /// Errors returned by DeleteResource
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourceError {
@@ -5304,20 +5184,16 @@ impl DeleteResourceError {
 }
 impl fmt::Display for DeleteResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourceError::BadRequest(ref cause) => cause,
-            DeleteResourceError::Conflict(ref cause) => cause,
-            DeleteResourceError::NotFound(ref cause) => cause,
-            DeleteResourceError::TooManyRequests(ref cause) => cause,
-            DeleteResourceError::Unauthorized(ref cause) => cause,
+            DeleteResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourceError {}
 /// Errors returned by DeleteRestApi
 #[derive(Debug, PartialEq)]
 pub enum DeleteRestApiError {
@@ -5356,19 +5232,15 @@ impl DeleteRestApiError {
 }
 impl fmt::Display for DeleteRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRestApiError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRestApiError::BadRequest(ref cause) => cause,
-            DeleteRestApiError::NotFound(ref cause) => cause,
-            DeleteRestApiError::TooManyRequests(ref cause) => cause,
-            DeleteRestApiError::Unauthorized(ref cause) => cause,
+            DeleteRestApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteRestApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRestApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteRestApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRestApiError {}
 /// Errors returned by DeleteStage
 #[derive(Debug, PartialEq)]
 pub enum DeleteStageError {
@@ -5407,19 +5279,15 @@ impl DeleteStageError {
 }
 impl fmt::Display for DeleteStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStageError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStageError::BadRequest(ref cause) => cause,
-            DeleteStageError::NotFound(ref cause) => cause,
-            DeleteStageError::TooManyRequests(ref cause) => cause,
-            DeleteStageError::Unauthorized(ref cause) => cause,
+            DeleteStageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteStageError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStageError {}
 /// Errors returned by DeleteUsagePlan
 #[derive(Debug, PartialEq)]
 pub enum DeleteUsagePlanError {
@@ -5458,19 +5326,15 @@ impl DeleteUsagePlanError {
 }
 impl fmt::Display for DeleteUsagePlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUsagePlanError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUsagePlanError::BadRequest(ref cause) => cause,
-            DeleteUsagePlanError::NotFound(ref cause) => cause,
-            DeleteUsagePlanError::TooManyRequests(ref cause) => cause,
-            DeleteUsagePlanError::Unauthorized(ref cause) => cause,
+            DeleteUsagePlanError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteUsagePlanError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUsagePlanError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteUsagePlanError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUsagePlanError {}
 /// Errors returned by DeleteUsagePlanKey
 #[derive(Debug, PartialEq)]
 pub enum DeleteUsagePlanKeyError {
@@ -5514,20 +5378,16 @@ impl DeleteUsagePlanKeyError {
 }
 impl fmt::Display for DeleteUsagePlanKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUsagePlanKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUsagePlanKeyError::BadRequest(ref cause) => cause,
-            DeleteUsagePlanKeyError::Conflict(ref cause) => cause,
-            DeleteUsagePlanKeyError::NotFound(ref cause) => cause,
-            DeleteUsagePlanKeyError::TooManyRequests(ref cause) => cause,
-            DeleteUsagePlanKeyError::Unauthorized(ref cause) => cause,
+            DeleteUsagePlanKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteUsagePlanKeyError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteUsagePlanKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUsagePlanKeyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteUsagePlanKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUsagePlanKeyError {}
 /// Errors returned by DeleteVpcLink
 #[derive(Debug, PartialEq)]
 pub enum DeleteVpcLinkError {
@@ -5566,19 +5426,15 @@ impl DeleteVpcLinkError {
 }
 impl fmt::Display for DeleteVpcLinkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVpcLinkError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVpcLinkError::BadRequest(ref cause) => cause,
-            DeleteVpcLinkError::NotFound(ref cause) => cause,
-            DeleteVpcLinkError::TooManyRequests(ref cause) => cause,
-            DeleteVpcLinkError::Unauthorized(ref cause) => cause,
+            DeleteVpcLinkError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVpcLinkError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVpcLinkError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteVpcLinkError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVpcLinkError {}
 /// Errors returned by FlushStageAuthorizersCache
 #[derive(Debug, PartialEq)]
 pub enum FlushStageAuthorizersCacheError {
@@ -5625,19 +5481,15 @@ impl FlushStageAuthorizersCacheError {
 }
 impl fmt::Display for FlushStageAuthorizersCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FlushStageAuthorizersCacheError {
-    fn description(&self) -> &str {
         match *self {
-            FlushStageAuthorizersCacheError::BadRequest(ref cause) => cause,
-            FlushStageAuthorizersCacheError::NotFound(ref cause) => cause,
-            FlushStageAuthorizersCacheError::TooManyRequests(ref cause) => cause,
-            FlushStageAuthorizersCacheError::Unauthorized(ref cause) => cause,
+            FlushStageAuthorizersCacheError::BadRequest(ref cause) => write!(f, "{}", cause),
+            FlushStageAuthorizersCacheError::NotFound(ref cause) => write!(f, "{}", cause),
+            FlushStageAuthorizersCacheError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            FlushStageAuthorizersCacheError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for FlushStageAuthorizersCacheError {}
 /// Errors returned by FlushStageCache
 #[derive(Debug, PartialEq)]
 pub enum FlushStageCacheError {
@@ -5676,19 +5528,15 @@ impl FlushStageCacheError {
 }
 impl fmt::Display for FlushStageCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FlushStageCacheError {
-    fn description(&self) -> &str {
         match *self {
-            FlushStageCacheError::BadRequest(ref cause) => cause,
-            FlushStageCacheError::NotFound(ref cause) => cause,
-            FlushStageCacheError::TooManyRequests(ref cause) => cause,
-            FlushStageCacheError::Unauthorized(ref cause) => cause,
+            FlushStageCacheError::BadRequest(ref cause) => write!(f, "{}", cause),
+            FlushStageCacheError::NotFound(ref cause) => write!(f, "{}", cause),
+            FlushStageCacheError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            FlushStageCacheError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for FlushStageCacheError {}
 /// Errors returned by GenerateClientCertificate
 #[derive(Debug, PartialEq)]
 pub enum GenerateClientCertificateError {
@@ -5728,18 +5576,14 @@ impl GenerateClientCertificateError {
 }
 impl fmt::Display for GenerateClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateClientCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateClientCertificateError::LimitExceeded(ref cause) => cause,
-            GenerateClientCertificateError::TooManyRequests(ref cause) => cause,
-            GenerateClientCertificateError::Unauthorized(ref cause) => cause,
+            GenerateClientCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GenerateClientCertificateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GenerateClientCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateClientCertificateError {}
 /// Errors returned by GetAccount
 #[derive(Debug, PartialEq)]
 pub enum GetAccountError {
@@ -5773,18 +5617,14 @@ impl GetAccountError {
 }
 impl fmt::Display for GetAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountError::NotFound(ref cause) => cause,
-            GetAccountError::TooManyRequests(ref cause) => cause,
-            GetAccountError::Unauthorized(ref cause) => cause,
+            GetAccountError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAccountError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetAccountError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountError {}
 /// Errors returned by GetApiKey
 #[derive(Debug, PartialEq)]
 pub enum GetApiKeyError {
@@ -5818,18 +5658,14 @@ impl GetApiKeyError {
 }
 impl fmt::Display for GetApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApiKeyError {
-    fn description(&self) -> &str {
         match *self {
-            GetApiKeyError::NotFound(ref cause) => cause,
-            GetApiKeyError::TooManyRequests(ref cause) => cause,
-            GetApiKeyError::Unauthorized(ref cause) => cause,
+            GetApiKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApiKeyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetApiKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApiKeyError {}
 /// Errors returned by GetApiKeys
 #[derive(Debug, PartialEq)]
 pub enum GetApiKeysError {
@@ -5863,18 +5699,14 @@ impl GetApiKeysError {
 }
 impl fmt::Display for GetApiKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApiKeysError {
-    fn description(&self) -> &str {
         match *self {
-            GetApiKeysError::BadRequest(ref cause) => cause,
-            GetApiKeysError::TooManyRequests(ref cause) => cause,
-            GetApiKeysError::Unauthorized(ref cause) => cause,
+            GetApiKeysError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetApiKeysError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetApiKeysError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApiKeysError {}
 /// Errors returned by GetAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum GetAuthorizerError {
@@ -5908,18 +5740,14 @@ impl GetAuthorizerError {
 }
 impl fmt::Display for GetAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            GetAuthorizerError::NotFound(ref cause) => cause,
-            GetAuthorizerError::TooManyRequests(ref cause) => cause,
-            GetAuthorizerError::Unauthorized(ref cause) => cause,
+            GetAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAuthorizerError {}
 /// Errors returned by GetAuthorizers
 #[derive(Debug, PartialEq)]
 pub enum GetAuthorizersError {
@@ -5958,19 +5786,15 @@ impl GetAuthorizersError {
 }
 impl fmt::Display for GetAuthorizersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAuthorizersError {
-    fn description(&self) -> &str {
         match *self {
-            GetAuthorizersError::BadRequest(ref cause) => cause,
-            GetAuthorizersError::NotFound(ref cause) => cause,
-            GetAuthorizersError::TooManyRequests(ref cause) => cause,
-            GetAuthorizersError::Unauthorized(ref cause) => cause,
+            GetAuthorizersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetAuthorizersError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAuthorizersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetAuthorizersError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAuthorizersError {}
 /// Errors returned by GetBasePathMapping
 #[derive(Debug, PartialEq)]
 pub enum GetBasePathMappingError {
@@ -6004,18 +5828,14 @@ impl GetBasePathMappingError {
 }
 impl fmt::Display for GetBasePathMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBasePathMappingError {
-    fn description(&self) -> &str {
         match *self {
-            GetBasePathMappingError::NotFound(ref cause) => cause,
-            GetBasePathMappingError::TooManyRequests(ref cause) => cause,
-            GetBasePathMappingError::Unauthorized(ref cause) => cause,
+            GetBasePathMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetBasePathMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetBasePathMappingError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBasePathMappingError {}
 /// Errors returned by GetBasePathMappings
 #[derive(Debug, PartialEq)]
 pub enum GetBasePathMappingsError {
@@ -6049,18 +5869,14 @@ impl GetBasePathMappingsError {
 }
 impl fmt::Display for GetBasePathMappingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBasePathMappingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetBasePathMappingsError::NotFound(ref cause) => cause,
-            GetBasePathMappingsError::TooManyRequests(ref cause) => cause,
-            GetBasePathMappingsError::Unauthorized(ref cause) => cause,
+            GetBasePathMappingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetBasePathMappingsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetBasePathMappingsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBasePathMappingsError {}
 /// Errors returned by GetClientCertificate
 #[derive(Debug, PartialEq)]
 pub enum GetClientCertificateError {
@@ -6096,18 +5912,14 @@ impl GetClientCertificateError {
 }
 impl fmt::Display for GetClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetClientCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            GetClientCertificateError::NotFound(ref cause) => cause,
-            GetClientCertificateError::TooManyRequests(ref cause) => cause,
-            GetClientCertificateError::Unauthorized(ref cause) => cause,
+            GetClientCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetClientCertificateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetClientCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetClientCertificateError {}
 /// Errors returned by GetClientCertificates
 #[derive(Debug, PartialEq)]
 pub enum GetClientCertificatesError {
@@ -6143,18 +5955,14 @@ impl GetClientCertificatesError {
 }
 impl fmt::Display for GetClientCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetClientCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            GetClientCertificatesError::BadRequest(ref cause) => cause,
-            GetClientCertificatesError::TooManyRequests(ref cause) => cause,
-            GetClientCertificatesError::Unauthorized(ref cause) => cause,
+            GetClientCertificatesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetClientCertificatesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetClientCertificatesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetClientCertificatesError {}
 /// Errors returned by GetDeployment
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentError {
@@ -6193,19 +6001,15 @@ impl GetDeploymentError {
 }
 impl fmt::Display for GetDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentError::NotFound(ref cause) => cause,
-            GetDeploymentError::ServiceUnavailable(ref cause) => cause,
-            GetDeploymentError::TooManyRequests(ref cause) => cause,
-            GetDeploymentError::Unauthorized(ref cause) => cause,
+            GetDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDeploymentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDeploymentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentError {}
 /// Errors returned by GetDeployments
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentsError {
@@ -6244,19 +6048,15 @@ impl GetDeploymentsError {
 }
 impl fmt::Display for GetDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentsError::BadRequest(ref cause) => cause,
-            GetDeploymentsError::ServiceUnavailable(ref cause) => cause,
-            GetDeploymentsError::TooManyRequests(ref cause) => cause,
-            GetDeploymentsError::Unauthorized(ref cause) => cause,
+            GetDeploymentsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDeploymentsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDeploymentsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDeploymentsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentsError {}
 /// Errors returned by GetDocumentationPart
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentationPartError {
@@ -6292,18 +6092,14 @@ impl GetDocumentationPartError {
 }
 impl fmt::Display for GetDocumentationPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentationPartError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentationPartError::NotFound(ref cause) => cause,
-            GetDocumentationPartError::TooManyRequests(ref cause) => cause,
-            GetDocumentationPartError::Unauthorized(ref cause) => cause,
+            GetDocumentationPartError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDocumentationPartError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDocumentationPartError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentationPartError {}
 /// Errors returned by GetDocumentationParts
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentationPartsError {
@@ -6344,19 +6140,15 @@ impl GetDocumentationPartsError {
 }
 impl fmt::Display for GetDocumentationPartsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentationPartsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentationPartsError::BadRequest(ref cause) => cause,
-            GetDocumentationPartsError::NotFound(ref cause) => cause,
-            GetDocumentationPartsError::TooManyRequests(ref cause) => cause,
-            GetDocumentationPartsError::Unauthorized(ref cause) => cause,
+            GetDocumentationPartsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDocumentationPartsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDocumentationPartsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDocumentationPartsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentationPartsError {}
 /// Errors returned by GetDocumentationVersion
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentationVersionError {
@@ -6394,18 +6186,14 @@ impl GetDocumentationVersionError {
 }
 impl fmt::Display for GetDocumentationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentationVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentationVersionError::NotFound(ref cause) => cause,
-            GetDocumentationVersionError::TooManyRequests(ref cause) => cause,
-            GetDocumentationVersionError::Unauthorized(ref cause) => cause,
+            GetDocumentationVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDocumentationVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDocumentationVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentationVersionError {}
 /// Errors returned by GetDocumentationVersions
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentationVersionsError {
@@ -6448,19 +6236,15 @@ impl GetDocumentationVersionsError {
 }
 impl fmt::Display for GetDocumentationVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentationVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentationVersionsError::BadRequest(ref cause) => cause,
-            GetDocumentationVersionsError::NotFound(ref cause) => cause,
-            GetDocumentationVersionsError::TooManyRequests(ref cause) => cause,
-            GetDocumentationVersionsError::Unauthorized(ref cause) => cause,
+            GetDocumentationVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDocumentationVersionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDocumentationVersionsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDocumentationVersionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentationVersionsError {}
 /// Errors returned by GetDomainName
 #[derive(Debug, PartialEq)]
 pub enum GetDomainNameError {
@@ -6499,19 +6283,15 @@ impl GetDomainNameError {
 }
 impl fmt::Display for GetDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainNameError::NotFound(ref cause) => cause,
-            GetDomainNameError::ServiceUnavailable(ref cause) => cause,
-            GetDomainNameError::TooManyRequests(ref cause) => cause,
-            GetDomainNameError::Unauthorized(ref cause) => cause,
+            GetDomainNameError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDomainNameError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDomainNameError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainNameError {}
 /// Errors returned by GetDomainNames
 #[derive(Debug, PartialEq)]
 pub enum GetDomainNamesError {
@@ -6545,18 +6325,14 @@ impl GetDomainNamesError {
 }
 impl fmt::Display for GetDomainNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainNamesError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainNamesError::BadRequest(ref cause) => cause,
-            GetDomainNamesError::TooManyRequests(ref cause) => cause,
-            GetDomainNamesError::Unauthorized(ref cause) => cause,
+            GetDomainNamesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDomainNamesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDomainNamesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainNamesError {}
 /// Errors returned by GetExport
 #[derive(Debug, PartialEq)]
 pub enum GetExportError {
@@ -6600,20 +6376,16 @@ impl GetExportError {
 }
 impl fmt::Display for GetExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetExportError {
-    fn description(&self) -> &str {
         match *self {
-            GetExportError::BadRequest(ref cause) => cause,
-            GetExportError::Conflict(ref cause) => cause,
-            GetExportError::NotFound(ref cause) => cause,
-            GetExportError::TooManyRequests(ref cause) => cause,
-            GetExportError::Unauthorized(ref cause) => cause,
+            GetExportError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetExportError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetExportError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetExportError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetExportError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetExportError {}
 /// Errors returned by GetGatewayResponse
 #[derive(Debug, PartialEq)]
 pub enum GetGatewayResponseError {
@@ -6647,18 +6419,14 @@ impl GetGatewayResponseError {
 }
 impl fmt::Display for GetGatewayResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGatewayResponseError {
-    fn description(&self) -> &str {
         match *self {
-            GetGatewayResponseError::NotFound(ref cause) => cause,
-            GetGatewayResponseError::TooManyRequests(ref cause) => cause,
-            GetGatewayResponseError::Unauthorized(ref cause) => cause,
+            GetGatewayResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetGatewayResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetGatewayResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGatewayResponseError {}
 /// Errors returned by GetGatewayResponses
 #[derive(Debug, PartialEq)]
 pub enum GetGatewayResponsesError {
@@ -6697,19 +6465,15 @@ impl GetGatewayResponsesError {
 }
 impl fmt::Display for GetGatewayResponsesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGatewayResponsesError {
-    fn description(&self) -> &str {
         match *self {
-            GetGatewayResponsesError::BadRequest(ref cause) => cause,
-            GetGatewayResponsesError::NotFound(ref cause) => cause,
-            GetGatewayResponsesError::TooManyRequests(ref cause) => cause,
-            GetGatewayResponsesError::Unauthorized(ref cause) => cause,
+            GetGatewayResponsesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetGatewayResponsesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetGatewayResponsesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetGatewayResponsesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGatewayResponsesError {}
 /// Errors returned by GetIntegration
 #[derive(Debug, PartialEq)]
 pub enum GetIntegrationError {
@@ -6743,18 +6507,14 @@ impl GetIntegrationError {
 }
 impl fmt::Display for GetIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntegrationError::NotFound(ref cause) => cause,
-            GetIntegrationError::TooManyRequests(ref cause) => cause,
-            GetIntegrationError::Unauthorized(ref cause) => cause,
+            GetIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetIntegrationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntegrationError {}
 /// Errors returned by GetIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum GetIntegrationResponseError {
@@ -6790,18 +6550,14 @@ impl GetIntegrationResponseError {
 }
 impl fmt::Display for GetIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntegrationResponseError::NotFound(ref cause) => cause,
-            GetIntegrationResponseError::TooManyRequests(ref cause) => cause,
-            GetIntegrationResponseError::Unauthorized(ref cause) => cause,
+            GetIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetIntegrationResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntegrationResponseError {}
 /// Errors returned by GetMethod
 #[derive(Debug, PartialEq)]
 pub enum GetMethodError {
@@ -6835,18 +6591,14 @@ impl GetMethodError {
 }
 impl fmt::Display for GetMethodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMethodError {
-    fn description(&self) -> &str {
         match *self {
-            GetMethodError::NotFound(ref cause) => cause,
-            GetMethodError::TooManyRequests(ref cause) => cause,
-            GetMethodError::Unauthorized(ref cause) => cause,
+            GetMethodError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetMethodError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetMethodError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMethodError {}
 /// Errors returned by GetMethodResponse
 #[derive(Debug, PartialEq)]
 pub enum GetMethodResponseError {
@@ -6880,18 +6632,14 @@ impl GetMethodResponseError {
 }
 impl fmt::Display for GetMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMethodResponseError {
-    fn description(&self) -> &str {
         match *self {
-            GetMethodResponseError::NotFound(ref cause) => cause,
-            GetMethodResponseError::TooManyRequests(ref cause) => cause,
-            GetMethodResponseError::Unauthorized(ref cause) => cause,
+            GetMethodResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetMethodResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetMethodResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMethodResponseError {}
 /// Errors returned by GetModel
 #[derive(Debug, PartialEq)]
 pub enum GetModelError {
@@ -6925,18 +6673,14 @@ impl GetModelError {
 }
 impl fmt::Display for GetModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetModelError {
-    fn description(&self) -> &str {
         match *self {
-            GetModelError::NotFound(ref cause) => cause,
-            GetModelError::TooManyRequests(ref cause) => cause,
-            GetModelError::Unauthorized(ref cause) => cause,
+            GetModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetModelError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetModelError {}
 /// Errors returned by GetModelTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetModelTemplateError {
@@ -6975,19 +6719,15 @@ impl GetModelTemplateError {
 }
 impl fmt::Display for GetModelTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetModelTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GetModelTemplateError::BadRequest(ref cause) => cause,
-            GetModelTemplateError::NotFound(ref cause) => cause,
-            GetModelTemplateError::TooManyRequests(ref cause) => cause,
-            GetModelTemplateError::Unauthorized(ref cause) => cause,
+            GetModelTemplateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetModelTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetModelTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetModelTemplateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetModelTemplateError {}
 /// Errors returned by GetModels
 #[derive(Debug, PartialEq)]
 pub enum GetModelsError {
@@ -7026,19 +6766,15 @@ impl GetModelsError {
 }
 impl fmt::Display for GetModelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetModelsError {
-    fn description(&self) -> &str {
         match *self {
-            GetModelsError::BadRequest(ref cause) => cause,
-            GetModelsError::NotFound(ref cause) => cause,
-            GetModelsError::TooManyRequests(ref cause) => cause,
-            GetModelsError::Unauthorized(ref cause) => cause,
+            GetModelsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetModelsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetModelsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetModelsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetModelsError {}
 /// Errors returned by GetRequestValidator
 #[derive(Debug, PartialEq)]
 pub enum GetRequestValidatorError {
@@ -7072,18 +6808,14 @@ impl GetRequestValidatorError {
 }
 impl fmt::Display for GetRequestValidatorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRequestValidatorError {
-    fn description(&self) -> &str {
         match *self {
-            GetRequestValidatorError::NotFound(ref cause) => cause,
-            GetRequestValidatorError::TooManyRequests(ref cause) => cause,
-            GetRequestValidatorError::Unauthorized(ref cause) => cause,
+            GetRequestValidatorError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRequestValidatorError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetRequestValidatorError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRequestValidatorError {}
 /// Errors returned by GetRequestValidators
 #[derive(Debug, PartialEq)]
 pub enum GetRequestValidatorsError {
@@ -7124,19 +6856,15 @@ impl GetRequestValidatorsError {
 }
 impl fmt::Display for GetRequestValidatorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRequestValidatorsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRequestValidatorsError::BadRequest(ref cause) => cause,
-            GetRequestValidatorsError::NotFound(ref cause) => cause,
-            GetRequestValidatorsError::TooManyRequests(ref cause) => cause,
-            GetRequestValidatorsError::Unauthorized(ref cause) => cause,
+            GetRequestValidatorsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetRequestValidatorsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRequestValidatorsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetRequestValidatorsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRequestValidatorsError {}
 /// Errors returned by GetResource
 #[derive(Debug, PartialEq)]
 pub enum GetResourceError {
@@ -7170,18 +6898,14 @@ impl GetResourceError {
 }
 impl fmt::Display for GetResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceError::NotFound(ref cause) => cause,
-            GetResourceError::TooManyRequests(ref cause) => cause,
-            GetResourceError::Unauthorized(ref cause) => cause,
+            GetResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourceError {}
 /// Errors returned by GetResources
 #[derive(Debug, PartialEq)]
 pub enum GetResourcesError {
@@ -7220,19 +6944,15 @@ impl GetResourcesError {
 }
 impl fmt::Display for GetResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourcesError::BadRequest(ref cause) => cause,
-            GetResourcesError::NotFound(ref cause) => cause,
-            GetResourcesError::TooManyRequests(ref cause) => cause,
-            GetResourcesError::Unauthorized(ref cause) => cause,
+            GetResourcesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourcesError {}
 /// Errors returned by GetRestApi
 #[derive(Debug, PartialEq)]
 pub enum GetRestApiError {
@@ -7266,18 +6986,14 @@ impl GetRestApiError {
 }
 impl fmt::Display for GetRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRestApiError {
-    fn description(&self) -> &str {
         match *self {
-            GetRestApiError::NotFound(ref cause) => cause,
-            GetRestApiError::TooManyRequests(ref cause) => cause,
-            GetRestApiError::Unauthorized(ref cause) => cause,
+            GetRestApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRestApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetRestApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRestApiError {}
 /// Errors returned by GetRestApis
 #[derive(Debug, PartialEq)]
 pub enum GetRestApisError {
@@ -7311,18 +7027,14 @@ impl GetRestApisError {
 }
 impl fmt::Display for GetRestApisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRestApisError {
-    fn description(&self) -> &str {
         match *self {
-            GetRestApisError::BadRequest(ref cause) => cause,
-            GetRestApisError::TooManyRequests(ref cause) => cause,
-            GetRestApisError::Unauthorized(ref cause) => cause,
+            GetRestApisError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetRestApisError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetRestApisError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRestApisError {}
 /// Errors returned by GetSdk
 #[derive(Debug, PartialEq)]
 pub enum GetSdkError {
@@ -7362,20 +7074,16 @@ impl GetSdkError {
 }
 impl fmt::Display for GetSdkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSdkError {
-    fn description(&self) -> &str {
         match *self {
-            GetSdkError::BadRequest(ref cause) => cause,
-            GetSdkError::Conflict(ref cause) => cause,
-            GetSdkError::NotFound(ref cause) => cause,
-            GetSdkError::TooManyRequests(ref cause) => cause,
-            GetSdkError::Unauthorized(ref cause) => cause,
+            GetSdkError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetSdkError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetSdkError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetSdkError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetSdkError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSdkError {}
 /// Errors returned by GetSdkType
 #[derive(Debug, PartialEq)]
 pub enum GetSdkTypeError {
@@ -7409,18 +7117,14 @@ impl GetSdkTypeError {
 }
 impl fmt::Display for GetSdkTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSdkTypeError {
-    fn description(&self) -> &str {
         match *self {
-            GetSdkTypeError::NotFound(ref cause) => cause,
-            GetSdkTypeError::TooManyRequests(ref cause) => cause,
-            GetSdkTypeError::Unauthorized(ref cause) => cause,
+            GetSdkTypeError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetSdkTypeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetSdkTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSdkTypeError {}
 /// Errors returned by GetSdkTypes
 #[derive(Debug, PartialEq)]
 pub enum GetSdkTypesError {
@@ -7449,17 +7153,13 @@ impl GetSdkTypesError {
 }
 impl fmt::Display for GetSdkTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSdkTypesError {
-    fn description(&self) -> &str {
         match *self {
-            GetSdkTypesError::TooManyRequests(ref cause) => cause,
-            GetSdkTypesError::Unauthorized(ref cause) => cause,
+            GetSdkTypesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetSdkTypesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSdkTypesError {}
 /// Errors returned by GetStage
 #[derive(Debug, PartialEq)]
 pub enum GetStageError {
@@ -7493,18 +7193,14 @@ impl GetStageError {
 }
 impl fmt::Display for GetStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStageError {
-    fn description(&self) -> &str {
         match *self {
-            GetStageError::NotFound(ref cause) => cause,
-            GetStageError::TooManyRequests(ref cause) => cause,
-            GetStageError::Unauthorized(ref cause) => cause,
+            GetStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetStageError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStageError {}
 /// Errors returned by GetStages
 #[derive(Debug, PartialEq)]
 pub enum GetStagesError {
@@ -7538,18 +7234,14 @@ impl GetStagesError {
 }
 impl fmt::Display for GetStagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStagesError {
-    fn description(&self) -> &str {
         match *self {
-            GetStagesError::NotFound(ref cause) => cause,
-            GetStagesError::TooManyRequests(ref cause) => cause,
-            GetStagesError::Unauthorized(ref cause) => cause,
+            GetStagesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetStagesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetStagesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStagesError {}
 /// Errors returned by GetTags
 #[derive(Debug, PartialEq)]
 pub enum GetTagsError {
@@ -7593,20 +7285,16 @@ impl GetTagsError {
 }
 impl fmt::Display for GetTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTagsError {
-    fn description(&self) -> &str {
         match *self {
-            GetTagsError::BadRequest(ref cause) => cause,
-            GetTagsError::LimitExceeded(ref cause) => cause,
-            GetTagsError::NotFound(ref cause) => cause,
-            GetTagsError::TooManyRequests(ref cause) => cause,
-            GetTagsError::Unauthorized(ref cause) => cause,
+            GetTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetTagsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetTagsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetTagsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetTagsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTagsError {}
 /// Errors returned by GetUsage
 #[derive(Debug, PartialEq)]
 pub enum GetUsageError {
@@ -7645,19 +7333,15 @@ impl GetUsageError {
 }
 impl fmt::Display for GetUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUsageError {
-    fn description(&self) -> &str {
         match *self {
-            GetUsageError::BadRequest(ref cause) => cause,
-            GetUsageError::NotFound(ref cause) => cause,
-            GetUsageError::TooManyRequests(ref cause) => cause,
-            GetUsageError::Unauthorized(ref cause) => cause,
+            GetUsageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUsageError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUsageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetUsageError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUsageError {}
 /// Errors returned by GetUsagePlan
 #[derive(Debug, PartialEq)]
 pub enum GetUsagePlanError {
@@ -7696,19 +7380,15 @@ impl GetUsagePlanError {
 }
 impl fmt::Display for GetUsagePlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUsagePlanError {
-    fn description(&self) -> &str {
         match *self {
-            GetUsagePlanError::BadRequest(ref cause) => cause,
-            GetUsagePlanError::NotFound(ref cause) => cause,
-            GetUsagePlanError::TooManyRequests(ref cause) => cause,
-            GetUsagePlanError::Unauthorized(ref cause) => cause,
+            GetUsagePlanError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUsagePlanError {}
 /// Errors returned by GetUsagePlanKey
 #[derive(Debug, PartialEq)]
 pub enum GetUsagePlanKeyError {
@@ -7747,19 +7427,15 @@ impl GetUsagePlanKeyError {
 }
 impl fmt::Display for GetUsagePlanKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUsagePlanKeyError {
-    fn description(&self) -> &str {
         match *self {
-            GetUsagePlanKeyError::BadRequest(ref cause) => cause,
-            GetUsagePlanKeyError::NotFound(ref cause) => cause,
-            GetUsagePlanKeyError::TooManyRequests(ref cause) => cause,
-            GetUsagePlanKeyError::Unauthorized(ref cause) => cause,
+            GetUsagePlanKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanKeyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUsagePlanKeyError {}
 /// Errors returned by GetUsagePlanKeys
 #[derive(Debug, PartialEq)]
 pub enum GetUsagePlanKeysError {
@@ -7798,19 +7474,15 @@ impl GetUsagePlanKeysError {
 }
 impl fmt::Display for GetUsagePlanKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUsagePlanKeysError {
-    fn description(&self) -> &str {
         match *self {
-            GetUsagePlanKeysError::BadRequest(ref cause) => cause,
-            GetUsagePlanKeysError::NotFound(ref cause) => cause,
-            GetUsagePlanKeysError::TooManyRequests(ref cause) => cause,
-            GetUsagePlanKeysError::Unauthorized(ref cause) => cause,
+            GetUsagePlanKeysError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanKeysError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanKeysError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetUsagePlanKeysError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUsagePlanKeysError {}
 /// Errors returned by GetUsagePlans
 #[derive(Debug, PartialEq)]
 pub enum GetUsagePlansError {
@@ -7854,20 +7526,16 @@ impl GetUsagePlansError {
 }
 impl fmt::Display for GetUsagePlansError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUsagePlansError {
-    fn description(&self) -> &str {
         match *self {
-            GetUsagePlansError::BadRequest(ref cause) => cause,
-            GetUsagePlansError::Conflict(ref cause) => cause,
-            GetUsagePlansError::NotFound(ref cause) => cause,
-            GetUsagePlansError::TooManyRequests(ref cause) => cause,
-            GetUsagePlansError::Unauthorized(ref cause) => cause,
+            GetUsagePlansError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUsagePlansError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetUsagePlansError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUsagePlansError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetUsagePlansError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUsagePlansError {}
 /// Errors returned by GetVpcLink
 #[derive(Debug, PartialEq)]
 pub enum GetVpcLinkError {
@@ -7901,18 +7569,14 @@ impl GetVpcLinkError {
 }
 impl fmt::Display for GetVpcLinkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVpcLinkError {
-    fn description(&self) -> &str {
         match *self {
-            GetVpcLinkError::NotFound(ref cause) => cause,
-            GetVpcLinkError::TooManyRequests(ref cause) => cause,
-            GetVpcLinkError::Unauthorized(ref cause) => cause,
+            GetVpcLinkError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetVpcLinkError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetVpcLinkError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVpcLinkError {}
 /// Errors returned by GetVpcLinks
 #[derive(Debug, PartialEq)]
 pub enum GetVpcLinksError {
@@ -7946,18 +7610,14 @@ impl GetVpcLinksError {
 }
 impl fmt::Display for GetVpcLinksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVpcLinksError {
-    fn description(&self) -> &str {
         match *self {
-            GetVpcLinksError::BadRequest(ref cause) => cause,
-            GetVpcLinksError::TooManyRequests(ref cause) => cause,
-            GetVpcLinksError::Unauthorized(ref cause) => cause,
+            GetVpcLinksError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetVpcLinksError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetVpcLinksError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVpcLinksError {}
 /// Errors returned by ImportApiKeys
 #[derive(Debug, PartialEq)]
 pub enum ImportApiKeysError {
@@ -8006,21 +7666,17 @@ impl ImportApiKeysError {
 }
 impl fmt::Display for ImportApiKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportApiKeysError {
-    fn description(&self) -> &str {
         match *self {
-            ImportApiKeysError::BadRequest(ref cause) => cause,
-            ImportApiKeysError::Conflict(ref cause) => cause,
-            ImportApiKeysError::LimitExceeded(ref cause) => cause,
-            ImportApiKeysError::NotFound(ref cause) => cause,
-            ImportApiKeysError::TooManyRequests(ref cause) => cause,
-            ImportApiKeysError::Unauthorized(ref cause) => cause,
+            ImportApiKeysError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ImportApiKeysError::Conflict(ref cause) => write!(f, "{}", cause),
+            ImportApiKeysError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ImportApiKeysError::NotFound(ref cause) => write!(f, "{}", cause),
+            ImportApiKeysError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ImportApiKeysError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportApiKeysError {}
 /// Errors returned by ImportDocumentationParts
 #[derive(Debug, PartialEq)]
 pub enum ImportDocumentationPartsError {
@@ -8070,20 +7726,16 @@ impl ImportDocumentationPartsError {
 }
 impl fmt::Display for ImportDocumentationPartsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportDocumentationPartsError {
-    fn description(&self) -> &str {
         match *self {
-            ImportDocumentationPartsError::BadRequest(ref cause) => cause,
-            ImportDocumentationPartsError::LimitExceeded(ref cause) => cause,
-            ImportDocumentationPartsError::NotFound(ref cause) => cause,
-            ImportDocumentationPartsError::TooManyRequests(ref cause) => cause,
-            ImportDocumentationPartsError::Unauthorized(ref cause) => cause,
+            ImportDocumentationPartsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ImportDocumentationPartsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ImportDocumentationPartsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ImportDocumentationPartsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ImportDocumentationPartsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportDocumentationPartsError {}
 /// Errors returned by ImportRestApi
 #[derive(Debug, PartialEq)]
 pub enum ImportRestApiError {
@@ -8127,20 +7779,16 @@ impl ImportRestApiError {
 }
 impl fmt::Display for ImportRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportRestApiError {
-    fn description(&self) -> &str {
         match *self {
-            ImportRestApiError::BadRequest(ref cause) => cause,
-            ImportRestApiError::Conflict(ref cause) => cause,
-            ImportRestApiError::LimitExceeded(ref cause) => cause,
-            ImportRestApiError::TooManyRequests(ref cause) => cause,
-            ImportRestApiError::Unauthorized(ref cause) => cause,
+            ImportRestApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ImportRestApiError::Conflict(ref cause) => write!(f, "{}", cause),
+            ImportRestApiError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ImportRestApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ImportRestApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportRestApiError {}
 /// Errors returned by PutGatewayResponse
 #[derive(Debug, PartialEq)]
 pub enum PutGatewayResponseError {
@@ -8184,20 +7832,16 @@ impl PutGatewayResponseError {
 }
 impl fmt::Display for PutGatewayResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutGatewayResponseError {
-    fn description(&self) -> &str {
         match *self {
-            PutGatewayResponseError::BadRequest(ref cause) => cause,
-            PutGatewayResponseError::LimitExceeded(ref cause) => cause,
-            PutGatewayResponseError::NotFound(ref cause) => cause,
-            PutGatewayResponseError::TooManyRequests(ref cause) => cause,
-            PutGatewayResponseError::Unauthorized(ref cause) => cause,
+            PutGatewayResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutGatewayResponseError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutGatewayResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutGatewayResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            PutGatewayResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutGatewayResponseError {}
 /// Errors returned by PutIntegration
 #[derive(Debug, PartialEq)]
 pub enum PutIntegrationError {
@@ -8241,20 +7885,16 @@ impl PutIntegrationError {
 }
 impl fmt::Display for PutIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            PutIntegrationError::BadRequest(ref cause) => cause,
-            PutIntegrationError::Conflict(ref cause) => cause,
-            PutIntegrationError::NotFound(ref cause) => cause,
-            PutIntegrationError::TooManyRequests(ref cause) => cause,
-            PutIntegrationError::Unauthorized(ref cause) => cause,
+            PutIntegrationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutIntegrationError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            PutIntegrationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutIntegrationError {}
 /// Errors returned by PutIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum PutIntegrationResponseError {
@@ -8307,21 +7947,17 @@ impl PutIntegrationResponseError {
 }
 impl fmt::Display for PutIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            PutIntegrationResponseError::BadRequest(ref cause) => cause,
-            PutIntegrationResponseError::Conflict(ref cause) => cause,
-            PutIntegrationResponseError::LimitExceeded(ref cause) => cause,
-            PutIntegrationResponseError::NotFound(ref cause) => cause,
-            PutIntegrationResponseError::TooManyRequests(ref cause) => cause,
-            PutIntegrationResponseError::Unauthorized(ref cause) => cause,
+            PutIntegrationResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutIntegrationResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutIntegrationResponseError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            PutIntegrationResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutIntegrationResponseError {}
 /// Errors returned by PutMethod
 #[derive(Debug, PartialEq)]
 pub enum PutMethodError {
@@ -8370,21 +8006,17 @@ impl PutMethodError {
 }
 impl fmt::Display for PutMethodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutMethodError {
-    fn description(&self) -> &str {
         match *self {
-            PutMethodError::BadRequest(ref cause) => cause,
-            PutMethodError::Conflict(ref cause) => cause,
-            PutMethodError::LimitExceeded(ref cause) => cause,
-            PutMethodError::NotFound(ref cause) => cause,
-            PutMethodError::TooManyRequests(ref cause) => cause,
-            PutMethodError::Unauthorized(ref cause) => cause,
+            PutMethodError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutMethodError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutMethodError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutMethodError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutMethodError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            PutMethodError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutMethodError {}
 /// Errors returned by PutMethodResponse
 #[derive(Debug, PartialEq)]
 pub enum PutMethodResponseError {
@@ -8433,21 +8065,17 @@ impl PutMethodResponseError {
 }
 impl fmt::Display for PutMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutMethodResponseError {
-    fn description(&self) -> &str {
         match *self {
-            PutMethodResponseError::BadRequest(ref cause) => cause,
-            PutMethodResponseError::Conflict(ref cause) => cause,
-            PutMethodResponseError::LimitExceeded(ref cause) => cause,
-            PutMethodResponseError::NotFound(ref cause) => cause,
-            PutMethodResponseError::TooManyRequests(ref cause) => cause,
-            PutMethodResponseError::Unauthorized(ref cause) => cause,
+            PutMethodResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutMethodResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutMethodResponseError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutMethodResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutMethodResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            PutMethodResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutMethodResponseError {}
 /// Errors returned by PutRestApi
 #[derive(Debug, PartialEq)]
 pub enum PutRestApiError {
@@ -8496,21 +8124,17 @@ impl PutRestApiError {
 }
 impl fmt::Display for PutRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRestApiError {
-    fn description(&self) -> &str {
         match *self {
-            PutRestApiError::BadRequest(ref cause) => cause,
-            PutRestApiError::Conflict(ref cause) => cause,
-            PutRestApiError::LimitExceeded(ref cause) => cause,
-            PutRestApiError::NotFound(ref cause) => cause,
-            PutRestApiError::TooManyRequests(ref cause) => cause,
-            PutRestApiError::Unauthorized(ref cause) => cause,
+            PutRestApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutRestApiError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutRestApiError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutRestApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutRestApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            PutRestApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRestApiError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -8559,21 +8183,17 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::Conflict(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
-            TagResourceError::Unauthorized(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TestInvokeAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum TestInvokeAuthorizerError {
@@ -8614,19 +8234,15 @@ impl TestInvokeAuthorizerError {
 }
 impl fmt::Display for TestInvokeAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestInvokeAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            TestInvokeAuthorizerError::BadRequest(ref cause) => cause,
-            TestInvokeAuthorizerError::NotFound(ref cause) => cause,
-            TestInvokeAuthorizerError::TooManyRequests(ref cause) => cause,
-            TestInvokeAuthorizerError::Unauthorized(ref cause) => cause,
+            TestInvokeAuthorizerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestInvokeAuthorizerError {}
 /// Errors returned by TestInvokeMethod
 #[derive(Debug, PartialEq)]
 pub enum TestInvokeMethodError {
@@ -8665,19 +8281,15 @@ impl TestInvokeMethodError {
 }
 impl fmt::Display for TestInvokeMethodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestInvokeMethodError {
-    fn description(&self) -> &str {
         match *self {
-            TestInvokeMethodError::BadRequest(ref cause) => cause,
-            TestInvokeMethodError::NotFound(ref cause) => cause,
-            TestInvokeMethodError::TooManyRequests(ref cause) => cause,
-            TestInvokeMethodError::Unauthorized(ref cause) => cause,
+            TestInvokeMethodError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TestInvokeMethodError::NotFound(ref cause) => write!(f, "{}", cause),
+            TestInvokeMethodError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            TestInvokeMethodError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestInvokeMethodError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -8721,20 +8333,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::Conflict(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
-            UntagResourceError::Unauthorized(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateAccount
 #[derive(Debug, PartialEq)]
 pub enum UpdateAccountError {
@@ -8773,19 +8381,15 @@ impl UpdateAccountError {
 }
 impl fmt::Display for UpdateAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAccountError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAccountError::BadRequest(ref cause) => cause,
-            UpdateAccountError::NotFound(ref cause) => cause,
-            UpdateAccountError::TooManyRequests(ref cause) => cause,
-            UpdateAccountError::Unauthorized(ref cause) => cause,
+            UpdateAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAccountError {}
 /// Errors returned by UpdateApiKey
 #[derive(Debug, PartialEq)]
 pub enum UpdateApiKeyError {
@@ -8829,20 +8433,16 @@ impl UpdateApiKeyError {
 }
 impl fmt::Display for UpdateApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApiKeyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApiKeyError::BadRequest(ref cause) => cause,
-            UpdateApiKeyError::Conflict(ref cause) => cause,
-            UpdateApiKeyError::NotFound(ref cause) => cause,
-            UpdateApiKeyError::TooManyRequests(ref cause) => cause,
-            UpdateApiKeyError::Unauthorized(ref cause) => cause,
+            UpdateApiKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApiKeyError {}
 /// Errors returned by UpdateAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum UpdateAuthorizerError {
@@ -8881,19 +8481,15 @@ impl UpdateAuthorizerError {
 }
 impl fmt::Display for UpdateAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAuthorizerError::BadRequest(ref cause) => cause,
-            UpdateAuthorizerError::NotFound(ref cause) => cause,
-            UpdateAuthorizerError::TooManyRequests(ref cause) => cause,
-            UpdateAuthorizerError::Unauthorized(ref cause) => cause,
+            UpdateAuthorizerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAuthorizerError {}
 /// Errors returned by UpdateBasePathMapping
 #[derive(Debug, PartialEq)]
 pub enum UpdateBasePathMappingError {
@@ -8939,20 +8535,16 @@ impl UpdateBasePathMappingError {
 }
 impl fmt::Display for UpdateBasePathMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBasePathMappingError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBasePathMappingError::BadRequest(ref cause) => cause,
-            UpdateBasePathMappingError::Conflict(ref cause) => cause,
-            UpdateBasePathMappingError::NotFound(ref cause) => cause,
-            UpdateBasePathMappingError::TooManyRequests(ref cause) => cause,
-            UpdateBasePathMappingError::Unauthorized(ref cause) => cause,
+            UpdateBasePathMappingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBasePathMappingError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateBasePathMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateBasePathMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateBasePathMappingError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBasePathMappingError {}
 /// Errors returned by UpdateClientCertificate
 #[derive(Debug, PartialEq)]
 pub enum UpdateClientCertificateError {
@@ -8995,19 +8587,15 @@ impl UpdateClientCertificateError {
 }
 impl fmt::Display for UpdateClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClientCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClientCertificateError::BadRequest(ref cause) => cause,
-            UpdateClientCertificateError::NotFound(ref cause) => cause,
-            UpdateClientCertificateError::TooManyRequests(ref cause) => cause,
-            UpdateClientCertificateError::Unauthorized(ref cause) => cause,
+            UpdateClientCertificateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateClientCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateClientCertificateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateClientCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClientCertificateError {}
 /// Errors returned by UpdateDeployment
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeploymentError {
@@ -9051,20 +8639,16 @@ impl UpdateDeploymentError {
 }
 impl fmt::Display for UpdateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeploymentError::BadRequest(ref cause) => cause,
-            UpdateDeploymentError::NotFound(ref cause) => cause,
-            UpdateDeploymentError::ServiceUnavailable(ref cause) => cause,
-            UpdateDeploymentError::TooManyRequests(ref cause) => cause,
-            UpdateDeploymentError::Unauthorized(ref cause) => cause,
+            UpdateDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDeploymentError {}
 /// Errors returned by UpdateDocumentationPart
 #[derive(Debug, PartialEq)]
 pub enum UpdateDocumentationPartError {
@@ -9119,21 +8703,17 @@ impl UpdateDocumentationPartError {
 }
 impl fmt::Display for UpdateDocumentationPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDocumentationPartError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDocumentationPartError::BadRequest(ref cause) => cause,
-            UpdateDocumentationPartError::Conflict(ref cause) => cause,
-            UpdateDocumentationPartError::LimitExceeded(ref cause) => cause,
-            UpdateDocumentationPartError::NotFound(ref cause) => cause,
-            UpdateDocumentationPartError::TooManyRequests(ref cause) => cause,
-            UpdateDocumentationPartError::Unauthorized(ref cause) => cause,
+            UpdateDocumentationPartError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationPartError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationPartError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationPartError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationPartError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationPartError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDocumentationPartError {}
 /// Errors returned by UpdateDocumentationVersion
 #[derive(Debug, PartialEq)]
 pub enum UpdateDocumentationVersionError {
@@ -9185,20 +8765,16 @@ impl UpdateDocumentationVersionError {
 }
 impl fmt::Display for UpdateDocumentationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDocumentationVersionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDocumentationVersionError::BadRequest(ref cause) => cause,
-            UpdateDocumentationVersionError::Conflict(ref cause) => cause,
-            UpdateDocumentationVersionError::NotFound(ref cause) => cause,
-            UpdateDocumentationVersionError::TooManyRequests(ref cause) => cause,
-            UpdateDocumentationVersionError::Unauthorized(ref cause) => cause,
+            UpdateDocumentationVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentationVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDocumentationVersionError {}
 /// Errors returned by UpdateDomainName
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainNameError {
@@ -9242,20 +8818,16 @@ impl UpdateDomainNameError {
 }
 impl fmt::Display for UpdateDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainNameError::BadRequest(ref cause) => cause,
-            UpdateDomainNameError::Conflict(ref cause) => cause,
-            UpdateDomainNameError::NotFound(ref cause) => cause,
-            UpdateDomainNameError::TooManyRequests(ref cause) => cause,
-            UpdateDomainNameError::Unauthorized(ref cause) => cause,
+            UpdateDomainNameError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainNameError {}
 /// Errors returned by UpdateGatewayResponse
 #[derive(Debug, PartialEq)]
 pub enum UpdateGatewayResponseError {
@@ -9296,19 +8868,15 @@ impl UpdateGatewayResponseError {
 }
 impl fmt::Display for UpdateGatewayResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGatewayResponseError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGatewayResponseError::BadRequest(ref cause) => cause,
-            UpdateGatewayResponseError::NotFound(ref cause) => cause,
-            UpdateGatewayResponseError::TooManyRequests(ref cause) => cause,
-            UpdateGatewayResponseError::Unauthorized(ref cause) => cause,
+            UpdateGatewayResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGatewayResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGatewayResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateGatewayResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGatewayResponseError {}
 /// Errors returned by UpdateIntegration
 #[derive(Debug, PartialEq)]
 pub enum UpdateIntegrationError {
@@ -9352,20 +8920,16 @@ impl UpdateIntegrationError {
 }
 impl fmt::Display for UpdateIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIntegrationError::BadRequest(ref cause) => cause,
-            UpdateIntegrationError::Conflict(ref cause) => cause,
-            UpdateIntegrationError::NotFound(ref cause) => cause,
-            UpdateIntegrationError::TooManyRequests(ref cause) => cause,
-            UpdateIntegrationError::Unauthorized(ref cause) => cause,
+            UpdateIntegrationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIntegrationError {}
 /// Errors returned by UpdateIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum UpdateIntegrationResponseError {
@@ -9415,20 +8979,16 @@ impl UpdateIntegrationResponseError {
 }
 impl fmt::Display for UpdateIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIntegrationResponseError::BadRequest(ref cause) => cause,
-            UpdateIntegrationResponseError::Conflict(ref cause) => cause,
-            UpdateIntegrationResponseError::NotFound(ref cause) => cause,
-            UpdateIntegrationResponseError::TooManyRequests(ref cause) => cause,
-            UpdateIntegrationResponseError::Unauthorized(ref cause) => cause,
+            UpdateIntegrationResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIntegrationResponseError {}
 /// Errors returned by UpdateMethod
 #[derive(Debug, PartialEq)]
 pub enum UpdateMethodError {
@@ -9472,20 +9032,16 @@ impl UpdateMethodError {
 }
 impl fmt::Display for UpdateMethodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMethodError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMethodError::BadRequest(ref cause) => cause,
-            UpdateMethodError::Conflict(ref cause) => cause,
-            UpdateMethodError::NotFound(ref cause) => cause,
-            UpdateMethodError::TooManyRequests(ref cause) => cause,
-            UpdateMethodError::Unauthorized(ref cause) => cause,
+            UpdateMethodError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateMethodError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateMethodError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMethodError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateMethodError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMethodError {}
 /// Errors returned by UpdateMethodResponse
 #[derive(Debug, PartialEq)]
 pub enum UpdateMethodResponseError {
@@ -9536,21 +9092,17 @@ impl UpdateMethodResponseError {
 }
 impl fmt::Display for UpdateMethodResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMethodResponseError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMethodResponseError::BadRequest(ref cause) => cause,
-            UpdateMethodResponseError::Conflict(ref cause) => cause,
-            UpdateMethodResponseError::LimitExceeded(ref cause) => cause,
-            UpdateMethodResponseError::NotFound(ref cause) => cause,
-            UpdateMethodResponseError::TooManyRequests(ref cause) => cause,
-            UpdateMethodResponseError::Unauthorized(ref cause) => cause,
+            UpdateMethodResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateMethodResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateMethodResponseError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateMethodResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMethodResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateMethodResponseError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMethodResponseError {}
 /// Errors returned by UpdateModel
 #[derive(Debug, PartialEq)]
 pub enum UpdateModelError {
@@ -9594,20 +9146,16 @@ impl UpdateModelError {
 }
 impl fmt::Display for UpdateModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateModelError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateModelError::BadRequest(ref cause) => cause,
-            UpdateModelError::Conflict(ref cause) => cause,
-            UpdateModelError::NotFound(ref cause) => cause,
-            UpdateModelError::TooManyRequests(ref cause) => cause,
-            UpdateModelError::Unauthorized(ref cause) => cause,
+            UpdateModelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateModelError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateModelError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateModelError {}
 /// Errors returned by UpdateRequestValidator
 #[derive(Debug, PartialEq)]
 pub enum UpdateRequestValidatorError {
@@ -9648,19 +9196,15 @@ impl UpdateRequestValidatorError {
 }
 impl fmt::Display for UpdateRequestValidatorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRequestValidatorError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRequestValidatorError::BadRequest(ref cause) => cause,
-            UpdateRequestValidatorError::NotFound(ref cause) => cause,
-            UpdateRequestValidatorError::TooManyRequests(ref cause) => cause,
-            UpdateRequestValidatorError::Unauthorized(ref cause) => cause,
+            UpdateRequestValidatorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRequestValidatorError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRequestValidatorError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateRequestValidatorError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRequestValidatorError {}
 /// Errors returned by UpdateResource
 #[derive(Debug, PartialEq)]
 pub enum UpdateResourceError {
@@ -9704,20 +9248,16 @@ impl UpdateResourceError {
 }
 impl fmt::Display for UpdateResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateResourceError::BadRequest(ref cause) => cause,
-            UpdateResourceError::Conflict(ref cause) => cause,
-            UpdateResourceError::NotFound(ref cause) => cause,
-            UpdateResourceError::TooManyRequests(ref cause) => cause,
-            UpdateResourceError::Unauthorized(ref cause) => cause,
+            UpdateResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateResourceError {}
 /// Errors returned by UpdateRestApi
 #[derive(Debug, PartialEq)]
 pub enum UpdateRestApiError {
@@ -9761,20 +9301,16 @@ impl UpdateRestApiError {
 }
 impl fmt::Display for UpdateRestApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRestApiError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRestApiError::BadRequest(ref cause) => cause,
-            UpdateRestApiError::Conflict(ref cause) => cause,
-            UpdateRestApiError::NotFound(ref cause) => cause,
-            UpdateRestApiError::TooManyRequests(ref cause) => cause,
-            UpdateRestApiError::Unauthorized(ref cause) => cause,
+            UpdateRestApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRestApiError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateRestApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRestApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateRestApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRestApiError {}
 /// Errors returned by UpdateStage
 #[derive(Debug, PartialEq)]
 pub enum UpdateStageError {
@@ -9818,20 +9354,16 @@ impl UpdateStageError {
 }
 impl fmt::Display for UpdateStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStageError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStageError::BadRequest(ref cause) => cause,
-            UpdateStageError::Conflict(ref cause) => cause,
-            UpdateStageError::NotFound(ref cause) => cause,
-            UpdateStageError::TooManyRequests(ref cause) => cause,
-            UpdateStageError::Unauthorized(ref cause) => cause,
+            UpdateStageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateStageError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateStageError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStageError {}
 /// Errors returned by UpdateUsage
 #[derive(Debug, PartialEq)]
 pub enum UpdateUsageError {
@@ -9870,19 +9402,15 @@ impl UpdateUsageError {
 }
 impl fmt::Display for UpdateUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUsageError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUsageError::BadRequest(ref cause) => cause,
-            UpdateUsageError::NotFound(ref cause) => cause,
-            UpdateUsageError::TooManyRequests(ref cause) => cause,
-            UpdateUsageError::Unauthorized(ref cause) => cause,
+            UpdateUsageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUsageError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUsageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateUsageError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUsageError {}
 /// Errors returned by UpdateUsagePlan
 #[derive(Debug, PartialEq)]
 pub enum UpdateUsagePlanError {
@@ -9926,20 +9454,16 @@ impl UpdateUsagePlanError {
 }
 impl fmt::Display for UpdateUsagePlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUsagePlanError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUsagePlanError::BadRequest(ref cause) => cause,
-            UpdateUsagePlanError::Conflict(ref cause) => cause,
-            UpdateUsagePlanError::NotFound(ref cause) => cause,
-            UpdateUsagePlanError::TooManyRequests(ref cause) => cause,
-            UpdateUsagePlanError::Unauthorized(ref cause) => cause,
+            UpdateUsagePlanError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUsagePlanError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateUsagePlanError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUsagePlanError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateUsagePlanError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUsagePlanError {}
 /// Errors returned by UpdateVpcLink
 #[derive(Debug, PartialEq)]
 pub enum UpdateVpcLinkError {
@@ -9983,20 +9507,16 @@ impl UpdateVpcLinkError {
 }
 impl fmt::Display for UpdateVpcLinkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVpcLinkError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVpcLinkError::BadRequest(ref cause) => cause,
-            UpdateVpcLinkError::Conflict(ref cause) => cause,
-            UpdateVpcLinkError::NotFound(ref cause) => cause,
-            UpdateVpcLinkError::TooManyRequests(ref cause) => cause,
-            UpdateVpcLinkError::Unauthorized(ref cause) => cause,
+            UpdateVpcLinkError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateVpcLinkError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateVpcLinkError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateVpcLinkError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateVpcLinkError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVpcLinkError {}
 /// Trait representing the capabilities of the Amazon API Gateway API. Amazon API Gateway clients implement this trait.
 pub trait ApiGateway {
     /// <p><p>Create an <a>ApiKey</a> resource. </p> <div class="seeAlso"><a href="https://docs.aws.amazon.com/cli/latest/reference/apigateway/create-api-key.html">AWS CLI</a></div></p>

--- a/rusoto/services/apigatewaymanagementapi/src/generated.rs
+++ b/rusoto/services/apigatewaymanagementapi/src/generated.rs
@@ -109,18 +109,14 @@ impl DeleteConnectionError {
 }
 impl fmt::Display for DeleteConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConnectionError::Forbidden(ref cause) => cause,
-            DeleteConnectionError::Gone(ref cause) => cause,
-            DeleteConnectionError::LimitExceeded(ref cause) => cause,
+            DeleteConnectionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteConnectionError::Gone(ref cause) => write!(f, "{}", cause),
+            DeleteConnectionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConnectionError {}
 /// Errors returned by GetConnection
 #[derive(Debug, PartialEq)]
 pub enum GetConnectionError {
@@ -152,18 +148,14 @@ impl GetConnectionError {
 }
 impl fmt::Display for GetConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectionError::Forbidden(ref cause) => cause,
-            GetConnectionError::Gone(ref cause) => cause,
-            GetConnectionError::LimitExceeded(ref cause) => cause,
+            GetConnectionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetConnectionError::Gone(ref cause) => write!(f, "{}", cause),
+            GetConnectionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectionError {}
 /// Errors returned by PostToConnection
 #[derive(Debug, PartialEq)]
 pub enum PostToConnectionError {
@@ -202,19 +194,15 @@ impl PostToConnectionError {
 }
 impl fmt::Display for PostToConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PostToConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            PostToConnectionError::Forbidden(ref cause) => cause,
-            PostToConnectionError::Gone(ref cause) => cause,
-            PostToConnectionError::LimitExceeded(ref cause) => cause,
-            PostToConnectionError::PayloadTooLarge(ref cause) => cause,
+            PostToConnectionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            PostToConnectionError::Gone(ref cause) => write!(f, "{}", cause),
+            PostToConnectionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PostToConnectionError::PayloadTooLarge(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PostToConnectionError {}
 /// Trait representing the capabilities of the AmazonApiGatewayManagementApi API. AmazonApiGatewayManagementApi clients implement this trait.
 pub trait ApiGatewayManagementApi {
     /// <p>Delete the connection with the provided id.</p>

--- a/rusoto/services/apigatewayv2/src/generated.rs
+++ b/rusoto/services/apigatewayv2/src/generated.rs
@@ -3545,19 +3545,15 @@ impl CreateApiError {
 }
 impl fmt::Display for CreateApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApiError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApiError::BadRequest(ref cause) => cause,
-            CreateApiError::Conflict(ref cause) => cause,
-            CreateApiError::NotFound(ref cause) => cause,
-            CreateApiError::TooManyRequests(ref cause) => cause,
+            CreateApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateApiError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApiError {}
 /// Errors returned by CreateApiMapping
 #[derive(Debug, PartialEq)]
 pub enum CreateApiMappingError {
@@ -3596,19 +3592,15 @@ impl CreateApiMappingError {
 }
 impl fmt::Display for CreateApiMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApiMappingError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApiMappingError::BadRequest(ref cause) => cause,
-            CreateApiMappingError::Conflict(ref cause) => cause,
-            CreateApiMappingError::NotFound(ref cause) => cause,
-            CreateApiMappingError::TooManyRequests(ref cause) => cause,
+            CreateApiMappingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateApiMappingError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateApiMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateApiMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApiMappingError {}
 /// Errors returned by CreateAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum CreateAuthorizerError {
@@ -3647,19 +3639,15 @@ impl CreateAuthorizerError {
 }
 impl fmt::Display for CreateAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAuthorizerError::BadRequest(ref cause) => cause,
-            CreateAuthorizerError::Conflict(ref cause) => cause,
-            CreateAuthorizerError::NotFound(ref cause) => cause,
-            CreateAuthorizerError::TooManyRequests(ref cause) => cause,
+            CreateAuthorizerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAuthorizerError {}
 /// Errors returned by CreateDeployment
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentError {
@@ -3698,19 +3686,15 @@ impl CreateDeploymentError {
 }
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentError::BadRequest(ref cause) => cause,
-            CreateDeploymentError::Conflict(ref cause) => cause,
-            CreateDeploymentError::NotFound(ref cause) => cause,
-            CreateDeploymentError::TooManyRequests(ref cause) => cause,
+            CreateDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeploymentError {}
 /// Errors returned by CreateDomainName
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainNameError {
@@ -3753,20 +3737,16 @@ impl CreateDomainNameError {
 }
 impl fmt::Display for CreateDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainNameError::AccessDenied(ref cause) => cause,
-            CreateDomainNameError::BadRequest(ref cause) => cause,
-            CreateDomainNameError::Conflict(ref cause) => cause,
-            CreateDomainNameError::NotFound(ref cause) => cause,
-            CreateDomainNameError::TooManyRequests(ref cause) => cause,
+            CreateDomainNameError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDomainNameError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDomainNameError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateDomainNameError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainNameError {}
 /// Errors returned by CreateIntegration
 #[derive(Debug, PartialEq)]
 pub enum CreateIntegrationError {
@@ -3805,19 +3785,15 @@ impl CreateIntegrationError {
 }
 impl fmt::Display for CreateIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIntegrationError::BadRequest(ref cause) => cause,
-            CreateIntegrationError::Conflict(ref cause) => cause,
-            CreateIntegrationError::NotFound(ref cause) => cause,
-            CreateIntegrationError::TooManyRequests(ref cause) => cause,
+            CreateIntegrationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateIntegrationError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIntegrationError {}
 /// Errors returned by CreateIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum CreateIntegrationResponseError {
@@ -3860,19 +3836,15 @@ impl CreateIntegrationResponseError {
 }
 impl fmt::Display for CreateIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIntegrationResponseError::BadRequest(ref cause) => cause,
-            CreateIntegrationResponseError::Conflict(ref cause) => cause,
-            CreateIntegrationResponseError::NotFound(ref cause) => cause,
-            CreateIntegrationResponseError::TooManyRequests(ref cause) => cause,
+            CreateIntegrationResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateIntegrationResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIntegrationResponseError {}
 /// Errors returned by CreateModel
 #[derive(Debug, PartialEq)]
 pub enum CreateModelError {
@@ -3911,19 +3883,15 @@ impl CreateModelError {
 }
 impl fmt::Display for CreateModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateModelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateModelError::BadRequest(ref cause) => cause,
-            CreateModelError::Conflict(ref cause) => cause,
-            CreateModelError::NotFound(ref cause) => cause,
-            CreateModelError::TooManyRequests(ref cause) => cause,
+            CreateModelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateModelError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateModelError {}
 /// Errors returned by CreateRoute
 #[derive(Debug, PartialEq)]
 pub enum CreateRouteError {
@@ -3962,19 +3930,15 @@ impl CreateRouteError {
 }
 impl fmt::Display for CreateRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRouteError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRouteError::BadRequest(ref cause) => cause,
-            CreateRouteError::Conflict(ref cause) => cause,
-            CreateRouteError::NotFound(ref cause) => cause,
-            CreateRouteError::TooManyRequests(ref cause) => cause,
+            CreateRouteError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRouteError {}
 /// Errors returned by CreateRouteResponse
 #[derive(Debug, PartialEq)]
 pub enum CreateRouteResponseError {
@@ -4013,19 +3977,15 @@ impl CreateRouteResponseError {
 }
 impl fmt::Display for CreateRouteResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRouteResponseError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRouteResponseError::BadRequest(ref cause) => cause,
-            CreateRouteResponseError::Conflict(ref cause) => cause,
-            CreateRouteResponseError::NotFound(ref cause) => cause,
-            CreateRouteResponseError::TooManyRequests(ref cause) => cause,
+            CreateRouteResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRouteResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateRouteResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRouteResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRouteResponseError {}
 /// Errors returned by CreateStage
 #[derive(Debug, PartialEq)]
 pub enum CreateStageError {
@@ -4064,19 +4024,15 @@ impl CreateStageError {
 }
 impl fmt::Display for CreateStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStageError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStageError::BadRequest(ref cause) => cause,
-            CreateStageError::Conflict(ref cause) => cause,
-            CreateStageError::NotFound(ref cause) => cause,
-            CreateStageError::TooManyRequests(ref cause) => cause,
+            CreateStageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateStageError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStageError {}
 /// Errors returned by DeleteApi
 #[derive(Debug, PartialEq)]
 pub enum DeleteApiError {
@@ -4105,17 +4061,13 @@ impl DeleteApiError {
 }
 impl fmt::Display for DeleteApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApiError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApiError::NotFound(ref cause) => cause,
-            DeleteApiError::TooManyRequests(ref cause) => cause,
+            DeleteApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApiError {}
 /// Errors returned by DeleteApiMapping
 #[derive(Debug, PartialEq)]
 pub enum DeleteApiMappingError {
@@ -4149,18 +4101,14 @@ impl DeleteApiMappingError {
 }
 impl fmt::Display for DeleteApiMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApiMappingError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApiMappingError::BadRequest(ref cause) => cause,
-            DeleteApiMappingError::NotFound(ref cause) => cause,
-            DeleteApiMappingError::TooManyRequests(ref cause) => cause,
+            DeleteApiMappingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteApiMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApiMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApiMappingError {}
 /// Errors returned by DeleteAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum DeleteAuthorizerError {
@@ -4189,17 +4137,13 @@ impl DeleteAuthorizerError {
 }
 impl fmt::Display for DeleteAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAuthorizerError::NotFound(ref cause) => cause,
-            DeleteAuthorizerError::TooManyRequests(ref cause) => cause,
+            DeleteAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAuthorizerError {}
 /// Errors returned by DeleteCorsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteCorsConfigurationError {
@@ -4230,17 +4174,13 @@ impl DeleteCorsConfigurationError {
 }
 impl fmt::Display for DeleteCorsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCorsConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCorsConfigurationError::NotFound(ref cause) => cause,
-            DeleteCorsConfigurationError::TooManyRequests(ref cause) => cause,
+            DeleteCorsConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCorsConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCorsConfigurationError {}
 /// Errors returned by DeleteDeployment
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeploymentError {
@@ -4269,17 +4209,13 @@ impl DeleteDeploymentError {
 }
 impl fmt::Display for DeleteDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeploymentError::NotFound(ref cause) => cause,
-            DeleteDeploymentError::TooManyRequests(ref cause) => cause,
+            DeleteDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeploymentError {}
 /// Errors returned by DeleteDomainName
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainNameError {
@@ -4308,17 +4244,13 @@ impl DeleteDomainNameError {
 }
 impl fmt::Display for DeleteDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainNameError::NotFound(ref cause) => cause,
-            DeleteDomainNameError::TooManyRequests(ref cause) => cause,
+            DeleteDomainNameError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainNameError {}
 /// Errors returned by DeleteIntegration
 #[derive(Debug, PartialEq)]
 pub enum DeleteIntegrationError {
@@ -4347,17 +4279,13 @@ impl DeleteIntegrationError {
 }
 impl fmt::Display for DeleteIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIntegrationError::NotFound(ref cause) => cause,
-            DeleteIntegrationError::TooManyRequests(ref cause) => cause,
+            DeleteIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIntegrationError {}
 /// Errors returned by DeleteIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum DeleteIntegrationResponseError {
@@ -4388,17 +4316,13 @@ impl DeleteIntegrationResponseError {
 }
 impl fmt::Display for DeleteIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIntegrationResponseError::NotFound(ref cause) => cause,
-            DeleteIntegrationResponseError::TooManyRequests(ref cause) => cause,
+            DeleteIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIntegrationResponseError {}
 /// Errors returned by DeleteModel
 #[derive(Debug, PartialEq)]
 pub enum DeleteModelError {
@@ -4427,17 +4351,13 @@ impl DeleteModelError {
 }
 impl fmt::Display for DeleteModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteModelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteModelError::NotFound(ref cause) => cause,
-            DeleteModelError::TooManyRequests(ref cause) => cause,
+            DeleteModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteModelError {}
 /// Errors returned by DeleteRoute
 #[derive(Debug, PartialEq)]
 pub enum DeleteRouteError {
@@ -4466,17 +4386,13 @@ impl DeleteRouteError {
 }
 impl fmt::Display for DeleteRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRouteError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRouteError::NotFound(ref cause) => cause,
-            DeleteRouteError::TooManyRequests(ref cause) => cause,
+            DeleteRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRouteError {}
 /// Errors returned by DeleteRouteResponse
 #[derive(Debug, PartialEq)]
 pub enum DeleteRouteResponseError {
@@ -4505,17 +4421,13 @@ impl DeleteRouteResponseError {
 }
 impl fmt::Display for DeleteRouteResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRouteResponseError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRouteResponseError::NotFound(ref cause) => cause,
-            DeleteRouteResponseError::TooManyRequests(ref cause) => cause,
+            DeleteRouteResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRouteResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRouteResponseError {}
 /// Errors returned by DeleteRouteSettings
 #[derive(Debug, PartialEq)]
 pub enum DeleteRouteSettingsError {
@@ -4544,17 +4456,13 @@ impl DeleteRouteSettingsError {
 }
 impl fmt::Display for DeleteRouteSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRouteSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRouteSettingsError::NotFound(ref cause) => cause,
-            DeleteRouteSettingsError::TooManyRequests(ref cause) => cause,
+            DeleteRouteSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRouteSettingsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRouteSettingsError {}
 /// Errors returned by DeleteStage
 #[derive(Debug, PartialEq)]
 pub enum DeleteStageError {
@@ -4583,17 +4491,13 @@ impl DeleteStageError {
 }
 impl fmt::Display for DeleteStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStageError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStageError::NotFound(ref cause) => cause,
-            DeleteStageError::TooManyRequests(ref cause) => cause,
+            DeleteStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStageError {}
 /// Errors returned by GetApi
 #[derive(Debug, PartialEq)]
 pub enum GetApiError {
@@ -4620,17 +4524,13 @@ impl GetApiError {
 }
 impl fmt::Display for GetApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApiError {
-    fn description(&self) -> &str {
         match *self {
-            GetApiError::NotFound(ref cause) => cause,
-            GetApiError::TooManyRequests(ref cause) => cause,
+            GetApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApiError {}
 /// Errors returned by GetApiMapping
 #[derive(Debug, PartialEq)]
 pub enum GetApiMappingError {
@@ -4664,18 +4564,14 @@ impl GetApiMappingError {
 }
 impl fmt::Display for GetApiMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApiMappingError {
-    fn description(&self) -> &str {
         match *self {
-            GetApiMappingError::BadRequest(ref cause) => cause,
-            GetApiMappingError::NotFound(ref cause) => cause,
-            GetApiMappingError::TooManyRequests(ref cause) => cause,
+            GetApiMappingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetApiMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApiMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApiMappingError {}
 /// Errors returned by GetApiMappings
 #[derive(Debug, PartialEq)]
 pub enum GetApiMappingsError {
@@ -4709,18 +4605,14 @@ impl GetApiMappingsError {
 }
 impl fmt::Display for GetApiMappingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApiMappingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetApiMappingsError::BadRequest(ref cause) => cause,
-            GetApiMappingsError::NotFound(ref cause) => cause,
-            GetApiMappingsError::TooManyRequests(ref cause) => cause,
+            GetApiMappingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetApiMappingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApiMappingsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApiMappingsError {}
 /// Errors returned by GetApis
 #[derive(Debug, PartialEq)]
 pub enum GetApisError {
@@ -4754,18 +4646,14 @@ impl GetApisError {
 }
 impl fmt::Display for GetApisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApisError {
-    fn description(&self) -> &str {
         match *self {
-            GetApisError::BadRequest(ref cause) => cause,
-            GetApisError::NotFound(ref cause) => cause,
-            GetApisError::TooManyRequests(ref cause) => cause,
+            GetApisError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetApisError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApisError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApisError {}
 /// Errors returned by GetAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum GetAuthorizerError {
@@ -4794,17 +4682,13 @@ impl GetAuthorizerError {
 }
 impl fmt::Display for GetAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            GetAuthorizerError::NotFound(ref cause) => cause,
-            GetAuthorizerError::TooManyRequests(ref cause) => cause,
+            GetAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAuthorizerError {}
 /// Errors returned by GetAuthorizers
 #[derive(Debug, PartialEq)]
 pub enum GetAuthorizersError {
@@ -4838,18 +4722,14 @@ impl GetAuthorizersError {
 }
 impl fmt::Display for GetAuthorizersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAuthorizersError {
-    fn description(&self) -> &str {
         match *self {
-            GetAuthorizersError::BadRequest(ref cause) => cause,
-            GetAuthorizersError::NotFound(ref cause) => cause,
-            GetAuthorizersError::TooManyRequests(ref cause) => cause,
+            GetAuthorizersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetAuthorizersError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAuthorizersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAuthorizersError {}
 /// Errors returned by GetDeployment
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentError {
@@ -4878,17 +4758,13 @@ impl GetDeploymentError {
 }
 impl fmt::Display for GetDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentError::NotFound(ref cause) => cause,
-            GetDeploymentError::TooManyRequests(ref cause) => cause,
+            GetDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentError {}
 /// Errors returned by GetDeployments
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentsError {
@@ -4922,18 +4798,14 @@ impl GetDeploymentsError {
 }
 impl fmt::Display for GetDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentsError::BadRequest(ref cause) => cause,
-            GetDeploymentsError::NotFound(ref cause) => cause,
-            GetDeploymentsError::TooManyRequests(ref cause) => cause,
+            GetDeploymentsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDeploymentsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDeploymentsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentsError {}
 /// Errors returned by GetDomainName
 #[derive(Debug, PartialEq)]
 pub enum GetDomainNameError {
@@ -4962,17 +4834,13 @@ impl GetDomainNameError {
 }
 impl fmt::Display for GetDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainNameError::NotFound(ref cause) => cause,
-            GetDomainNameError::TooManyRequests(ref cause) => cause,
+            GetDomainNameError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainNameError {}
 /// Errors returned by GetDomainNames
 #[derive(Debug, PartialEq)]
 pub enum GetDomainNamesError {
@@ -5006,18 +4874,14 @@ impl GetDomainNamesError {
 }
 impl fmt::Display for GetDomainNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainNamesError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainNamesError::BadRequest(ref cause) => cause,
-            GetDomainNamesError::NotFound(ref cause) => cause,
-            GetDomainNamesError::TooManyRequests(ref cause) => cause,
+            GetDomainNamesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDomainNamesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDomainNamesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainNamesError {}
 /// Errors returned by GetIntegration
 #[derive(Debug, PartialEq)]
 pub enum GetIntegrationError {
@@ -5046,17 +4910,13 @@ impl GetIntegrationError {
 }
 impl fmt::Display for GetIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntegrationError::NotFound(ref cause) => cause,
-            GetIntegrationError::TooManyRequests(ref cause) => cause,
+            GetIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntegrationError {}
 /// Errors returned by GetIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum GetIntegrationResponseError {
@@ -5087,17 +4947,13 @@ impl GetIntegrationResponseError {
 }
 impl fmt::Display for GetIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntegrationResponseError::NotFound(ref cause) => cause,
-            GetIntegrationResponseError::TooManyRequests(ref cause) => cause,
+            GetIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntegrationResponseError {}
 /// Errors returned by GetIntegrationResponses
 #[derive(Debug, PartialEq)]
 pub enum GetIntegrationResponsesError {
@@ -5133,18 +4989,14 @@ impl GetIntegrationResponsesError {
 }
 impl fmt::Display for GetIntegrationResponsesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntegrationResponsesError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntegrationResponsesError::BadRequest(ref cause) => cause,
-            GetIntegrationResponsesError::NotFound(ref cause) => cause,
-            GetIntegrationResponsesError::TooManyRequests(ref cause) => cause,
+            GetIntegrationResponsesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetIntegrationResponsesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetIntegrationResponsesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntegrationResponsesError {}
 /// Errors returned by GetIntegrations
 #[derive(Debug, PartialEq)]
 pub enum GetIntegrationsError {
@@ -5178,18 +5030,14 @@ impl GetIntegrationsError {
 }
 impl fmt::Display for GetIntegrationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntegrationsError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntegrationsError::BadRequest(ref cause) => cause,
-            GetIntegrationsError::NotFound(ref cause) => cause,
-            GetIntegrationsError::TooManyRequests(ref cause) => cause,
+            GetIntegrationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetIntegrationsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetIntegrationsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntegrationsError {}
 /// Errors returned by GetModel
 #[derive(Debug, PartialEq)]
 pub enum GetModelError {
@@ -5218,17 +5066,13 @@ impl GetModelError {
 }
 impl fmt::Display for GetModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetModelError {
-    fn description(&self) -> &str {
         match *self {
-            GetModelError::NotFound(ref cause) => cause,
-            GetModelError::TooManyRequests(ref cause) => cause,
+            GetModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetModelError {}
 /// Errors returned by GetModelTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetModelTemplateError {
@@ -5257,17 +5101,13 @@ impl GetModelTemplateError {
 }
 impl fmt::Display for GetModelTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetModelTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GetModelTemplateError::NotFound(ref cause) => cause,
-            GetModelTemplateError::TooManyRequests(ref cause) => cause,
+            GetModelTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetModelTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetModelTemplateError {}
 /// Errors returned by GetModels
 #[derive(Debug, PartialEq)]
 pub enum GetModelsError {
@@ -5301,18 +5141,14 @@ impl GetModelsError {
 }
 impl fmt::Display for GetModelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetModelsError {
-    fn description(&self) -> &str {
         match *self {
-            GetModelsError::BadRequest(ref cause) => cause,
-            GetModelsError::NotFound(ref cause) => cause,
-            GetModelsError::TooManyRequests(ref cause) => cause,
+            GetModelsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetModelsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetModelsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetModelsError {}
 /// Errors returned by GetRoute
 #[derive(Debug, PartialEq)]
 pub enum GetRouteError {
@@ -5341,17 +5177,13 @@ impl GetRouteError {
 }
 impl fmt::Display for GetRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRouteError {
-    fn description(&self) -> &str {
         match *self {
-            GetRouteError::NotFound(ref cause) => cause,
-            GetRouteError::TooManyRequests(ref cause) => cause,
+            GetRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRouteError {}
 /// Errors returned by GetRouteResponse
 #[derive(Debug, PartialEq)]
 pub enum GetRouteResponseError {
@@ -5380,17 +5212,13 @@ impl GetRouteResponseError {
 }
 impl fmt::Display for GetRouteResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRouteResponseError {
-    fn description(&self) -> &str {
         match *self {
-            GetRouteResponseError::NotFound(ref cause) => cause,
-            GetRouteResponseError::TooManyRequests(ref cause) => cause,
+            GetRouteResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRouteResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRouteResponseError {}
 /// Errors returned by GetRouteResponses
 #[derive(Debug, PartialEq)]
 pub enum GetRouteResponsesError {
@@ -5424,18 +5252,14 @@ impl GetRouteResponsesError {
 }
 impl fmt::Display for GetRouteResponsesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRouteResponsesError {
-    fn description(&self) -> &str {
         match *self {
-            GetRouteResponsesError::BadRequest(ref cause) => cause,
-            GetRouteResponsesError::NotFound(ref cause) => cause,
-            GetRouteResponsesError::TooManyRequests(ref cause) => cause,
+            GetRouteResponsesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetRouteResponsesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRouteResponsesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRouteResponsesError {}
 /// Errors returned by GetRoutes
 #[derive(Debug, PartialEq)]
 pub enum GetRoutesError {
@@ -5469,18 +5293,14 @@ impl GetRoutesError {
 }
 impl fmt::Display for GetRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRoutesError {
-    fn description(&self) -> &str {
         match *self {
-            GetRoutesError::BadRequest(ref cause) => cause,
-            GetRoutesError::NotFound(ref cause) => cause,
-            GetRoutesError::TooManyRequests(ref cause) => cause,
+            GetRoutesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetRoutesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRoutesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRoutesError {}
 /// Errors returned by GetStage
 #[derive(Debug, PartialEq)]
 pub enum GetStageError {
@@ -5509,17 +5329,13 @@ impl GetStageError {
 }
 impl fmt::Display for GetStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStageError {
-    fn description(&self) -> &str {
         match *self {
-            GetStageError::NotFound(ref cause) => cause,
-            GetStageError::TooManyRequests(ref cause) => cause,
+            GetStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStageError {}
 /// Errors returned by GetStages
 #[derive(Debug, PartialEq)]
 pub enum GetStagesError {
@@ -5553,18 +5369,14 @@ impl GetStagesError {
 }
 impl fmt::Display for GetStagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStagesError {
-    fn description(&self) -> &str {
         match *self {
-            GetStagesError::BadRequest(ref cause) => cause,
-            GetStagesError::NotFound(ref cause) => cause,
-            GetStagesError::TooManyRequests(ref cause) => cause,
+            GetStagesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetStagesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetStagesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStagesError {}
 /// Errors returned by GetTags
 #[derive(Debug, PartialEq)]
 pub enum GetTagsError {
@@ -5603,19 +5415,15 @@ impl GetTagsError {
 }
 impl fmt::Display for GetTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTagsError {
-    fn description(&self) -> &str {
         match *self {
-            GetTagsError::BadRequest(ref cause) => cause,
-            GetTagsError::Conflict(ref cause) => cause,
-            GetTagsError::NotFound(ref cause) => cause,
-            GetTagsError::TooManyRequests(ref cause) => cause,
+            GetTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetTagsError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetTagsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetTagsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTagsError {}
 /// Errors returned by ImportApi
 #[derive(Debug, PartialEq)]
 pub enum ImportApiError {
@@ -5654,19 +5462,15 @@ impl ImportApiError {
 }
 impl fmt::Display for ImportApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportApiError {
-    fn description(&self) -> &str {
         match *self {
-            ImportApiError::BadRequest(ref cause) => cause,
-            ImportApiError::Conflict(ref cause) => cause,
-            ImportApiError::NotFound(ref cause) => cause,
-            ImportApiError::TooManyRequests(ref cause) => cause,
+            ImportApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ImportApiError::Conflict(ref cause) => write!(f, "{}", cause),
+            ImportApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            ImportApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportApiError {}
 /// Errors returned by ReimportApi
 #[derive(Debug, PartialEq)]
 pub enum ReimportApiError {
@@ -5705,19 +5509,15 @@ impl ReimportApiError {
 }
 impl fmt::Display for ReimportApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReimportApiError {
-    fn description(&self) -> &str {
         match *self {
-            ReimportApiError::BadRequest(ref cause) => cause,
-            ReimportApiError::Conflict(ref cause) => cause,
-            ReimportApiError::NotFound(ref cause) => cause,
-            ReimportApiError::TooManyRequests(ref cause) => cause,
+            ReimportApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ReimportApiError::Conflict(ref cause) => write!(f, "{}", cause),
+            ReimportApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            ReimportApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReimportApiError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5756,19 +5556,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::Conflict(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -5807,19 +5603,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::Conflict(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateApi
 #[derive(Debug, PartialEq)]
 pub enum UpdateApiError {
@@ -5858,19 +5650,15 @@ impl UpdateApiError {
 }
 impl fmt::Display for UpdateApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApiError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApiError::BadRequest(ref cause) => cause,
-            UpdateApiError::Conflict(ref cause) => cause,
-            UpdateApiError::NotFound(ref cause) => cause,
-            UpdateApiError::TooManyRequests(ref cause) => cause,
+            UpdateApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateApiError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateApiError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApiError {}
 /// Errors returned by UpdateApiMapping
 #[derive(Debug, PartialEq)]
 pub enum UpdateApiMappingError {
@@ -5909,19 +5697,15 @@ impl UpdateApiMappingError {
 }
 impl fmt::Display for UpdateApiMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApiMappingError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApiMappingError::BadRequest(ref cause) => cause,
-            UpdateApiMappingError::Conflict(ref cause) => cause,
-            UpdateApiMappingError::NotFound(ref cause) => cause,
-            UpdateApiMappingError::TooManyRequests(ref cause) => cause,
+            UpdateApiMappingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateApiMappingError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateApiMappingError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateApiMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApiMappingError {}
 /// Errors returned by UpdateAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum UpdateAuthorizerError {
@@ -5960,19 +5744,15 @@ impl UpdateAuthorizerError {
 }
 impl fmt::Display for UpdateAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAuthorizerError::BadRequest(ref cause) => cause,
-            UpdateAuthorizerError::Conflict(ref cause) => cause,
-            UpdateAuthorizerError::NotFound(ref cause) => cause,
-            UpdateAuthorizerError::TooManyRequests(ref cause) => cause,
+            UpdateAuthorizerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAuthorizerError {}
 /// Errors returned by UpdateDeployment
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeploymentError {
@@ -6011,19 +5791,15 @@ impl UpdateDeploymentError {
 }
 impl fmt::Display for UpdateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeploymentError::BadRequest(ref cause) => cause,
-            UpdateDeploymentError::Conflict(ref cause) => cause,
-            UpdateDeploymentError::NotFound(ref cause) => cause,
-            UpdateDeploymentError::TooManyRequests(ref cause) => cause,
+            UpdateDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDeploymentError {}
 /// Errors returned by UpdateDomainName
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainNameError {
@@ -6062,19 +5838,15 @@ impl UpdateDomainNameError {
 }
 impl fmt::Display for UpdateDomainNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainNameError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainNameError::BadRequest(ref cause) => cause,
-            UpdateDomainNameError::Conflict(ref cause) => cause,
-            UpdateDomainNameError::NotFound(ref cause) => cause,
-            UpdateDomainNameError::TooManyRequests(ref cause) => cause,
+            UpdateDomainNameError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainNameError {}
 /// Errors returned by UpdateIntegration
 #[derive(Debug, PartialEq)]
 pub enum UpdateIntegrationError {
@@ -6113,19 +5885,15 @@ impl UpdateIntegrationError {
 }
 impl fmt::Display for UpdateIntegrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIntegrationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIntegrationError::BadRequest(ref cause) => cause,
-            UpdateIntegrationError::Conflict(ref cause) => cause,
-            UpdateIntegrationError::NotFound(ref cause) => cause,
-            UpdateIntegrationError::TooManyRequests(ref cause) => cause,
+            UpdateIntegrationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIntegrationError {}
 /// Errors returned by UpdateIntegrationResponse
 #[derive(Debug, PartialEq)]
 pub enum UpdateIntegrationResponseError {
@@ -6168,19 +5936,15 @@ impl UpdateIntegrationResponseError {
 }
 impl fmt::Display for UpdateIntegrationResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIntegrationResponseError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIntegrationResponseError::BadRequest(ref cause) => cause,
-            UpdateIntegrationResponseError::Conflict(ref cause) => cause,
-            UpdateIntegrationResponseError::NotFound(ref cause) => cause,
-            UpdateIntegrationResponseError::TooManyRequests(ref cause) => cause,
+            UpdateIntegrationResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateIntegrationResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIntegrationResponseError {}
 /// Errors returned by UpdateModel
 #[derive(Debug, PartialEq)]
 pub enum UpdateModelError {
@@ -6219,19 +5983,15 @@ impl UpdateModelError {
 }
 impl fmt::Display for UpdateModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateModelError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateModelError::BadRequest(ref cause) => cause,
-            UpdateModelError::Conflict(ref cause) => cause,
-            UpdateModelError::NotFound(ref cause) => cause,
-            UpdateModelError::TooManyRequests(ref cause) => cause,
+            UpdateModelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateModelError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateModelError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateModelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateModelError {}
 /// Errors returned by UpdateRoute
 #[derive(Debug, PartialEq)]
 pub enum UpdateRouteError {
@@ -6270,19 +6030,15 @@ impl UpdateRouteError {
 }
 impl fmt::Display for UpdateRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRouteError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRouteError::BadRequest(ref cause) => cause,
-            UpdateRouteError::Conflict(ref cause) => cause,
-            UpdateRouteError::NotFound(ref cause) => cause,
-            UpdateRouteError::TooManyRequests(ref cause) => cause,
+            UpdateRouteError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRouteError {}
 /// Errors returned by UpdateRouteResponse
 #[derive(Debug, PartialEq)]
 pub enum UpdateRouteResponseError {
@@ -6321,19 +6077,15 @@ impl UpdateRouteResponseError {
 }
 impl fmt::Display for UpdateRouteResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRouteResponseError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRouteResponseError::BadRequest(ref cause) => cause,
-            UpdateRouteResponseError::Conflict(ref cause) => cause,
-            UpdateRouteResponseError::NotFound(ref cause) => cause,
-            UpdateRouteResponseError::TooManyRequests(ref cause) => cause,
+            UpdateRouteResponseError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRouteResponseError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateRouteResponseError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRouteResponseError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRouteResponseError {}
 /// Errors returned by UpdateStage
 #[derive(Debug, PartialEq)]
 pub enum UpdateStageError {
@@ -6372,19 +6124,15 @@ impl UpdateStageError {
 }
 impl fmt::Display for UpdateStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStageError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStageError::BadRequest(ref cause) => cause,
-            UpdateStageError::Conflict(ref cause) => cause,
-            UpdateStageError::NotFound(ref cause) => cause,
-            UpdateStageError::TooManyRequests(ref cause) => cause,
+            UpdateStageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateStageError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateStageError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStageError {}
 /// Trait representing the capabilities of the AmazonApiGatewayV2 API. AmazonApiGatewayV2 clients implement this trait.
 pub trait ApiGatewayV2 {
     /// <p>Creates an Api resource.</p>

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -685,18 +685,14 @@ impl DeleteScalingPolicyError {
 }
 impl fmt::Display for DeleteScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScalingPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScalingPolicyError::ConcurrentUpdate(ref cause) => cause,
-            DeleteScalingPolicyError::InternalService(ref cause) => cause,
-            DeleteScalingPolicyError::ObjectNotFound(ref cause) => cause,
+            DeleteScalingPolicyError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DeleteScalingPolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteScalingPolicyError::ObjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScalingPolicyError {}
 /// Errors returned by DeleteScheduledAction
 #[derive(Debug, PartialEq)]
 pub enum DeleteScheduledActionError {
@@ -736,18 +732,14 @@ impl DeleteScheduledActionError {
 }
 impl fmt::Display for DeleteScheduledActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScheduledActionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScheduledActionError::ConcurrentUpdate(ref cause) => cause,
-            DeleteScheduledActionError::InternalService(ref cause) => cause,
-            DeleteScheduledActionError::ObjectNotFound(ref cause) => cause,
+            DeleteScheduledActionError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DeleteScheduledActionError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteScheduledActionError::ObjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScheduledActionError {}
 /// Errors returned by DeregisterScalableTarget
 #[derive(Debug, PartialEq)]
 pub enum DeregisterScalableTargetError {
@@ -787,18 +779,14 @@ impl DeregisterScalableTargetError {
 }
 impl fmt::Display for DeregisterScalableTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterScalableTargetError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterScalableTargetError::ConcurrentUpdate(ref cause) => cause,
-            DeregisterScalableTargetError::InternalService(ref cause) => cause,
-            DeregisterScalableTargetError::ObjectNotFound(ref cause) => cause,
+            DeregisterScalableTargetError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DeregisterScalableTargetError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeregisterScalableTargetError::ObjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterScalableTargetError {}
 /// Errors returned by DescribeScalableTargets
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalableTargetsError {
@@ -838,18 +826,14 @@ impl DescribeScalableTargetsError {
 }
 impl fmt::Display for DescribeScalableTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalableTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalableTargetsError::ConcurrentUpdate(ref cause) => cause,
-            DescribeScalableTargetsError::InternalService(ref cause) => cause,
-            DescribeScalableTargetsError::InvalidNextToken(ref cause) => cause,
+            DescribeScalableTargetsError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DescribeScalableTargetsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScalableTargetsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScalableTargetsError {}
 /// Errors returned by DescribeScalingActivities
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingActivitiesError {
@@ -889,18 +873,14 @@ impl DescribeScalingActivitiesError {
 }
 impl fmt::Display for DescribeScalingActivitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingActivitiesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingActivitiesError::ConcurrentUpdate(ref cause) => cause,
-            DescribeScalingActivitiesError::InternalService(ref cause) => cause,
-            DescribeScalingActivitiesError::InvalidNextToken(ref cause) => cause,
+            DescribeScalingActivitiesError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DescribeScalingActivitiesError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScalingActivitiesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScalingActivitiesError {}
 /// Errors returned by DescribeScalingPolicies
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingPoliciesError {
@@ -947,19 +927,15 @@ impl DescribeScalingPoliciesError {
 }
 impl fmt::Display for DescribeScalingPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingPoliciesError::ConcurrentUpdate(ref cause) => cause,
-            DescribeScalingPoliciesError::FailedResourceAccess(ref cause) => cause,
-            DescribeScalingPoliciesError::InternalService(ref cause) => cause,
-            DescribeScalingPoliciesError::InvalidNextToken(ref cause) => cause,
+            DescribeScalingPoliciesError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPoliciesError::FailedResourceAccess(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPoliciesError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPoliciesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScalingPoliciesError {}
 /// Errors returned by DescribeScheduledActions
 #[derive(Debug, PartialEq)]
 pub enum DescribeScheduledActionsError {
@@ -999,18 +975,14 @@ impl DescribeScheduledActionsError {
 }
 impl fmt::Display for DescribeScheduledActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScheduledActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScheduledActionsError::ConcurrentUpdate(ref cause) => cause,
-            DescribeScheduledActionsError::InternalService(ref cause) => cause,
-            DescribeScheduledActionsError::InvalidNextToken(ref cause) => cause,
+            DescribeScheduledActionsError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DescribeScheduledActionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScheduledActionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScheduledActionsError {}
 /// Errors returned by PutScalingPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutScalingPolicyError {
@@ -1056,20 +1028,16 @@ impl PutScalingPolicyError {
 }
 impl fmt::Display for PutScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutScalingPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutScalingPolicyError::ConcurrentUpdate(ref cause) => cause,
-            PutScalingPolicyError::FailedResourceAccess(ref cause) => cause,
-            PutScalingPolicyError::InternalService(ref cause) => cause,
-            PutScalingPolicyError::LimitExceeded(ref cause) => cause,
-            PutScalingPolicyError::ObjectNotFound(ref cause) => cause,
+            PutScalingPolicyError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::FailedResourceAccess(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::ObjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutScalingPolicyError {}
 /// Errors returned by PutScheduledAction
 #[derive(Debug, PartialEq)]
 pub enum PutScheduledActionError {
@@ -1108,19 +1076,15 @@ impl PutScheduledActionError {
 }
 impl fmt::Display for PutScheduledActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutScheduledActionError {
-    fn description(&self) -> &str {
         match *self {
-            PutScheduledActionError::ConcurrentUpdate(ref cause) => cause,
-            PutScheduledActionError::InternalService(ref cause) => cause,
-            PutScheduledActionError::LimitExceeded(ref cause) => cause,
-            PutScheduledActionError::ObjectNotFound(ref cause) => cause,
+            PutScheduledActionError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            PutScheduledActionError::InternalService(ref cause) => write!(f, "{}", cause),
+            PutScheduledActionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutScheduledActionError::ObjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutScheduledActionError {}
 /// Errors returned by RegisterScalableTarget
 #[derive(Debug, PartialEq)]
 pub enum RegisterScalableTargetError {
@@ -1160,18 +1124,14 @@ impl RegisterScalableTargetError {
 }
 impl fmt::Display for RegisterScalableTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterScalableTargetError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterScalableTargetError::ConcurrentUpdate(ref cause) => cause,
-            RegisterScalableTargetError::InternalService(ref cause) => cause,
-            RegisterScalableTargetError::LimitExceeded(ref cause) => cause,
+            RegisterScalableTargetError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            RegisterScalableTargetError::InternalService(ref cause) => write!(f, "{}", cause),
+            RegisterScalableTargetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterScalableTargetError {}
 /// Trait representing the capabilities of the Application Auto Scaling API. Application Auto Scaling clients implement this trait.
 pub trait ApplicationAutoScaling {
     /// <p>Deletes the specified scaling policy for an Application Auto Scaling scalable target.</p> <p>Deleting a step scaling policy deletes the underlying alarm action, but does not delete the CloudWatch alarm associated with the scaling policy, even if it no longer has an associated action.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-step-scaling-policies.html#delete-step-scaling-policy">Delete a Step Scaling Policy</a> and <a href="https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-target-tracking.html#delete-target-tracking-policy">Delete a Target Tracking Scaling Policy</a> in the <i>Application Auto Scaling User Guide</i>.</p> <p>To create a scaling policy or update an existing one, see <a>PutScalingPolicy</a>.</p>

--- a/rusoto/services/appmesh/src/generated.rs
+++ b/rusoto/services/appmesh/src/generated.rs
@@ -1708,23 +1708,19 @@ impl CreateMeshError {
 }
 impl fmt::Display for CreateMeshError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMeshError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMeshError::BadRequest(ref cause) => cause,
-            CreateMeshError::Conflict(ref cause) => cause,
-            CreateMeshError::Forbidden(ref cause) => cause,
-            CreateMeshError::InternalServerError(ref cause) => cause,
-            CreateMeshError::LimitExceeded(ref cause) => cause,
-            CreateMeshError::NotFound(ref cause) => cause,
-            CreateMeshError::ServiceUnavailable(ref cause) => cause,
-            CreateMeshError::TooManyRequests(ref cause) => cause,
+            CreateMeshError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateMeshError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateMeshError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateMeshError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateMeshError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateMeshError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateMeshError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateMeshError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMeshError {}
 /// Errors returned by CreateRoute
 #[derive(Debug, PartialEq)]
 pub enum CreateRouteError {
@@ -1788,23 +1784,19 @@ impl CreateRouteError {
 }
 impl fmt::Display for CreateRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRouteError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRouteError::BadRequest(ref cause) => cause,
-            CreateRouteError::Conflict(ref cause) => cause,
-            CreateRouteError::Forbidden(ref cause) => cause,
-            CreateRouteError::InternalServerError(ref cause) => cause,
-            CreateRouteError::LimitExceeded(ref cause) => cause,
-            CreateRouteError::NotFound(ref cause) => cause,
-            CreateRouteError::ServiceUnavailable(ref cause) => cause,
-            CreateRouteError::TooManyRequests(ref cause) => cause,
+            CreateRouteError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRouteError {}
 /// Errors returned by CreateVirtualNode
 #[derive(Debug, PartialEq)]
 pub enum CreateVirtualNodeError {
@@ -1872,23 +1864,19 @@ impl CreateVirtualNodeError {
 }
 impl fmt::Display for CreateVirtualNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVirtualNodeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVirtualNodeError::BadRequest(ref cause) => cause,
-            CreateVirtualNodeError::Conflict(ref cause) => cause,
-            CreateVirtualNodeError::Forbidden(ref cause) => cause,
-            CreateVirtualNodeError::InternalServerError(ref cause) => cause,
-            CreateVirtualNodeError::LimitExceeded(ref cause) => cause,
-            CreateVirtualNodeError::NotFound(ref cause) => cause,
-            CreateVirtualNodeError::ServiceUnavailable(ref cause) => cause,
-            CreateVirtualNodeError::TooManyRequests(ref cause) => cause,
+            CreateVirtualNodeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateVirtualNodeError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateVirtualNodeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateVirtualNodeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateVirtualNodeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateVirtualNodeError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateVirtualNodeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateVirtualNodeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVirtualNodeError {}
 /// Errors returned by CreateVirtualRouter
 #[derive(Debug, PartialEq)]
 pub enum CreateVirtualRouterError {
@@ -1956,23 +1944,19 @@ impl CreateVirtualRouterError {
 }
 impl fmt::Display for CreateVirtualRouterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVirtualRouterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVirtualRouterError::BadRequest(ref cause) => cause,
-            CreateVirtualRouterError::Conflict(ref cause) => cause,
-            CreateVirtualRouterError::Forbidden(ref cause) => cause,
-            CreateVirtualRouterError::InternalServerError(ref cause) => cause,
-            CreateVirtualRouterError::LimitExceeded(ref cause) => cause,
-            CreateVirtualRouterError::NotFound(ref cause) => cause,
-            CreateVirtualRouterError::ServiceUnavailable(ref cause) => cause,
-            CreateVirtualRouterError::TooManyRequests(ref cause) => cause,
+            CreateVirtualRouterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateVirtualRouterError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateVirtualRouterError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateVirtualRouterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateVirtualRouterError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateVirtualRouterError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateVirtualRouterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateVirtualRouterError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVirtualRouterError {}
 /// Errors returned by CreateVirtualService
 #[derive(Debug, PartialEq)]
 pub enum CreateVirtualServiceError {
@@ -2042,23 +2026,19 @@ impl CreateVirtualServiceError {
 }
 impl fmt::Display for CreateVirtualServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVirtualServiceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVirtualServiceError::BadRequest(ref cause) => cause,
-            CreateVirtualServiceError::Conflict(ref cause) => cause,
-            CreateVirtualServiceError::Forbidden(ref cause) => cause,
-            CreateVirtualServiceError::InternalServerError(ref cause) => cause,
-            CreateVirtualServiceError::LimitExceeded(ref cause) => cause,
-            CreateVirtualServiceError::NotFound(ref cause) => cause,
-            CreateVirtualServiceError::ServiceUnavailable(ref cause) => cause,
-            CreateVirtualServiceError::TooManyRequests(ref cause) => cause,
+            CreateVirtualServiceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateVirtualServiceError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateVirtualServiceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateVirtualServiceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateVirtualServiceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateVirtualServiceError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateVirtualServiceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateVirtualServiceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVirtualServiceError {}
 /// Errors returned by DeleteMesh
 #[derive(Debug, PartialEq)]
 pub enum DeleteMeshError {
@@ -2116,22 +2096,18 @@ impl DeleteMeshError {
 }
 impl fmt::Display for DeleteMeshError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMeshError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMeshError::BadRequest(ref cause) => cause,
-            DeleteMeshError::Forbidden(ref cause) => cause,
-            DeleteMeshError::InternalServerError(ref cause) => cause,
-            DeleteMeshError::NotFound(ref cause) => cause,
-            DeleteMeshError::ResourceInUse(ref cause) => cause,
-            DeleteMeshError::ServiceUnavailable(ref cause) => cause,
-            DeleteMeshError::TooManyRequests(ref cause) => cause,
+            DeleteMeshError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMeshError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteMeshError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteMeshError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMeshError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteMeshError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteMeshError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMeshError {}
 /// Errors returned by DeleteRoute
 #[derive(Debug, PartialEq)]
 pub enum DeleteRouteError {
@@ -2189,22 +2165,18 @@ impl DeleteRouteError {
 }
 impl fmt::Display for DeleteRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRouteError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRouteError::BadRequest(ref cause) => cause,
-            DeleteRouteError::Forbidden(ref cause) => cause,
-            DeleteRouteError::InternalServerError(ref cause) => cause,
-            DeleteRouteError::NotFound(ref cause) => cause,
-            DeleteRouteError::ResourceInUse(ref cause) => cause,
-            DeleteRouteError::ServiceUnavailable(ref cause) => cause,
-            DeleteRouteError::TooManyRequests(ref cause) => cause,
+            DeleteRouteError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteRouteError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteRouteError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRouteError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteRouteError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRouteError {}
 /// Errors returned by DeleteVirtualNode
 #[derive(Debug, PartialEq)]
 pub enum DeleteVirtualNodeError {
@@ -2266,22 +2238,18 @@ impl DeleteVirtualNodeError {
 }
 impl fmt::Display for DeleteVirtualNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVirtualNodeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVirtualNodeError::BadRequest(ref cause) => cause,
-            DeleteVirtualNodeError::Forbidden(ref cause) => cause,
-            DeleteVirtualNodeError::InternalServerError(ref cause) => cause,
-            DeleteVirtualNodeError::NotFound(ref cause) => cause,
-            DeleteVirtualNodeError::ResourceInUse(ref cause) => cause,
-            DeleteVirtualNodeError::ServiceUnavailable(ref cause) => cause,
-            DeleteVirtualNodeError::TooManyRequests(ref cause) => cause,
+            DeleteVirtualNodeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualNodeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualNodeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualNodeError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualNodeError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualNodeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualNodeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVirtualNodeError {}
 /// Errors returned by DeleteVirtualRouter
 #[derive(Debug, PartialEq)]
 pub enum DeleteVirtualRouterError {
@@ -2343,22 +2311,18 @@ impl DeleteVirtualRouterError {
 }
 impl fmt::Display for DeleteVirtualRouterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVirtualRouterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVirtualRouterError::BadRequest(ref cause) => cause,
-            DeleteVirtualRouterError::Forbidden(ref cause) => cause,
-            DeleteVirtualRouterError::InternalServerError(ref cause) => cause,
-            DeleteVirtualRouterError::NotFound(ref cause) => cause,
-            DeleteVirtualRouterError::ResourceInUse(ref cause) => cause,
-            DeleteVirtualRouterError::ServiceUnavailable(ref cause) => cause,
-            DeleteVirtualRouterError::TooManyRequests(ref cause) => cause,
+            DeleteVirtualRouterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualRouterError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualRouterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualRouterError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualRouterError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualRouterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualRouterError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVirtualRouterError {}
 /// Errors returned by DeleteVirtualService
 #[derive(Debug, PartialEq)]
 pub enum DeleteVirtualServiceError {
@@ -2416,21 +2380,17 @@ impl DeleteVirtualServiceError {
 }
 impl fmt::Display for DeleteVirtualServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVirtualServiceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVirtualServiceError::BadRequest(ref cause) => cause,
-            DeleteVirtualServiceError::Forbidden(ref cause) => cause,
-            DeleteVirtualServiceError::InternalServerError(ref cause) => cause,
-            DeleteVirtualServiceError::NotFound(ref cause) => cause,
-            DeleteVirtualServiceError::ServiceUnavailable(ref cause) => cause,
-            DeleteVirtualServiceError::TooManyRequests(ref cause) => cause,
+            DeleteVirtualServiceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualServiceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualServiceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualServiceError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualServiceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualServiceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVirtualServiceError {}
 /// Errors returned by DescribeMesh
 #[derive(Debug, PartialEq)]
 pub enum DescribeMeshError {
@@ -2482,21 +2442,17 @@ impl DescribeMeshError {
 }
 impl fmt::Display for DescribeMeshError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMeshError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMeshError::BadRequest(ref cause) => cause,
-            DescribeMeshError::Forbidden(ref cause) => cause,
-            DescribeMeshError::InternalServerError(ref cause) => cause,
-            DescribeMeshError::NotFound(ref cause) => cause,
-            DescribeMeshError::ServiceUnavailable(ref cause) => cause,
-            DescribeMeshError::TooManyRequests(ref cause) => cause,
+            DescribeMeshError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMeshError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeMeshError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeMeshError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMeshError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeMeshError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMeshError {}
 /// Errors returned by DescribeRoute
 #[derive(Debug, PartialEq)]
 pub enum DescribeRouteError {
@@ -2548,21 +2504,17 @@ impl DescribeRouteError {
 }
 impl fmt::Display for DescribeRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRouteError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRouteError::BadRequest(ref cause) => cause,
-            DescribeRouteError::Forbidden(ref cause) => cause,
-            DescribeRouteError::InternalServerError(ref cause) => cause,
-            DescribeRouteError::NotFound(ref cause) => cause,
-            DescribeRouteError::ServiceUnavailable(ref cause) => cause,
-            DescribeRouteError::TooManyRequests(ref cause) => cause,
+            DescribeRouteError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeRouteError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeRouteError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeRouteError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRouteError {}
 /// Errors returned by DescribeVirtualNode
 #[derive(Debug, PartialEq)]
 pub enum DescribeVirtualNodeError {
@@ -2618,21 +2570,17 @@ impl DescribeVirtualNodeError {
 }
 impl fmt::Display for DescribeVirtualNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVirtualNodeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVirtualNodeError::BadRequest(ref cause) => cause,
-            DescribeVirtualNodeError::Forbidden(ref cause) => cause,
-            DescribeVirtualNodeError::InternalServerError(ref cause) => cause,
-            DescribeVirtualNodeError::NotFound(ref cause) => cause,
-            DescribeVirtualNodeError::ServiceUnavailable(ref cause) => cause,
-            DescribeVirtualNodeError::TooManyRequests(ref cause) => cause,
+            DescribeVirtualNodeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualNodeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualNodeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualNodeError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualNodeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualNodeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVirtualNodeError {}
 /// Errors returned by DescribeVirtualRouter
 #[derive(Debug, PartialEq)]
 pub enum DescribeVirtualRouterError {
@@ -2690,21 +2638,17 @@ impl DescribeVirtualRouterError {
 }
 impl fmt::Display for DescribeVirtualRouterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVirtualRouterError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVirtualRouterError::BadRequest(ref cause) => cause,
-            DescribeVirtualRouterError::Forbidden(ref cause) => cause,
-            DescribeVirtualRouterError::InternalServerError(ref cause) => cause,
-            DescribeVirtualRouterError::NotFound(ref cause) => cause,
-            DescribeVirtualRouterError::ServiceUnavailable(ref cause) => cause,
-            DescribeVirtualRouterError::TooManyRequests(ref cause) => cause,
+            DescribeVirtualRouterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualRouterError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualRouterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualRouterError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualRouterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualRouterError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVirtualRouterError {}
 /// Errors returned by DescribeVirtualService
 #[derive(Debug, PartialEq)]
 pub enum DescribeVirtualServiceError {
@@ -2762,21 +2706,17 @@ impl DescribeVirtualServiceError {
 }
 impl fmt::Display for DescribeVirtualServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVirtualServiceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVirtualServiceError::BadRequest(ref cause) => cause,
-            DescribeVirtualServiceError::Forbidden(ref cause) => cause,
-            DescribeVirtualServiceError::InternalServerError(ref cause) => cause,
-            DescribeVirtualServiceError::NotFound(ref cause) => cause,
-            DescribeVirtualServiceError::ServiceUnavailable(ref cause) => cause,
-            DescribeVirtualServiceError::TooManyRequests(ref cause) => cause,
+            DescribeVirtualServiceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualServiceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualServiceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualServiceError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualServiceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualServiceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVirtualServiceError {}
 /// Errors returned by ListMeshes
 #[derive(Debug, PartialEq)]
 pub enum ListMeshesError {
@@ -2828,21 +2768,17 @@ impl ListMeshesError {
 }
 impl fmt::Display for ListMeshesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMeshesError {
-    fn description(&self) -> &str {
         match *self {
-            ListMeshesError::BadRequest(ref cause) => cause,
-            ListMeshesError::Forbidden(ref cause) => cause,
-            ListMeshesError::InternalServerError(ref cause) => cause,
-            ListMeshesError::NotFound(ref cause) => cause,
-            ListMeshesError::ServiceUnavailable(ref cause) => cause,
-            ListMeshesError::TooManyRequests(ref cause) => cause,
+            ListMeshesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListMeshesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListMeshesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListMeshesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListMeshesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListMeshesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMeshesError {}
 /// Errors returned by ListRoutes
 #[derive(Debug, PartialEq)]
 pub enum ListRoutesError {
@@ -2894,21 +2830,17 @@ impl ListRoutesError {
 }
 impl fmt::Display for ListRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRoutesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRoutesError::BadRequest(ref cause) => cause,
-            ListRoutesError::Forbidden(ref cause) => cause,
-            ListRoutesError::InternalServerError(ref cause) => cause,
-            ListRoutesError::NotFound(ref cause) => cause,
-            ListRoutesError::ServiceUnavailable(ref cause) => cause,
-            ListRoutesError::TooManyRequests(ref cause) => cause,
+            ListRoutesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListRoutesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListRoutesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListRoutesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListRoutesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListRoutesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRoutesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2964,21 +2896,17 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::Forbidden(ref cause) => cause,
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
-            ListTagsForResourceError::NotFound(ref cause) => cause,
-            ListTagsForResourceError::ServiceUnavailable(ref cause) => cause,
-            ListTagsForResourceError::TooManyRequests(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListVirtualNodes
 #[derive(Debug, PartialEq)]
 pub enum ListVirtualNodesError {
@@ -3032,21 +2960,17 @@ impl ListVirtualNodesError {
 }
 impl fmt::Display for ListVirtualNodesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVirtualNodesError {
-    fn description(&self) -> &str {
         match *self {
-            ListVirtualNodesError::BadRequest(ref cause) => cause,
-            ListVirtualNodesError::Forbidden(ref cause) => cause,
-            ListVirtualNodesError::InternalServerError(ref cause) => cause,
-            ListVirtualNodesError::NotFound(ref cause) => cause,
-            ListVirtualNodesError::ServiceUnavailable(ref cause) => cause,
-            ListVirtualNodesError::TooManyRequests(ref cause) => cause,
+            ListVirtualNodesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListVirtualNodesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListVirtualNodesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListVirtualNodesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListVirtualNodesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListVirtualNodesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVirtualNodesError {}
 /// Errors returned by ListVirtualRouters
 #[derive(Debug, PartialEq)]
 pub enum ListVirtualRoutersError {
@@ -3102,21 +3026,17 @@ impl ListVirtualRoutersError {
 }
 impl fmt::Display for ListVirtualRoutersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVirtualRoutersError {
-    fn description(&self) -> &str {
         match *self {
-            ListVirtualRoutersError::BadRequest(ref cause) => cause,
-            ListVirtualRoutersError::Forbidden(ref cause) => cause,
-            ListVirtualRoutersError::InternalServerError(ref cause) => cause,
-            ListVirtualRoutersError::NotFound(ref cause) => cause,
-            ListVirtualRoutersError::ServiceUnavailable(ref cause) => cause,
-            ListVirtualRoutersError::TooManyRequests(ref cause) => cause,
+            ListVirtualRoutersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListVirtualRoutersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListVirtualRoutersError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListVirtualRoutersError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListVirtualRoutersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListVirtualRoutersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVirtualRoutersError {}
 /// Errors returned by ListVirtualServices
 #[derive(Debug, PartialEq)]
 pub enum ListVirtualServicesError {
@@ -3172,21 +3092,17 @@ impl ListVirtualServicesError {
 }
 impl fmt::Display for ListVirtualServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVirtualServicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListVirtualServicesError::BadRequest(ref cause) => cause,
-            ListVirtualServicesError::Forbidden(ref cause) => cause,
-            ListVirtualServicesError::InternalServerError(ref cause) => cause,
-            ListVirtualServicesError::NotFound(ref cause) => cause,
-            ListVirtualServicesError::ServiceUnavailable(ref cause) => cause,
-            ListVirtualServicesError::TooManyRequests(ref cause) => cause,
+            ListVirtualServicesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListVirtualServicesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListVirtualServicesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListVirtualServicesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListVirtualServicesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListVirtualServicesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVirtualServicesError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3245,22 +3161,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::Forbidden(ref cause) => cause,
-            TagResourceError::InternalServerError(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::ServiceUnavailable(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3312,21 +3224,17 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::Forbidden(ref cause) => cause,
-            UntagResourceError::InternalServerError(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::ServiceUnavailable(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateMesh
 #[derive(Debug, PartialEq)]
 pub enum UpdateMeshError {
@@ -3384,22 +3292,18 @@ impl UpdateMeshError {
 }
 impl fmt::Display for UpdateMeshError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMeshError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMeshError::BadRequest(ref cause) => cause,
-            UpdateMeshError::Conflict(ref cause) => cause,
-            UpdateMeshError::Forbidden(ref cause) => cause,
-            UpdateMeshError::InternalServerError(ref cause) => cause,
-            UpdateMeshError::NotFound(ref cause) => cause,
-            UpdateMeshError::ServiceUnavailable(ref cause) => cause,
-            UpdateMeshError::TooManyRequests(ref cause) => cause,
+            UpdateMeshError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateMeshError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateMeshError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateMeshError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateMeshError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMeshError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateMeshError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMeshError {}
 /// Errors returned by UpdateRoute
 #[derive(Debug, PartialEq)]
 pub enum UpdateRouteError {
@@ -3463,23 +3367,19 @@ impl UpdateRouteError {
 }
 impl fmt::Display for UpdateRouteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRouteError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRouteError::BadRequest(ref cause) => cause,
-            UpdateRouteError::Conflict(ref cause) => cause,
-            UpdateRouteError::Forbidden(ref cause) => cause,
-            UpdateRouteError::InternalServerError(ref cause) => cause,
-            UpdateRouteError::LimitExceeded(ref cause) => cause,
-            UpdateRouteError::NotFound(ref cause) => cause,
-            UpdateRouteError::ServiceUnavailable(ref cause) => cause,
-            UpdateRouteError::TooManyRequests(ref cause) => cause,
+            UpdateRouteError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateRouteError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRouteError {}
 /// Errors returned by UpdateVirtualNode
 #[derive(Debug, PartialEq)]
 pub enum UpdateVirtualNodeError {
@@ -3547,23 +3447,19 @@ impl UpdateVirtualNodeError {
 }
 impl fmt::Display for UpdateVirtualNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVirtualNodeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVirtualNodeError::BadRequest(ref cause) => cause,
-            UpdateVirtualNodeError::Conflict(ref cause) => cause,
-            UpdateVirtualNodeError::Forbidden(ref cause) => cause,
-            UpdateVirtualNodeError::InternalServerError(ref cause) => cause,
-            UpdateVirtualNodeError::LimitExceeded(ref cause) => cause,
-            UpdateVirtualNodeError::NotFound(ref cause) => cause,
-            UpdateVirtualNodeError::ServiceUnavailable(ref cause) => cause,
-            UpdateVirtualNodeError::TooManyRequests(ref cause) => cause,
+            UpdateVirtualNodeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualNodeError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualNodeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualNodeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualNodeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualNodeError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualNodeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualNodeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVirtualNodeError {}
 /// Errors returned by UpdateVirtualRouter
 #[derive(Debug, PartialEq)]
 pub enum UpdateVirtualRouterError {
@@ -3631,23 +3527,19 @@ impl UpdateVirtualRouterError {
 }
 impl fmt::Display for UpdateVirtualRouterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVirtualRouterError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVirtualRouterError::BadRequest(ref cause) => cause,
-            UpdateVirtualRouterError::Conflict(ref cause) => cause,
-            UpdateVirtualRouterError::Forbidden(ref cause) => cause,
-            UpdateVirtualRouterError::InternalServerError(ref cause) => cause,
-            UpdateVirtualRouterError::LimitExceeded(ref cause) => cause,
-            UpdateVirtualRouterError::NotFound(ref cause) => cause,
-            UpdateVirtualRouterError::ServiceUnavailable(ref cause) => cause,
-            UpdateVirtualRouterError::TooManyRequests(ref cause) => cause,
+            UpdateVirtualRouterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualRouterError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualRouterError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualRouterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualRouterError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualRouterError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualRouterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualRouterError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVirtualRouterError {}
 /// Errors returned by UpdateVirtualService
 #[derive(Debug, PartialEq)]
 pub enum UpdateVirtualServiceError {
@@ -3717,23 +3609,19 @@ impl UpdateVirtualServiceError {
 }
 impl fmt::Display for UpdateVirtualServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVirtualServiceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVirtualServiceError::BadRequest(ref cause) => cause,
-            UpdateVirtualServiceError::Conflict(ref cause) => cause,
-            UpdateVirtualServiceError::Forbidden(ref cause) => cause,
-            UpdateVirtualServiceError::InternalServerError(ref cause) => cause,
-            UpdateVirtualServiceError::LimitExceeded(ref cause) => cause,
-            UpdateVirtualServiceError::NotFound(ref cause) => cause,
-            UpdateVirtualServiceError::ServiceUnavailable(ref cause) => cause,
-            UpdateVirtualServiceError::TooManyRequests(ref cause) => cause,
+            UpdateVirtualServiceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualServiceError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualServiceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualServiceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualServiceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualServiceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualServiceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateVirtualServiceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVirtualServiceError {}
 /// Trait representing the capabilities of the AWS App Mesh API. AWS App Mesh clients implement this trait.
 pub trait AppMesh {
     /// <p>Creates a service mesh. A service mesh is a logical boundary for network traffic between

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -1981,21 +1981,17 @@ impl AssociateFleetError {
 }
 impl fmt::Display for AssociateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateFleetError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateFleetError::ConcurrentModification(ref cause) => cause,
-            AssociateFleetError::IncompatibleImage(ref cause) => cause,
-            AssociateFleetError::InvalidAccountStatus(ref cause) => cause,
-            AssociateFleetError::LimitExceeded(ref cause) => cause,
-            AssociateFleetError::OperationNotPermitted(ref cause) => cause,
-            AssociateFleetError::ResourceNotFound(ref cause) => cause,
+            AssociateFleetError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            AssociateFleetError::IncompatibleImage(ref cause) => write!(f, "{}", cause),
+            AssociateFleetError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            AssociateFleetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateFleetError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            AssociateFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateFleetError {}
 /// Errors returned by BatchAssociateUserStack
 #[derive(Debug, PartialEq)]
 pub enum BatchAssociateUserStackError {
@@ -2021,16 +2017,14 @@ impl BatchAssociateUserStackError {
 }
 impl fmt::Display for BatchAssociateUserStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchAssociateUserStackError {
-    fn description(&self) -> &str {
         match *self {
-            BatchAssociateUserStackError::OperationNotPermitted(ref cause) => cause,
+            BatchAssociateUserStackError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchAssociateUserStackError {}
 /// Errors returned by BatchDisassociateUserStack
 #[derive(Debug, PartialEq)]
 pub enum BatchDisassociateUserStackError {}
@@ -2050,14 +2044,10 @@ impl BatchDisassociateUserStackError {
 }
 impl fmt::Display for BatchDisassociateUserStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDisassociateUserStackError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for BatchDisassociateUserStackError {}
 /// Errors returned by CopyImage
 #[derive(Debug, PartialEq)]
 pub enum CopyImageError {
@@ -2106,21 +2096,17 @@ impl CopyImageError {
 }
 impl fmt::Display for CopyImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyImageError {
-    fn description(&self) -> &str {
         match *self {
-            CopyImageError::IncompatibleImage(ref cause) => cause,
-            CopyImageError::InvalidAccountStatus(ref cause) => cause,
-            CopyImageError::LimitExceeded(ref cause) => cause,
-            CopyImageError::ResourceAlreadyExists(ref cause) => cause,
-            CopyImageError::ResourceNotAvailable(ref cause) => cause,
-            CopyImageError::ResourceNotFound(ref cause) => cause,
+            CopyImageError::IncompatibleImage(ref cause) => write!(f, "{}", cause),
+            CopyImageError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            CopyImageError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CopyImageError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CopyImageError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            CopyImageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopyImageError {}
 /// Errors returned by CreateDirectoryConfig
 #[derive(Debug, PartialEq)]
 pub enum CreateDirectoryConfigError {
@@ -2158,18 +2144,14 @@ impl CreateDirectoryConfigError {
 }
 impl fmt::Display for CreateDirectoryConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDirectoryConfigError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDirectoryConfigError::InvalidAccountStatus(ref cause) => cause,
-            CreateDirectoryConfigError::LimitExceeded(ref cause) => cause,
-            CreateDirectoryConfigError::ResourceAlreadyExists(ref cause) => cause,
+            CreateDirectoryConfigError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryConfigError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryConfigError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDirectoryConfigError {}
 /// Errors returned by CreateFleet
 #[derive(Debug, PartialEq)]
 pub enum CreateFleetError {
@@ -2240,25 +2222,21 @@ impl CreateFleetError {
 }
 impl fmt::Display for CreateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFleetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFleetError::ConcurrentModification(ref cause) => cause,
-            CreateFleetError::IncompatibleImage(ref cause) => cause,
-            CreateFleetError::InvalidAccountStatus(ref cause) => cause,
-            CreateFleetError::InvalidParameterCombination(ref cause) => cause,
-            CreateFleetError::InvalidRole(ref cause) => cause,
-            CreateFleetError::LimitExceeded(ref cause) => cause,
-            CreateFleetError::OperationNotPermitted(ref cause) => cause,
-            CreateFleetError::ResourceAlreadyExists(ref cause) => cause,
-            CreateFleetError::ResourceNotAvailable(ref cause) => cause,
-            CreateFleetError::ResourceNotFound(ref cause) => cause,
+            CreateFleetError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::IncompatibleImage(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFleetError {}
 /// Errors returned by CreateImageBuilder
 #[derive(Debug, PartialEq)]
 pub enum CreateImageBuilderError {
@@ -2341,25 +2319,23 @@ impl CreateImageBuilderError {
 }
 impl fmt::Display for CreateImageBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateImageBuilderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateImageBuilderError::ConcurrentModification(ref cause) => cause,
-            CreateImageBuilderError::IncompatibleImage(ref cause) => cause,
-            CreateImageBuilderError::InvalidAccountStatus(ref cause) => cause,
-            CreateImageBuilderError::InvalidParameterCombination(ref cause) => cause,
-            CreateImageBuilderError::InvalidRole(ref cause) => cause,
-            CreateImageBuilderError::LimitExceeded(ref cause) => cause,
-            CreateImageBuilderError::OperationNotPermitted(ref cause) => cause,
-            CreateImageBuilderError::ResourceAlreadyExists(ref cause) => cause,
-            CreateImageBuilderError::ResourceNotAvailable(ref cause) => cause,
-            CreateImageBuilderError::ResourceNotFound(ref cause) => cause,
+            CreateImageBuilderError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::IncompatibleImage(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateImageBuilderError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            CreateImageBuilderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateImageBuilderError {}
 /// Errors returned by CreateImageBuilderStreamingURL
 #[derive(Debug, PartialEq)]
 pub enum CreateImageBuilderStreamingURLError {
@@ -2394,17 +2370,17 @@ impl CreateImageBuilderStreamingURLError {
 }
 impl fmt::Display for CreateImageBuilderStreamingURLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateImageBuilderStreamingURLError {
-    fn description(&self) -> &str {
         match *self {
-            CreateImageBuilderStreamingURLError::OperationNotPermitted(ref cause) => cause,
-            CreateImageBuilderStreamingURLError::ResourceNotFound(ref cause) => cause,
+            CreateImageBuilderStreamingURLError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateImageBuilderStreamingURLError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateImageBuilderStreamingURLError {}
 /// Errors returned by CreateStack
 #[derive(Debug, PartialEq)]
 pub enum CreateStackError {
@@ -2460,22 +2436,18 @@ impl CreateStackError {
 }
 impl fmt::Display for CreateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStackError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStackError::ConcurrentModification(ref cause) => cause,
-            CreateStackError::InvalidAccountStatus(ref cause) => cause,
-            CreateStackError::InvalidParameterCombination(ref cause) => cause,
-            CreateStackError::InvalidRole(ref cause) => cause,
-            CreateStackError::LimitExceeded(ref cause) => cause,
-            CreateStackError::ResourceAlreadyExists(ref cause) => cause,
-            CreateStackError::ResourceNotFound(ref cause) => cause,
+            CreateStackError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateStackError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            CreateStackError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            CreateStackError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            CreateStackError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStackError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStackError {}
 /// Errors returned by CreateStreamingURL
 #[derive(Debug, PartialEq)]
 pub enum CreateStreamingURLError {
@@ -2520,19 +2492,17 @@ impl CreateStreamingURLError {
 }
 impl fmt::Display for CreateStreamingURLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStreamingURLError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStreamingURLError::InvalidParameterCombination(ref cause) => cause,
-            CreateStreamingURLError::OperationNotPermitted(ref cause) => cause,
-            CreateStreamingURLError::ResourceNotAvailable(ref cause) => cause,
-            CreateStreamingURLError::ResourceNotFound(ref cause) => cause,
+            CreateStreamingURLError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingURLError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateStreamingURLError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            CreateStreamingURLError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStreamingURLError {}
 /// Errors returned by CreateUsageReportSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateUsageReportSubscriptionError {
@@ -2574,18 +2544,16 @@ impl CreateUsageReportSubscriptionError {
 }
 impl fmt::Display for CreateUsageReportSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUsageReportSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUsageReportSubscriptionError::InvalidAccountStatus(ref cause) => cause,
-            CreateUsageReportSubscriptionError::InvalidRole(ref cause) => cause,
-            CreateUsageReportSubscriptionError::LimitExceeded(ref cause) => cause,
+            CreateUsageReportSubscriptionError::InvalidAccountStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUsageReportSubscriptionError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            CreateUsageReportSubscriptionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUsageReportSubscriptionError {}
 /// Errors returned by CreateUser
 #[derive(Debug, PartialEq)]
 pub enum CreateUserError {
@@ -2631,20 +2599,16 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::InvalidAccountStatus(ref cause) => cause,
-            CreateUserError::InvalidParameterCombination(ref cause) => cause,
-            CreateUserError::LimitExceeded(ref cause) => cause,
-            CreateUserError::OperationNotPermitted(ref cause) => cause,
-            CreateUserError::ResourceAlreadyExists(ref cause) => cause,
+            CreateUserError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            CreateUserError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by DeleteDirectoryConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteDirectoryConfigError {
@@ -2675,17 +2639,13 @@ impl DeleteDirectoryConfigError {
 }
 impl fmt::Display for DeleteDirectoryConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDirectoryConfigError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDirectoryConfigError::ResourceInUse(ref cause) => cause,
-            DeleteDirectoryConfigError::ResourceNotFound(ref cause) => cause,
+            DeleteDirectoryConfigError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryConfigError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDirectoryConfigError {}
 /// Errors returned by DeleteFleet
 #[derive(Debug, PartialEq)]
 pub enum DeleteFleetError {
@@ -2719,18 +2679,14 @@ impl DeleteFleetError {
 }
 impl fmt::Display for DeleteFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFleetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFleetError::ConcurrentModification(ref cause) => cause,
-            DeleteFleetError::ResourceInUse(ref cause) => cause,
-            DeleteFleetError::ResourceNotFound(ref cause) => cause,
+            DeleteFleetError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFleetError {}
 /// Errors returned by DeleteImage
 #[derive(Debug, PartialEq)]
 pub enum DeleteImageError {
@@ -2769,19 +2725,15 @@ impl DeleteImageError {
 }
 impl fmt::Display for DeleteImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteImageError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteImageError::ConcurrentModification(ref cause) => cause,
-            DeleteImageError::OperationNotPermitted(ref cause) => cause,
-            DeleteImageError::ResourceInUse(ref cause) => cause,
-            DeleteImageError::ResourceNotFound(ref cause) => cause,
+            DeleteImageError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteImageError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteImageError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteImageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteImageError {}
 /// Errors returned by DeleteImageBuilder
 #[derive(Debug, PartialEq)]
 pub enum DeleteImageBuilderError {
@@ -2819,18 +2771,14 @@ impl DeleteImageBuilderError {
 }
 impl fmt::Display for DeleteImageBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteImageBuilderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteImageBuilderError::ConcurrentModification(ref cause) => cause,
-            DeleteImageBuilderError::OperationNotPermitted(ref cause) => cause,
-            DeleteImageBuilderError::ResourceNotFound(ref cause) => cause,
+            DeleteImageBuilderError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteImageBuilderError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteImageBuilderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteImageBuilderError {}
 /// Errors returned by DeleteImagePermissions
 #[derive(Debug, PartialEq)]
 pub enum DeleteImagePermissionsError {
@@ -2863,17 +2811,13 @@ impl DeleteImagePermissionsError {
 }
 impl fmt::Display for DeleteImagePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteImagePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteImagePermissionsError::ResourceNotAvailable(ref cause) => cause,
-            DeleteImagePermissionsError::ResourceNotFound(ref cause) => cause,
+            DeleteImagePermissionsError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            DeleteImagePermissionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteImagePermissionsError {}
 /// Errors returned by DeleteStack
 #[derive(Debug, PartialEq)]
 pub enum DeleteStackError {
@@ -2907,18 +2851,14 @@ impl DeleteStackError {
 }
 impl fmt::Display for DeleteStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStackError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStackError::ConcurrentModification(ref cause) => cause,
-            DeleteStackError::ResourceInUse(ref cause) => cause,
-            DeleteStackError::ResourceNotFound(ref cause) => cause,
+            DeleteStackError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteStackError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStackError {}
 /// Errors returned by DeleteUsageReportSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteUsageReportSubscriptionError {
@@ -2953,17 +2893,17 @@ impl DeleteUsageReportSubscriptionError {
 }
 impl fmt::Display for DeleteUsageReportSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUsageReportSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUsageReportSubscriptionError::InvalidAccountStatus(ref cause) => cause,
-            DeleteUsageReportSubscriptionError::ResourceNotFound(ref cause) => cause,
+            DeleteUsageReportSubscriptionError::InvalidAccountStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteUsageReportSubscriptionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteUsageReportSubscriptionError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -2987,16 +2927,12 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::ResourceNotFound(ref cause) => cause,
+            DeleteUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DescribeDirectoryConfigs
 #[derive(Debug, PartialEq)]
 pub enum DescribeDirectoryConfigsError {
@@ -3022,16 +2958,12 @@ impl DescribeDirectoryConfigsError {
 }
 impl fmt::Display for DescribeDirectoryConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDirectoryConfigsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDirectoryConfigsError::ResourceNotFound(ref cause) => cause,
+            DescribeDirectoryConfigsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDirectoryConfigsError {}
 /// Errors returned by DescribeFleets
 #[derive(Debug, PartialEq)]
 pub enum DescribeFleetsError {
@@ -3055,16 +2987,12 @@ impl DescribeFleetsError {
 }
 impl fmt::Display for DescribeFleetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFleetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFleetsError::ResourceNotFound(ref cause) => cause,
+            DescribeFleetsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFleetsError {}
 /// Errors returned by DescribeImageBuilders
 #[derive(Debug, PartialEq)]
 pub enum DescribeImageBuildersError {
@@ -3090,16 +3018,12 @@ impl DescribeImageBuildersError {
 }
 impl fmt::Display for DescribeImageBuildersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeImageBuildersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeImageBuildersError::ResourceNotFound(ref cause) => cause,
+            DescribeImageBuildersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeImageBuildersError {}
 /// Errors returned by DescribeImagePermissions
 #[derive(Debug, PartialEq)]
 pub enum DescribeImagePermissionsError {
@@ -3125,16 +3049,12 @@ impl DescribeImagePermissionsError {
 }
 impl fmt::Display for DescribeImagePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeImagePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeImagePermissionsError::ResourceNotFound(ref cause) => cause,
+            DescribeImagePermissionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeImagePermissionsError {}
 /// Errors returned by DescribeImages
 #[derive(Debug, PartialEq)]
 pub enum DescribeImagesError {
@@ -3165,17 +3085,13 @@ impl DescribeImagesError {
 }
 impl fmt::Display for DescribeImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeImagesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeImagesError::InvalidParameterCombination(ref cause) => cause,
-            DescribeImagesError::ResourceNotFound(ref cause) => cause,
+            DescribeImagesError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            DescribeImagesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeImagesError {}
 /// Errors returned by DescribeSessions
 #[derive(Debug, PartialEq)]
 pub enum DescribeSessionsError {
@@ -3201,16 +3117,12 @@ impl DescribeSessionsError {
 }
 impl fmt::Display for DescribeSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSessionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSessionsError::InvalidParameterCombination(ref cause) => cause,
+            DescribeSessionsError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSessionsError {}
 /// Errors returned by DescribeStacks
 #[derive(Debug, PartialEq)]
 pub enum DescribeStacksError {
@@ -3234,16 +3146,12 @@ impl DescribeStacksError {
 }
 impl fmt::Display for DescribeStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStacksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStacksError::ResourceNotFound(ref cause) => cause,
+            DescribeStacksError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStacksError {}
 /// Errors returned by DescribeUsageReportSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeUsageReportSubscriptionsError {
@@ -3278,17 +3186,17 @@ impl DescribeUsageReportSubscriptionsError {
 }
 impl fmt::Display for DescribeUsageReportSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUsageReportSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUsageReportSubscriptionsError::InvalidAccountStatus(ref cause) => cause,
-            DescribeUsageReportSubscriptionsError::ResourceNotFound(ref cause) => cause,
+            DescribeUsageReportSubscriptionsError::InvalidAccountStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeUsageReportSubscriptionsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeUsageReportSubscriptionsError {}
 /// Errors returned by DescribeUserStackAssociations
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserStackAssociationsError {
@@ -3316,16 +3224,14 @@ impl DescribeUserStackAssociationsError {
 }
 impl fmt::Display for DescribeUserStackAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserStackAssociationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserStackAssociationsError::InvalidParameterCombination(ref cause) => cause,
+            DescribeUserStackAssociationsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeUserStackAssociationsError {}
 /// Errors returned by DescribeUsers
 #[derive(Debug, PartialEq)]
 pub enum DescribeUsersError {
@@ -3356,17 +3262,13 @@ impl DescribeUsersError {
 }
 impl fmt::Display for DescribeUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUsersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUsersError::InvalidParameterCombination(ref cause) => cause,
-            DescribeUsersError::ResourceNotFound(ref cause) => cause,
+            DescribeUsersError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            DescribeUsersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUsersError {}
 /// Errors returned by DisableUser
 #[derive(Debug, PartialEq)]
 pub enum DisableUserError {
@@ -3390,16 +3292,12 @@ impl DisableUserError {
 }
 impl fmt::Display for DisableUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableUserError {
-    fn description(&self) -> &str {
         match *self {
-            DisableUserError::ResourceNotFound(ref cause) => cause,
+            DisableUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableUserError {}
 /// Errors returned by DisassociateFleet
 #[derive(Debug, PartialEq)]
 pub enum DisassociateFleetError {
@@ -3435,18 +3333,14 @@ impl DisassociateFleetError {
 }
 impl fmt::Display for DisassociateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateFleetError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateFleetError::ConcurrentModification(ref cause) => cause,
-            DisassociateFleetError::ResourceInUse(ref cause) => cause,
-            DisassociateFleetError::ResourceNotFound(ref cause) => cause,
+            DisassociateFleetError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DisassociateFleetError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DisassociateFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateFleetError {}
 /// Errors returned by EnableUser
 #[derive(Debug, PartialEq)]
 pub enum EnableUserError {
@@ -3475,17 +3369,13 @@ impl EnableUserError {
 }
 impl fmt::Display for EnableUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableUserError {
-    fn description(&self) -> &str {
         match *self {
-            EnableUserError::InvalidAccountStatus(ref cause) => cause,
-            EnableUserError::ResourceNotFound(ref cause) => cause,
+            EnableUserError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            EnableUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableUserError {}
 /// Errors returned by ExpireSession
 #[derive(Debug, PartialEq)]
 pub enum ExpireSessionError {}
@@ -3503,14 +3393,10 @@ impl ExpireSessionError {
 }
 impl fmt::Display for ExpireSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExpireSessionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ExpireSessionError {}
 /// Errors returned by ListAssociatedFleets
 #[derive(Debug, PartialEq)]
 pub enum ListAssociatedFleetsError {}
@@ -3528,14 +3414,10 @@ impl ListAssociatedFleetsError {
 }
 impl fmt::Display for ListAssociatedFleetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssociatedFleetsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListAssociatedFleetsError {}
 /// Errors returned by ListAssociatedStacks
 #[derive(Debug, PartialEq)]
 pub enum ListAssociatedStacksError {}
@@ -3553,14 +3435,10 @@ impl ListAssociatedStacksError {
 }
 impl fmt::Display for ListAssociatedStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssociatedStacksError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListAssociatedStacksError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3586,16 +3464,12 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by StartFleet
 #[derive(Debug, PartialEq)]
 pub enum StartFleetError {
@@ -3649,22 +3523,18 @@ impl StartFleetError {
 }
 impl fmt::Display for StartFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartFleetError {
-    fn description(&self) -> &str {
         match *self {
-            StartFleetError::ConcurrentModification(ref cause) => cause,
-            StartFleetError::InvalidAccountStatus(ref cause) => cause,
-            StartFleetError::InvalidRole(ref cause) => cause,
-            StartFleetError::LimitExceeded(ref cause) => cause,
-            StartFleetError::OperationNotPermitted(ref cause) => cause,
-            StartFleetError::ResourceNotAvailable(ref cause) => cause,
-            StartFleetError::ResourceNotFound(ref cause) => cause,
+            StartFleetError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            StartFleetError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            StartFleetError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            StartFleetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartFleetError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StartFleetError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            StartFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartFleetError {}
 /// Errors returned by StartImageBuilder
 #[derive(Debug, PartialEq)]
 pub enum StartImageBuilderError {
@@ -3714,20 +3584,16 @@ impl StartImageBuilderError {
 }
 impl fmt::Display for StartImageBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartImageBuilderError {
-    fn description(&self) -> &str {
         match *self {
-            StartImageBuilderError::ConcurrentModification(ref cause) => cause,
-            StartImageBuilderError::IncompatibleImage(ref cause) => cause,
-            StartImageBuilderError::InvalidAccountStatus(ref cause) => cause,
-            StartImageBuilderError::ResourceNotAvailable(ref cause) => cause,
-            StartImageBuilderError::ResourceNotFound(ref cause) => cause,
+            StartImageBuilderError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            StartImageBuilderError::IncompatibleImage(ref cause) => write!(f, "{}", cause),
+            StartImageBuilderError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            StartImageBuilderError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            StartImageBuilderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartImageBuilderError {}
 /// Errors returned by StopFleet
 #[derive(Debug, PartialEq)]
 pub enum StopFleetError {
@@ -3756,17 +3622,13 @@ impl StopFleetError {
 }
 impl fmt::Display for StopFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopFleetError {
-    fn description(&self) -> &str {
         match *self {
-            StopFleetError::ConcurrentModification(ref cause) => cause,
-            StopFleetError::ResourceNotFound(ref cause) => cause,
+            StopFleetError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            StopFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopFleetError {}
 /// Errors returned by StopImageBuilder
 #[derive(Debug, PartialEq)]
 pub enum StopImageBuilderError {
@@ -3804,18 +3666,14 @@ impl StopImageBuilderError {
 }
 impl fmt::Display for StopImageBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopImageBuilderError {
-    fn description(&self) -> &str {
         match *self {
-            StopImageBuilderError::ConcurrentModification(ref cause) => cause,
-            StopImageBuilderError::OperationNotPermitted(ref cause) => cause,
-            StopImageBuilderError::ResourceNotFound(ref cause) => cause,
+            StopImageBuilderError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            StopImageBuilderError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StopImageBuilderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopImageBuilderError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3849,18 +3707,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidAccountStatus(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3884,16 +3738,12 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateDirectoryConfig
 #[derive(Debug, PartialEq)]
 pub enum UpdateDirectoryConfigError {
@@ -3931,18 +3781,14 @@ impl UpdateDirectoryConfigError {
 }
 impl fmt::Display for UpdateDirectoryConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDirectoryConfigError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDirectoryConfigError::ConcurrentModification(ref cause) => cause,
-            UpdateDirectoryConfigError::ResourceInUse(ref cause) => cause,
-            UpdateDirectoryConfigError::ResourceNotFound(ref cause) => cause,
+            UpdateDirectoryConfigError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateDirectoryConfigError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateDirectoryConfigError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDirectoryConfigError {}
 /// Errors returned by UpdateFleet
 #[derive(Debug, PartialEq)]
 pub enum UpdateFleetError {
@@ -4013,25 +3859,21 @@ impl UpdateFleetError {
 }
 impl fmt::Display for UpdateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFleetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFleetError::ConcurrentModification(ref cause) => cause,
-            UpdateFleetError::IncompatibleImage(ref cause) => cause,
-            UpdateFleetError::InvalidAccountStatus(ref cause) => cause,
-            UpdateFleetError::InvalidParameterCombination(ref cause) => cause,
-            UpdateFleetError::InvalidRole(ref cause) => cause,
-            UpdateFleetError::LimitExceeded(ref cause) => cause,
-            UpdateFleetError::OperationNotPermitted(ref cause) => cause,
-            UpdateFleetError::ResourceInUse(ref cause) => cause,
-            UpdateFleetError::ResourceNotAvailable(ref cause) => cause,
-            UpdateFleetError::ResourceNotFound(ref cause) => cause,
+            UpdateFleetError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::IncompatibleImage(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            UpdateFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFleetError {}
 /// Errors returned by UpdateImagePermissions
 #[derive(Debug, PartialEq)]
 pub enum UpdateImagePermissionsError {
@@ -4071,18 +3913,14 @@ impl UpdateImagePermissionsError {
 }
 impl fmt::Display for UpdateImagePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateImagePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateImagePermissionsError::LimitExceeded(ref cause) => cause,
-            UpdateImagePermissionsError::ResourceNotAvailable(ref cause) => cause,
-            UpdateImagePermissionsError::ResourceNotFound(ref cause) => cause,
+            UpdateImagePermissionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateImagePermissionsError::ResourceNotAvailable(ref cause) => write!(f, "{}", cause),
+            UpdateImagePermissionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateImagePermissionsError {}
 /// Errors returned by UpdateStack
 #[derive(Debug, PartialEq)]
 pub enum UpdateStackError {
@@ -4148,24 +3986,20 @@ impl UpdateStackError {
 }
 impl fmt::Display for UpdateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStackError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStackError::ConcurrentModification(ref cause) => cause,
-            UpdateStackError::IncompatibleImage(ref cause) => cause,
-            UpdateStackError::InvalidAccountStatus(ref cause) => cause,
-            UpdateStackError::InvalidParameterCombination(ref cause) => cause,
-            UpdateStackError::InvalidRole(ref cause) => cause,
-            UpdateStackError::LimitExceeded(ref cause) => cause,
-            UpdateStackError::OperationNotPermitted(ref cause) => cause,
-            UpdateStackError::ResourceInUse(ref cause) => cause,
-            UpdateStackError::ResourceNotFound(ref cause) => cause,
+            UpdateStackError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::IncompatibleImage(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::InvalidAccountStatus(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStackError {}
 /// Trait representing the capabilities of the Amazon AppStream API. Amazon AppStream clients implement this trait.
 pub trait AppStream {
     /// <p>Associates the specified fleet with the specified stack.</p>

--- a/rusoto/services/appsync/src/generated.rs
+++ b/rusoto/services/appsync/src/generated.rs
@@ -1632,20 +1632,16 @@ impl CreateApiCacheError {
 }
 impl fmt::Display for CreateApiCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApiCacheError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApiCacheError::BadRequest(ref cause) => cause,
-            CreateApiCacheError::ConcurrentModification(ref cause) => cause,
-            CreateApiCacheError::InternalFailure(ref cause) => cause,
-            CreateApiCacheError::NotFound(ref cause) => cause,
-            CreateApiCacheError::Unauthorized(ref cause) => cause,
+            CreateApiCacheError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateApiCacheError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateApiCacheError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateApiCacheError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateApiCacheError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApiCacheError {}
 /// Errors returned by CreateApiKey
 #[derive(Debug, PartialEq)]
 pub enum CreateApiKeyError {
@@ -1701,22 +1697,18 @@ impl CreateApiKeyError {
 }
 impl fmt::Display for CreateApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApiKeyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApiKeyError::ApiKeyLimitExceeded(ref cause) => cause,
-            CreateApiKeyError::ApiKeyValidityOutOfBounds(ref cause) => cause,
-            CreateApiKeyError::BadRequest(ref cause) => cause,
-            CreateApiKeyError::InternalFailure(ref cause) => cause,
-            CreateApiKeyError::LimitExceeded(ref cause) => cause,
-            CreateApiKeyError::NotFound(ref cause) => cause,
-            CreateApiKeyError::Unauthorized(ref cause) => cause,
+            CreateApiKeyError::ApiKeyLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::ApiKeyValidityOutOfBounds(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateApiKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApiKeyError {}
 /// Errors returned by CreateDataSource
 #[derive(Debug, PartialEq)]
 pub enum CreateDataSourceError {
@@ -1762,20 +1754,16 @@ impl CreateDataSourceError {
 }
 impl fmt::Display for CreateDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDataSourceError::BadRequest(ref cause) => cause,
-            CreateDataSourceError::ConcurrentModification(ref cause) => cause,
-            CreateDataSourceError::InternalFailure(ref cause) => cause,
-            CreateDataSourceError::NotFound(ref cause) => cause,
-            CreateDataSourceError::Unauthorized(ref cause) => cause,
+            CreateDataSourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDataSourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateDataSourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDataSourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDataSourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDataSourceError {}
 /// Errors returned by CreateFunction
 #[derive(Debug, PartialEq)]
 pub enum CreateFunctionError {
@@ -1816,19 +1804,15 @@ impl CreateFunctionError {
 }
 impl fmt::Display for CreateFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFunctionError::ConcurrentModification(ref cause) => cause,
-            CreateFunctionError::InternalFailure(ref cause) => cause,
-            CreateFunctionError::NotFound(ref cause) => cause,
-            CreateFunctionError::Unauthorized(ref cause) => cause,
+            CreateFunctionError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFunctionError {}
 /// Errors returned by CreateGraphqlApi
 #[derive(Debug, PartialEq)]
 pub enum CreateGraphqlApiError {
@@ -1879,21 +1863,17 @@ impl CreateGraphqlApiError {
 }
 impl fmt::Display for CreateGraphqlApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGraphqlApiError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGraphqlApiError::ApiLimitExceeded(ref cause) => cause,
-            CreateGraphqlApiError::BadRequest(ref cause) => cause,
-            CreateGraphqlApiError::ConcurrentModification(ref cause) => cause,
-            CreateGraphqlApiError::InternalFailure(ref cause) => cause,
-            CreateGraphqlApiError::LimitExceeded(ref cause) => cause,
-            CreateGraphqlApiError::Unauthorized(ref cause) => cause,
+            CreateGraphqlApiError::ApiLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGraphqlApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateGraphqlApiError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateGraphqlApiError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateGraphqlApiError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGraphqlApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGraphqlApiError {}
 /// Errors returned by CreateResolver
 #[derive(Debug, PartialEq)]
 pub enum CreateResolverError {
@@ -1934,19 +1914,15 @@ impl CreateResolverError {
 }
 impl fmt::Display for CreateResolverError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResolverError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResolverError::ConcurrentModification(ref cause) => cause,
-            CreateResolverError::InternalFailure(ref cause) => cause,
-            CreateResolverError::NotFound(ref cause) => cause,
-            CreateResolverError::Unauthorized(ref cause) => cause,
+            CreateResolverError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateResolverError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateResolverError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateResolverError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateResolverError {}
 /// Errors returned by CreateType
 #[derive(Debug, PartialEq)]
 pub enum CreateTypeError {
@@ -1990,20 +1966,16 @@ impl CreateTypeError {
 }
 impl fmt::Display for CreateTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTypeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTypeError::BadRequest(ref cause) => cause,
-            CreateTypeError::ConcurrentModification(ref cause) => cause,
-            CreateTypeError::InternalFailure(ref cause) => cause,
-            CreateTypeError::NotFound(ref cause) => cause,
-            CreateTypeError::Unauthorized(ref cause) => cause,
+            CreateTypeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateTypeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateTypeError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTypeError {}
 /// Errors returned by DeleteApiCache
 #[derive(Debug, PartialEq)]
 pub enum DeleteApiCacheError {
@@ -2049,20 +2021,16 @@ impl DeleteApiCacheError {
 }
 impl fmt::Display for DeleteApiCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApiCacheError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApiCacheError::BadRequest(ref cause) => cause,
-            DeleteApiCacheError::ConcurrentModification(ref cause) => cause,
-            DeleteApiCacheError::InternalFailure(ref cause) => cause,
-            DeleteApiCacheError::NotFound(ref cause) => cause,
-            DeleteApiCacheError::Unauthorized(ref cause) => cause,
+            DeleteApiCacheError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteApiCacheError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteApiCacheError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteApiCacheError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApiCacheError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApiCacheError {}
 /// Errors returned by DeleteApiKey
 #[derive(Debug, PartialEq)]
 pub enum DeleteApiKeyError {
@@ -2101,19 +2069,15 @@ impl DeleteApiKeyError {
 }
 impl fmt::Display for DeleteApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApiKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApiKeyError::BadRequest(ref cause) => cause,
-            DeleteApiKeyError::InternalFailure(ref cause) => cause,
-            DeleteApiKeyError::NotFound(ref cause) => cause,
-            DeleteApiKeyError::Unauthorized(ref cause) => cause,
+            DeleteApiKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteApiKeyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteApiKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApiKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApiKeyError {}
 /// Errors returned by DeleteDataSource
 #[derive(Debug, PartialEq)]
 pub enum DeleteDataSourceError {
@@ -2159,20 +2123,16 @@ impl DeleteDataSourceError {
 }
 impl fmt::Display for DeleteDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDataSourceError::BadRequest(ref cause) => cause,
-            DeleteDataSourceError::ConcurrentModification(ref cause) => cause,
-            DeleteDataSourceError::InternalFailure(ref cause) => cause,
-            DeleteDataSourceError::NotFound(ref cause) => cause,
-            DeleteDataSourceError::Unauthorized(ref cause) => cause,
+            DeleteDataSourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDataSourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteDataSourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDataSourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDataSourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDataSourceError {}
 /// Errors returned by DeleteFunction
 #[derive(Debug, PartialEq)]
 pub enum DeleteFunctionError {
@@ -2213,19 +2173,15 @@ impl DeleteFunctionError {
 }
 impl fmt::Display for DeleteFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFunctionError::ConcurrentModification(ref cause) => cause,
-            DeleteFunctionError::InternalFailure(ref cause) => cause,
-            DeleteFunctionError::NotFound(ref cause) => cause,
-            DeleteFunctionError::Unauthorized(ref cause) => cause,
+            DeleteFunctionError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFunctionError {}
 /// Errors returned by DeleteGraphqlApi
 #[derive(Debug, PartialEq)]
 pub enum DeleteGraphqlApiError {
@@ -2276,21 +2232,17 @@ impl DeleteGraphqlApiError {
 }
 impl fmt::Display for DeleteGraphqlApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGraphqlApiError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGraphqlApiError::AccessDenied(ref cause) => cause,
-            DeleteGraphqlApiError::BadRequest(ref cause) => cause,
-            DeleteGraphqlApiError::ConcurrentModification(ref cause) => cause,
-            DeleteGraphqlApiError::InternalFailure(ref cause) => cause,
-            DeleteGraphqlApiError::NotFound(ref cause) => cause,
-            DeleteGraphqlApiError::Unauthorized(ref cause) => cause,
+            DeleteGraphqlApiError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteGraphqlApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteGraphqlApiError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteGraphqlApiError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteGraphqlApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteGraphqlApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGraphqlApiError {}
 /// Errors returned by DeleteResolver
 #[derive(Debug, PartialEq)]
 pub enum DeleteResolverError {
@@ -2331,19 +2283,15 @@ impl DeleteResolverError {
 }
 impl fmt::Display for DeleteResolverError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResolverError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResolverError::ConcurrentModification(ref cause) => cause,
-            DeleteResolverError::InternalFailure(ref cause) => cause,
-            DeleteResolverError::NotFound(ref cause) => cause,
-            DeleteResolverError::Unauthorized(ref cause) => cause,
+            DeleteResolverError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteResolverError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteResolverError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteResolverError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResolverError {}
 /// Errors returned by DeleteType
 #[derive(Debug, PartialEq)]
 pub enum DeleteTypeError {
@@ -2387,20 +2335,16 @@ impl DeleteTypeError {
 }
 impl fmt::Display for DeleteTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTypeError::BadRequest(ref cause) => cause,
-            DeleteTypeError::ConcurrentModification(ref cause) => cause,
-            DeleteTypeError::InternalFailure(ref cause) => cause,
-            DeleteTypeError::NotFound(ref cause) => cause,
-            DeleteTypeError::Unauthorized(ref cause) => cause,
+            DeleteTypeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteTypeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteTypeError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTypeError {}
 /// Errors returned by FlushApiCache
 #[derive(Debug, PartialEq)]
 pub enum FlushApiCacheError {
@@ -2446,20 +2390,16 @@ impl FlushApiCacheError {
 }
 impl fmt::Display for FlushApiCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FlushApiCacheError {
-    fn description(&self) -> &str {
         match *self {
-            FlushApiCacheError::BadRequest(ref cause) => cause,
-            FlushApiCacheError::ConcurrentModification(ref cause) => cause,
-            FlushApiCacheError::InternalFailure(ref cause) => cause,
-            FlushApiCacheError::NotFound(ref cause) => cause,
-            FlushApiCacheError::Unauthorized(ref cause) => cause,
+            FlushApiCacheError::BadRequest(ref cause) => write!(f, "{}", cause),
+            FlushApiCacheError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            FlushApiCacheError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            FlushApiCacheError::NotFound(ref cause) => write!(f, "{}", cause),
+            FlushApiCacheError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for FlushApiCacheError {}
 /// Errors returned by GetApiCache
 #[derive(Debug, PartialEq)]
 pub enum GetApiCacheError {
@@ -2503,20 +2443,16 @@ impl GetApiCacheError {
 }
 impl fmt::Display for GetApiCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApiCacheError {
-    fn description(&self) -> &str {
         match *self {
-            GetApiCacheError::BadRequest(ref cause) => cause,
-            GetApiCacheError::ConcurrentModification(ref cause) => cause,
-            GetApiCacheError::InternalFailure(ref cause) => cause,
-            GetApiCacheError::NotFound(ref cause) => cause,
-            GetApiCacheError::Unauthorized(ref cause) => cause,
+            GetApiCacheError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetApiCacheError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            GetApiCacheError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetApiCacheError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApiCacheError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApiCacheError {}
 /// Errors returned by GetDataSource
 #[derive(Debug, PartialEq)]
 pub enum GetDataSourceError {
@@ -2562,20 +2498,16 @@ impl GetDataSourceError {
 }
 impl fmt::Display for GetDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDataSourceError::BadRequest(ref cause) => cause,
-            GetDataSourceError::ConcurrentModification(ref cause) => cause,
-            GetDataSourceError::InternalFailure(ref cause) => cause,
-            GetDataSourceError::NotFound(ref cause) => cause,
-            GetDataSourceError::Unauthorized(ref cause) => cause,
+            GetDataSourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDataSourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            GetDataSourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetDataSourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDataSourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDataSourceError {}
 /// Errors returned by GetFunction
 #[derive(Debug, PartialEq)]
 pub enum GetFunctionError {
@@ -2609,18 +2541,14 @@ impl GetFunctionError {
 }
 impl fmt::Display for GetFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            GetFunctionError::ConcurrentModification(ref cause) => cause,
-            GetFunctionError::NotFound(ref cause) => cause,
-            GetFunctionError::Unauthorized(ref cause) => cause,
+            GetFunctionError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            GetFunctionError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetFunctionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFunctionError {}
 /// Errors returned by GetGraphqlApi
 #[derive(Debug, PartialEq)]
 pub enum GetGraphqlApiError {
@@ -2664,20 +2592,16 @@ impl GetGraphqlApiError {
 }
 impl fmt::Display for GetGraphqlApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGraphqlApiError {
-    fn description(&self) -> &str {
         match *self {
-            GetGraphqlApiError::AccessDenied(ref cause) => cause,
-            GetGraphqlApiError::BadRequest(ref cause) => cause,
-            GetGraphqlApiError::InternalFailure(ref cause) => cause,
-            GetGraphqlApiError::NotFound(ref cause) => cause,
-            GetGraphqlApiError::Unauthorized(ref cause) => cause,
+            GetGraphqlApiError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetGraphqlApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetGraphqlApiError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetGraphqlApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetGraphqlApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGraphqlApiError {}
 /// Errors returned by GetIntrospectionSchema
 #[derive(Debug, PartialEq)]
 pub enum GetIntrospectionSchemaError {
@@ -2720,19 +2644,15 @@ impl GetIntrospectionSchemaError {
 }
 impl fmt::Display for GetIntrospectionSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntrospectionSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntrospectionSchemaError::GraphQLSchema(ref cause) => cause,
-            GetIntrospectionSchemaError::InternalFailure(ref cause) => cause,
-            GetIntrospectionSchemaError::NotFound(ref cause) => cause,
-            GetIntrospectionSchemaError::Unauthorized(ref cause) => cause,
+            GetIntrospectionSchemaError::GraphQLSchema(ref cause) => write!(f, "{}", cause),
+            GetIntrospectionSchemaError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetIntrospectionSchemaError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetIntrospectionSchemaError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntrospectionSchemaError {}
 /// Errors returned by GetResolver
 #[derive(Debug, PartialEq)]
 pub enum GetResolverError {
@@ -2766,18 +2686,14 @@ impl GetResolverError {
 }
 impl fmt::Display for GetResolverError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResolverError {
-    fn description(&self) -> &str {
         match *self {
-            GetResolverError::ConcurrentModification(ref cause) => cause,
-            GetResolverError::NotFound(ref cause) => cause,
-            GetResolverError::Unauthorized(ref cause) => cause,
+            GetResolverError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            GetResolverError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetResolverError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResolverError {}
 /// Errors returned by GetSchemaCreationStatus
 #[derive(Debug, PartialEq)]
 pub enum GetSchemaCreationStatusError {
@@ -2820,19 +2736,15 @@ impl GetSchemaCreationStatusError {
 }
 impl fmt::Display for GetSchemaCreationStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSchemaCreationStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetSchemaCreationStatusError::BadRequest(ref cause) => cause,
-            GetSchemaCreationStatusError::InternalFailure(ref cause) => cause,
-            GetSchemaCreationStatusError::NotFound(ref cause) => cause,
-            GetSchemaCreationStatusError::Unauthorized(ref cause) => cause,
+            GetSchemaCreationStatusError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetSchemaCreationStatusError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetSchemaCreationStatusError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetSchemaCreationStatusError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSchemaCreationStatusError {}
 /// Errors returned by GetType
 #[derive(Debug, PartialEq)]
 pub enum GetTypeError {
@@ -2876,20 +2788,16 @@ impl GetTypeError {
 }
 impl fmt::Display for GetTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTypeError {
-    fn description(&self) -> &str {
         match *self {
-            GetTypeError::BadRequest(ref cause) => cause,
-            GetTypeError::ConcurrentModification(ref cause) => cause,
-            GetTypeError::InternalFailure(ref cause) => cause,
-            GetTypeError::NotFound(ref cause) => cause,
-            GetTypeError::Unauthorized(ref cause) => cause,
+            GetTypeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetTypeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            GetTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetTypeError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTypeError {}
 /// Errors returned by ListApiKeys
 #[derive(Debug, PartialEq)]
 pub enum ListApiKeysError {
@@ -2928,19 +2836,15 @@ impl ListApiKeysError {
 }
 impl fmt::Display for ListApiKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApiKeysError {
-    fn description(&self) -> &str {
         match *self {
-            ListApiKeysError::BadRequest(ref cause) => cause,
-            ListApiKeysError::InternalFailure(ref cause) => cause,
-            ListApiKeysError::NotFound(ref cause) => cause,
-            ListApiKeysError::Unauthorized(ref cause) => cause,
+            ListApiKeysError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListApiKeysError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListApiKeysError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListApiKeysError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListApiKeysError {}
 /// Errors returned by ListDataSources
 #[derive(Debug, PartialEq)]
 pub enum ListDataSourcesError {
@@ -2979,19 +2883,15 @@ impl ListDataSourcesError {
 }
 impl fmt::Display for ListDataSourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDataSourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDataSourcesError::BadRequest(ref cause) => cause,
-            ListDataSourcesError::InternalFailure(ref cause) => cause,
-            ListDataSourcesError::NotFound(ref cause) => cause,
-            ListDataSourcesError::Unauthorized(ref cause) => cause,
+            ListDataSourcesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListDataSourcesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDataSourcesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListDataSourcesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDataSourcesError {}
 /// Errors returned by ListFunctions
 #[derive(Debug, PartialEq)]
 pub enum ListFunctionsError {
@@ -3030,19 +2930,15 @@ impl ListFunctionsError {
 }
 impl fmt::Display for ListFunctionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFunctionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFunctionsError::BadRequest(ref cause) => cause,
-            ListFunctionsError::InternalFailure(ref cause) => cause,
-            ListFunctionsError::NotFound(ref cause) => cause,
-            ListFunctionsError::Unauthorized(ref cause) => cause,
+            ListFunctionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListFunctionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListFunctionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListFunctionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFunctionsError {}
 /// Errors returned by ListGraphqlApis
 #[derive(Debug, PartialEq)]
 pub enum ListGraphqlApisError {
@@ -3076,18 +2972,14 @@ impl ListGraphqlApisError {
 }
 impl fmt::Display for ListGraphqlApisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGraphqlApisError {
-    fn description(&self) -> &str {
         match *self {
-            ListGraphqlApisError::BadRequest(ref cause) => cause,
-            ListGraphqlApisError::InternalFailure(ref cause) => cause,
-            ListGraphqlApisError::Unauthorized(ref cause) => cause,
+            ListGraphqlApisError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListGraphqlApisError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListGraphqlApisError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGraphqlApisError {}
 /// Errors returned by ListResolvers
 #[derive(Debug, PartialEq)]
 pub enum ListResolversError {
@@ -3126,19 +3018,15 @@ impl ListResolversError {
 }
 impl fmt::Display for ListResolversError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResolversError {
-    fn description(&self) -> &str {
         match *self {
-            ListResolversError::BadRequest(ref cause) => cause,
-            ListResolversError::InternalFailure(ref cause) => cause,
-            ListResolversError::NotFound(ref cause) => cause,
-            ListResolversError::Unauthorized(ref cause) => cause,
+            ListResolversError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListResolversError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListResolversError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListResolversError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResolversError {}
 /// Errors returned by ListResolversByFunction
 #[derive(Debug, PartialEq)]
 pub enum ListResolversByFunctionError {
@@ -3181,19 +3069,15 @@ impl ListResolversByFunctionError {
 }
 impl fmt::Display for ListResolversByFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResolversByFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            ListResolversByFunctionError::BadRequest(ref cause) => cause,
-            ListResolversByFunctionError::InternalFailure(ref cause) => cause,
-            ListResolversByFunctionError::NotFound(ref cause) => cause,
-            ListResolversByFunctionError::Unauthorized(ref cause) => cause,
+            ListResolversByFunctionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListResolversByFunctionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListResolversByFunctionError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListResolversByFunctionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResolversByFunctionError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3242,21 +3126,17 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AccessDenied(ref cause) => cause,
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::InternalFailure(ref cause) => cause,
-            ListTagsForResourceError::LimitExceeded(ref cause) => cause,
-            ListTagsForResourceError::NotFound(ref cause) => cause,
-            ListTagsForResourceError::Unauthorized(ref cause) => cause,
+            ListTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTypes
 #[derive(Debug, PartialEq)]
 pub enum ListTypesError {
@@ -3300,20 +3180,16 @@ impl ListTypesError {
 }
 impl fmt::Display for ListTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTypesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTypesError::BadRequest(ref cause) => cause,
-            ListTypesError::ConcurrentModification(ref cause) => cause,
-            ListTypesError::InternalFailure(ref cause) => cause,
-            ListTypesError::NotFound(ref cause) => cause,
-            ListTypesError::Unauthorized(ref cause) => cause,
+            ListTypesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTypesError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            ListTypesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTypesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListTypesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTypesError {}
 /// Errors returned by StartSchemaCreation
 #[derive(Debug, PartialEq)]
 pub enum StartSchemaCreationError {
@@ -3359,20 +3235,16 @@ impl StartSchemaCreationError {
 }
 impl fmt::Display for StartSchemaCreationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartSchemaCreationError {
-    fn description(&self) -> &str {
         match *self {
-            StartSchemaCreationError::BadRequest(ref cause) => cause,
-            StartSchemaCreationError::ConcurrentModification(ref cause) => cause,
-            StartSchemaCreationError::InternalFailure(ref cause) => cause,
-            StartSchemaCreationError::NotFound(ref cause) => cause,
-            StartSchemaCreationError::Unauthorized(ref cause) => cause,
+            StartSchemaCreationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartSchemaCreationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            StartSchemaCreationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartSchemaCreationError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartSchemaCreationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartSchemaCreationError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3421,21 +3293,17 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AccessDenied(ref cause) => cause,
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::InternalFailure(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::Unauthorized(ref cause) => cause,
+            TagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3484,21 +3352,17 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AccessDenied(ref cause) => cause,
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::InternalFailure(ref cause) => cause,
-            UntagResourceError::LimitExceeded(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::Unauthorized(ref cause) => cause,
+            UntagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateApiCache
 #[derive(Debug, PartialEq)]
 pub enum UpdateApiCacheError {
@@ -3544,20 +3408,16 @@ impl UpdateApiCacheError {
 }
 impl fmt::Display for UpdateApiCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApiCacheError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApiCacheError::BadRequest(ref cause) => cause,
-            UpdateApiCacheError::ConcurrentModification(ref cause) => cause,
-            UpdateApiCacheError::InternalFailure(ref cause) => cause,
-            UpdateApiCacheError::NotFound(ref cause) => cause,
-            UpdateApiCacheError::Unauthorized(ref cause) => cause,
+            UpdateApiCacheError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateApiCacheError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateApiCacheError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateApiCacheError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateApiCacheError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApiCacheError {}
 /// Errors returned by UpdateApiKey
 #[derive(Debug, PartialEq)]
 pub enum UpdateApiKeyError {
@@ -3608,21 +3468,17 @@ impl UpdateApiKeyError {
 }
 impl fmt::Display for UpdateApiKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApiKeyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApiKeyError::ApiKeyValidityOutOfBounds(ref cause) => cause,
-            UpdateApiKeyError::BadRequest(ref cause) => cause,
-            UpdateApiKeyError::InternalFailure(ref cause) => cause,
-            UpdateApiKeyError::LimitExceeded(ref cause) => cause,
-            UpdateApiKeyError::NotFound(ref cause) => cause,
-            UpdateApiKeyError::Unauthorized(ref cause) => cause,
+            UpdateApiKeyError::ApiKeyValidityOutOfBounds(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateApiKeyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApiKeyError {}
 /// Errors returned by UpdateDataSource
 #[derive(Debug, PartialEq)]
 pub enum UpdateDataSourceError {
@@ -3668,20 +3524,16 @@ impl UpdateDataSourceError {
 }
 impl fmt::Display for UpdateDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDataSourceError::BadRequest(ref cause) => cause,
-            UpdateDataSourceError::ConcurrentModification(ref cause) => cause,
-            UpdateDataSourceError::InternalFailure(ref cause) => cause,
-            UpdateDataSourceError::NotFound(ref cause) => cause,
-            UpdateDataSourceError::Unauthorized(ref cause) => cause,
+            UpdateDataSourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDataSourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateDataSourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDataSourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDataSourceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDataSourceError {}
 /// Errors returned by UpdateFunction
 #[derive(Debug, PartialEq)]
 pub enum UpdateFunctionError {
@@ -3722,19 +3574,15 @@ impl UpdateFunctionError {
 }
 impl fmt::Display for UpdateFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFunctionError::ConcurrentModification(ref cause) => cause,
-            UpdateFunctionError::InternalFailure(ref cause) => cause,
-            UpdateFunctionError::NotFound(ref cause) => cause,
-            UpdateFunctionError::Unauthorized(ref cause) => cause,
+            UpdateFunctionError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFunctionError {}
 /// Errors returned by UpdateGraphqlApi
 #[derive(Debug, PartialEq)]
 pub enum UpdateGraphqlApiError {
@@ -3785,21 +3633,17 @@ impl UpdateGraphqlApiError {
 }
 impl fmt::Display for UpdateGraphqlApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGraphqlApiError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGraphqlApiError::AccessDenied(ref cause) => cause,
-            UpdateGraphqlApiError::BadRequest(ref cause) => cause,
-            UpdateGraphqlApiError::ConcurrentModification(ref cause) => cause,
-            UpdateGraphqlApiError::InternalFailure(ref cause) => cause,
-            UpdateGraphqlApiError::NotFound(ref cause) => cause,
-            UpdateGraphqlApiError::Unauthorized(ref cause) => cause,
+            UpdateGraphqlApiError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateGraphqlApiError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGraphqlApiError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateGraphqlApiError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateGraphqlApiError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGraphqlApiError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGraphqlApiError {}
 /// Errors returned by UpdateResolver
 #[derive(Debug, PartialEq)]
 pub enum UpdateResolverError {
@@ -3840,19 +3684,15 @@ impl UpdateResolverError {
 }
 impl fmt::Display for UpdateResolverError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateResolverError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateResolverError::ConcurrentModification(ref cause) => cause,
-            UpdateResolverError::InternalFailure(ref cause) => cause,
-            UpdateResolverError::NotFound(ref cause) => cause,
-            UpdateResolverError::Unauthorized(ref cause) => cause,
+            UpdateResolverError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateResolverError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateResolverError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateResolverError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateResolverError {}
 /// Errors returned by UpdateType
 #[derive(Debug, PartialEq)]
 pub enum UpdateTypeError {
@@ -3896,20 +3736,16 @@ impl UpdateTypeError {
 }
 impl fmt::Display for UpdateTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTypeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTypeError::BadRequest(ref cause) => cause,
-            UpdateTypeError::ConcurrentModification(ref cause) => cause,
-            UpdateTypeError::InternalFailure(ref cause) => cause,
-            UpdateTypeError::NotFound(ref cause) => cause,
-            UpdateTypeError::Unauthorized(ref cause) => cause,
+            UpdateTypeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateTypeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateTypeError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTypeError {}
 /// Trait representing the capabilities of the AWSAppSync API. AWSAppSync clients implement this trait.
 pub trait AppSync {
     /// <p>Creates a cache for the GraphQL API.</p>

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -873,17 +873,13 @@ impl BatchGetNamedQueryError {
 }
 impl fmt::Display for BatchGetNamedQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetNamedQueryError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetNamedQueryError::InternalServer(ref cause) => cause,
-            BatchGetNamedQueryError::InvalidRequest(ref cause) => cause,
+            BatchGetNamedQueryError::InternalServer(ref cause) => write!(f, "{}", cause),
+            BatchGetNamedQueryError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetNamedQueryError {}
 /// Errors returned by BatchGetQueryExecution
 #[derive(Debug, PartialEq)]
 pub enum BatchGetQueryExecutionError {
@@ -916,17 +912,13 @@ impl BatchGetQueryExecutionError {
 }
 impl fmt::Display for BatchGetQueryExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetQueryExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetQueryExecutionError::InternalServer(ref cause) => cause,
-            BatchGetQueryExecutionError::InvalidRequest(ref cause) => cause,
+            BatchGetQueryExecutionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            BatchGetQueryExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetQueryExecutionError {}
 /// Errors returned by CreateNamedQuery
 #[derive(Debug, PartialEq)]
 pub enum CreateNamedQueryError {
@@ -955,17 +947,13 @@ impl CreateNamedQueryError {
 }
 impl fmt::Display for CreateNamedQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNamedQueryError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNamedQueryError::InternalServer(ref cause) => cause,
-            CreateNamedQueryError::InvalidRequest(ref cause) => cause,
+            CreateNamedQueryError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateNamedQueryError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateNamedQueryError {}
 /// Errors returned by CreateWorkGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateWorkGroupError {
@@ -994,17 +982,13 @@ impl CreateWorkGroupError {
 }
 impl fmt::Display for CreateWorkGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWorkGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWorkGroupError::InternalServer(ref cause) => cause,
-            CreateWorkGroupError::InvalidRequest(ref cause) => cause,
+            CreateWorkGroupError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateWorkGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWorkGroupError {}
 /// Errors returned by DeleteNamedQuery
 #[derive(Debug, PartialEq)]
 pub enum DeleteNamedQueryError {
@@ -1033,17 +1017,13 @@ impl DeleteNamedQueryError {
 }
 impl fmt::Display for DeleteNamedQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNamedQueryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNamedQueryError::InternalServer(ref cause) => cause,
-            DeleteNamedQueryError::InvalidRequest(ref cause) => cause,
+            DeleteNamedQueryError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteNamedQueryError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteNamedQueryError {}
 /// Errors returned by DeleteWorkGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteWorkGroupError {
@@ -1072,17 +1052,13 @@ impl DeleteWorkGroupError {
 }
 impl fmt::Display for DeleteWorkGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWorkGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWorkGroupError::InternalServer(ref cause) => cause,
-            DeleteWorkGroupError::InvalidRequest(ref cause) => cause,
+            DeleteWorkGroupError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteWorkGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWorkGroupError {}
 /// Errors returned by GetNamedQuery
 #[derive(Debug, PartialEq)]
 pub enum GetNamedQueryError {
@@ -1111,17 +1087,13 @@ impl GetNamedQueryError {
 }
 impl fmt::Display for GetNamedQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetNamedQueryError {
-    fn description(&self) -> &str {
         match *self {
-            GetNamedQueryError::InternalServer(ref cause) => cause,
-            GetNamedQueryError::InvalidRequest(ref cause) => cause,
+            GetNamedQueryError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetNamedQueryError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetNamedQueryError {}
 /// Errors returned by GetQueryExecution
 #[derive(Debug, PartialEq)]
 pub enum GetQueryExecutionError {
@@ -1150,17 +1122,13 @@ impl GetQueryExecutionError {
 }
 impl fmt::Display for GetQueryExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQueryExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            GetQueryExecutionError::InternalServer(ref cause) => cause,
-            GetQueryExecutionError::InvalidRequest(ref cause) => cause,
+            GetQueryExecutionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetQueryExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQueryExecutionError {}
 /// Errors returned by GetQueryResults
 #[derive(Debug, PartialEq)]
 pub enum GetQueryResultsError {
@@ -1189,17 +1157,13 @@ impl GetQueryResultsError {
 }
 impl fmt::Display for GetQueryResultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQueryResultsError {
-    fn description(&self) -> &str {
         match *self {
-            GetQueryResultsError::InternalServer(ref cause) => cause,
-            GetQueryResultsError::InvalidRequest(ref cause) => cause,
+            GetQueryResultsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetQueryResultsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQueryResultsError {}
 /// Errors returned by GetWorkGroup
 #[derive(Debug, PartialEq)]
 pub enum GetWorkGroupError {
@@ -1228,17 +1192,13 @@ impl GetWorkGroupError {
 }
 impl fmt::Display for GetWorkGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWorkGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetWorkGroupError::InternalServer(ref cause) => cause,
-            GetWorkGroupError::InvalidRequest(ref cause) => cause,
+            GetWorkGroupError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetWorkGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWorkGroupError {}
 /// Errors returned by ListNamedQueries
 #[derive(Debug, PartialEq)]
 pub enum ListNamedQueriesError {
@@ -1267,17 +1227,13 @@ impl ListNamedQueriesError {
 }
 impl fmt::Display for ListNamedQueriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListNamedQueriesError {
-    fn description(&self) -> &str {
         match *self {
-            ListNamedQueriesError::InternalServer(ref cause) => cause,
-            ListNamedQueriesError::InvalidRequest(ref cause) => cause,
+            ListNamedQueriesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListNamedQueriesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListNamedQueriesError {}
 /// Errors returned by ListQueryExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListQueryExecutionsError {
@@ -1306,17 +1262,13 @@ impl ListQueryExecutionsError {
 }
 impl fmt::Display for ListQueryExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQueryExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListQueryExecutionsError::InternalServer(ref cause) => cause,
-            ListQueryExecutionsError::InvalidRequest(ref cause) => cause,
+            ListQueryExecutionsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListQueryExecutionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListQueryExecutionsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1352,18 +1304,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalServer(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListWorkGroups
 #[derive(Debug, PartialEq)]
 pub enum ListWorkGroupsError {
@@ -1392,17 +1340,13 @@ impl ListWorkGroupsError {
 }
 impl fmt::Display for ListWorkGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWorkGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListWorkGroupsError::InternalServer(ref cause) => cause,
-            ListWorkGroupsError::InvalidRequest(ref cause) => cause,
+            ListWorkGroupsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListWorkGroupsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWorkGroupsError {}
 /// Errors returned by StartQueryExecution
 #[derive(Debug, PartialEq)]
 pub enum StartQueryExecutionError {
@@ -1436,18 +1380,14 @@ impl StartQueryExecutionError {
 }
 impl fmt::Display for StartQueryExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartQueryExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StartQueryExecutionError::InternalServer(ref cause) => cause,
-            StartQueryExecutionError::InvalidRequest(ref cause) => cause,
-            StartQueryExecutionError::TooManyRequests(ref cause) => cause,
+            StartQueryExecutionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StartQueryExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartQueryExecutionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartQueryExecutionError {}
 /// Errors returned by StopQueryExecution
 #[derive(Debug, PartialEq)]
 pub enum StopQueryExecutionError {
@@ -1476,17 +1416,13 @@ impl StopQueryExecutionError {
 }
 impl fmt::Display for StopQueryExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopQueryExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StopQueryExecutionError::InternalServer(ref cause) => cause,
-            StopQueryExecutionError::InvalidRequest(ref cause) => cause,
+            StopQueryExecutionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StopQueryExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopQueryExecutionError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1520,18 +1456,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalServer(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1565,18 +1497,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalServer(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateWorkGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateWorkGroupError {
@@ -1605,17 +1533,13 @@ impl UpdateWorkGroupError {
 }
 impl fmt::Display for UpdateWorkGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateWorkGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateWorkGroupError::InternalServer(ref cause) => cause,
-            UpdateWorkGroupError::InvalidRequest(ref cause) => cause,
+            UpdateWorkGroupError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UpdateWorkGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateWorkGroupError {}
 /// Trait representing the capabilities of the Amazon Athena API. Amazon Athena clients implement this trait.
 pub trait Athena {
     /// <p>Returns the details of a single named query or a list of up to 50 queries, which you provide as an array of query ID strings. Requires you to have access to the workgroup in which the queries were saved. Use <a>ListNamedQueriesInput</a> to get the list of named query IDs in the specified workgroup. If information could not be retrieved for a submitted query ID, information about the query ID submitted is listed under <a>UnprocessedNamedQueryId</a>. Named queries differ from executed queries. Use <a>BatchGetQueryExecutionInput</a> to get details about each unique query execution, and <a>ListQueryExecutionsInput</a> to get a list of query execution IDs.</p>

--- a/rusoto/services/autoscaling-plans/src/generated.rs
+++ b/rusoto/services/autoscaling-plans/src/generated.rs
@@ -504,18 +504,14 @@ impl CreateScalingPlanError {
 }
 impl fmt::Display for CreateScalingPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateScalingPlanError {
-    fn description(&self) -> &str {
         match *self {
-            CreateScalingPlanError::ConcurrentUpdate(ref cause) => cause,
-            CreateScalingPlanError::InternalService(ref cause) => cause,
-            CreateScalingPlanError::LimitExceeded(ref cause) => cause,
+            CreateScalingPlanError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            CreateScalingPlanError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateScalingPlanError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateScalingPlanError {}
 /// Errors returned by DeleteScalingPlan
 #[derive(Debug, PartialEq)]
 pub enum DeleteScalingPlanError {
@@ -549,18 +545,14 @@ impl DeleteScalingPlanError {
 }
 impl fmt::Display for DeleteScalingPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScalingPlanError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScalingPlanError::ConcurrentUpdate(ref cause) => cause,
-            DeleteScalingPlanError::InternalService(ref cause) => cause,
-            DeleteScalingPlanError::ObjectNotFound(ref cause) => cause,
+            DeleteScalingPlanError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DeleteScalingPlanError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteScalingPlanError::ObjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScalingPlanError {}
 /// Errors returned by DescribeScalingPlanResources
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingPlanResourcesError {
@@ -602,18 +594,18 @@ impl DescribeScalingPlanResourcesError {
 }
 impl fmt::Display for DescribeScalingPlanResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingPlanResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingPlanResourcesError::ConcurrentUpdate(ref cause) => cause,
-            DescribeScalingPlanResourcesError::InternalService(ref cause) => cause,
-            DescribeScalingPlanResourcesError::InvalidNextToken(ref cause) => cause,
+            DescribeScalingPlanResourcesError::ConcurrentUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeScalingPlanResourcesError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPlanResourcesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeScalingPlanResourcesError {}
 /// Errors returned by DescribeScalingPlans
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingPlansError {
@@ -653,18 +645,14 @@ impl DescribeScalingPlansError {
 }
 impl fmt::Display for DescribeScalingPlansError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingPlansError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingPlansError::ConcurrentUpdate(ref cause) => cause,
-            DescribeScalingPlansError::InternalService(ref cause) => cause,
-            DescribeScalingPlansError::InvalidNextToken(ref cause) => cause,
+            DescribeScalingPlansError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPlansError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPlansError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScalingPlansError {}
 /// Errors returned by GetScalingPlanResourceForecastData
 #[derive(Debug, PartialEq)]
 pub enum GetScalingPlanResourceForecastDataError {
@@ -692,16 +680,14 @@ impl GetScalingPlanResourceForecastDataError {
 }
 impl fmt::Display for GetScalingPlanResourceForecastDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetScalingPlanResourceForecastDataError {
-    fn description(&self) -> &str {
         match *self {
-            GetScalingPlanResourceForecastDataError::InternalService(ref cause) => cause,
+            GetScalingPlanResourceForecastDataError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetScalingPlanResourceForecastDataError {}
 /// Errors returned by UpdateScalingPlan
 #[derive(Debug, PartialEq)]
 pub enum UpdateScalingPlanError {
@@ -735,18 +721,14 @@ impl UpdateScalingPlanError {
 }
 impl fmt::Display for UpdateScalingPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateScalingPlanError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateScalingPlanError::ConcurrentUpdate(ref cause) => cause,
-            UpdateScalingPlanError::InternalService(ref cause) => cause,
-            UpdateScalingPlanError::ObjectNotFound(ref cause) => cause,
+            UpdateScalingPlanError::ConcurrentUpdate(ref cause) => write!(f, "{}", cause),
+            UpdateScalingPlanError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateScalingPlanError::ObjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateScalingPlanError {}
 /// Trait representing the capabilities of the AWS Auto Scaling Plans API. AWS Auto Scaling Plans clients implement this trait.
 pub trait AutoscalingPlans {
     /// <p>Creates a scaling plan.</p>

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -7040,17 +7040,13 @@ impl AttachInstancesError {
 }
 impl fmt::Display for AttachInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            AttachInstancesError::ResourceContentionFault(ref cause) => cause,
-            AttachInstancesError::ServiceLinkedRoleFailure(ref cause) => cause,
+            AttachInstancesError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            AttachInstancesError::ServiceLinkedRoleFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachInstancesError {}
 /// Errors returned by AttachLoadBalancerTargetGroups
 #[derive(Debug, PartialEq)]
 pub enum AttachLoadBalancerTargetGroupsError {
@@ -7101,17 +7097,17 @@ impl AttachLoadBalancerTargetGroupsError {
 }
 impl fmt::Display for AttachLoadBalancerTargetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachLoadBalancerTargetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            AttachLoadBalancerTargetGroupsError::ResourceContentionFault(ref cause) => cause,
-            AttachLoadBalancerTargetGroupsError::ServiceLinkedRoleFailure(ref cause) => cause,
+            AttachLoadBalancerTargetGroupsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachLoadBalancerTargetGroupsError::ServiceLinkedRoleFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AttachLoadBalancerTargetGroupsError {}
 /// Errors returned by AttachLoadBalancers
 #[derive(Debug, PartialEq)]
 pub enum AttachLoadBalancersError {
@@ -7158,17 +7154,13 @@ impl AttachLoadBalancersError {
 }
 impl fmt::Display for AttachLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachLoadBalancersError {
-    fn description(&self) -> &str {
         match *self {
-            AttachLoadBalancersError::ResourceContentionFault(ref cause) => cause,
-            AttachLoadBalancersError::ServiceLinkedRoleFailure(ref cause) => cause,
+            AttachLoadBalancersError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            AttachLoadBalancersError::ServiceLinkedRoleFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachLoadBalancersError {}
 /// Errors returned by BatchDeleteScheduledAction
 #[derive(Debug, PartialEq)]
 pub enum BatchDeleteScheduledActionError {
@@ -7210,16 +7202,14 @@ impl BatchDeleteScheduledActionError {
 }
 impl fmt::Display for BatchDeleteScheduledActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteScheduledActionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeleteScheduledActionError::ResourceContentionFault(ref cause) => cause,
+            BatchDeleteScheduledActionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchDeleteScheduledActionError {}
 /// Errors returned by BatchPutScheduledUpdateGroupAction
 #[derive(Debug, PartialEq)]
 pub enum BatchPutScheduledUpdateGroupActionError {
@@ -7279,18 +7269,20 @@ impl BatchPutScheduledUpdateGroupActionError {
 }
 impl fmt::Display for BatchPutScheduledUpdateGroupActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchPutScheduledUpdateGroupActionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchPutScheduledUpdateGroupActionError::AlreadyExistsFault(ref cause) => cause,
-            BatchPutScheduledUpdateGroupActionError::LimitExceededFault(ref cause) => cause,
-            BatchPutScheduledUpdateGroupActionError::ResourceContentionFault(ref cause) => cause,
+            BatchPutScheduledUpdateGroupActionError::AlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchPutScheduledUpdateGroupActionError::LimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchPutScheduledUpdateGroupActionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchPutScheduledUpdateGroupActionError {}
 /// Errors returned by CompleteLifecycleAction
 #[derive(Debug, PartialEq)]
 pub enum CompleteLifecycleActionError {
@@ -7330,16 +7322,14 @@ impl CompleteLifecycleActionError {
 }
 impl fmt::Display for CompleteLifecycleActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CompleteLifecycleActionError {
-    fn description(&self) -> &str {
         match *self {
-            CompleteLifecycleActionError::ResourceContentionFault(ref cause) => cause,
+            CompleteLifecycleActionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CompleteLifecycleActionError {}
 /// Errors returned by CreateAutoScalingGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateAutoScalingGroupError {
@@ -7402,19 +7392,19 @@ impl CreateAutoScalingGroupError {
 }
 impl fmt::Display for CreateAutoScalingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAutoScalingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAutoScalingGroupError::AlreadyExistsFault(ref cause) => cause,
-            CreateAutoScalingGroupError::LimitExceededFault(ref cause) => cause,
-            CreateAutoScalingGroupError::ResourceContentionFault(ref cause) => cause,
-            CreateAutoScalingGroupError::ServiceLinkedRoleFailure(ref cause) => cause,
+            CreateAutoScalingGroupError::AlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateAutoScalingGroupError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateAutoScalingGroupError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAutoScalingGroupError::ServiceLinkedRoleFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateAutoScalingGroupError {}
 /// Errors returned by CreateLaunchConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateLaunchConfigurationError {
@@ -7472,18 +7462,16 @@ impl CreateLaunchConfigurationError {
 }
 impl fmt::Display for CreateLaunchConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLaunchConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLaunchConfigurationError::AlreadyExistsFault(ref cause) => cause,
-            CreateLaunchConfigurationError::LimitExceededFault(ref cause) => cause,
-            CreateLaunchConfigurationError::ResourceContentionFault(ref cause) => cause,
+            CreateLaunchConfigurationError::AlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateLaunchConfigurationError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateLaunchConfigurationError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateLaunchConfigurationError {}
 /// Errors returned by CreateOrUpdateTags
 #[derive(Debug, PartialEq)]
 pub enum CreateOrUpdateTagsError {
@@ -7542,19 +7530,15 @@ impl CreateOrUpdateTagsError {
 }
 impl fmt::Display for CreateOrUpdateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOrUpdateTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOrUpdateTagsError::AlreadyExistsFault(ref cause) => cause,
-            CreateOrUpdateTagsError::LimitExceededFault(ref cause) => cause,
-            CreateOrUpdateTagsError::ResourceContentionFault(ref cause) => cause,
-            CreateOrUpdateTagsError::ResourceInUseFault(ref cause) => cause,
+            CreateOrUpdateTagsError::AlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateOrUpdateTagsError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateOrUpdateTagsError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            CreateOrUpdateTagsError::ResourceInUseFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateOrUpdateTagsError {}
 /// Errors returned by DeleteAutoScalingGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteAutoScalingGroupError {
@@ -7610,18 +7594,18 @@ impl DeleteAutoScalingGroupError {
 }
 impl fmt::Display for DeleteAutoScalingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAutoScalingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAutoScalingGroupError::ResourceContentionFault(ref cause) => cause,
-            DeleteAutoScalingGroupError::ResourceInUseFault(ref cause) => cause,
-            DeleteAutoScalingGroupError::ScalingActivityInProgressFault(ref cause) => cause,
+            DeleteAutoScalingGroupError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAutoScalingGroupError::ResourceInUseFault(ref cause) => write!(f, "{}", cause),
+            DeleteAutoScalingGroupError::ScalingActivityInProgressFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteAutoScalingGroupError {}
 /// Errors returned by DeleteLaunchConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteLaunchConfigurationError {
@@ -7670,17 +7654,15 @@ impl DeleteLaunchConfigurationError {
 }
 impl fmt::Display for DeleteLaunchConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLaunchConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLaunchConfigurationError::ResourceContentionFault(ref cause) => cause,
-            DeleteLaunchConfigurationError::ResourceInUseFault(ref cause) => cause,
+            DeleteLaunchConfigurationError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLaunchConfigurationError::ResourceInUseFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLaunchConfigurationError {}
 /// Errors returned by DeleteLifecycleHook
 #[derive(Debug, PartialEq)]
 pub enum DeleteLifecycleHookError {
@@ -7718,16 +7700,12 @@ impl DeleteLifecycleHookError {
 }
 impl fmt::Display for DeleteLifecycleHookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLifecycleHookError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLifecycleHookError::ResourceContentionFault(ref cause) => cause,
+            DeleteLifecycleHookError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLifecycleHookError {}
 /// Errors returned by DeleteNotificationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteNotificationConfigurationError {
@@ -7769,16 +7747,14 @@ impl DeleteNotificationConfigurationError {
 }
 impl fmt::Display for DeleteNotificationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNotificationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNotificationConfigurationError::ResourceContentionFault(ref cause) => cause,
+            DeleteNotificationConfigurationError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteNotificationConfigurationError {}
 /// Errors returned by DeletePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeletePolicyError {
@@ -7823,17 +7799,13 @@ impl DeletePolicyError {
 }
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePolicyError::ResourceContentionFault(ref cause) => cause,
-            DeletePolicyError::ServiceLinkedRoleFailure(ref cause) => cause,
+            DeletePolicyError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::ServiceLinkedRoleFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePolicyError {}
 /// Errors returned by DeleteScheduledAction
 #[derive(Debug, PartialEq)]
 pub enum DeleteScheduledActionError {
@@ -7873,16 +7845,14 @@ impl DeleteScheduledActionError {
 }
 impl fmt::Display for DeleteScheduledActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScheduledActionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScheduledActionError::ResourceContentionFault(ref cause) => cause,
+            DeleteScheduledActionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteScheduledActionError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -7927,17 +7897,13 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::ResourceContentionFault(ref cause) => cause,
-            DeleteTagsError::ResourceInUseFault(ref cause) => cause,
+            DeleteTagsError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::ResourceInUseFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DescribeAccountLimits
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountLimitsError {
@@ -7977,16 +7943,14 @@ impl DescribeAccountLimitsError {
 }
 impl fmt::Display for DescribeAccountLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountLimitsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAccountLimitsError::ResourceContentionFault(ref cause) => cause,
+            DescribeAccountLimitsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAccountLimitsError {}
 /// Errors returned by DescribeAdjustmentTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAdjustmentTypesError {
@@ -8026,16 +7990,14 @@ impl DescribeAdjustmentTypesError {
 }
 impl fmt::Display for DescribeAdjustmentTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAdjustmentTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAdjustmentTypesError::ResourceContentionFault(ref cause) => cause,
+            DescribeAdjustmentTypesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAdjustmentTypesError {}
 /// Errors returned by DescribeAutoScalingGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeAutoScalingGroupsError {
@@ -8082,17 +8044,15 @@ impl DescribeAutoScalingGroupsError {
 }
 impl fmt::Display for DescribeAutoScalingGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAutoScalingGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAutoScalingGroupsError::InvalidNextToken(ref cause) => cause,
-            DescribeAutoScalingGroupsError::ResourceContentionFault(ref cause) => cause,
+            DescribeAutoScalingGroupsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeAutoScalingGroupsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAutoScalingGroupsError {}
 /// Errors returned by DescribeAutoScalingInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeAutoScalingInstancesError {
@@ -8143,17 +8103,17 @@ impl DescribeAutoScalingInstancesError {
 }
 impl fmt::Display for DescribeAutoScalingInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAutoScalingInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAutoScalingInstancesError::InvalidNextToken(ref cause) => cause,
-            DescribeAutoScalingInstancesError::ResourceContentionFault(ref cause) => cause,
+            DescribeAutoScalingInstancesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutoScalingInstancesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAutoScalingInstancesError {}
 /// Errors returned by DescribeAutoScalingNotificationTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAutoScalingNotificationTypesError {
@@ -8195,16 +8155,14 @@ impl DescribeAutoScalingNotificationTypesError {
 }
 impl fmt::Display for DescribeAutoScalingNotificationTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAutoScalingNotificationTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAutoScalingNotificationTypesError::ResourceContentionFault(ref cause) => cause,
+            DescribeAutoScalingNotificationTypesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAutoScalingNotificationTypesError {}
 /// Errors returned by DescribeLaunchConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeLaunchConfigurationsError {
@@ -8255,17 +8213,17 @@ impl DescribeLaunchConfigurationsError {
 }
 impl fmt::Display for DescribeLaunchConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLaunchConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLaunchConfigurationsError::InvalidNextToken(ref cause) => cause,
-            DescribeLaunchConfigurationsError::ResourceContentionFault(ref cause) => cause,
+            DescribeLaunchConfigurationsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeLaunchConfigurationsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLaunchConfigurationsError {}
 /// Errors returned by DescribeLifecycleHookTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeLifecycleHookTypesError {
@@ -8307,16 +8265,14 @@ impl DescribeLifecycleHookTypesError {
 }
 impl fmt::Display for DescribeLifecycleHookTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLifecycleHookTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLifecycleHookTypesError::ResourceContentionFault(ref cause) => cause,
+            DescribeLifecycleHookTypesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLifecycleHookTypesError {}
 /// Errors returned by DescribeLifecycleHooks
 #[derive(Debug, PartialEq)]
 pub enum DescribeLifecycleHooksError {
@@ -8356,16 +8312,14 @@ impl DescribeLifecycleHooksError {
 }
 impl fmt::Display for DescribeLifecycleHooksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLifecycleHooksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLifecycleHooksError::ResourceContentionFault(ref cause) => cause,
+            DescribeLifecycleHooksError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLifecycleHooksError {}
 /// Errors returned by DescribeLoadBalancerTargetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancerTargetGroupsError {
@@ -8407,16 +8361,14 @@ impl DescribeLoadBalancerTargetGroupsError {
 }
 impl fmt::Display for DescribeLoadBalancerTargetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancerTargetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancerTargetGroupsError::ResourceContentionFault(ref cause) => cause,
+            DescribeLoadBalancerTargetGroupsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLoadBalancerTargetGroupsError {}
 /// Errors returned by DescribeLoadBalancers
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancersError {
@@ -8456,16 +8408,14 @@ impl DescribeLoadBalancersError {
 }
 impl fmt::Display for DescribeLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancersError::ResourceContentionFault(ref cause) => cause,
+            DescribeLoadBalancersError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLoadBalancersError {}
 /// Errors returned by DescribeMetricCollectionTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeMetricCollectionTypesError {
@@ -8507,16 +8457,14 @@ impl DescribeMetricCollectionTypesError {
 }
 impl fmt::Display for DescribeMetricCollectionTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMetricCollectionTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMetricCollectionTypesError::ResourceContentionFault(ref cause) => cause,
+            DescribeMetricCollectionTypesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMetricCollectionTypesError {}
 /// Errors returned by DescribeNotificationConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeNotificationConfigurationsError {
@@ -8567,17 +8515,17 @@ impl DescribeNotificationConfigurationsError {
 }
 impl fmt::Display for DescribeNotificationConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNotificationConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeNotificationConfigurationsError::InvalidNextToken(ref cause) => cause,
-            DescribeNotificationConfigurationsError::ResourceContentionFault(ref cause) => cause,
+            DescribeNotificationConfigurationsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNotificationConfigurationsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeNotificationConfigurationsError {}
 /// Errors returned by DescribePolicies
 #[derive(Debug, PartialEq)]
 pub enum DescribePoliciesError {
@@ -8629,18 +8577,14 @@ impl DescribePoliciesError {
 }
 impl fmt::Display for DescribePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePoliciesError::InvalidNextToken(ref cause) => cause,
-            DescribePoliciesError::ResourceContentionFault(ref cause) => cause,
-            DescribePoliciesError::ServiceLinkedRoleFailure(ref cause) => cause,
+            DescribePoliciesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribePoliciesError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            DescribePoliciesError::ServiceLinkedRoleFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePoliciesError {}
 /// Errors returned by DescribeScalingActivities
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingActivitiesError {
@@ -8687,17 +8631,15 @@ impl DescribeScalingActivitiesError {
 }
 impl fmt::Display for DescribeScalingActivitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingActivitiesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingActivitiesError::InvalidNextToken(ref cause) => cause,
-            DescribeScalingActivitiesError::ResourceContentionFault(ref cause) => cause,
+            DescribeScalingActivitiesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeScalingActivitiesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeScalingActivitiesError {}
 /// Errors returned by DescribeScalingProcessTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingProcessTypesError {
@@ -8739,16 +8681,14 @@ impl DescribeScalingProcessTypesError {
 }
 impl fmt::Display for DescribeScalingProcessTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingProcessTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingProcessTypesError::ResourceContentionFault(ref cause) => cause,
+            DescribeScalingProcessTypesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeScalingProcessTypesError {}
 /// Errors returned by DescribeScheduledActions
 #[derive(Debug, PartialEq)]
 pub enum DescribeScheduledActionsError {
@@ -8795,17 +8735,15 @@ impl DescribeScheduledActionsError {
 }
 impl fmt::Display for DescribeScheduledActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScheduledActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScheduledActionsError::InvalidNextToken(ref cause) => cause,
-            DescribeScheduledActionsError::ResourceContentionFault(ref cause) => cause,
+            DescribeScheduledActionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeScheduledActionsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeScheduledActionsError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -8850,17 +8788,13 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::InvalidNextToken(ref cause) => cause,
-            DescribeTagsError::ResourceContentionFault(ref cause) => cause,
+            DescribeTagsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by DescribeTerminationPolicyTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeTerminationPolicyTypesError {
@@ -8902,16 +8836,14 @@ impl DescribeTerminationPolicyTypesError {
 }
 impl fmt::Display for DescribeTerminationPolicyTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTerminationPolicyTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTerminationPolicyTypesError::ResourceContentionFault(ref cause) => cause,
+            DescribeTerminationPolicyTypesError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTerminationPolicyTypesError {}
 /// Errors returned by DetachInstances
 #[derive(Debug, PartialEq)]
 pub enum DetachInstancesError {
@@ -8949,16 +8881,12 @@ impl DetachInstancesError {
 }
 impl fmt::Display for DetachInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DetachInstancesError::ResourceContentionFault(ref cause) => cause,
+            DetachInstancesError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachInstancesError {}
 /// Errors returned by DetachLoadBalancerTargetGroups
 #[derive(Debug, PartialEq)]
 pub enum DetachLoadBalancerTargetGroupsError {
@@ -9000,16 +8928,14 @@ impl DetachLoadBalancerTargetGroupsError {
 }
 impl fmt::Display for DetachLoadBalancerTargetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachLoadBalancerTargetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DetachLoadBalancerTargetGroupsError::ResourceContentionFault(ref cause) => cause,
+            DetachLoadBalancerTargetGroupsError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DetachLoadBalancerTargetGroupsError {}
 /// Errors returned by DetachLoadBalancers
 #[derive(Debug, PartialEq)]
 pub enum DetachLoadBalancersError {
@@ -9047,16 +8973,12 @@ impl DetachLoadBalancersError {
 }
 impl fmt::Display for DetachLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachLoadBalancersError {
-    fn description(&self) -> &str {
         match *self {
-            DetachLoadBalancersError::ResourceContentionFault(ref cause) => cause,
+            DetachLoadBalancersError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachLoadBalancersError {}
 /// Errors returned by DisableMetricsCollection
 #[derive(Debug, PartialEq)]
 pub enum DisableMetricsCollectionError {
@@ -9096,16 +9018,14 @@ impl DisableMetricsCollectionError {
 }
 impl fmt::Display for DisableMetricsCollectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableMetricsCollectionError {
-    fn description(&self) -> &str {
         match *self {
-            DisableMetricsCollectionError::ResourceContentionFault(ref cause) => cause,
+            DisableMetricsCollectionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisableMetricsCollectionError {}
 /// Errors returned by EnableMetricsCollection
 #[derive(Debug, PartialEq)]
 pub enum EnableMetricsCollectionError {
@@ -9145,16 +9065,14 @@ impl EnableMetricsCollectionError {
 }
 impl fmt::Display for EnableMetricsCollectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableMetricsCollectionError {
-    fn description(&self) -> &str {
         match *self {
-            EnableMetricsCollectionError::ResourceContentionFault(ref cause) => cause,
+            EnableMetricsCollectionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for EnableMetricsCollectionError {}
 /// Errors returned by EnterStandby
 #[derive(Debug, PartialEq)]
 pub enum EnterStandbyError {
@@ -9192,16 +9110,12 @@ impl EnterStandbyError {
 }
 impl fmt::Display for EnterStandbyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnterStandbyError {
-    fn description(&self) -> &str {
         match *self {
-            EnterStandbyError::ResourceContentionFault(ref cause) => cause,
+            EnterStandbyError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnterStandbyError {}
 /// Errors returned by ExecutePolicy
 #[derive(Debug, PartialEq)]
 pub enum ExecutePolicyError {
@@ -9248,17 +9162,13 @@ impl ExecutePolicyError {
 }
 impl fmt::Display for ExecutePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExecutePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            ExecutePolicyError::ResourceContentionFault(ref cause) => cause,
-            ExecutePolicyError::ScalingActivityInProgressFault(ref cause) => cause,
+            ExecutePolicyError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            ExecutePolicyError::ScalingActivityInProgressFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExecutePolicyError {}
 /// Errors returned by ExitStandby
 #[derive(Debug, PartialEq)]
 pub enum ExitStandbyError {
@@ -9296,16 +9206,12 @@ impl ExitStandbyError {
 }
 impl fmt::Display for ExitStandbyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExitStandbyError {
-    fn description(&self) -> &str {
         match *self {
-            ExitStandbyError::ResourceContentionFault(ref cause) => cause,
+            ExitStandbyError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExitStandbyError {}
 /// Errors returned by PutLifecycleHook
 #[derive(Debug, PartialEq)]
 pub enum PutLifecycleHookError {
@@ -9350,17 +9256,13 @@ impl PutLifecycleHookError {
 }
 impl fmt::Display for PutLifecycleHookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLifecycleHookError {
-    fn description(&self) -> &str {
         match *self {
-            PutLifecycleHookError::LimitExceededFault(ref cause) => cause,
-            PutLifecycleHookError::ResourceContentionFault(ref cause) => cause,
+            PutLifecycleHookError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            PutLifecycleHookError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLifecycleHookError {}
 /// Errors returned by PutNotificationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutNotificationConfigurationError {
@@ -9420,18 +9322,20 @@ impl PutNotificationConfigurationError {
 }
 impl fmt::Display for PutNotificationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutNotificationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutNotificationConfigurationError::LimitExceededFault(ref cause) => cause,
-            PutNotificationConfigurationError::ResourceContentionFault(ref cause) => cause,
-            PutNotificationConfigurationError::ServiceLinkedRoleFailure(ref cause) => cause,
+            PutNotificationConfigurationError::LimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutNotificationConfigurationError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutNotificationConfigurationError::ServiceLinkedRoleFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutNotificationConfigurationError {}
 /// Errors returned by PutScalingPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutScalingPolicyError {
@@ -9483,18 +9387,14 @@ impl PutScalingPolicyError {
 }
 impl fmt::Display for PutScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutScalingPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutScalingPolicyError::LimitExceededFault(ref cause) => cause,
-            PutScalingPolicyError::ResourceContentionFault(ref cause) => cause,
-            PutScalingPolicyError::ServiceLinkedRoleFailure(ref cause) => cause,
+            PutScalingPolicyError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::ServiceLinkedRoleFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutScalingPolicyError {}
 /// Errors returned by PutScheduledUpdateGroupAction
 #[derive(Debug, PartialEq)]
 pub enum PutScheduledUpdateGroupActionError {
@@ -9554,18 +9454,20 @@ impl PutScheduledUpdateGroupActionError {
 }
 impl fmt::Display for PutScheduledUpdateGroupActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutScheduledUpdateGroupActionError {
-    fn description(&self) -> &str {
         match *self {
-            PutScheduledUpdateGroupActionError::AlreadyExistsFault(ref cause) => cause,
-            PutScheduledUpdateGroupActionError::LimitExceededFault(ref cause) => cause,
-            PutScheduledUpdateGroupActionError::ResourceContentionFault(ref cause) => cause,
+            PutScheduledUpdateGroupActionError::AlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutScheduledUpdateGroupActionError::LimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutScheduledUpdateGroupActionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutScheduledUpdateGroupActionError {}
 /// Errors returned by RecordLifecycleActionHeartbeat
 #[derive(Debug, PartialEq)]
 pub enum RecordLifecycleActionHeartbeatError {
@@ -9607,16 +9509,14 @@ impl RecordLifecycleActionHeartbeatError {
 }
 impl fmt::Display for RecordLifecycleActionHeartbeatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RecordLifecycleActionHeartbeatError {
-    fn description(&self) -> &str {
         match *self {
-            RecordLifecycleActionHeartbeatError::ResourceContentionFault(ref cause) => cause,
+            RecordLifecycleActionHeartbeatError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RecordLifecycleActionHeartbeatError {}
 /// Errors returned by ResumeProcesses
 #[derive(Debug, PartialEq)]
 pub enum ResumeProcessesError {
@@ -9661,17 +9561,13 @@ impl ResumeProcessesError {
 }
 impl fmt::Display for ResumeProcessesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResumeProcessesError {
-    fn description(&self) -> &str {
         match *self {
-            ResumeProcessesError::ResourceContentionFault(ref cause) => cause,
-            ResumeProcessesError::ResourceInUseFault(ref cause) => cause,
+            ResumeProcessesError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            ResumeProcessesError::ResourceInUseFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResumeProcessesError {}
 /// Errors returned by SetDesiredCapacity
 #[derive(Debug, PartialEq)]
 pub enum SetDesiredCapacityError {
@@ -9718,17 +9614,15 @@ impl SetDesiredCapacityError {
 }
 impl fmt::Display for SetDesiredCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetDesiredCapacityError {
-    fn description(&self) -> &str {
         match *self {
-            SetDesiredCapacityError::ResourceContentionFault(ref cause) => cause,
-            SetDesiredCapacityError::ScalingActivityInProgressFault(ref cause) => cause,
+            SetDesiredCapacityError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            SetDesiredCapacityError::ScalingActivityInProgressFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetDesiredCapacityError {}
 /// Errors returned by SetInstanceHealth
 #[derive(Debug, PartialEq)]
 pub enum SetInstanceHealthError {
@@ -9766,16 +9660,12 @@ impl SetInstanceHealthError {
 }
 impl fmt::Display for SetInstanceHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetInstanceHealthError {
-    fn description(&self) -> &str {
         match *self {
-            SetInstanceHealthError::ResourceContentionFault(ref cause) => cause,
+            SetInstanceHealthError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetInstanceHealthError {}
 /// Errors returned by SetInstanceProtection
 #[derive(Debug, PartialEq)]
 pub enum SetInstanceProtectionError {
@@ -9822,17 +9712,15 @@ impl SetInstanceProtectionError {
 }
 impl fmt::Display for SetInstanceProtectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetInstanceProtectionError {
-    fn description(&self) -> &str {
         match *self {
-            SetInstanceProtectionError::LimitExceededFault(ref cause) => cause,
-            SetInstanceProtectionError::ResourceContentionFault(ref cause) => cause,
+            SetInstanceProtectionError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            SetInstanceProtectionError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetInstanceProtectionError {}
 /// Errors returned by SuspendProcesses
 #[derive(Debug, PartialEq)]
 pub enum SuspendProcessesError {
@@ -9877,17 +9765,13 @@ impl SuspendProcessesError {
 }
 impl fmt::Display for SuspendProcessesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SuspendProcessesError {
-    fn description(&self) -> &str {
         match *self {
-            SuspendProcessesError::ResourceContentionFault(ref cause) => cause,
-            SuspendProcessesError::ResourceInUseFault(ref cause) => cause,
+            SuspendProcessesError::ResourceContentionFault(ref cause) => write!(f, "{}", cause),
+            SuspendProcessesError::ResourceInUseFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SuspendProcessesError {}
 /// Errors returned by TerminateInstanceInAutoScalingGroup
 #[derive(Debug, PartialEq)]
 pub enum TerminateInstanceInAutoScalingGroupError {
@@ -9936,19 +9820,17 @@ impl TerminateInstanceInAutoScalingGroupError {
 }
 impl fmt::Display for TerminateInstanceInAutoScalingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateInstanceInAutoScalingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateInstanceInAutoScalingGroupError::ResourceContentionFault(ref cause) => cause,
+            TerminateInstanceInAutoScalingGroupError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             TerminateInstanceInAutoScalingGroupError::ScalingActivityInProgressFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for TerminateInstanceInAutoScalingGroupError {}
 /// Errors returned by UpdateAutoScalingGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateAutoScalingGroupError {
@@ -10006,18 +9888,20 @@ impl UpdateAutoScalingGroupError {
 }
 impl fmt::Display for UpdateAutoScalingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAutoScalingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAutoScalingGroupError::ResourceContentionFault(ref cause) => cause,
-            UpdateAutoScalingGroupError::ScalingActivityInProgressFault(ref cause) => cause,
-            UpdateAutoScalingGroupError::ServiceLinkedRoleFailure(ref cause) => cause,
+            UpdateAutoScalingGroupError::ResourceContentionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAutoScalingGroupError::ScalingActivityInProgressFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAutoScalingGroupError::ServiceLinkedRoleFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateAutoScalingGroupError {}
 /// Trait representing the capabilities of the Auto Scaling API. Auto Scaling clients implement this trait.
 pub trait Autoscaling {
     /// <p>Attaches one or more EC2 instances to the specified Auto Scaling group.</p> <p>When you attach instances, Amazon EC2 Auto Scaling increases the desired capacity of the group by the number of instances being attached. If the number of instances being attached plus the desired capacity of the group exceeds the maximum size of the group, the operation fails.</p> <p>If there is a Classic Load Balancer attached to your Auto Scaling group, the instances are also registered with the load balancer. If there are target groups attached to your Auto Scaling group, the instances are also registered with the target groups.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-instance-asg.html">Attach EC2 Instances to Your Auto Scaling Group</a> in the <i>Amazon EC2 Auto Scaling User Guide</i>.</p>

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -1340,17 +1340,13 @@ impl CancelJobError {
 }
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelJobError {
-    fn description(&self) -> &str {
         match *self {
-            CancelJobError::Client(ref cause) => cause,
-            CancelJobError::Server(ref cause) => cause,
+            CancelJobError::Client(ref cause) => write!(f, "{}", cause),
+            CancelJobError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelJobError {}
 /// Errors returned by CreateComputeEnvironment
 #[derive(Debug, PartialEq)]
 pub enum CreateComputeEnvironmentError {
@@ -1379,17 +1375,13 @@ impl CreateComputeEnvironmentError {
 }
 impl fmt::Display for CreateComputeEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateComputeEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateComputeEnvironmentError::Client(ref cause) => cause,
-            CreateComputeEnvironmentError::Server(ref cause) => cause,
+            CreateComputeEnvironmentError::Client(ref cause) => write!(f, "{}", cause),
+            CreateComputeEnvironmentError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateComputeEnvironmentError {}
 /// Errors returned by CreateJobQueue
 #[derive(Debug, PartialEq)]
 pub enum CreateJobQueueError {
@@ -1418,17 +1410,13 @@ impl CreateJobQueueError {
 }
 impl fmt::Display for CreateJobQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobQueueError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobQueueError::Client(ref cause) => cause,
-            CreateJobQueueError::Server(ref cause) => cause,
+            CreateJobQueueError::Client(ref cause) => write!(f, "{}", cause),
+            CreateJobQueueError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobQueueError {}
 /// Errors returned by DeleteComputeEnvironment
 #[derive(Debug, PartialEq)]
 pub enum DeleteComputeEnvironmentError {
@@ -1457,17 +1445,13 @@ impl DeleteComputeEnvironmentError {
 }
 impl fmt::Display for DeleteComputeEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteComputeEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteComputeEnvironmentError::Client(ref cause) => cause,
-            DeleteComputeEnvironmentError::Server(ref cause) => cause,
+            DeleteComputeEnvironmentError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteComputeEnvironmentError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteComputeEnvironmentError {}
 /// Errors returned by DeleteJobQueue
 #[derive(Debug, PartialEq)]
 pub enum DeleteJobQueueError {
@@ -1496,17 +1480,13 @@ impl DeleteJobQueueError {
 }
 impl fmt::Display for DeleteJobQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteJobQueueError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteJobQueueError::Client(ref cause) => cause,
-            DeleteJobQueueError::Server(ref cause) => cause,
+            DeleteJobQueueError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteJobQueueError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteJobQueueError {}
 /// Errors returned by DeregisterJobDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeregisterJobDefinitionError {
@@ -1535,17 +1515,13 @@ impl DeregisterJobDefinitionError {
 }
 impl fmt::Display for DeregisterJobDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterJobDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterJobDefinitionError::Client(ref cause) => cause,
-            DeregisterJobDefinitionError::Server(ref cause) => cause,
+            DeregisterJobDefinitionError::Client(ref cause) => write!(f, "{}", cause),
+            DeregisterJobDefinitionError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterJobDefinitionError {}
 /// Errors returned by DescribeComputeEnvironments
 #[derive(Debug, PartialEq)]
 pub enum DescribeComputeEnvironmentsError {
@@ -1576,17 +1552,13 @@ impl DescribeComputeEnvironmentsError {
 }
 impl fmt::Display for DescribeComputeEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeComputeEnvironmentsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeComputeEnvironmentsError::Client(ref cause) => cause,
-            DescribeComputeEnvironmentsError::Server(ref cause) => cause,
+            DescribeComputeEnvironmentsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeComputeEnvironmentsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeComputeEnvironmentsError {}
 /// Errors returned by DescribeJobDefinitions
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobDefinitionsError {
@@ -1615,17 +1587,13 @@ impl DescribeJobDefinitionsError {
 }
 impl fmt::Display for DescribeJobDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobDefinitionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobDefinitionsError::Client(ref cause) => cause,
-            DescribeJobDefinitionsError::Server(ref cause) => cause,
+            DescribeJobDefinitionsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeJobDefinitionsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobDefinitionsError {}
 /// Errors returned by DescribeJobQueues
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobQueuesError {
@@ -1654,17 +1622,13 @@ impl DescribeJobQueuesError {
 }
 impl fmt::Display for DescribeJobQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobQueuesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobQueuesError::Client(ref cause) => cause,
-            DescribeJobQueuesError::Server(ref cause) => cause,
+            DescribeJobQueuesError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeJobQueuesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobQueuesError {}
 /// Errors returned by DescribeJobs
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobsError {
@@ -1693,17 +1657,13 @@ impl DescribeJobsError {
 }
 impl fmt::Display for DescribeJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobsError::Client(ref cause) => cause,
-            DescribeJobsError::Server(ref cause) => cause,
+            DescribeJobsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeJobsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobsError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -1728,17 +1688,13 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::Client(ref cause) => cause,
-            ListJobsError::Server(ref cause) => cause,
+            ListJobsError::Client(ref cause) => write!(f, "{}", cause),
+            ListJobsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by RegisterJobDefinition
 #[derive(Debug, PartialEq)]
 pub enum RegisterJobDefinitionError {
@@ -1767,17 +1723,13 @@ impl RegisterJobDefinitionError {
 }
 impl fmt::Display for RegisterJobDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterJobDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterJobDefinitionError::Client(ref cause) => cause,
-            RegisterJobDefinitionError::Server(ref cause) => cause,
+            RegisterJobDefinitionError::Client(ref cause) => write!(f, "{}", cause),
+            RegisterJobDefinitionError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterJobDefinitionError {}
 /// Errors returned by SubmitJob
 #[derive(Debug, PartialEq)]
 pub enum SubmitJobError {
@@ -1802,17 +1754,13 @@ impl SubmitJobError {
 }
 impl fmt::Display for SubmitJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubmitJobError {
-    fn description(&self) -> &str {
         match *self {
-            SubmitJobError::Client(ref cause) => cause,
-            SubmitJobError::Server(ref cause) => cause,
+            SubmitJobError::Client(ref cause) => write!(f, "{}", cause),
+            SubmitJobError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SubmitJobError {}
 /// Errors returned by TerminateJob
 #[derive(Debug, PartialEq)]
 pub enum TerminateJobError {
@@ -1841,17 +1789,13 @@ impl TerminateJobError {
 }
 impl fmt::Display for TerminateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateJobError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateJobError::Client(ref cause) => cause,
-            TerminateJobError::Server(ref cause) => cause,
+            TerminateJobError::Client(ref cause) => write!(f, "{}", cause),
+            TerminateJobError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TerminateJobError {}
 /// Errors returned by UpdateComputeEnvironment
 #[derive(Debug, PartialEq)]
 pub enum UpdateComputeEnvironmentError {
@@ -1880,17 +1824,13 @@ impl UpdateComputeEnvironmentError {
 }
 impl fmt::Display for UpdateComputeEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateComputeEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateComputeEnvironmentError::Client(ref cause) => cause,
-            UpdateComputeEnvironmentError::Server(ref cause) => cause,
+            UpdateComputeEnvironmentError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateComputeEnvironmentError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateComputeEnvironmentError {}
 /// Errors returned by UpdateJobQueue
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobQueueError {
@@ -1919,17 +1859,13 @@ impl UpdateJobQueueError {
 }
 impl fmt::Display for UpdateJobQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateJobQueueError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateJobQueueError::Client(ref cause) => cause,
-            UpdateJobQueueError::Server(ref cause) => cause,
+            UpdateJobQueueError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateJobQueueError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateJobQueueError {}
 /// Trait representing the capabilities of the AWS Batch API. AWS Batch clients implement this trait.
 pub trait Batch {
     /// <p>Cancels a job in an AWS Batch job queue. Jobs that are in the <code>SUBMITTED</code>, <code>PENDING</code>, or <code>RUNNABLE</code> state are cancelled. Jobs that have progressed to <code>STARTING</code> or <code>RUNNING</code> are not cancelled (but the API operation still succeeds, even if no job is cancelled); these jobs must be terminated with the <a>TerminateJob</a> operation.</p>

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -616,20 +616,16 @@ impl CreateBudgetError {
 }
 impl fmt::Display for CreateBudgetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBudgetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBudgetError::AccessDenied(ref cause) => cause,
-            CreateBudgetError::CreationLimitExceeded(ref cause) => cause,
-            CreateBudgetError::DuplicateRecord(ref cause) => cause,
-            CreateBudgetError::InternalError(ref cause) => cause,
-            CreateBudgetError::InvalidParameter(ref cause) => cause,
+            CreateBudgetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateBudgetError::CreationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBudgetError::DuplicateRecord(ref cause) => write!(f, "{}", cause),
+            CreateBudgetError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateBudgetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBudgetError {}
 /// Errors returned by CreateNotification
 #[derive(Debug, PartialEq)]
 pub enum CreateNotificationError {
@@ -680,21 +676,17 @@ impl CreateNotificationError {
 }
 impl fmt::Display for CreateNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNotificationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNotificationError::AccessDenied(ref cause) => cause,
-            CreateNotificationError::CreationLimitExceeded(ref cause) => cause,
-            CreateNotificationError::DuplicateRecord(ref cause) => cause,
-            CreateNotificationError::InternalError(ref cause) => cause,
-            CreateNotificationError::InvalidParameter(ref cause) => cause,
-            CreateNotificationError::NotFound(ref cause) => cause,
+            CreateNotificationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateNotificationError::CreationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateNotificationError::DuplicateRecord(ref cause) => write!(f, "{}", cause),
+            CreateNotificationError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateNotificationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateNotificationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateNotificationError {}
 /// Errors returned by CreateSubscriber
 #[derive(Debug, PartialEq)]
 pub enum CreateSubscriberError {
@@ -745,21 +737,17 @@ impl CreateSubscriberError {
 }
 impl fmt::Display for CreateSubscriberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSubscriberError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSubscriberError::AccessDenied(ref cause) => cause,
-            CreateSubscriberError::CreationLimitExceeded(ref cause) => cause,
-            CreateSubscriberError::DuplicateRecord(ref cause) => cause,
-            CreateSubscriberError::InternalError(ref cause) => cause,
-            CreateSubscriberError::InvalidParameter(ref cause) => cause,
-            CreateSubscriberError::NotFound(ref cause) => cause,
+            CreateSubscriberError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateSubscriberError::CreationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSubscriberError::DuplicateRecord(ref cause) => write!(f, "{}", cause),
+            CreateSubscriberError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateSubscriberError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateSubscriberError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSubscriberError {}
 /// Errors returned by DeleteBudget
 #[derive(Debug, PartialEq)]
 pub enum DeleteBudgetError {
@@ -798,19 +786,15 @@ impl DeleteBudgetError {
 }
 impl fmt::Display for DeleteBudgetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBudgetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBudgetError::AccessDenied(ref cause) => cause,
-            DeleteBudgetError::InternalError(ref cause) => cause,
-            DeleteBudgetError::InvalidParameter(ref cause) => cause,
-            DeleteBudgetError::NotFound(ref cause) => cause,
+            DeleteBudgetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteBudgetError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteBudgetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteBudgetError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBudgetError {}
 /// Errors returned by DeleteNotification
 #[derive(Debug, PartialEq)]
 pub enum DeleteNotificationError {
@@ -849,19 +833,15 @@ impl DeleteNotificationError {
 }
 impl fmt::Display for DeleteNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNotificationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNotificationError::AccessDenied(ref cause) => cause,
-            DeleteNotificationError::InternalError(ref cause) => cause,
-            DeleteNotificationError::InvalidParameter(ref cause) => cause,
-            DeleteNotificationError::NotFound(ref cause) => cause,
+            DeleteNotificationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteNotificationError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteNotificationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteNotificationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteNotificationError {}
 /// Errors returned by DeleteSubscriber
 #[derive(Debug, PartialEq)]
 pub enum DeleteSubscriberError {
@@ -900,19 +880,15 @@ impl DeleteSubscriberError {
 }
 impl fmt::Display for DeleteSubscriberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSubscriberError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSubscriberError::AccessDenied(ref cause) => cause,
-            DeleteSubscriberError::InternalError(ref cause) => cause,
-            DeleteSubscriberError::InvalidParameter(ref cause) => cause,
-            DeleteSubscriberError::NotFound(ref cause) => cause,
+            DeleteSubscriberError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriberError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriberError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriberError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSubscriberError {}
 /// Errors returned by DescribeBudget
 #[derive(Debug, PartialEq)]
 pub enum DescribeBudgetError {
@@ -951,19 +927,15 @@ impl DescribeBudgetError {
 }
 impl fmt::Display for DescribeBudgetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBudgetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBudgetError::AccessDenied(ref cause) => cause,
-            DescribeBudgetError::InternalError(ref cause) => cause,
-            DescribeBudgetError::InvalidParameter(ref cause) => cause,
-            DescribeBudgetError::NotFound(ref cause) => cause,
+            DescribeBudgetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBudgetError {}
 /// Errors returned by DescribeBudgetPerformanceHistory
 #[derive(Debug, PartialEq)]
 pub enum DescribeBudgetPerformanceHistoryError {
@@ -1026,21 +998,27 @@ impl DescribeBudgetPerformanceHistoryError {
 }
 impl fmt::Display for DescribeBudgetPerformanceHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBudgetPerformanceHistoryError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBudgetPerformanceHistoryError::AccessDenied(ref cause) => cause,
-            DescribeBudgetPerformanceHistoryError::ExpiredNextToken(ref cause) => cause,
-            DescribeBudgetPerformanceHistoryError::InternalError(ref cause) => cause,
-            DescribeBudgetPerformanceHistoryError::InvalidNextToken(ref cause) => cause,
-            DescribeBudgetPerformanceHistoryError::InvalidParameter(ref cause) => cause,
-            DescribeBudgetPerformanceHistoryError::NotFound(ref cause) => cause,
+            DescribeBudgetPerformanceHistoryError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeBudgetPerformanceHistoryError::ExpiredNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeBudgetPerformanceHistoryError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeBudgetPerformanceHistoryError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeBudgetPerformanceHistoryError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeBudgetPerformanceHistoryError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBudgetPerformanceHistoryError {}
 /// Errors returned by DescribeBudgets
 #[derive(Debug, PartialEq)]
 pub enum DescribeBudgetsError {
@@ -1089,21 +1067,17 @@ impl DescribeBudgetsError {
 }
 impl fmt::Display for DescribeBudgetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBudgetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBudgetsError::AccessDenied(ref cause) => cause,
-            DescribeBudgetsError::ExpiredNextToken(ref cause) => cause,
-            DescribeBudgetsError::InternalError(ref cause) => cause,
-            DescribeBudgetsError::InvalidNextToken(ref cause) => cause,
-            DescribeBudgetsError::InvalidParameter(ref cause) => cause,
-            DescribeBudgetsError::NotFound(ref cause) => cause,
+            DescribeBudgetsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetsError::ExpiredNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetsError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeBudgetsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBudgetsError {}
 /// Errors returned by DescribeNotificationsForBudget
 #[derive(Debug, PartialEq)]
 pub enum DescribeNotificationsForBudgetError {
@@ -1166,21 +1140,23 @@ impl DescribeNotificationsForBudgetError {
 }
 impl fmt::Display for DescribeNotificationsForBudgetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNotificationsForBudgetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeNotificationsForBudgetError::AccessDenied(ref cause) => cause,
-            DescribeNotificationsForBudgetError::ExpiredNextToken(ref cause) => cause,
-            DescribeNotificationsForBudgetError::InternalError(ref cause) => cause,
-            DescribeNotificationsForBudgetError::InvalidNextToken(ref cause) => cause,
-            DescribeNotificationsForBudgetError::InvalidParameter(ref cause) => cause,
-            DescribeNotificationsForBudgetError::NotFound(ref cause) => cause,
+            DescribeNotificationsForBudgetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeNotificationsForBudgetError::ExpiredNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNotificationsForBudgetError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeNotificationsForBudgetError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNotificationsForBudgetError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNotificationsForBudgetError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeNotificationsForBudgetError {}
 /// Errors returned by DescribeSubscribersForNotification
 #[derive(Debug, PartialEq)]
 pub enum DescribeSubscribersForNotificationError {
@@ -1243,21 +1219,27 @@ impl DescribeSubscribersForNotificationError {
 }
 impl fmt::Display for DescribeSubscribersForNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSubscribersForNotificationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSubscribersForNotificationError::AccessDenied(ref cause) => cause,
-            DescribeSubscribersForNotificationError::ExpiredNextToken(ref cause) => cause,
-            DescribeSubscribersForNotificationError::InternalError(ref cause) => cause,
-            DescribeSubscribersForNotificationError::InvalidNextToken(ref cause) => cause,
-            DescribeSubscribersForNotificationError::InvalidParameter(ref cause) => cause,
-            DescribeSubscribersForNotificationError::NotFound(ref cause) => cause,
+            DescribeSubscribersForNotificationError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeSubscribersForNotificationError::ExpiredNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeSubscribersForNotificationError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeSubscribersForNotificationError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeSubscribersForNotificationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeSubscribersForNotificationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSubscribersForNotificationError {}
 /// Errors returned by UpdateBudget
 #[derive(Debug, PartialEq)]
 pub enum UpdateBudgetError {
@@ -1296,19 +1278,15 @@ impl UpdateBudgetError {
 }
 impl fmt::Display for UpdateBudgetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBudgetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBudgetError::AccessDenied(ref cause) => cause,
-            UpdateBudgetError::InternalError(ref cause) => cause,
-            UpdateBudgetError::InvalidParameter(ref cause) => cause,
-            UpdateBudgetError::NotFound(ref cause) => cause,
+            UpdateBudgetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateBudgetError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateBudgetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateBudgetError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBudgetError {}
 /// Errors returned by UpdateNotification
 #[derive(Debug, PartialEq)]
 pub enum UpdateNotificationError {
@@ -1352,20 +1330,16 @@ impl UpdateNotificationError {
 }
 impl fmt::Display for UpdateNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNotificationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNotificationError::AccessDenied(ref cause) => cause,
-            UpdateNotificationError::DuplicateRecord(ref cause) => cause,
-            UpdateNotificationError::InternalError(ref cause) => cause,
-            UpdateNotificationError::InvalidParameter(ref cause) => cause,
-            UpdateNotificationError::NotFound(ref cause) => cause,
+            UpdateNotificationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateNotificationError::DuplicateRecord(ref cause) => write!(f, "{}", cause),
+            UpdateNotificationError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateNotificationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateNotificationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNotificationError {}
 /// Errors returned by UpdateSubscriber
 #[derive(Debug, PartialEq)]
 pub enum UpdateSubscriberError {
@@ -1409,20 +1383,16 @@ impl UpdateSubscriberError {
 }
 impl fmt::Display for UpdateSubscriberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSubscriberError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSubscriberError::AccessDenied(ref cause) => cause,
-            UpdateSubscriberError::DuplicateRecord(ref cause) => cause,
-            UpdateSubscriberError::InternalError(ref cause) => cause,
-            UpdateSubscriberError::InvalidParameter(ref cause) => cause,
-            UpdateSubscriberError::NotFound(ref cause) => cause,
+            UpdateSubscriberError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriberError::DuplicateRecord(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriberError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriberError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriberError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSubscriberError {}
 /// Trait representing the capabilities of the AWSBudgets API. AWSBudgets clients implement this trait.
 pub trait Budgets {
     /// <p><p>Creates a budget and, if included, notifications and subscribers. </p> <important> <p>Only one of <code>BudgetLimit</code> or <code>PlannedBudgetLimits</code> can be present in the syntax at one time. Use the syntax that matches your case. The Request Syntax section shows the <code>BudgetLimit</code> syntax. For <code>PlannedBudgetLimits</code>, see the <a href="https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_CreateBudget.html#API_CreateBudget_Examples">Examples</a> section. </p> </important></p>

--- a/rusoto/services/ce/src/generated.rs
+++ b/rusoto/services/ce/src/generated.rs
@@ -2105,17 +2105,15 @@ impl CreateCostCategoryDefinitionError {
 }
 impl fmt::Display for CreateCostCategoryDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCostCategoryDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCostCategoryDefinitionError::LimitExceeded(ref cause) => cause,
-            CreateCostCategoryDefinitionError::ServiceQuotaExceeded(ref cause) => cause,
+            CreateCostCategoryDefinitionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCostCategoryDefinitionError::ServiceQuotaExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCostCategoryDefinitionError {}
 /// Errors returned by DeleteCostCategoryDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteCostCategoryDefinitionError {
@@ -2150,17 +2148,15 @@ impl DeleteCostCategoryDefinitionError {
 }
 impl fmt::Display for DeleteCostCategoryDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCostCategoryDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCostCategoryDefinitionError::LimitExceeded(ref cause) => cause,
-            DeleteCostCategoryDefinitionError::ResourceNotFound(ref cause) => cause,
+            DeleteCostCategoryDefinitionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteCostCategoryDefinitionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCostCategoryDefinitionError {}
 /// Errors returned by DescribeCostCategoryDefinition
 #[derive(Debug, PartialEq)]
 pub enum DescribeCostCategoryDefinitionError {
@@ -2195,17 +2191,15 @@ impl DescribeCostCategoryDefinitionError {
 }
 impl fmt::Display for DescribeCostCategoryDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCostCategoryDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCostCategoryDefinitionError::LimitExceeded(ref cause) => cause,
-            DescribeCostCategoryDefinitionError::ResourceNotFound(ref cause) => cause,
+            DescribeCostCategoryDefinitionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeCostCategoryDefinitionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCostCategoryDefinitionError {}
 /// Errors returned by GetCostAndUsage
 #[derive(Debug, PartialEq)]
 pub enum GetCostAndUsageError {
@@ -2249,20 +2243,16 @@ impl GetCostAndUsageError {
 }
 impl fmt::Display for GetCostAndUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCostAndUsageError {
-    fn description(&self) -> &str {
         match *self {
-            GetCostAndUsageError::BillExpiration(ref cause) => cause,
-            GetCostAndUsageError::DataUnavailable(ref cause) => cause,
-            GetCostAndUsageError::InvalidNextToken(ref cause) => cause,
-            GetCostAndUsageError::LimitExceeded(ref cause) => cause,
-            GetCostAndUsageError::RequestChanged(ref cause) => cause,
+            GetCostAndUsageError::BillExpiration(ref cause) => write!(f, "{}", cause),
+            GetCostAndUsageError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetCostAndUsageError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetCostAndUsageError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetCostAndUsageError::RequestChanged(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCostAndUsageError {}
 /// Errors returned by GetCostAndUsageWithResources
 #[derive(Debug, PartialEq)]
 pub enum GetCostAndUsageWithResourcesError {
@@ -2318,20 +2308,18 @@ impl GetCostAndUsageWithResourcesError {
 }
 impl fmt::Display for GetCostAndUsageWithResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCostAndUsageWithResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            GetCostAndUsageWithResourcesError::BillExpiration(ref cause) => cause,
-            GetCostAndUsageWithResourcesError::DataUnavailable(ref cause) => cause,
-            GetCostAndUsageWithResourcesError::InvalidNextToken(ref cause) => cause,
-            GetCostAndUsageWithResourcesError::LimitExceeded(ref cause) => cause,
-            GetCostAndUsageWithResourcesError::RequestChanged(ref cause) => cause,
+            GetCostAndUsageWithResourcesError::BillExpiration(ref cause) => write!(f, "{}", cause),
+            GetCostAndUsageWithResourcesError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetCostAndUsageWithResourcesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCostAndUsageWithResourcesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetCostAndUsageWithResourcesError::RequestChanged(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCostAndUsageWithResourcesError {}
 /// Errors returned by GetCostForecast
 #[derive(Debug, PartialEq)]
 pub enum GetCostForecastError {
@@ -2360,17 +2348,13 @@ impl GetCostForecastError {
 }
 impl fmt::Display for GetCostForecastError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCostForecastError {
-    fn description(&self) -> &str {
         match *self {
-            GetCostForecastError::DataUnavailable(ref cause) => cause,
-            GetCostForecastError::LimitExceeded(ref cause) => cause,
+            GetCostForecastError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetCostForecastError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCostForecastError {}
 /// Errors returned by GetDimensionValues
 #[derive(Debug, PartialEq)]
 pub enum GetDimensionValuesError {
@@ -2414,20 +2398,16 @@ impl GetDimensionValuesError {
 }
 impl fmt::Display for GetDimensionValuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDimensionValuesError {
-    fn description(&self) -> &str {
         match *self {
-            GetDimensionValuesError::BillExpiration(ref cause) => cause,
-            GetDimensionValuesError::DataUnavailable(ref cause) => cause,
-            GetDimensionValuesError::InvalidNextToken(ref cause) => cause,
-            GetDimensionValuesError::LimitExceeded(ref cause) => cause,
-            GetDimensionValuesError::RequestChanged(ref cause) => cause,
+            GetDimensionValuesError::BillExpiration(ref cause) => write!(f, "{}", cause),
+            GetDimensionValuesError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDimensionValuesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetDimensionValuesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetDimensionValuesError::RequestChanged(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDimensionValuesError {}
 /// Errors returned by GetReservationCoverage
 #[derive(Debug, PartialEq)]
 pub enum GetReservationCoverageError {
@@ -2467,18 +2447,14 @@ impl GetReservationCoverageError {
 }
 impl fmt::Display for GetReservationCoverageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReservationCoverageError {
-    fn description(&self) -> &str {
         match *self {
-            GetReservationCoverageError::DataUnavailable(ref cause) => cause,
-            GetReservationCoverageError::InvalidNextToken(ref cause) => cause,
-            GetReservationCoverageError::LimitExceeded(ref cause) => cause,
+            GetReservationCoverageError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetReservationCoverageError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetReservationCoverageError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetReservationCoverageError {}
 /// Errors returned by GetReservationPurchaseRecommendation
 #[derive(Debug, PartialEq)]
 pub enum GetReservationPurchaseRecommendationError {
@@ -2520,18 +2496,20 @@ impl GetReservationPurchaseRecommendationError {
 }
 impl fmt::Display for GetReservationPurchaseRecommendationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReservationPurchaseRecommendationError {
-    fn description(&self) -> &str {
         match *self {
-            GetReservationPurchaseRecommendationError::DataUnavailable(ref cause) => cause,
-            GetReservationPurchaseRecommendationError::InvalidNextToken(ref cause) => cause,
-            GetReservationPurchaseRecommendationError::LimitExceeded(ref cause) => cause,
+            GetReservationPurchaseRecommendationError::DataUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetReservationPurchaseRecommendationError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetReservationPurchaseRecommendationError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetReservationPurchaseRecommendationError {}
 /// Errors returned by GetReservationUtilization
 #[derive(Debug, PartialEq)]
 pub enum GetReservationUtilizationError {
@@ -2571,18 +2549,14 @@ impl GetReservationUtilizationError {
 }
 impl fmt::Display for GetReservationUtilizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReservationUtilizationError {
-    fn description(&self) -> &str {
         match *self {
-            GetReservationUtilizationError::DataUnavailable(ref cause) => cause,
-            GetReservationUtilizationError::InvalidNextToken(ref cause) => cause,
-            GetReservationUtilizationError::LimitExceeded(ref cause) => cause,
+            GetReservationUtilizationError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetReservationUtilizationError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetReservationUtilizationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetReservationUtilizationError {}
 /// Errors returned by GetRightsizingRecommendation
 #[derive(Debug, PartialEq)]
 pub enum GetRightsizingRecommendationError {
@@ -2617,17 +2591,15 @@ impl GetRightsizingRecommendationError {
 }
 impl fmt::Display for GetRightsizingRecommendationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRightsizingRecommendationError {
-    fn description(&self) -> &str {
         match *self {
-            GetRightsizingRecommendationError::InvalidNextToken(ref cause) => cause,
-            GetRightsizingRecommendationError::LimitExceeded(ref cause) => cause,
+            GetRightsizingRecommendationError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRightsizingRecommendationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRightsizingRecommendationError {}
 /// Errors returned by GetSavingsPlansCoverage
 #[derive(Debug, PartialEq)]
 pub enum GetSavingsPlansCoverageError {
@@ -2667,18 +2639,14 @@ impl GetSavingsPlansCoverageError {
 }
 impl fmt::Display for GetSavingsPlansCoverageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSavingsPlansCoverageError {
-    fn description(&self) -> &str {
         match *self {
-            GetSavingsPlansCoverageError::DataUnavailable(ref cause) => cause,
-            GetSavingsPlansCoverageError::InvalidNextToken(ref cause) => cause,
-            GetSavingsPlansCoverageError::LimitExceeded(ref cause) => cause,
+            GetSavingsPlansCoverageError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetSavingsPlansCoverageError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetSavingsPlansCoverageError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSavingsPlansCoverageError {}
 /// Errors returned by GetSavingsPlansPurchaseRecommendation
 #[derive(Debug, PartialEq)]
 pub enum GetSavingsPlansPurchaseRecommendationError {
@@ -2713,17 +2681,17 @@ impl GetSavingsPlansPurchaseRecommendationError {
 }
 impl fmt::Display for GetSavingsPlansPurchaseRecommendationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSavingsPlansPurchaseRecommendationError {
-    fn description(&self) -> &str {
         match *self {
-            GetSavingsPlansPurchaseRecommendationError::InvalidNextToken(ref cause) => cause,
-            GetSavingsPlansPurchaseRecommendationError::LimitExceeded(ref cause) => cause,
+            GetSavingsPlansPurchaseRecommendationError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetSavingsPlansPurchaseRecommendationError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetSavingsPlansPurchaseRecommendationError {}
 /// Errors returned by GetSavingsPlansUtilization
 #[derive(Debug, PartialEq)]
 pub enum GetSavingsPlansUtilizationError {
@@ -2758,17 +2726,13 @@ impl GetSavingsPlansUtilizationError {
 }
 impl fmt::Display for GetSavingsPlansUtilizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSavingsPlansUtilizationError {
-    fn description(&self) -> &str {
         match *self {
-            GetSavingsPlansUtilizationError::DataUnavailable(ref cause) => cause,
-            GetSavingsPlansUtilizationError::LimitExceeded(ref cause) => cause,
+            GetSavingsPlansUtilizationError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetSavingsPlansUtilizationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSavingsPlansUtilizationError {}
 /// Errors returned by GetSavingsPlansUtilizationDetails
 #[derive(Debug, PartialEq)]
 pub enum GetSavingsPlansUtilizationDetailsError {
@@ -2810,18 +2774,20 @@ impl GetSavingsPlansUtilizationDetailsError {
 }
 impl fmt::Display for GetSavingsPlansUtilizationDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSavingsPlansUtilizationDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetSavingsPlansUtilizationDetailsError::DataUnavailable(ref cause) => cause,
-            GetSavingsPlansUtilizationDetailsError::InvalidNextToken(ref cause) => cause,
-            GetSavingsPlansUtilizationDetailsError::LimitExceeded(ref cause) => cause,
+            GetSavingsPlansUtilizationDetailsError::DataUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetSavingsPlansUtilizationDetailsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetSavingsPlansUtilizationDetailsError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetSavingsPlansUtilizationDetailsError {}
 /// Errors returned by GetTags
 #[derive(Debug, PartialEq)]
 pub enum GetTagsError {
@@ -2865,20 +2831,16 @@ impl GetTagsError {
 }
 impl fmt::Display for GetTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTagsError {
-    fn description(&self) -> &str {
         match *self {
-            GetTagsError::BillExpiration(ref cause) => cause,
-            GetTagsError::DataUnavailable(ref cause) => cause,
-            GetTagsError::InvalidNextToken(ref cause) => cause,
-            GetTagsError::LimitExceeded(ref cause) => cause,
-            GetTagsError::RequestChanged(ref cause) => cause,
+            GetTagsError::BillExpiration(ref cause) => write!(f, "{}", cause),
+            GetTagsError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetTagsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetTagsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetTagsError::RequestChanged(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTagsError {}
 /// Errors returned by GetUsageForecast
 #[derive(Debug, PartialEq)]
 pub enum GetUsageForecastError {
@@ -2914,18 +2876,14 @@ impl GetUsageForecastError {
 }
 impl fmt::Display for GetUsageForecastError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUsageForecastError {
-    fn description(&self) -> &str {
         match *self {
-            GetUsageForecastError::DataUnavailable(ref cause) => cause,
-            GetUsageForecastError::LimitExceeded(ref cause) => cause,
-            GetUsageForecastError::UnresolvableUsageUnit(ref cause) => cause,
+            GetUsageForecastError::DataUnavailable(ref cause) => write!(f, "{}", cause),
+            GetUsageForecastError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetUsageForecastError::UnresolvableUsageUnit(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUsageForecastError {}
 /// Errors returned by ListCostCategoryDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListCostCategoryDefinitionsError {
@@ -2953,16 +2911,12 @@ impl ListCostCategoryDefinitionsError {
 }
 impl fmt::Display for ListCostCategoryDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCostCategoryDefinitionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListCostCategoryDefinitionsError::LimitExceeded(ref cause) => cause,
+            ListCostCategoryDefinitionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCostCategoryDefinitionsError {}
 /// Errors returned by UpdateCostCategoryDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateCostCategoryDefinitionError {
@@ -3004,18 +2958,18 @@ impl UpdateCostCategoryDefinitionError {
 }
 impl fmt::Display for UpdateCostCategoryDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCostCategoryDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCostCategoryDefinitionError::LimitExceeded(ref cause) => cause,
-            UpdateCostCategoryDefinitionError::ResourceNotFound(ref cause) => cause,
-            UpdateCostCategoryDefinitionError::ServiceQuotaExceeded(ref cause) => cause,
+            UpdateCostCategoryDefinitionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateCostCategoryDefinitionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCostCategoryDefinitionError::ServiceQuotaExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateCostCategoryDefinitionError {}
 /// Trait representing the capabilities of the AWS Cost Explorer API. AWS Cost Explorer clients implement this trait.
 pub trait CostExplorer {
     /// <p><important> <p> <i> <b>Cost Category is in preview release for AWS Billing and Cost Management and is subject to change. Your use of Cost Categories is subject to the Beta Service Participation terms of the <a href="https://aws.amazon.com/service-terms/">AWS Service Terms</a> (Section 1.10).</b> </i> </p> </important> <p>Creates a new Cost Category with the requested name and rules.</p></p>

--- a/rusoto/services/chime/src/generated.rs
+++ b/rusoto/services/chime/src/generated.rs
@@ -2628,23 +2628,23 @@ impl AssociatePhoneNumberWithUserError {
 }
 impl fmt::Display for AssociatePhoneNumberWithUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociatePhoneNumberWithUserError {
-    fn description(&self) -> &str {
         match *self {
-            AssociatePhoneNumberWithUserError::AccessDenied(ref cause) => cause,
-            AssociatePhoneNumberWithUserError::BadRequest(ref cause) => cause,
-            AssociatePhoneNumberWithUserError::Forbidden(ref cause) => cause,
-            AssociatePhoneNumberWithUserError::NotFound(ref cause) => cause,
-            AssociatePhoneNumberWithUserError::ServiceFailure(ref cause) => cause,
-            AssociatePhoneNumberWithUserError::ServiceUnavailable(ref cause) => cause,
-            AssociatePhoneNumberWithUserError::ThrottledClient(ref cause) => cause,
-            AssociatePhoneNumberWithUserError::UnauthorizedClient(ref cause) => cause,
+            AssociatePhoneNumberWithUserError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AssociatePhoneNumberWithUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            AssociatePhoneNumberWithUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            AssociatePhoneNumberWithUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            AssociatePhoneNumberWithUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            AssociatePhoneNumberWithUserError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumberWithUserError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            AssociatePhoneNumberWithUserError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociatePhoneNumberWithUserError {}
 /// Errors returned by AssociatePhoneNumbersWithVoiceConnector
 #[derive(Debug, PartialEq)]
 pub enum AssociatePhoneNumbersWithVoiceConnectorError {
@@ -2721,23 +2721,35 @@ impl AssociatePhoneNumbersWithVoiceConnectorError {
 }
 impl fmt::Display for AssociatePhoneNumbersWithVoiceConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociatePhoneNumbersWithVoiceConnectorError {
-    fn description(&self) -> &str {
         match *self {
-            AssociatePhoneNumbersWithVoiceConnectorError::AccessDenied(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorError::BadRequest(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorError::Forbidden(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorError::NotFound(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorError::ServiceFailure(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorError::ServiceUnavailable(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorError::ThrottledClient(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorError::UnauthorizedClient(ref cause) => cause,
+            AssociatePhoneNumbersWithVoiceConnectorError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociatePhoneNumbersWithVoiceConnectorError {}
 /// Errors returned by AssociatePhoneNumbersWithVoiceConnectorGroup
 #[derive(Debug, PartialEq)]
 pub enum AssociatePhoneNumbersWithVoiceConnectorGroupError {
@@ -2818,27 +2830,35 @@ impl AssociatePhoneNumbersWithVoiceConnectorGroupError {
 }
 impl fmt::Display for AssociatePhoneNumbersWithVoiceConnectorGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociatePhoneNumbersWithVoiceConnectorGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AssociatePhoneNumbersWithVoiceConnectorGroupError::AccessDenied(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorGroupError::BadRequest(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorGroupError::Forbidden(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorGroupError::NotFound(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorGroupError::ServiceFailure(ref cause) => cause,
-            AssociatePhoneNumbersWithVoiceConnectorGroupError::ServiceUnavailable(ref cause) => {
-                cause
+            AssociatePhoneNumbersWithVoiceConnectorGroupError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
             }
-            AssociatePhoneNumbersWithVoiceConnectorGroupError::ThrottledClient(ref cause) => cause,
+            AssociatePhoneNumbersWithVoiceConnectorGroupError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorGroupError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorGroupError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorGroupError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorGroupError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePhoneNumbersWithVoiceConnectorGroupError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
             AssociatePhoneNumbersWithVoiceConnectorGroupError::UnauthorizedClient(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for AssociatePhoneNumbersWithVoiceConnectorGroupError {}
 /// Errors returned by BatchCreateAttendee
 #[derive(Debug, PartialEq)]
 pub enum BatchCreateAttendeeError {
@@ -2903,23 +2923,19 @@ impl BatchCreateAttendeeError {
 }
 impl fmt::Display for BatchCreateAttendeeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchCreateAttendeeError {
-    fn description(&self) -> &str {
         match *self {
-            BatchCreateAttendeeError::BadRequest(ref cause) => cause,
-            BatchCreateAttendeeError::Forbidden(ref cause) => cause,
-            BatchCreateAttendeeError::NotFound(ref cause) => cause,
-            BatchCreateAttendeeError::ResourceLimitExceeded(ref cause) => cause,
-            BatchCreateAttendeeError::ServiceFailure(ref cause) => cause,
-            BatchCreateAttendeeError::ServiceUnavailable(ref cause) => cause,
-            BatchCreateAttendeeError::ThrottledClient(ref cause) => cause,
-            BatchCreateAttendeeError::UnauthorizedClient(ref cause) => cause,
+            BatchCreateAttendeeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchCreateAttendeeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchCreateAttendeeError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchCreateAttendeeError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchCreateAttendeeError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            BatchCreateAttendeeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchCreateAttendeeError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            BatchCreateAttendeeError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchCreateAttendeeError {}
 /// Errors returned by BatchCreateRoomMembership
 #[derive(Debug, PartialEq)]
 pub enum BatchCreateRoomMembershipError {
@@ -2976,21 +2992,17 @@ impl BatchCreateRoomMembershipError {
 }
 impl fmt::Display for BatchCreateRoomMembershipError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchCreateRoomMembershipError {
-    fn description(&self) -> &str {
         match *self {
-            BatchCreateRoomMembershipError::BadRequest(ref cause) => cause,
-            BatchCreateRoomMembershipError::Forbidden(ref cause) => cause,
-            BatchCreateRoomMembershipError::NotFound(ref cause) => cause,
-            BatchCreateRoomMembershipError::ServiceFailure(ref cause) => cause,
-            BatchCreateRoomMembershipError::ServiceUnavailable(ref cause) => cause,
-            BatchCreateRoomMembershipError::UnauthorizedClient(ref cause) => cause,
+            BatchCreateRoomMembershipError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchCreateRoomMembershipError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchCreateRoomMembershipError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchCreateRoomMembershipError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            BatchCreateRoomMembershipError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchCreateRoomMembershipError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchCreateRoomMembershipError {}
 /// Errors returned by BatchDeletePhoneNumber
 #[derive(Debug, PartialEq)]
 pub enum BatchDeletePhoneNumberError {
@@ -3052,22 +3064,18 @@ impl BatchDeletePhoneNumberError {
 }
 impl fmt::Display for BatchDeletePhoneNumberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeletePhoneNumberError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeletePhoneNumberError::BadRequest(ref cause) => cause,
-            BatchDeletePhoneNumberError::Forbidden(ref cause) => cause,
-            BatchDeletePhoneNumberError::NotFound(ref cause) => cause,
-            BatchDeletePhoneNumberError::ServiceFailure(ref cause) => cause,
-            BatchDeletePhoneNumberError::ServiceUnavailable(ref cause) => cause,
-            BatchDeletePhoneNumberError::ThrottledClient(ref cause) => cause,
-            BatchDeletePhoneNumberError::UnauthorizedClient(ref cause) => cause,
+            BatchDeletePhoneNumberError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchDeletePhoneNumberError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchDeletePhoneNumberError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchDeletePhoneNumberError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            BatchDeletePhoneNumberError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchDeletePhoneNumberError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            BatchDeletePhoneNumberError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeletePhoneNumberError {}
 /// Errors returned by BatchSuspendUser
 #[derive(Debug, PartialEq)]
 pub enum BatchSuspendUserError {
@@ -3121,22 +3129,18 @@ impl BatchSuspendUserError {
 }
 impl fmt::Display for BatchSuspendUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchSuspendUserError {
-    fn description(&self) -> &str {
         match *self {
-            BatchSuspendUserError::BadRequest(ref cause) => cause,
-            BatchSuspendUserError::Forbidden(ref cause) => cause,
-            BatchSuspendUserError::NotFound(ref cause) => cause,
-            BatchSuspendUserError::ServiceFailure(ref cause) => cause,
-            BatchSuspendUserError::ServiceUnavailable(ref cause) => cause,
-            BatchSuspendUserError::ThrottledClient(ref cause) => cause,
-            BatchSuspendUserError::UnauthorizedClient(ref cause) => cause,
+            BatchSuspendUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchSuspendUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchSuspendUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchSuspendUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            BatchSuspendUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchSuspendUserError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            BatchSuspendUserError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchSuspendUserError {}
 /// Errors returned by BatchUnsuspendUser
 #[derive(Debug, PartialEq)]
 pub enum BatchUnsuspendUserError {
@@ -3194,22 +3198,18 @@ impl BatchUnsuspendUserError {
 }
 impl fmt::Display for BatchUnsuspendUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchUnsuspendUserError {
-    fn description(&self) -> &str {
         match *self {
-            BatchUnsuspendUserError::BadRequest(ref cause) => cause,
-            BatchUnsuspendUserError::Forbidden(ref cause) => cause,
-            BatchUnsuspendUserError::NotFound(ref cause) => cause,
-            BatchUnsuspendUserError::ServiceFailure(ref cause) => cause,
-            BatchUnsuspendUserError::ServiceUnavailable(ref cause) => cause,
-            BatchUnsuspendUserError::ThrottledClient(ref cause) => cause,
-            BatchUnsuspendUserError::UnauthorizedClient(ref cause) => cause,
+            BatchUnsuspendUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchUnsuspendUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchUnsuspendUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchUnsuspendUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            BatchUnsuspendUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchUnsuspendUserError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            BatchUnsuspendUserError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchUnsuspendUserError {}
 /// Errors returned by BatchUpdatePhoneNumber
 #[derive(Debug, PartialEq)]
 pub enum BatchUpdatePhoneNumberError {
@@ -3271,22 +3271,18 @@ impl BatchUpdatePhoneNumberError {
 }
 impl fmt::Display for BatchUpdatePhoneNumberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchUpdatePhoneNumberError {
-    fn description(&self) -> &str {
         match *self {
-            BatchUpdatePhoneNumberError::BadRequest(ref cause) => cause,
-            BatchUpdatePhoneNumberError::Forbidden(ref cause) => cause,
-            BatchUpdatePhoneNumberError::NotFound(ref cause) => cause,
-            BatchUpdatePhoneNumberError::ServiceFailure(ref cause) => cause,
-            BatchUpdatePhoneNumberError::ServiceUnavailable(ref cause) => cause,
-            BatchUpdatePhoneNumberError::ThrottledClient(ref cause) => cause,
-            BatchUpdatePhoneNumberError::UnauthorizedClient(ref cause) => cause,
+            BatchUpdatePhoneNumberError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchUpdatePhoneNumberError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchUpdatePhoneNumberError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchUpdatePhoneNumberError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            BatchUpdatePhoneNumberError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchUpdatePhoneNumberError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            BatchUpdatePhoneNumberError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchUpdatePhoneNumberError {}
 /// Errors returned by BatchUpdateUser
 #[derive(Debug, PartialEq)]
 pub enum BatchUpdateUserError {
@@ -3340,22 +3336,18 @@ impl BatchUpdateUserError {
 }
 impl fmt::Display for BatchUpdateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchUpdateUserError {
-    fn description(&self) -> &str {
         match *self {
-            BatchUpdateUserError::BadRequest(ref cause) => cause,
-            BatchUpdateUserError::Forbidden(ref cause) => cause,
-            BatchUpdateUserError::NotFound(ref cause) => cause,
-            BatchUpdateUserError::ServiceFailure(ref cause) => cause,
-            BatchUpdateUserError::ServiceUnavailable(ref cause) => cause,
-            BatchUpdateUserError::ThrottledClient(ref cause) => cause,
-            BatchUpdateUserError::UnauthorizedClient(ref cause) => cause,
+            BatchUpdateUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchUpdateUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchUpdateUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchUpdateUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            BatchUpdateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchUpdateUserError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            BatchUpdateUserError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchUpdateUserError {}
 /// Errors returned by CreateAccount
 #[derive(Debug, PartialEq)]
 pub enum CreateAccountError {
@@ -3409,22 +3401,18 @@ impl CreateAccountError {
 }
 impl fmt::Display for CreateAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAccountError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAccountError::BadRequest(ref cause) => cause,
-            CreateAccountError::Forbidden(ref cause) => cause,
-            CreateAccountError::NotFound(ref cause) => cause,
-            CreateAccountError::ServiceFailure(ref cause) => cause,
-            CreateAccountError::ServiceUnavailable(ref cause) => cause,
-            CreateAccountError::ThrottledClient(ref cause) => cause,
-            CreateAccountError::UnauthorizedClient(ref cause) => cause,
+            CreateAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAccountError {}
 /// Errors returned by CreateAttendee
 #[derive(Debug, PartialEq)]
 pub enum CreateAttendeeError {
@@ -3485,23 +3473,19 @@ impl CreateAttendeeError {
 }
 impl fmt::Display for CreateAttendeeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAttendeeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAttendeeError::BadRequest(ref cause) => cause,
-            CreateAttendeeError::Forbidden(ref cause) => cause,
-            CreateAttendeeError::NotFound(ref cause) => cause,
-            CreateAttendeeError::ResourceLimitExceeded(ref cause) => cause,
-            CreateAttendeeError::ServiceFailure(ref cause) => cause,
-            CreateAttendeeError::ServiceUnavailable(ref cause) => cause,
-            CreateAttendeeError::ThrottledClient(ref cause) => cause,
-            CreateAttendeeError::UnauthorizedClient(ref cause) => cause,
+            CreateAttendeeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateAttendeeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateAttendeeError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateAttendeeError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAttendeeError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateAttendeeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateAttendeeError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            CreateAttendeeError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAttendeeError {}
 /// Errors returned by CreateBot
 #[derive(Debug, PartialEq)]
 pub enum CreateBotError {
@@ -3555,22 +3539,18 @@ impl CreateBotError {
 }
 impl fmt::Display for CreateBotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBotError::BadRequest(ref cause) => cause,
-            CreateBotError::Forbidden(ref cause) => cause,
-            CreateBotError::NotFound(ref cause) => cause,
-            CreateBotError::ResourceLimitExceeded(ref cause) => cause,
-            CreateBotError::ServiceFailure(ref cause) => cause,
-            CreateBotError::ServiceUnavailable(ref cause) => cause,
-            CreateBotError::UnauthorizedClient(ref cause) => cause,
+            CreateBotError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateBotError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateBotError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateBotError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBotError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateBotError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateBotError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBotError {}
 /// Errors returned by CreateMeeting
 #[derive(Debug, PartialEq)]
 pub enum CreateMeetingError {
@@ -3624,22 +3604,18 @@ impl CreateMeetingError {
 }
 impl fmt::Display for CreateMeetingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMeetingError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMeetingError::BadRequest(ref cause) => cause,
-            CreateMeetingError::Forbidden(ref cause) => cause,
-            CreateMeetingError::ResourceLimitExceeded(ref cause) => cause,
-            CreateMeetingError::ServiceFailure(ref cause) => cause,
-            CreateMeetingError::ServiceUnavailable(ref cause) => cause,
-            CreateMeetingError::ThrottledClient(ref cause) => cause,
-            CreateMeetingError::UnauthorizedClient(ref cause) => cause,
+            CreateMeetingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateMeetingError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateMeetingError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateMeetingError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateMeetingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateMeetingError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            CreateMeetingError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMeetingError {}
 /// Errors returned by CreatePhoneNumberOrder
 #[derive(Debug, PartialEq)]
 pub enum CreatePhoneNumberOrderError {
@@ -3708,23 +3684,19 @@ impl CreatePhoneNumberOrderError {
 }
 impl fmt::Display for CreatePhoneNumberOrderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePhoneNumberOrderError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePhoneNumberOrderError::AccessDenied(ref cause) => cause,
-            CreatePhoneNumberOrderError::BadRequest(ref cause) => cause,
-            CreatePhoneNumberOrderError::Forbidden(ref cause) => cause,
-            CreatePhoneNumberOrderError::ResourceLimitExceeded(ref cause) => cause,
-            CreatePhoneNumberOrderError::ServiceFailure(ref cause) => cause,
-            CreatePhoneNumberOrderError::ServiceUnavailable(ref cause) => cause,
-            CreatePhoneNumberOrderError::ThrottledClient(ref cause) => cause,
-            CreatePhoneNumberOrderError::UnauthorizedClient(ref cause) => cause,
+            CreatePhoneNumberOrderError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreatePhoneNumberOrderError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreatePhoneNumberOrderError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreatePhoneNumberOrderError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePhoneNumberOrderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreatePhoneNumberOrderError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreatePhoneNumberOrderError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            CreatePhoneNumberOrderError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePhoneNumberOrderError {}
 /// Errors returned by CreateRoom
 #[derive(Debug, PartialEq)]
 pub enum CreateRoomError {
@@ -3778,22 +3750,18 @@ impl CreateRoomError {
 }
 impl fmt::Display for CreateRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRoomError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRoomError::BadRequest(ref cause) => cause,
-            CreateRoomError::Forbidden(ref cause) => cause,
-            CreateRoomError::NotFound(ref cause) => cause,
-            CreateRoomError::ResourceLimitExceeded(ref cause) => cause,
-            CreateRoomError::ServiceFailure(ref cause) => cause,
-            CreateRoomError::ServiceUnavailable(ref cause) => cause,
-            CreateRoomError::UnauthorizedClient(ref cause) => cause,
+            CreateRoomError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRoomError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateRoomError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRoomError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRoomError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateRoomError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateRoomError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRoomError {}
 /// Errors returned by CreateRoomMembership
 #[derive(Debug, PartialEq)]
 pub enum CreateRoomMembershipError {
@@ -3858,23 +3826,19 @@ impl CreateRoomMembershipError {
 }
 impl fmt::Display for CreateRoomMembershipError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRoomMembershipError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRoomMembershipError::BadRequest(ref cause) => cause,
-            CreateRoomMembershipError::Conflict(ref cause) => cause,
-            CreateRoomMembershipError::Forbidden(ref cause) => cause,
-            CreateRoomMembershipError::NotFound(ref cause) => cause,
-            CreateRoomMembershipError::ResourceLimitExceeded(ref cause) => cause,
-            CreateRoomMembershipError::ServiceFailure(ref cause) => cause,
-            CreateRoomMembershipError::ServiceUnavailable(ref cause) => cause,
-            CreateRoomMembershipError::UnauthorizedClient(ref cause) => cause,
+            CreateRoomMembershipError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRoomMembershipError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateRoomMembershipError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateRoomMembershipError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRoomMembershipError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRoomMembershipError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateRoomMembershipError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateRoomMembershipError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRoomMembershipError {}
 /// Errors returned by CreateVoiceConnector
 #[derive(Debug, PartialEq)]
 pub enum CreateVoiceConnectorError {
@@ -3941,23 +3905,19 @@ impl CreateVoiceConnectorError {
 }
 impl fmt::Display for CreateVoiceConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVoiceConnectorError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVoiceConnectorError::AccessDenied(ref cause) => cause,
-            CreateVoiceConnectorError::BadRequest(ref cause) => cause,
-            CreateVoiceConnectorError::Forbidden(ref cause) => cause,
-            CreateVoiceConnectorError::ResourceLimitExceeded(ref cause) => cause,
-            CreateVoiceConnectorError::ServiceFailure(ref cause) => cause,
-            CreateVoiceConnectorError::ServiceUnavailable(ref cause) => cause,
-            CreateVoiceConnectorError::ThrottledClient(ref cause) => cause,
-            CreateVoiceConnectorError::UnauthorizedClient(ref cause) => cause,
+            CreateVoiceConnectorError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVoiceConnectorError {}
 /// Errors returned by CreateVoiceConnectorGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateVoiceConnectorGroupError {
@@ -4030,23 +3990,21 @@ impl CreateVoiceConnectorGroupError {
 }
 impl fmt::Display for CreateVoiceConnectorGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVoiceConnectorGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVoiceConnectorGroupError::AccessDenied(ref cause) => cause,
-            CreateVoiceConnectorGroupError::BadRequest(ref cause) => cause,
-            CreateVoiceConnectorGroupError::Forbidden(ref cause) => cause,
-            CreateVoiceConnectorGroupError::ResourceLimitExceeded(ref cause) => cause,
-            CreateVoiceConnectorGroupError::ServiceFailure(ref cause) => cause,
-            CreateVoiceConnectorGroupError::ServiceUnavailable(ref cause) => cause,
-            CreateVoiceConnectorGroupError::ThrottledClient(ref cause) => cause,
-            CreateVoiceConnectorGroupError::UnauthorizedClient(ref cause) => cause,
+            CreateVoiceConnectorGroupError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorGroupError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateVoiceConnectorGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorGroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorGroupError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            CreateVoiceConnectorGroupError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVoiceConnectorGroupError {}
 /// Errors returned by DeleteAccount
 #[derive(Debug, PartialEq)]
 pub enum DeleteAccountError {
@@ -4105,23 +4063,19 @@ impl DeleteAccountError {
 }
 impl fmt::Display for DeleteAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAccountError::BadRequest(ref cause) => cause,
-            DeleteAccountError::Forbidden(ref cause) => cause,
-            DeleteAccountError::NotFound(ref cause) => cause,
-            DeleteAccountError::ServiceFailure(ref cause) => cause,
-            DeleteAccountError::ServiceUnavailable(ref cause) => cause,
-            DeleteAccountError::ThrottledClient(ref cause) => cause,
-            DeleteAccountError::UnauthorizedClient(ref cause) => cause,
-            DeleteAccountError::UnprocessableEntity(ref cause) => cause,
+            DeleteAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteAccountError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteAccountError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAccountError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteAccountError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteAccountError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            DeleteAccountError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
+            DeleteAccountError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAccountError {}
 /// Errors returned by DeleteAttendee
 #[derive(Debug, PartialEq)]
 pub enum DeleteAttendeeError {
@@ -4175,22 +4129,18 @@ impl DeleteAttendeeError {
 }
 impl fmt::Display for DeleteAttendeeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAttendeeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAttendeeError::BadRequest(ref cause) => cause,
-            DeleteAttendeeError::Forbidden(ref cause) => cause,
-            DeleteAttendeeError::NotFound(ref cause) => cause,
-            DeleteAttendeeError::ServiceFailure(ref cause) => cause,
-            DeleteAttendeeError::ServiceUnavailable(ref cause) => cause,
-            DeleteAttendeeError::ThrottledClient(ref cause) => cause,
-            DeleteAttendeeError::UnauthorizedClient(ref cause) => cause,
+            DeleteAttendeeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteAttendeeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteAttendeeError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAttendeeError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteAttendeeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteAttendeeError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            DeleteAttendeeError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAttendeeError {}
 /// Errors returned by DeleteEventsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteEventsConfigurationError {
@@ -4249,21 +4199,19 @@ impl DeleteEventsConfigurationError {
 }
 impl fmt::Display for DeleteEventsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEventsConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEventsConfigurationError::BadRequest(ref cause) => cause,
-            DeleteEventsConfigurationError::Forbidden(ref cause) => cause,
-            DeleteEventsConfigurationError::ResourceLimitExceeded(ref cause) => cause,
-            DeleteEventsConfigurationError::ServiceFailure(ref cause) => cause,
-            DeleteEventsConfigurationError::ServiceUnavailable(ref cause) => cause,
-            DeleteEventsConfigurationError::UnauthorizedClient(ref cause) => cause,
+            DeleteEventsConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteEventsConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteEventsConfigurationError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteEventsConfigurationError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteEventsConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteEventsConfigurationError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEventsConfigurationError {}
 /// Errors returned by DeleteMeeting
 #[derive(Debug, PartialEq)]
 pub enum DeleteMeetingError {
@@ -4317,22 +4265,18 @@ impl DeleteMeetingError {
 }
 impl fmt::Display for DeleteMeetingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMeetingError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMeetingError::BadRequest(ref cause) => cause,
-            DeleteMeetingError::Forbidden(ref cause) => cause,
-            DeleteMeetingError::NotFound(ref cause) => cause,
-            DeleteMeetingError::ServiceFailure(ref cause) => cause,
-            DeleteMeetingError::ServiceUnavailable(ref cause) => cause,
-            DeleteMeetingError::ThrottledClient(ref cause) => cause,
-            DeleteMeetingError::UnauthorizedClient(ref cause) => cause,
+            DeleteMeetingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMeetingError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteMeetingError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMeetingError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteMeetingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteMeetingError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            DeleteMeetingError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMeetingError {}
 /// Errors returned by DeletePhoneNumber
 #[derive(Debug, PartialEq)]
 pub enum DeletePhoneNumberError {
@@ -4390,22 +4334,18 @@ impl DeletePhoneNumberError {
 }
 impl fmt::Display for DeletePhoneNumberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePhoneNumberError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePhoneNumberError::BadRequest(ref cause) => cause,
-            DeletePhoneNumberError::Forbidden(ref cause) => cause,
-            DeletePhoneNumberError::NotFound(ref cause) => cause,
-            DeletePhoneNumberError::ServiceFailure(ref cause) => cause,
-            DeletePhoneNumberError::ServiceUnavailable(ref cause) => cause,
-            DeletePhoneNumberError::ThrottledClient(ref cause) => cause,
-            DeletePhoneNumberError::UnauthorizedClient(ref cause) => cause,
+            DeletePhoneNumberError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeletePhoneNumberError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeletePhoneNumberError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeletePhoneNumberError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeletePhoneNumberError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeletePhoneNumberError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            DeletePhoneNumberError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePhoneNumberError {}
 /// Errors returned by DeleteRoom
 #[derive(Debug, PartialEq)]
 pub enum DeleteRoomError {
@@ -4454,21 +4394,17 @@ impl DeleteRoomError {
 }
 impl fmt::Display for DeleteRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRoomError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRoomError::BadRequest(ref cause) => cause,
-            DeleteRoomError::Forbidden(ref cause) => cause,
-            DeleteRoomError::NotFound(ref cause) => cause,
-            DeleteRoomError::ServiceFailure(ref cause) => cause,
-            DeleteRoomError::ServiceUnavailable(ref cause) => cause,
-            DeleteRoomError::UnauthorizedClient(ref cause) => cause,
+            DeleteRoomError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteRoomError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteRoomError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRoomError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRoomError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteRoomError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRoomError {}
 /// Errors returned by DeleteRoomMembership
 #[derive(Debug, PartialEq)]
 pub enum DeleteRoomMembershipError {
@@ -4521,21 +4457,17 @@ impl DeleteRoomMembershipError {
 }
 impl fmt::Display for DeleteRoomMembershipError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRoomMembershipError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRoomMembershipError::BadRequest(ref cause) => cause,
-            DeleteRoomMembershipError::Forbidden(ref cause) => cause,
-            DeleteRoomMembershipError::NotFound(ref cause) => cause,
-            DeleteRoomMembershipError::ServiceFailure(ref cause) => cause,
-            DeleteRoomMembershipError::ServiceUnavailable(ref cause) => cause,
-            DeleteRoomMembershipError::UnauthorizedClient(ref cause) => cause,
+            DeleteRoomMembershipError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteRoomMembershipError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteRoomMembershipError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRoomMembershipError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRoomMembershipError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteRoomMembershipError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRoomMembershipError {}
 /// Errors returned by DeleteVoiceConnector
 #[derive(Debug, PartialEq)]
 pub enum DeleteVoiceConnectorError {
@@ -4600,23 +4532,19 @@ impl DeleteVoiceConnectorError {
 }
 impl fmt::Display for DeleteVoiceConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVoiceConnectorError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVoiceConnectorError::BadRequest(ref cause) => cause,
-            DeleteVoiceConnectorError::Conflict(ref cause) => cause,
-            DeleteVoiceConnectorError::Forbidden(ref cause) => cause,
-            DeleteVoiceConnectorError::NotFound(ref cause) => cause,
-            DeleteVoiceConnectorError::ServiceFailure(ref cause) => cause,
-            DeleteVoiceConnectorError::ServiceUnavailable(ref cause) => cause,
-            DeleteVoiceConnectorError::ThrottledClient(ref cause) => cause,
-            DeleteVoiceConnectorError::UnauthorizedClient(ref cause) => cause,
+            DeleteVoiceConnectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVoiceConnectorError {}
 /// Errors returned by DeleteVoiceConnectorGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteVoiceConnectorGroupError {
@@ -4685,23 +4613,19 @@ impl DeleteVoiceConnectorGroupError {
 }
 impl fmt::Display for DeleteVoiceConnectorGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVoiceConnectorGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVoiceConnectorGroupError::BadRequest(ref cause) => cause,
-            DeleteVoiceConnectorGroupError::Conflict(ref cause) => cause,
-            DeleteVoiceConnectorGroupError::Forbidden(ref cause) => cause,
-            DeleteVoiceConnectorGroupError::NotFound(ref cause) => cause,
-            DeleteVoiceConnectorGroupError::ServiceFailure(ref cause) => cause,
-            DeleteVoiceConnectorGroupError::ServiceUnavailable(ref cause) => cause,
-            DeleteVoiceConnectorGroupError::ThrottledClient(ref cause) => cause,
-            DeleteVoiceConnectorGroupError::UnauthorizedClient(ref cause) => cause,
+            DeleteVoiceConnectorGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorGroupError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorGroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorGroupError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorGroupError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVoiceConnectorGroupError {}
 /// Errors returned by DeleteVoiceConnectorOrigination
 #[derive(Debug, PartialEq)]
 pub enum DeleteVoiceConnectorOriginationError {
@@ -4771,22 +4695,26 @@ impl DeleteVoiceConnectorOriginationError {
 }
 impl fmt::Display for DeleteVoiceConnectorOriginationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVoiceConnectorOriginationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVoiceConnectorOriginationError::BadRequest(ref cause) => cause,
-            DeleteVoiceConnectorOriginationError::Forbidden(ref cause) => cause,
-            DeleteVoiceConnectorOriginationError::NotFound(ref cause) => cause,
-            DeleteVoiceConnectorOriginationError::ServiceFailure(ref cause) => cause,
-            DeleteVoiceConnectorOriginationError::ServiceUnavailable(ref cause) => cause,
-            DeleteVoiceConnectorOriginationError::ThrottledClient(ref cause) => cause,
-            DeleteVoiceConnectorOriginationError::UnauthorizedClient(ref cause) => cause,
+            DeleteVoiceConnectorOriginationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorOriginationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorOriginationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorOriginationError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorOriginationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorOriginationError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorOriginationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteVoiceConnectorOriginationError {}
 /// Errors returned by DeleteVoiceConnectorStreamingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteVoiceConnectorStreamingConfigurationError {
@@ -4860,22 +4788,32 @@ impl DeleteVoiceConnectorStreamingConfigurationError {
 }
 impl fmt::Display for DeleteVoiceConnectorStreamingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVoiceConnectorStreamingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVoiceConnectorStreamingConfigurationError::BadRequest(ref cause) => cause,
-            DeleteVoiceConnectorStreamingConfigurationError::Forbidden(ref cause) => cause,
-            DeleteVoiceConnectorStreamingConfigurationError::NotFound(ref cause) => cause,
-            DeleteVoiceConnectorStreamingConfigurationError::ServiceFailure(ref cause) => cause,
-            DeleteVoiceConnectorStreamingConfigurationError::ServiceUnavailable(ref cause) => cause,
-            DeleteVoiceConnectorStreamingConfigurationError::ThrottledClient(ref cause) => cause,
-            DeleteVoiceConnectorStreamingConfigurationError::UnauthorizedClient(ref cause) => cause,
+            DeleteVoiceConnectorStreamingConfigurationError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorStreamingConfigurationError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorStreamingConfigurationError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorStreamingConfigurationError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorStreamingConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorStreamingConfigurationError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorStreamingConfigurationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteVoiceConnectorStreamingConfigurationError {}
 /// Errors returned by DeleteVoiceConnectorTermination
 #[derive(Debug, PartialEq)]
 pub enum DeleteVoiceConnectorTerminationError {
@@ -4945,22 +4883,26 @@ impl DeleteVoiceConnectorTerminationError {
 }
 impl fmt::Display for DeleteVoiceConnectorTerminationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVoiceConnectorTerminationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVoiceConnectorTerminationError::BadRequest(ref cause) => cause,
-            DeleteVoiceConnectorTerminationError::Forbidden(ref cause) => cause,
-            DeleteVoiceConnectorTerminationError::NotFound(ref cause) => cause,
-            DeleteVoiceConnectorTerminationError::ServiceFailure(ref cause) => cause,
-            DeleteVoiceConnectorTerminationError::ServiceUnavailable(ref cause) => cause,
-            DeleteVoiceConnectorTerminationError::ThrottledClient(ref cause) => cause,
-            DeleteVoiceConnectorTerminationError::UnauthorizedClient(ref cause) => cause,
+            DeleteVoiceConnectorTerminationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorTerminationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorTerminationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVoiceConnectorTerminationError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteVoiceConnectorTerminationError {}
 /// Errors returned by DeleteVoiceConnectorTerminationCredentials
 #[derive(Debug, PartialEq)]
 pub enum DeleteVoiceConnectorTerminationCredentialsError {
@@ -5034,22 +4976,32 @@ impl DeleteVoiceConnectorTerminationCredentialsError {
 }
 impl fmt::Display for DeleteVoiceConnectorTerminationCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVoiceConnectorTerminationCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVoiceConnectorTerminationCredentialsError::BadRequest(ref cause) => cause,
-            DeleteVoiceConnectorTerminationCredentialsError::Forbidden(ref cause) => cause,
-            DeleteVoiceConnectorTerminationCredentialsError::NotFound(ref cause) => cause,
-            DeleteVoiceConnectorTerminationCredentialsError::ServiceFailure(ref cause) => cause,
-            DeleteVoiceConnectorTerminationCredentialsError::ServiceUnavailable(ref cause) => cause,
-            DeleteVoiceConnectorTerminationCredentialsError::ThrottledClient(ref cause) => cause,
-            DeleteVoiceConnectorTerminationCredentialsError::UnauthorizedClient(ref cause) => cause,
+            DeleteVoiceConnectorTerminationCredentialsError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationCredentialsError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationCredentialsError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationCredentialsError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationCredentialsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationCredentialsError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVoiceConnectorTerminationCredentialsError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteVoiceConnectorTerminationCredentialsError {}
 /// Errors returned by DisassociatePhoneNumberFromUser
 #[derive(Debug, PartialEq)]
 pub enum DisassociatePhoneNumberFromUserError {
@@ -5119,22 +5071,26 @@ impl DisassociatePhoneNumberFromUserError {
 }
 impl fmt::Display for DisassociatePhoneNumberFromUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociatePhoneNumberFromUserError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociatePhoneNumberFromUserError::BadRequest(ref cause) => cause,
-            DisassociatePhoneNumberFromUserError::Forbidden(ref cause) => cause,
-            DisassociatePhoneNumberFromUserError::NotFound(ref cause) => cause,
-            DisassociatePhoneNumberFromUserError::ServiceFailure(ref cause) => cause,
-            DisassociatePhoneNumberFromUserError::ServiceUnavailable(ref cause) => cause,
-            DisassociatePhoneNumberFromUserError::ThrottledClient(ref cause) => cause,
-            DisassociatePhoneNumberFromUserError::UnauthorizedClient(ref cause) => cause,
+            DisassociatePhoneNumberFromUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DisassociatePhoneNumberFromUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DisassociatePhoneNumberFromUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            DisassociatePhoneNumberFromUserError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumberFromUserError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumberFromUserError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumberFromUserError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociatePhoneNumberFromUserError {}
 /// Errors returned by DisassociatePhoneNumbersFromVoiceConnector
 #[derive(Debug, PartialEq)]
 pub enum DisassociatePhoneNumbersFromVoiceConnectorError {
@@ -5208,22 +5164,32 @@ impl DisassociatePhoneNumbersFromVoiceConnectorError {
 }
 impl fmt::Display for DisassociatePhoneNumbersFromVoiceConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociatePhoneNumbersFromVoiceConnectorError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociatePhoneNumbersFromVoiceConnectorError::BadRequest(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorError::Forbidden(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorError::NotFound(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorError::ServiceFailure(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorError::ServiceUnavailable(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorError::ThrottledClient(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorError::UnauthorizedClient(ref cause) => cause,
+            DisassociatePhoneNumbersFromVoiceConnectorError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociatePhoneNumbersFromVoiceConnectorError {}
 /// Errors returned by DisassociatePhoneNumbersFromVoiceConnectorGroup
 #[derive(Debug, PartialEq)]
 pub enum DisassociatePhoneNumbersFromVoiceConnectorGroupError {
@@ -5301,30 +5267,32 @@ impl DisassociatePhoneNumbersFromVoiceConnectorGroupError {
 }
 impl fmt::Display for DisassociatePhoneNumbersFromVoiceConnectorGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociatePhoneNumbersFromVoiceConnectorGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociatePhoneNumbersFromVoiceConnectorGroupError::BadRequest(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorGroupError::Forbidden(ref cause) => cause,
-            DisassociatePhoneNumbersFromVoiceConnectorGroupError::NotFound(ref cause) => cause,
+            DisassociatePhoneNumbersFromVoiceConnectorGroupError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorGroupError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePhoneNumbersFromVoiceConnectorGroupError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DisassociatePhoneNumbersFromVoiceConnectorGroupError::ServiceFailure(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DisassociatePhoneNumbersFromVoiceConnectorGroupError::ServiceUnavailable(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DisassociatePhoneNumbersFromVoiceConnectorGroupError::ThrottledClient(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DisassociatePhoneNumbersFromVoiceConnectorGroupError::UnauthorizedClient(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DisassociatePhoneNumbersFromVoiceConnectorGroupError {}
 /// Errors returned by GetAccount
 #[derive(Debug, PartialEq)]
 pub enum GetAccountError {
@@ -5378,22 +5346,18 @@ impl GetAccountError {
 }
 impl fmt::Display for GetAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountError::BadRequest(ref cause) => cause,
-            GetAccountError::Forbidden(ref cause) => cause,
-            GetAccountError::NotFound(ref cause) => cause,
-            GetAccountError::ServiceFailure(ref cause) => cause,
-            GetAccountError::ServiceUnavailable(ref cause) => cause,
-            GetAccountError::ThrottledClient(ref cause) => cause,
-            GetAccountError::UnauthorizedClient(ref cause) => cause,
+            GetAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetAccountError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetAccountError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAccountError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetAccountError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetAccountError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetAccountError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountError {}
 /// Errors returned by GetAccountSettings
 #[derive(Debug, PartialEq)]
 pub enum GetAccountSettingsError {
@@ -5451,22 +5415,18 @@ impl GetAccountSettingsError {
 }
 impl fmt::Display for GetAccountSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountSettingsError::BadRequest(ref cause) => cause,
-            GetAccountSettingsError::Forbidden(ref cause) => cause,
-            GetAccountSettingsError::NotFound(ref cause) => cause,
-            GetAccountSettingsError::ServiceFailure(ref cause) => cause,
-            GetAccountSettingsError::ServiceUnavailable(ref cause) => cause,
-            GetAccountSettingsError::ThrottledClient(ref cause) => cause,
-            GetAccountSettingsError::UnauthorizedClient(ref cause) => cause,
+            GetAccountSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountSettingsError {}
 /// Errors returned by GetAttendee
 #[derive(Debug, PartialEq)]
 pub enum GetAttendeeError {
@@ -5520,22 +5480,18 @@ impl GetAttendeeError {
 }
 impl fmt::Display for GetAttendeeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAttendeeError {
-    fn description(&self) -> &str {
         match *self {
-            GetAttendeeError::BadRequest(ref cause) => cause,
-            GetAttendeeError::Forbidden(ref cause) => cause,
-            GetAttendeeError::NotFound(ref cause) => cause,
-            GetAttendeeError::ServiceFailure(ref cause) => cause,
-            GetAttendeeError::ServiceUnavailable(ref cause) => cause,
-            GetAttendeeError::ThrottledClient(ref cause) => cause,
-            GetAttendeeError::UnauthorizedClient(ref cause) => cause,
+            GetAttendeeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetAttendeeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetAttendeeError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAttendeeError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetAttendeeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetAttendeeError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetAttendeeError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAttendeeError {}
 /// Errors returned by GetBot
 #[derive(Debug, PartialEq)]
 pub enum GetBotError {
@@ -5582,21 +5538,17 @@ impl GetBotError {
 }
 impl fmt::Display for GetBotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotError::BadRequest(ref cause) => cause,
-            GetBotError::Forbidden(ref cause) => cause,
-            GetBotError::NotFound(ref cause) => cause,
-            GetBotError::ServiceFailure(ref cause) => cause,
-            GetBotError::ServiceUnavailable(ref cause) => cause,
-            GetBotError::UnauthorizedClient(ref cause) => cause,
+            GetBotError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetBotError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetBotError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetBotError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetBotError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotError {}
 /// Errors returned by GetEventsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetEventsConfigurationError {
@@ -5658,22 +5610,18 @@ impl GetEventsConfigurationError {
 }
 impl fmt::Display for GetEventsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEventsConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetEventsConfigurationError::BadRequest(ref cause) => cause,
-            GetEventsConfigurationError::Forbidden(ref cause) => cause,
-            GetEventsConfigurationError::NotFound(ref cause) => cause,
-            GetEventsConfigurationError::ResourceLimitExceeded(ref cause) => cause,
-            GetEventsConfigurationError::ServiceFailure(ref cause) => cause,
-            GetEventsConfigurationError::ServiceUnavailable(ref cause) => cause,
-            GetEventsConfigurationError::UnauthorizedClient(ref cause) => cause,
+            GetEventsConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetEventsConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetEventsConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetEventsConfigurationError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetEventsConfigurationError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetEventsConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetEventsConfigurationError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEventsConfigurationError {}
 /// Errors returned by GetGlobalSettings
 #[derive(Debug, PartialEq)]
 pub enum GetGlobalSettingsError {
@@ -5726,21 +5674,17 @@ impl GetGlobalSettingsError {
 }
 impl fmt::Display for GetGlobalSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGlobalSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetGlobalSettingsError::BadRequest(ref cause) => cause,
-            GetGlobalSettingsError::Forbidden(ref cause) => cause,
-            GetGlobalSettingsError::ServiceFailure(ref cause) => cause,
-            GetGlobalSettingsError::ServiceUnavailable(ref cause) => cause,
-            GetGlobalSettingsError::ThrottledClient(ref cause) => cause,
-            GetGlobalSettingsError::UnauthorizedClient(ref cause) => cause,
+            GetGlobalSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetGlobalSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetGlobalSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetGlobalSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetGlobalSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetGlobalSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGlobalSettingsError {}
 /// Errors returned by GetMeeting
 #[derive(Debug, PartialEq)]
 pub enum GetMeetingError {
@@ -5794,22 +5738,18 @@ impl GetMeetingError {
 }
 impl fmt::Display for GetMeetingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMeetingError {
-    fn description(&self) -> &str {
         match *self {
-            GetMeetingError::BadRequest(ref cause) => cause,
-            GetMeetingError::Forbidden(ref cause) => cause,
-            GetMeetingError::NotFound(ref cause) => cause,
-            GetMeetingError::ServiceFailure(ref cause) => cause,
-            GetMeetingError::ServiceUnavailable(ref cause) => cause,
-            GetMeetingError::ThrottledClient(ref cause) => cause,
-            GetMeetingError::UnauthorizedClient(ref cause) => cause,
+            GetMeetingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetMeetingError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetMeetingError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetMeetingError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetMeetingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetMeetingError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetMeetingError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMeetingError {}
 /// Errors returned by GetPhoneNumber
 #[derive(Debug, PartialEq)]
 pub enum GetPhoneNumberError {
@@ -5863,22 +5803,18 @@ impl GetPhoneNumberError {
 }
 impl fmt::Display for GetPhoneNumberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPhoneNumberError {
-    fn description(&self) -> &str {
         match *self {
-            GetPhoneNumberError::BadRequest(ref cause) => cause,
-            GetPhoneNumberError::Forbidden(ref cause) => cause,
-            GetPhoneNumberError::NotFound(ref cause) => cause,
-            GetPhoneNumberError::ServiceFailure(ref cause) => cause,
-            GetPhoneNumberError::ServiceUnavailable(ref cause) => cause,
-            GetPhoneNumberError::ThrottledClient(ref cause) => cause,
-            GetPhoneNumberError::UnauthorizedClient(ref cause) => cause,
+            GetPhoneNumberError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPhoneNumberError {}
 /// Errors returned by GetPhoneNumberOrder
 #[derive(Debug, PartialEq)]
 pub enum GetPhoneNumberOrderError {
@@ -5936,22 +5872,18 @@ impl GetPhoneNumberOrderError {
 }
 impl fmt::Display for GetPhoneNumberOrderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPhoneNumberOrderError {
-    fn description(&self) -> &str {
         match *self {
-            GetPhoneNumberOrderError::BadRequest(ref cause) => cause,
-            GetPhoneNumberOrderError::Forbidden(ref cause) => cause,
-            GetPhoneNumberOrderError::NotFound(ref cause) => cause,
-            GetPhoneNumberOrderError::ServiceFailure(ref cause) => cause,
-            GetPhoneNumberOrderError::ServiceUnavailable(ref cause) => cause,
-            GetPhoneNumberOrderError::ThrottledClient(ref cause) => cause,
-            GetPhoneNumberOrderError::UnauthorizedClient(ref cause) => cause,
+            GetPhoneNumberOrderError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberOrderError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberOrderError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberOrderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberOrderError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberOrderError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberOrderError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPhoneNumberOrderError {}
 /// Errors returned by GetPhoneNumberSettings
 #[derive(Debug, PartialEq)]
 pub enum GetPhoneNumberSettingsError {
@@ -6008,21 +5940,17 @@ impl GetPhoneNumberSettingsError {
 }
 impl fmt::Display for GetPhoneNumberSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPhoneNumberSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetPhoneNumberSettingsError::BadRequest(ref cause) => cause,
-            GetPhoneNumberSettingsError::Forbidden(ref cause) => cause,
-            GetPhoneNumberSettingsError::ServiceFailure(ref cause) => cause,
-            GetPhoneNumberSettingsError::ServiceUnavailable(ref cause) => cause,
-            GetPhoneNumberSettingsError::ThrottledClient(ref cause) => cause,
-            GetPhoneNumberSettingsError::UnauthorizedClient(ref cause) => cause,
+            GetPhoneNumberSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetPhoneNumberSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPhoneNumberSettingsError {}
 /// Errors returned by GetRoom
 #[derive(Debug, PartialEq)]
 pub enum GetRoomError {
@@ -6071,21 +5999,17 @@ impl GetRoomError {
 }
 impl fmt::Display for GetRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRoomError {
-    fn description(&self) -> &str {
         match *self {
-            GetRoomError::BadRequest(ref cause) => cause,
-            GetRoomError::Forbidden(ref cause) => cause,
-            GetRoomError::NotFound(ref cause) => cause,
-            GetRoomError::ServiceFailure(ref cause) => cause,
-            GetRoomError::ServiceUnavailable(ref cause) => cause,
-            GetRoomError::UnauthorizedClient(ref cause) => cause,
+            GetRoomError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetRoomError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetRoomError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRoomError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetRoomError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetRoomError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRoomError {}
 /// Errors returned by GetUser
 #[derive(Debug, PartialEq)]
 pub enum GetUserError {
@@ -6139,22 +6063,18 @@ impl GetUserError {
 }
 impl fmt::Display for GetUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserError::BadRequest(ref cause) => cause,
-            GetUserError::Forbidden(ref cause) => cause,
-            GetUserError::NotFound(ref cause) => cause,
-            GetUserError::ServiceFailure(ref cause) => cause,
-            GetUserError::ServiceUnavailable(ref cause) => cause,
-            GetUserError::ThrottledClient(ref cause) => cause,
-            GetUserError::UnauthorizedClient(ref cause) => cause,
+            GetUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetUserError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetUserError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserError {}
 /// Errors returned by GetUserSettings
 #[derive(Debug, PartialEq)]
 pub enum GetUserSettingsError {
@@ -6208,22 +6128,18 @@ impl GetUserSettingsError {
 }
 impl fmt::Display for GetUserSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserSettingsError::BadRequest(ref cause) => cause,
-            GetUserSettingsError::Forbidden(ref cause) => cause,
-            GetUserSettingsError::NotFound(ref cause) => cause,
-            GetUserSettingsError::ServiceFailure(ref cause) => cause,
-            GetUserSettingsError::ServiceUnavailable(ref cause) => cause,
-            GetUserSettingsError::ThrottledClient(ref cause) => cause,
-            GetUserSettingsError::UnauthorizedClient(ref cause) => cause,
+            GetUserSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUserSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetUserSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUserSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetUserSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetUserSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetUserSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserSettingsError {}
 /// Errors returned by GetVoiceConnector
 #[derive(Debug, PartialEq)]
 pub enum GetVoiceConnectorError {
@@ -6281,22 +6197,18 @@ impl GetVoiceConnectorError {
 }
 impl fmt::Display for GetVoiceConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVoiceConnectorError {
-    fn description(&self) -> &str {
         match *self {
-            GetVoiceConnectorError::BadRequest(ref cause) => cause,
-            GetVoiceConnectorError::Forbidden(ref cause) => cause,
-            GetVoiceConnectorError::NotFound(ref cause) => cause,
-            GetVoiceConnectorError::ServiceFailure(ref cause) => cause,
-            GetVoiceConnectorError::ServiceUnavailable(ref cause) => cause,
-            GetVoiceConnectorError::ThrottledClient(ref cause) => cause,
-            GetVoiceConnectorError::UnauthorizedClient(ref cause) => cause,
+            GetVoiceConnectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVoiceConnectorError {}
 /// Errors returned by GetVoiceConnectorGroup
 #[derive(Debug, PartialEq)]
 pub enum GetVoiceConnectorGroupError {
@@ -6358,22 +6270,18 @@ impl GetVoiceConnectorGroupError {
 }
 impl fmt::Display for GetVoiceConnectorGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVoiceConnectorGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetVoiceConnectorGroupError::BadRequest(ref cause) => cause,
-            GetVoiceConnectorGroupError::Forbidden(ref cause) => cause,
-            GetVoiceConnectorGroupError::NotFound(ref cause) => cause,
-            GetVoiceConnectorGroupError::ServiceFailure(ref cause) => cause,
-            GetVoiceConnectorGroupError::ServiceUnavailable(ref cause) => cause,
-            GetVoiceConnectorGroupError::ThrottledClient(ref cause) => cause,
-            GetVoiceConnectorGroupError::UnauthorizedClient(ref cause) => cause,
+            GetVoiceConnectorGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorGroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorGroupError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorGroupError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVoiceConnectorGroupError {}
 /// Errors returned by GetVoiceConnectorLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetVoiceConnectorLoggingConfigurationError {
@@ -6443,22 +6351,32 @@ impl GetVoiceConnectorLoggingConfigurationError {
 }
 impl fmt::Display for GetVoiceConnectorLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVoiceConnectorLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetVoiceConnectorLoggingConfigurationError::BadRequest(ref cause) => cause,
-            GetVoiceConnectorLoggingConfigurationError::Forbidden(ref cause) => cause,
-            GetVoiceConnectorLoggingConfigurationError::NotFound(ref cause) => cause,
-            GetVoiceConnectorLoggingConfigurationError::ServiceFailure(ref cause) => cause,
-            GetVoiceConnectorLoggingConfigurationError::ServiceUnavailable(ref cause) => cause,
-            GetVoiceConnectorLoggingConfigurationError::ThrottledClient(ref cause) => cause,
-            GetVoiceConnectorLoggingConfigurationError::UnauthorizedClient(ref cause) => cause,
+            GetVoiceConnectorLoggingConfigurationError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorLoggingConfigurationError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorLoggingConfigurationError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorLoggingConfigurationError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorLoggingConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorLoggingConfigurationError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorLoggingConfigurationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetVoiceConnectorLoggingConfigurationError {}
 /// Errors returned by GetVoiceConnectorOrigination
 #[derive(Debug, PartialEq)]
 pub enum GetVoiceConnectorOriginationError {
@@ -6528,22 +6446,22 @@ impl GetVoiceConnectorOriginationError {
 }
 impl fmt::Display for GetVoiceConnectorOriginationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVoiceConnectorOriginationError {
-    fn description(&self) -> &str {
         match *self {
-            GetVoiceConnectorOriginationError::BadRequest(ref cause) => cause,
-            GetVoiceConnectorOriginationError::Forbidden(ref cause) => cause,
-            GetVoiceConnectorOriginationError::NotFound(ref cause) => cause,
-            GetVoiceConnectorOriginationError::ServiceFailure(ref cause) => cause,
-            GetVoiceConnectorOriginationError::ServiceUnavailable(ref cause) => cause,
-            GetVoiceConnectorOriginationError::ThrottledClient(ref cause) => cause,
-            GetVoiceConnectorOriginationError::UnauthorizedClient(ref cause) => cause,
+            GetVoiceConnectorOriginationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorOriginationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorOriginationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorOriginationError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorOriginationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorOriginationError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorOriginationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetVoiceConnectorOriginationError {}
 /// Errors returned by GetVoiceConnectorStreamingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetVoiceConnectorStreamingConfigurationError {
@@ -6613,22 +6531,32 @@ impl GetVoiceConnectorStreamingConfigurationError {
 }
 impl fmt::Display for GetVoiceConnectorStreamingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVoiceConnectorStreamingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetVoiceConnectorStreamingConfigurationError::BadRequest(ref cause) => cause,
-            GetVoiceConnectorStreamingConfigurationError::Forbidden(ref cause) => cause,
-            GetVoiceConnectorStreamingConfigurationError::NotFound(ref cause) => cause,
-            GetVoiceConnectorStreamingConfigurationError::ServiceFailure(ref cause) => cause,
-            GetVoiceConnectorStreamingConfigurationError::ServiceUnavailable(ref cause) => cause,
-            GetVoiceConnectorStreamingConfigurationError::ThrottledClient(ref cause) => cause,
-            GetVoiceConnectorStreamingConfigurationError::UnauthorizedClient(ref cause) => cause,
+            GetVoiceConnectorStreamingConfigurationError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorStreamingConfigurationError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorStreamingConfigurationError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorStreamingConfigurationError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorStreamingConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorStreamingConfigurationError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorStreamingConfigurationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetVoiceConnectorStreamingConfigurationError {}
 /// Errors returned by GetVoiceConnectorTermination
 #[derive(Debug, PartialEq)]
 pub enum GetVoiceConnectorTerminationError {
@@ -6698,22 +6626,22 @@ impl GetVoiceConnectorTerminationError {
 }
 impl fmt::Display for GetVoiceConnectorTerminationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVoiceConnectorTerminationError {
-    fn description(&self) -> &str {
         match *self {
-            GetVoiceConnectorTerminationError::BadRequest(ref cause) => cause,
-            GetVoiceConnectorTerminationError::Forbidden(ref cause) => cause,
-            GetVoiceConnectorTerminationError::NotFound(ref cause) => cause,
-            GetVoiceConnectorTerminationError::ServiceFailure(ref cause) => cause,
-            GetVoiceConnectorTerminationError::ServiceUnavailable(ref cause) => cause,
-            GetVoiceConnectorTerminationError::ThrottledClient(ref cause) => cause,
-            GetVoiceConnectorTerminationError::UnauthorizedClient(ref cause) => cause,
+            GetVoiceConnectorTerminationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorTerminationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorTerminationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorTerminationError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorTerminationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorTerminationError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorTerminationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetVoiceConnectorTerminationError {}
 /// Errors returned by GetVoiceConnectorTerminationHealth
 #[derive(Debug, PartialEq)]
 pub enum GetVoiceConnectorTerminationHealthError {
@@ -6783,22 +6711,28 @@ impl GetVoiceConnectorTerminationHealthError {
 }
 impl fmt::Display for GetVoiceConnectorTerminationHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVoiceConnectorTerminationHealthError {
-    fn description(&self) -> &str {
         match *self {
-            GetVoiceConnectorTerminationHealthError::BadRequest(ref cause) => cause,
-            GetVoiceConnectorTerminationHealthError::Forbidden(ref cause) => cause,
-            GetVoiceConnectorTerminationHealthError::NotFound(ref cause) => cause,
-            GetVoiceConnectorTerminationHealthError::ServiceFailure(ref cause) => cause,
-            GetVoiceConnectorTerminationHealthError::ServiceUnavailable(ref cause) => cause,
-            GetVoiceConnectorTerminationHealthError::ThrottledClient(ref cause) => cause,
-            GetVoiceConnectorTerminationHealthError::UnauthorizedClient(ref cause) => cause,
+            GetVoiceConnectorTerminationHealthError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorTerminationHealthError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorTerminationHealthError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetVoiceConnectorTerminationHealthError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorTerminationHealthError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorTerminationHealthError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetVoiceConnectorTerminationHealthError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetVoiceConnectorTerminationHealthError {}
 /// Errors returned by InviteUsers
 #[derive(Debug, PartialEq)]
 pub enum InviteUsersError {
@@ -6852,22 +6786,18 @@ impl InviteUsersError {
 }
 impl fmt::Display for InviteUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InviteUsersError {
-    fn description(&self) -> &str {
         match *self {
-            InviteUsersError::BadRequest(ref cause) => cause,
-            InviteUsersError::Forbidden(ref cause) => cause,
-            InviteUsersError::NotFound(ref cause) => cause,
-            InviteUsersError::ServiceFailure(ref cause) => cause,
-            InviteUsersError::ServiceUnavailable(ref cause) => cause,
-            InviteUsersError::ThrottledClient(ref cause) => cause,
-            InviteUsersError::UnauthorizedClient(ref cause) => cause,
+            InviteUsersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            InviteUsersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            InviteUsersError::NotFound(ref cause) => write!(f, "{}", cause),
+            InviteUsersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            InviteUsersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            InviteUsersError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            InviteUsersError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InviteUsersError {}
 /// Errors returned by ListAccounts
 #[derive(Debug, PartialEq)]
 pub enum ListAccountsError {
@@ -6921,22 +6851,18 @@ impl ListAccountsError {
 }
 impl fmt::Display for ListAccountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAccountsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAccountsError::BadRequest(ref cause) => cause,
-            ListAccountsError::Forbidden(ref cause) => cause,
-            ListAccountsError::NotFound(ref cause) => cause,
-            ListAccountsError::ServiceFailure(ref cause) => cause,
-            ListAccountsError::ServiceUnavailable(ref cause) => cause,
-            ListAccountsError::ThrottledClient(ref cause) => cause,
-            ListAccountsError::UnauthorizedClient(ref cause) => cause,
+            ListAccountsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAccountsError {}
 /// Errors returned by ListAttendees
 #[derive(Debug, PartialEq)]
 pub enum ListAttendeesError {
@@ -6990,22 +6916,18 @@ impl ListAttendeesError {
 }
 impl fmt::Display for ListAttendeesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttendeesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttendeesError::BadRequest(ref cause) => cause,
-            ListAttendeesError::Forbidden(ref cause) => cause,
-            ListAttendeesError::NotFound(ref cause) => cause,
-            ListAttendeesError::ServiceFailure(ref cause) => cause,
-            ListAttendeesError::ServiceUnavailable(ref cause) => cause,
-            ListAttendeesError::ThrottledClient(ref cause) => cause,
-            ListAttendeesError::UnauthorizedClient(ref cause) => cause,
+            ListAttendeesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListAttendeesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListAttendeesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListAttendeesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListAttendeesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListAttendeesError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListAttendeesError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttendeesError {}
 /// Errors returned by ListBots
 #[derive(Debug, PartialEq)]
 pub enum ListBotsError {
@@ -7054,21 +6976,17 @@ impl ListBotsError {
 }
 impl fmt::Display for ListBotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBotsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBotsError::BadRequest(ref cause) => cause,
-            ListBotsError::Forbidden(ref cause) => cause,
-            ListBotsError::NotFound(ref cause) => cause,
-            ListBotsError::ServiceFailure(ref cause) => cause,
-            ListBotsError::ServiceUnavailable(ref cause) => cause,
-            ListBotsError::UnauthorizedClient(ref cause) => cause,
+            ListBotsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListBotsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListBotsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListBotsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListBotsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListBotsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBotsError {}
 /// Errors returned by ListMeetings
 #[derive(Debug, PartialEq)]
 pub enum ListMeetingsError {
@@ -7117,21 +7035,17 @@ impl ListMeetingsError {
 }
 impl fmt::Display for ListMeetingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMeetingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMeetingsError::BadRequest(ref cause) => cause,
-            ListMeetingsError::Forbidden(ref cause) => cause,
-            ListMeetingsError::ServiceFailure(ref cause) => cause,
-            ListMeetingsError::ServiceUnavailable(ref cause) => cause,
-            ListMeetingsError::ThrottledClient(ref cause) => cause,
-            ListMeetingsError::UnauthorizedClient(ref cause) => cause,
+            ListMeetingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListMeetingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListMeetingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListMeetingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListMeetingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListMeetingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMeetingsError {}
 /// Errors returned by ListPhoneNumberOrders
 #[derive(Debug, PartialEq)]
 pub enum ListPhoneNumberOrdersError {
@@ -7188,21 +7102,17 @@ impl ListPhoneNumberOrdersError {
 }
 impl fmt::Display for ListPhoneNumberOrdersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPhoneNumberOrdersError {
-    fn description(&self) -> &str {
         match *self {
-            ListPhoneNumberOrdersError::BadRequest(ref cause) => cause,
-            ListPhoneNumberOrdersError::Forbidden(ref cause) => cause,
-            ListPhoneNumberOrdersError::ServiceFailure(ref cause) => cause,
-            ListPhoneNumberOrdersError::ServiceUnavailable(ref cause) => cause,
-            ListPhoneNumberOrdersError::ThrottledClient(ref cause) => cause,
-            ListPhoneNumberOrdersError::UnauthorizedClient(ref cause) => cause,
+            ListPhoneNumberOrdersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumberOrdersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumberOrdersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumberOrdersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumberOrdersError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumberOrdersError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPhoneNumberOrdersError {}
 /// Errors returned by ListPhoneNumbers
 #[derive(Debug, PartialEq)]
 pub enum ListPhoneNumbersError {
@@ -7251,21 +7161,17 @@ impl ListPhoneNumbersError {
 }
 impl fmt::Display for ListPhoneNumbersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPhoneNumbersError {
-    fn description(&self) -> &str {
         match *self {
-            ListPhoneNumbersError::BadRequest(ref cause) => cause,
-            ListPhoneNumbersError::Forbidden(ref cause) => cause,
-            ListPhoneNumbersError::ServiceFailure(ref cause) => cause,
-            ListPhoneNumbersError::ServiceUnavailable(ref cause) => cause,
-            ListPhoneNumbersError::ThrottledClient(ref cause) => cause,
-            ListPhoneNumbersError::UnauthorizedClient(ref cause) => cause,
+            ListPhoneNumbersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPhoneNumbersError {}
 /// Errors returned by ListRoomMemberships
 #[derive(Debug, PartialEq)]
 pub enum ListRoomMembershipsError {
@@ -7318,21 +7224,17 @@ impl ListRoomMembershipsError {
 }
 impl fmt::Display for ListRoomMembershipsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRoomMembershipsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRoomMembershipsError::BadRequest(ref cause) => cause,
-            ListRoomMembershipsError::Forbidden(ref cause) => cause,
-            ListRoomMembershipsError::NotFound(ref cause) => cause,
-            ListRoomMembershipsError::ServiceFailure(ref cause) => cause,
-            ListRoomMembershipsError::ServiceUnavailable(ref cause) => cause,
-            ListRoomMembershipsError::UnauthorizedClient(ref cause) => cause,
+            ListRoomMembershipsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListRoomMembershipsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListRoomMembershipsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListRoomMembershipsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListRoomMembershipsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListRoomMembershipsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRoomMembershipsError {}
 /// Errors returned by ListRooms
 #[derive(Debug, PartialEq)]
 pub enum ListRoomsError {
@@ -7381,21 +7283,17 @@ impl ListRoomsError {
 }
 impl fmt::Display for ListRoomsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRoomsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRoomsError::BadRequest(ref cause) => cause,
-            ListRoomsError::Forbidden(ref cause) => cause,
-            ListRoomsError::NotFound(ref cause) => cause,
-            ListRoomsError::ServiceFailure(ref cause) => cause,
-            ListRoomsError::ServiceUnavailable(ref cause) => cause,
-            ListRoomsError::UnauthorizedClient(ref cause) => cause,
+            ListRoomsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListRoomsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListRoomsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListRoomsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListRoomsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListRoomsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRoomsError {}
 /// Errors returned by ListUsers
 #[derive(Debug, PartialEq)]
 pub enum ListUsersError {
@@ -7449,22 +7347,18 @@ impl ListUsersError {
 }
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersError::BadRequest(ref cause) => cause,
-            ListUsersError::Forbidden(ref cause) => cause,
-            ListUsersError::NotFound(ref cause) => cause,
-            ListUsersError::ServiceFailure(ref cause) => cause,
-            ListUsersError::ServiceUnavailable(ref cause) => cause,
-            ListUsersError::ThrottledClient(ref cause) => cause,
-            ListUsersError::UnauthorizedClient(ref cause) => cause,
+            ListUsersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListUsersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListUsersError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListUsersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListUsersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListUsersError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListUsersError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersError {}
 /// Errors returned by ListVoiceConnectorGroups
 #[derive(Debug, PartialEq)]
 pub enum ListVoiceConnectorGroupsError {
@@ -7521,21 +7415,17 @@ impl ListVoiceConnectorGroupsError {
 }
 impl fmt::Display for ListVoiceConnectorGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVoiceConnectorGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVoiceConnectorGroupsError::BadRequest(ref cause) => cause,
-            ListVoiceConnectorGroupsError::Forbidden(ref cause) => cause,
-            ListVoiceConnectorGroupsError::ServiceFailure(ref cause) => cause,
-            ListVoiceConnectorGroupsError::ServiceUnavailable(ref cause) => cause,
-            ListVoiceConnectorGroupsError::ThrottledClient(ref cause) => cause,
-            ListVoiceConnectorGroupsError::UnauthorizedClient(ref cause) => cause,
+            ListVoiceConnectorGroupsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorGroupsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorGroupsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorGroupsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorGroupsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorGroupsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVoiceConnectorGroupsError {}
 /// Errors returned by ListVoiceConnectorTerminationCredentials
 #[derive(Debug, PartialEq)]
 pub enum ListVoiceConnectorTerminationCredentialsError {
@@ -7605,22 +7495,32 @@ impl ListVoiceConnectorTerminationCredentialsError {
 }
 impl fmt::Display for ListVoiceConnectorTerminationCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVoiceConnectorTerminationCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVoiceConnectorTerminationCredentialsError::BadRequest(ref cause) => cause,
-            ListVoiceConnectorTerminationCredentialsError::Forbidden(ref cause) => cause,
-            ListVoiceConnectorTerminationCredentialsError::NotFound(ref cause) => cause,
-            ListVoiceConnectorTerminationCredentialsError::ServiceFailure(ref cause) => cause,
-            ListVoiceConnectorTerminationCredentialsError::ServiceUnavailable(ref cause) => cause,
-            ListVoiceConnectorTerminationCredentialsError::ThrottledClient(ref cause) => cause,
-            ListVoiceConnectorTerminationCredentialsError::UnauthorizedClient(ref cause) => cause,
+            ListVoiceConnectorTerminationCredentialsError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVoiceConnectorTerminationCredentialsError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVoiceConnectorTerminationCredentialsError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVoiceConnectorTerminationCredentialsError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVoiceConnectorTerminationCredentialsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVoiceConnectorTerminationCredentialsError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVoiceConnectorTerminationCredentialsError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListVoiceConnectorTerminationCredentialsError {}
 /// Errors returned by ListVoiceConnectors
 #[derive(Debug, PartialEq)]
 pub enum ListVoiceConnectorsError {
@@ -7673,21 +7573,17 @@ impl ListVoiceConnectorsError {
 }
 impl fmt::Display for ListVoiceConnectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVoiceConnectorsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVoiceConnectorsError::BadRequest(ref cause) => cause,
-            ListVoiceConnectorsError::Forbidden(ref cause) => cause,
-            ListVoiceConnectorsError::ServiceFailure(ref cause) => cause,
-            ListVoiceConnectorsError::ServiceUnavailable(ref cause) => cause,
-            ListVoiceConnectorsError::ThrottledClient(ref cause) => cause,
-            ListVoiceConnectorsError::UnauthorizedClient(ref cause) => cause,
+            ListVoiceConnectorsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ListVoiceConnectorsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVoiceConnectorsError {}
 /// Errors returned by LogoutUser
 #[derive(Debug, PartialEq)]
 pub enum LogoutUserError {
@@ -7741,22 +7637,18 @@ impl LogoutUserError {
 }
 impl fmt::Display for LogoutUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for LogoutUserError {
-    fn description(&self) -> &str {
         match *self {
-            LogoutUserError::BadRequest(ref cause) => cause,
-            LogoutUserError::Forbidden(ref cause) => cause,
-            LogoutUserError::NotFound(ref cause) => cause,
-            LogoutUserError::ServiceFailure(ref cause) => cause,
-            LogoutUserError::ServiceUnavailable(ref cause) => cause,
-            LogoutUserError::ThrottledClient(ref cause) => cause,
-            LogoutUserError::UnauthorizedClient(ref cause) => cause,
+            LogoutUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            LogoutUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            LogoutUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            LogoutUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            LogoutUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            LogoutUserError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            LogoutUserError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for LogoutUserError {}
 /// Errors returned by PutEventsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutEventsConfigurationError {
@@ -7818,22 +7710,18 @@ impl PutEventsConfigurationError {
 }
 impl fmt::Display for PutEventsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutEventsConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutEventsConfigurationError::BadRequest(ref cause) => cause,
-            PutEventsConfigurationError::Forbidden(ref cause) => cause,
-            PutEventsConfigurationError::NotFound(ref cause) => cause,
-            PutEventsConfigurationError::ResourceLimitExceeded(ref cause) => cause,
-            PutEventsConfigurationError::ServiceFailure(ref cause) => cause,
-            PutEventsConfigurationError::ServiceUnavailable(ref cause) => cause,
-            PutEventsConfigurationError::UnauthorizedClient(ref cause) => cause,
+            PutEventsConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutEventsConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            PutEventsConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutEventsConfigurationError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutEventsConfigurationError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            PutEventsConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            PutEventsConfigurationError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutEventsConfigurationError {}
 /// Errors returned by PutVoiceConnectorLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutVoiceConnectorLoggingConfigurationError {
@@ -7903,22 +7791,32 @@ impl PutVoiceConnectorLoggingConfigurationError {
 }
 impl fmt::Display for PutVoiceConnectorLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutVoiceConnectorLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutVoiceConnectorLoggingConfigurationError::BadRequest(ref cause) => cause,
-            PutVoiceConnectorLoggingConfigurationError::Forbidden(ref cause) => cause,
-            PutVoiceConnectorLoggingConfigurationError::NotFound(ref cause) => cause,
-            PutVoiceConnectorLoggingConfigurationError::ServiceFailure(ref cause) => cause,
-            PutVoiceConnectorLoggingConfigurationError::ServiceUnavailable(ref cause) => cause,
-            PutVoiceConnectorLoggingConfigurationError::ThrottledClient(ref cause) => cause,
-            PutVoiceConnectorLoggingConfigurationError::UnauthorizedClient(ref cause) => cause,
+            PutVoiceConnectorLoggingConfigurationError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorLoggingConfigurationError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorLoggingConfigurationError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorLoggingConfigurationError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorLoggingConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorLoggingConfigurationError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorLoggingConfigurationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutVoiceConnectorLoggingConfigurationError {}
 /// Errors returned by PutVoiceConnectorOrigination
 #[derive(Debug, PartialEq)]
 pub enum PutVoiceConnectorOriginationError {
@@ -7988,22 +7886,22 @@ impl PutVoiceConnectorOriginationError {
 }
 impl fmt::Display for PutVoiceConnectorOriginationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutVoiceConnectorOriginationError {
-    fn description(&self) -> &str {
         match *self {
-            PutVoiceConnectorOriginationError::BadRequest(ref cause) => cause,
-            PutVoiceConnectorOriginationError::Forbidden(ref cause) => cause,
-            PutVoiceConnectorOriginationError::NotFound(ref cause) => cause,
-            PutVoiceConnectorOriginationError::ServiceFailure(ref cause) => cause,
-            PutVoiceConnectorOriginationError::ServiceUnavailable(ref cause) => cause,
-            PutVoiceConnectorOriginationError::ThrottledClient(ref cause) => cause,
-            PutVoiceConnectorOriginationError::UnauthorizedClient(ref cause) => cause,
+            PutVoiceConnectorOriginationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorOriginationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorOriginationError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorOriginationError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorOriginationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorOriginationError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorOriginationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutVoiceConnectorOriginationError {}
 /// Errors returned by PutVoiceConnectorStreamingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutVoiceConnectorStreamingConfigurationError {
@@ -8073,22 +7971,32 @@ impl PutVoiceConnectorStreamingConfigurationError {
 }
 impl fmt::Display for PutVoiceConnectorStreamingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutVoiceConnectorStreamingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutVoiceConnectorStreamingConfigurationError::BadRequest(ref cause) => cause,
-            PutVoiceConnectorStreamingConfigurationError::Forbidden(ref cause) => cause,
-            PutVoiceConnectorStreamingConfigurationError::NotFound(ref cause) => cause,
-            PutVoiceConnectorStreamingConfigurationError::ServiceFailure(ref cause) => cause,
-            PutVoiceConnectorStreamingConfigurationError::ServiceUnavailable(ref cause) => cause,
-            PutVoiceConnectorStreamingConfigurationError::ThrottledClient(ref cause) => cause,
-            PutVoiceConnectorStreamingConfigurationError::UnauthorizedClient(ref cause) => cause,
+            PutVoiceConnectorStreamingConfigurationError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorStreamingConfigurationError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorStreamingConfigurationError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorStreamingConfigurationError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorStreamingConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorStreamingConfigurationError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorStreamingConfigurationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutVoiceConnectorStreamingConfigurationError {}
 /// Errors returned by PutVoiceConnectorTermination
 #[derive(Debug, PartialEq)]
 pub enum PutVoiceConnectorTerminationError {
@@ -8165,23 +8073,23 @@ impl PutVoiceConnectorTerminationError {
 }
 impl fmt::Display for PutVoiceConnectorTerminationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutVoiceConnectorTerminationError {
-    fn description(&self) -> &str {
         match *self {
-            PutVoiceConnectorTerminationError::AccessDenied(ref cause) => cause,
-            PutVoiceConnectorTerminationError::BadRequest(ref cause) => cause,
-            PutVoiceConnectorTerminationError::Forbidden(ref cause) => cause,
-            PutVoiceConnectorTerminationError::NotFound(ref cause) => cause,
-            PutVoiceConnectorTerminationError::ServiceFailure(ref cause) => cause,
-            PutVoiceConnectorTerminationError::ServiceUnavailable(ref cause) => cause,
-            PutVoiceConnectorTerminationError::ThrottledClient(ref cause) => cause,
-            PutVoiceConnectorTerminationError::UnauthorizedClient(ref cause) => cause,
+            PutVoiceConnectorTerminationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorTerminationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorTerminationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorTerminationError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorTerminationError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorTerminationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorTerminationError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            PutVoiceConnectorTerminationError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutVoiceConnectorTerminationError {}
 /// Errors returned by PutVoiceConnectorTerminationCredentials
 #[derive(Debug, PartialEq)]
 pub enum PutVoiceConnectorTerminationCredentialsError {
@@ -8251,22 +8159,32 @@ impl PutVoiceConnectorTerminationCredentialsError {
 }
 impl fmt::Display for PutVoiceConnectorTerminationCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutVoiceConnectorTerminationCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            PutVoiceConnectorTerminationCredentialsError::BadRequest(ref cause) => cause,
-            PutVoiceConnectorTerminationCredentialsError::Forbidden(ref cause) => cause,
-            PutVoiceConnectorTerminationCredentialsError::NotFound(ref cause) => cause,
-            PutVoiceConnectorTerminationCredentialsError::ServiceFailure(ref cause) => cause,
-            PutVoiceConnectorTerminationCredentialsError::ServiceUnavailable(ref cause) => cause,
-            PutVoiceConnectorTerminationCredentialsError::ThrottledClient(ref cause) => cause,
-            PutVoiceConnectorTerminationCredentialsError::UnauthorizedClient(ref cause) => cause,
+            PutVoiceConnectorTerminationCredentialsError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorTerminationCredentialsError::Forbidden(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorTerminationCredentialsError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorTerminationCredentialsError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorTerminationCredentialsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorTerminationCredentialsError::ThrottledClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutVoiceConnectorTerminationCredentialsError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutVoiceConnectorTerminationCredentialsError {}
 /// Errors returned by RegenerateSecurityToken
 #[derive(Debug, PartialEq)]
 pub enum RegenerateSecurityTokenError {
@@ -8321,21 +8239,17 @@ impl RegenerateSecurityTokenError {
 }
 impl fmt::Display for RegenerateSecurityTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegenerateSecurityTokenError {
-    fn description(&self) -> &str {
         match *self {
-            RegenerateSecurityTokenError::BadRequest(ref cause) => cause,
-            RegenerateSecurityTokenError::Forbidden(ref cause) => cause,
-            RegenerateSecurityTokenError::NotFound(ref cause) => cause,
-            RegenerateSecurityTokenError::ServiceFailure(ref cause) => cause,
-            RegenerateSecurityTokenError::ServiceUnavailable(ref cause) => cause,
-            RegenerateSecurityTokenError::UnauthorizedClient(ref cause) => cause,
+            RegenerateSecurityTokenError::BadRequest(ref cause) => write!(f, "{}", cause),
+            RegenerateSecurityTokenError::Forbidden(ref cause) => write!(f, "{}", cause),
+            RegenerateSecurityTokenError::NotFound(ref cause) => write!(f, "{}", cause),
+            RegenerateSecurityTokenError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            RegenerateSecurityTokenError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RegenerateSecurityTokenError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegenerateSecurityTokenError {}
 /// Errors returned by ResetPersonalPIN
 #[derive(Debug, PartialEq)]
 pub enum ResetPersonalPINError {
@@ -8389,22 +8303,18 @@ impl ResetPersonalPINError {
 }
 impl fmt::Display for ResetPersonalPINError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetPersonalPINError {
-    fn description(&self) -> &str {
         match *self {
-            ResetPersonalPINError::BadRequest(ref cause) => cause,
-            ResetPersonalPINError::Forbidden(ref cause) => cause,
-            ResetPersonalPINError::NotFound(ref cause) => cause,
-            ResetPersonalPINError::ServiceFailure(ref cause) => cause,
-            ResetPersonalPINError::ServiceUnavailable(ref cause) => cause,
-            ResetPersonalPINError::ThrottledClient(ref cause) => cause,
-            ResetPersonalPINError::UnauthorizedClient(ref cause) => cause,
+            ResetPersonalPINError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ResetPersonalPINError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ResetPersonalPINError::NotFound(ref cause) => write!(f, "{}", cause),
+            ResetPersonalPINError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            ResetPersonalPINError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ResetPersonalPINError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            ResetPersonalPINError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetPersonalPINError {}
 /// Errors returned by RestorePhoneNumber
 #[derive(Debug, PartialEq)]
 pub enum RestorePhoneNumberError {
@@ -8469,23 +8379,19 @@ impl RestorePhoneNumberError {
 }
 impl fmt::Display for RestorePhoneNumberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestorePhoneNumberError {
-    fn description(&self) -> &str {
         match *self {
-            RestorePhoneNumberError::BadRequest(ref cause) => cause,
-            RestorePhoneNumberError::Forbidden(ref cause) => cause,
-            RestorePhoneNumberError::NotFound(ref cause) => cause,
-            RestorePhoneNumberError::ResourceLimitExceeded(ref cause) => cause,
-            RestorePhoneNumberError::ServiceFailure(ref cause) => cause,
-            RestorePhoneNumberError::ServiceUnavailable(ref cause) => cause,
-            RestorePhoneNumberError::ThrottledClient(ref cause) => cause,
-            RestorePhoneNumberError::UnauthorizedClient(ref cause) => cause,
+            RestorePhoneNumberError::BadRequest(ref cause) => write!(f, "{}", cause),
+            RestorePhoneNumberError::Forbidden(ref cause) => write!(f, "{}", cause),
+            RestorePhoneNumberError::NotFound(ref cause) => write!(f, "{}", cause),
+            RestorePhoneNumberError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            RestorePhoneNumberError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            RestorePhoneNumberError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RestorePhoneNumberError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            RestorePhoneNumberError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestorePhoneNumberError {}
 /// Errors returned by SearchAvailablePhoneNumbers
 #[derive(Debug, PartialEq)]
 pub enum SearchAvailablePhoneNumbersError {
@@ -8555,22 +8461,22 @@ impl SearchAvailablePhoneNumbersError {
 }
 impl fmt::Display for SearchAvailablePhoneNumbersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchAvailablePhoneNumbersError {
-    fn description(&self) -> &str {
         match *self {
-            SearchAvailablePhoneNumbersError::AccessDenied(ref cause) => cause,
-            SearchAvailablePhoneNumbersError::BadRequest(ref cause) => cause,
-            SearchAvailablePhoneNumbersError::Forbidden(ref cause) => cause,
-            SearchAvailablePhoneNumbersError::ServiceFailure(ref cause) => cause,
-            SearchAvailablePhoneNumbersError::ServiceUnavailable(ref cause) => cause,
-            SearchAvailablePhoneNumbersError::ThrottledClient(ref cause) => cause,
-            SearchAvailablePhoneNumbersError::UnauthorizedClient(ref cause) => cause,
+            SearchAvailablePhoneNumbersError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SearchAvailablePhoneNumbersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            SearchAvailablePhoneNumbersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            SearchAvailablePhoneNumbersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            SearchAvailablePhoneNumbersError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SearchAvailablePhoneNumbersError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            SearchAvailablePhoneNumbersError::UnauthorizedClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SearchAvailablePhoneNumbersError {}
 /// Errors returned by UpdateAccount
 #[derive(Debug, PartialEq)]
 pub enum UpdateAccountError {
@@ -8624,22 +8530,18 @@ impl UpdateAccountError {
 }
 impl fmt::Display for UpdateAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAccountError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAccountError::BadRequest(ref cause) => cause,
-            UpdateAccountError::Forbidden(ref cause) => cause,
-            UpdateAccountError::NotFound(ref cause) => cause,
-            UpdateAccountError::ServiceFailure(ref cause) => cause,
-            UpdateAccountError::ServiceUnavailable(ref cause) => cause,
-            UpdateAccountError::ThrottledClient(ref cause) => cause,
-            UpdateAccountError::UnauthorizedClient(ref cause) => cause,
+            UpdateAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdateAccountError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAccountError {}
 /// Errors returned by UpdateAccountSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateAccountSettingsError {
@@ -8706,23 +8608,19 @@ impl UpdateAccountSettingsError {
 }
 impl fmt::Display for UpdateAccountSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAccountSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAccountSettingsError::BadRequest(ref cause) => cause,
-            UpdateAccountSettingsError::Conflict(ref cause) => cause,
-            UpdateAccountSettingsError::Forbidden(ref cause) => cause,
-            UpdateAccountSettingsError::NotFound(ref cause) => cause,
-            UpdateAccountSettingsError::ServiceFailure(ref cause) => cause,
-            UpdateAccountSettingsError::ServiceUnavailable(ref cause) => cause,
-            UpdateAccountSettingsError::ThrottledClient(ref cause) => cause,
-            UpdateAccountSettingsError::UnauthorizedClient(ref cause) => cause,
+            UpdateAccountSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAccountSettingsError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateAccountSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateAccountSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAccountSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateAccountSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateAccountSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdateAccountSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAccountSettingsError {}
 /// Errors returned by UpdateBot
 #[derive(Debug, PartialEq)]
 pub enum UpdateBotError {
@@ -8771,21 +8669,17 @@ impl UpdateBotError {
 }
 impl fmt::Display for UpdateBotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBotError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBotError::BadRequest(ref cause) => cause,
-            UpdateBotError::Forbidden(ref cause) => cause,
-            UpdateBotError::NotFound(ref cause) => cause,
-            UpdateBotError::ServiceFailure(ref cause) => cause,
-            UpdateBotError::ServiceUnavailable(ref cause) => cause,
-            UpdateBotError::UnauthorizedClient(ref cause) => cause,
+            UpdateBotError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBotError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateBotError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateBotError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateBotError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateBotError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBotError {}
 /// Errors returned by UpdateGlobalSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateGlobalSettingsError {
@@ -8840,21 +8734,17 @@ impl UpdateGlobalSettingsError {
 }
 impl fmt::Display for UpdateGlobalSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGlobalSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGlobalSettingsError::BadRequest(ref cause) => cause,
-            UpdateGlobalSettingsError::Forbidden(ref cause) => cause,
-            UpdateGlobalSettingsError::ServiceFailure(ref cause) => cause,
-            UpdateGlobalSettingsError::ServiceUnavailable(ref cause) => cause,
-            UpdateGlobalSettingsError::ThrottledClient(ref cause) => cause,
-            UpdateGlobalSettingsError::UnauthorizedClient(ref cause) => cause,
+            UpdateGlobalSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGlobalSettingsError {}
 /// Errors returned by UpdatePhoneNumber
 #[derive(Debug, PartialEq)]
 pub enum UpdatePhoneNumberError {
@@ -8912,22 +8802,18 @@ impl UpdatePhoneNumberError {
 }
 impl fmt::Display for UpdatePhoneNumberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePhoneNumberError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePhoneNumberError::BadRequest(ref cause) => cause,
-            UpdatePhoneNumberError::Forbidden(ref cause) => cause,
-            UpdatePhoneNumberError::NotFound(ref cause) => cause,
-            UpdatePhoneNumberError::ServiceFailure(ref cause) => cause,
-            UpdatePhoneNumberError::ServiceUnavailable(ref cause) => cause,
-            UpdatePhoneNumberError::ThrottledClient(ref cause) => cause,
-            UpdatePhoneNumberError::UnauthorizedClient(ref cause) => cause,
+            UpdatePhoneNumberError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePhoneNumberError {}
 /// Errors returned by UpdatePhoneNumberSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdatePhoneNumberSettingsError {
@@ -8986,21 +8872,17 @@ impl UpdatePhoneNumberSettingsError {
 }
 impl fmt::Display for UpdatePhoneNumberSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePhoneNumberSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePhoneNumberSettingsError::BadRequest(ref cause) => cause,
-            UpdatePhoneNumberSettingsError::Forbidden(ref cause) => cause,
-            UpdatePhoneNumberSettingsError::ServiceFailure(ref cause) => cause,
-            UpdatePhoneNumberSettingsError::ServiceUnavailable(ref cause) => cause,
-            UpdatePhoneNumberSettingsError::ThrottledClient(ref cause) => cause,
-            UpdatePhoneNumberSettingsError::UnauthorizedClient(ref cause) => cause,
+            UpdatePhoneNumberSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdatePhoneNumberSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePhoneNumberSettingsError {}
 /// Errors returned by UpdateRoom
 #[derive(Debug, PartialEq)]
 pub enum UpdateRoomError {
@@ -9049,21 +8931,17 @@ impl UpdateRoomError {
 }
 impl fmt::Display for UpdateRoomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRoomError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRoomError::BadRequest(ref cause) => cause,
-            UpdateRoomError::Forbidden(ref cause) => cause,
-            UpdateRoomError::NotFound(ref cause) => cause,
-            UpdateRoomError::ServiceFailure(ref cause) => cause,
-            UpdateRoomError::ServiceUnavailable(ref cause) => cause,
-            UpdateRoomError::UnauthorizedClient(ref cause) => cause,
+            UpdateRoomError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRoomError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateRoomError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRoomError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateRoomError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateRoomError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRoomError {}
 /// Errors returned by UpdateRoomMembership
 #[derive(Debug, PartialEq)]
 pub enum UpdateRoomMembershipError {
@@ -9116,21 +8994,17 @@ impl UpdateRoomMembershipError {
 }
 impl fmt::Display for UpdateRoomMembershipError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRoomMembershipError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRoomMembershipError::BadRequest(ref cause) => cause,
-            UpdateRoomMembershipError::Forbidden(ref cause) => cause,
-            UpdateRoomMembershipError::NotFound(ref cause) => cause,
-            UpdateRoomMembershipError::ServiceFailure(ref cause) => cause,
-            UpdateRoomMembershipError::ServiceUnavailable(ref cause) => cause,
-            UpdateRoomMembershipError::UnauthorizedClient(ref cause) => cause,
+            UpdateRoomMembershipError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRoomMembershipError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateRoomMembershipError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRoomMembershipError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateRoomMembershipError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateRoomMembershipError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRoomMembershipError {}
 /// Errors returned by UpdateUser
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserError {
@@ -9184,22 +9058,18 @@ impl UpdateUserError {
 }
 impl fmt::Display for UpdateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserError::BadRequest(ref cause) => cause,
-            UpdateUserError::Forbidden(ref cause) => cause,
-            UpdateUserError::NotFound(ref cause) => cause,
-            UpdateUserError::ServiceFailure(ref cause) => cause,
-            UpdateUserError::ServiceUnavailable(ref cause) => cause,
-            UpdateUserError::ThrottledClient(ref cause) => cause,
-            UpdateUserError::UnauthorizedClient(ref cause) => cause,
+            UpdateUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserError {}
 /// Errors returned by UpdateUserSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserSettingsError {
@@ -9257,22 +9127,18 @@ impl UpdateUserSettingsError {
 }
 impl fmt::Display for UpdateUserSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserSettingsError::BadRequest(ref cause) => cause,
-            UpdateUserSettingsError::Forbidden(ref cause) => cause,
-            UpdateUserSettingsError::NotFound(ref cause) => cause,
-            UpdateUserSettingsError::ServiceFailure(ref cause) => cause,
-            UpdateUserSettingsError::ServiceUnavailable(ref cause) => cause,
-            UpdateUserSettingsError::ThrottledClient(ref cause) => cause,
-            UpdateUserSettingsError::UnauthorizedClient(ref cause) => cause,
+            UpdateUserSettingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserSettingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateUserSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserSettingsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateUserSettingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateUserSettingsError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdateUserSettingsError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserSettingsError {}
 /// Errors returned by UpdateVoiceConnector
 #[derive(Debug, PartialEq)]
 pub enum UpdateVoiceConnectorError {
@@ -9332,22 +9198,18 @@ impl UpdateVoiceConnectorError {
 }
 impl fmt::Display for UpdateVoiceConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVoiceConnectorError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVoiceConnectorError::BadRequest(ref cause) => cause,
-            UpdateVoiceConnectorError::Forbidden(ref cause) => cause,
-            UpdateVoiceConnectorError::NotFound(ref cause) => cause,
-            UpdateVoiceConnectorError::ServiceFailure(ref cause) => cause,
-            UpdateVoiceConnectorError::ServiceUnavailable(ref cause) => cause,
-            UpdateVoiceConnectorError::ThrottledClient(ref cause) => cause,
-            UpdateVoiceConnectorError::UnauthorizedClient(ref cause) => cause,
+            UpdateVoiceConnectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVoiceConnectorError {}
 /// Errors returned by UpdateVoiceConnectorGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateVoiceConnectorGroupError {
@@ -9416,23 +9278,19 @@ impl UpdateVoiceConnectorGroupError {
 }
 impl fmt::Display for UpdateVoiceConnectorGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVoiceConnectorGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVoiceConnectorGroupError::BadRequest(ref cause) => cause,
-            UpdateVoiceConnectorGroupError::Conflict(ref cause) => cause,
-            UpdateVoiceConnectorGroupError::Forbidden(ref cause) => cause,
-            UpdateVoiceConnectorGroupError::NotFound(ref cause) => cause,
-            UpdateVoiceConnectorGroupError::ServiceFailure(ref cause) => cause,
-            UpdateVoiceConnectorGroupError::ServiceUnavailable(ref cause) => cause,
-            UpdateVoiceConnectorGroupError::ThrottledClient(ref cause) => cause,
-            UpdateVoiceConnectorGroupError::UnauthorizedClient(ref cause) => cause,
+            UpdateVoiceConnectorGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorGroupError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorGroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorGroupError::ThrottledClient(ref cause) => write!(f, "{}", cause),
+            UpdateVoiceConnectorGroupError::UnauthorizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVoiceConnectorGroupError {}
 /// Trait representing the capabilities of the Amazon Chime API. Amazon Chime clients implement this trait.
 pub trait Chime {
     /// <p>Associates a phone number with the specified Amazon Chime user.</p>

--- a/rusoto/services/cloud9/src/generated.rs
+++ b/rusoto/services/cloud9/src/generated.rs
@@ -383,22 +383,18 @@ impl CreateEnvironmentEC2Error {
 }
 impl fmt::Display for CreateEnvironmentEC2Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEnvironmentEC2Error {
-    fn description(&self) -> &str {
         match *self {
-            CreateEnvironmentEC2Error::BadRequest(ref cause) => cause,
-            CreateEnvironmentEC2Error::Conflict(ref cause) => cause,
-            CreateEnvironmentEC2Error::Forbidden(ref cause) => cause,
-            CreateEnvironmentEC2Error::InternalServerError(ref cause) => cause,
-            CreateEnvironmentEC2Error::LimitExceeded(ref cause) => cause,
-            CreateEnvironmentEC2Error::NotFound(ref cause) => cause,
-            CreateEnvironmentEC2Error::TooManyRequests(ref cause) => cause,
+            CreateEnvironmentEC2Error::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentEC2Error::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentEC2Error::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentEC2Error::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentEC2Error::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentEC2Error::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentEC2Error::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEnvironmentEC2Error {}
 /// Errors returned by CreateEnvironmentMembership
 #[derive(Debug, PartialEq)]
 pub enum CreateEnvironmentMembershipError {
@@ -468,22 +464,20 @@ impl CreateEnvironmentMembershipError {
 }
 impl fmt::Display for CreateEnvironmentMembershipError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEnvironmentMembershipError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEnvironmentMembershipError::BadRequest(ref cause) => cause,
-            CreateEnvironmentMembershipError::Conflict(ref cause) => cause,
-            CreateEnvironmentMembershipError::Forbidden(ref cause) => cause,
-            CreateEnvironmentMembershipError::InternalServerError(ref cause) => cause,
-            CreateEnvironmentMembershipError::LimitExceeded(ref cause) => cause,
-            CreateEnvironmentMembershipError::NotFound(ref cause) => cause,
-            CreateEnvironmentMembershipError::TooManyRequests(ref cause) => cause,
+            CreateEnvironmentMembershipError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentMembershipError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentMembershipError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentMembershipError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEnvironmentMembershipError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentMembershipError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentMembershipError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEnvironmentMembershipError {}
 /// Errors returned by DeleteEnvironment
 #[derive(Debug, PartialEq)]
 pub enum DeleteEnvironmentError {
@@ -539,22 +533,18 @@ impl DeleteEnvironmentError {
 }
 impl fmt::Display for DeleteEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEnvironmentError::BadRequest(ref cause) => cause,
-            DeleteEnvironmentError::Conflict(ref cause) => cause,
-            DeleteEnvironmentError::Forbidden(ref cause) => cause,
-            DeleteEnvironmentError::InternalServerError(ref cause) => cause,
-            DeleteEnvironmentError::LimitExceeded(ref cause) => cause,
-            DeleteEnvironmentError::NotFound(ref cause) => cause,
-            DeleteEnvironmentError::TooManyRequests(ref cause) => cause,
+            DeleteEnvironmentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEnvironmentError {}
 /// Errors returned by DeleteEnvironmentMembership
 #[derive(Debug, PartialEq)]
 pub enum DeleteEnvironmentMembershipError {
@@ -624,22 +614,20 @@ impl DeleteEnvironmentMembershipError {
 }
 impl fmt::Display for DeleteEnvironmentMembershipError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEnvironmentMembershipError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEnvironmentMembershipError::BadRequest(ref cause) => cause,
-            DeleteEnvironmentMembershipError::Conflict(ref cause) => cause,
-            DeleteEnvironmentMembershipError::Forbidden(ref cause) => cause,
-            DeleteEnvironmentMembershipError::InternalServerError(ref cause) => cause,
-            DeleteEnvironmentMembershipError::LimitExceeded(ref cause) => cause,
-            DeleteEnvironmentMembershipError::NotFound(ref cause) => cause,
-            DeleteEnvironmentMembershipError::TooManyRequests(ref cause) => cause,
+            DeleteEnvironmentMembershipError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentMembershipError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentMembershipError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentMembershipError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteEnvironmentMembershipError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentMembershipError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteEnvironmentMembershipError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEnvironmentMembershipError {}
 /// Errors returned by DescribeEnvironmentMemberships
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentMembershipsError {
@@ -709,22 +697,22 @@ impl DescribeEnvironmentMembershipsError {
 }
 impl fmt::Display for DescribeEnvironmentMembershipsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentMembershipsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEnvironmentMembershipsError::BadRequest(ref cause) => cause,
-            DescribeEnvironmentMembershipsError::Conflict(ref cause) => cause,
-            DescribeEnvironmentMembershipsError::Forbidden(ref cause) => cause,
-            DescribeEnvironmentMembershipsError::InternalServerError(ref cause) => cause,
-            DescribeEnvironmentMembershipsError::LimitExceeded(ref cause) => cause,
-            DescribeEnvironmentMembershipsError::NotFound(ref cause) => cause,
-            DescribeEnvironmentMembershipsError::TooManyRequests(ref cause) => cause,
+            DescribeEnvironmentMembershipsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentMembershipsError::Conflict(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentMembershipsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentMembershipsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEnvironmentMembershipsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentMembershipsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentMembershipsError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEnvironmentMembershipsError {}
 /// Errors returned by DescribeEnvironmentStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentStatusError {
@@ -786,22 +774,20 @@ impl DescribeEnvironmentStatusError {
 }
 impl fmt::Display for DescribeEnvironmentStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEnvironmentStatusError::BadRequest(ref cause) => cause,
-            DescribeEnvironmentStatusError::Conflict(ref cause) => cause,
-            DescribeEnvironmentStatusError::Forbidden(ref cause) => cause,
-            DescribeEnvironmentStatusError::InternalServerError(ref cause) => cause,
-            DescribeEnvironmentStatusError::LimitExceeded(ref cause) => cause,
-            DescribeEnvironmentStatusError::NotFound(ref cause) => cause,
-            DescribeEnvironmentStatusError::TooManyRequests(ref cause) => cause,
+            DescribeEnvironmentStatusError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentStatusError::Conflict(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentStatusError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentStatusError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEnvironmentStatusError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentStatusError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentStatusError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEnvironmentStatusError {}
 /// Errors returned by DescribeEnvironments
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentsError {
@@ -859,22 +845,18 @@ impl DescribeEnvironmentsError {
 }
 impl fmt::Display for DescribeEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEnvironmentsError::BadRequest(ref cause) => cause,
-            DescribeEnvironmentsError::Conflict(ref cause) => cause,
-            DescribeEnvironmentsError::Forbidden(ref cause) => cause,
-            DescribeEnvironmentsError::InternalServerError(ref cause) => cause,
-            DescribeEnvironmentsError::LimitExceeded(ref cause) => cause,
-            DescribeEnvironmentsError::NotFound(ref cause) => cause,
-            DescribeEnvironmentsError::TooManyRequests(ref cause) => cause,
+            DescribeEnvironmentsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentsError::Conflict(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEnvironmentsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEnvironmentsError {}
 /// Errors returned by ListEnvironments
 #[derive(Debug, PartialEq)]
 pub enum ListEnvironmentsError {
@@ -930,22 +912,18 @@ impl ListEnvironmentsError {
 }
 impl fmt::Display for ListEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEnvironmentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListEnvironmentsError::BadRequest(ref cause) => cause,
-            ListEnvironmentsError::Conflict(ref cause) => cause,
-            ListEnvironmentsError::Forbidden(ref cause) => cause,
-            ListEnvironmentsError::InternalServerError(ref cause) => cause,
-            ListEnvironmentsError::LimitExceeded(ref cause) => cause,
-            ListEnvironmentsError::NotFound(ref cause) => cause,
-            ListEnvironmentsError::TooManyRequests(ref cause) => cause,
+            ListEnvironmentsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListEnvironmentsError::Conflict(ref cause) => write!(f, "{}", cause),
+            ListEnvironmentsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListEnvironmentsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListEnvironmentsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListEnvironmentsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListEnvironmentsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEnvironmentsError {}
 /// Errors returned by UpdateEnvironment
 #[derive(Debug, PartialEq)]
 pub enum UpdateEnvironmentError {
@@ -1001,22 +979,18 @@ impl UpdateEnvironmentError {
 }
 impl fmt::Display for UpdateEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEnvironmentError::BadRequest(ref cause) => cause,
-            UpdateEnvironmentError::Conflict(ref cause) => cause,
-            UpdateEnvironmentError::Forbidden(ref cause) => cause,
-            UpdateEnvironmentError::InternalServerError(ref cause) => cause,
-            UpdateEnvironmentError::LimitExceeded(ref cause) => cause,
-            UpdateEnvironmentError::NotFound(ref cause) => cause,
-            UpdateEnvironmentError::TooManyRequests(ref cause) => cause,
+            UpdateEnvironmentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEnvironmentError {}
 /// Errors returned by UpdateEnvironmentMembership
 #[derive(Debug, PartialEq)]
 pub enum UpdateEnvironmentMembershipError {
@@ -1086,22 +1060,20 @@ impl UpdateEnvironmentMembershipError {
 }
 impl fmt::Display for UpdateEnvironmentMembershipError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEnvironmentMembershipError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEnvironmentMembershipError::BadRequest(ref cause) => cause,
-            UpdateEnvironmentMembershipError::Conflict(ref cause) => cause,
-            UpdateEnvironmentMembershipError::Forbidden(ref cause) => cause,
-            UpdateEnvironmentMembershipError::InternalServerError(ref cause) => cause,
-            UpdateEnvironmentMembershipError::LimitExceeded(ref cause) => cause,
-            UpdateEnvironmentMembershipError::NotFound(ref cause) => cause,
-            UpdateEnvironmentMembershipError::TooManyRequests(ref cause) => cause,
+            UpdateEnvironmentMembershipError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentMembershipError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentMembershipError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentMembershipError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateEnvironmentMembershipError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentMembershipError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentMembershipError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEnvironmentMembershipError {}
 /// Trait representing the capabilities of the AWS Cloud9 API. AWS Cloud9 clients implement this trait.
 pub trait Cloud9 {
     /// <p>Creates an AWS Cloud9 development environment, launches an Amazon Elastic Compute Cloud (Amazon EC2) instance, and then connects from the instance to the environment.</p>

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -3167,23 +3167,19 @@ impl AddFacetToObjectError {
 }
 impl fmt::Display for AddFacetToObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddFacetToObjectError {
-    fn description(&self) -> &str {
         match *self {
-            AddFacetToObjectError::AccessDenied(ref cause) => cause,
-            AddFacetToObjectError::DirectoryNotEnabled(ref cause) => cause,
-            AddFacetToObjectError::FacetValidation(ref cause) => cause,
-            AddFacetToObjectError::InternalService(ref cause) => cause,
-            AddFacetToObjectError::InvalidArn(ref cause) => cause,
-            AddFacetToObjectError::LimitExceeded(ref cause) => cause,
-            AddFacetToObjectError::ResourceNotFound(ref cause) => cause,
-            AddFacetToObjectError::RetryableConflict(ref cause) => cause,
+            AddFacetToObjectError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AddFacetToObjectError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            AddFacetToObjectError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            AddFacetToObjectError::InternalService(ref cause) => write!(f, "{}", cause),
+            AddFacetToObjectError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            AddFacetToObjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddFacetToObjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddFacetToObjectError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddFacetToObjectError {}
 /// Errors returned by ApplySchema
 #[derive(Debug, PartialEq)]
 pub enum ApplySchemaError {
@@ -3242,23 +3238,19 @@ impl ApplySchemaError {
 }
 impl fmt::Display for ApplySchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApplySchemaError {
-    fn description(&self) -> &str {
         match *self {
-            ApplySchemaError::AccessDenied(ref cause) => cause,
-            ApplySchemaError::InternalService(ref cause) => cause,
-            ApplySchemaError::InvalidArn(ref cause) => cause,
-            ApplySchemaError::InvalidAttachment(ref cause) => cause,
-            ApplySchemaError::LimitExceeded(ref cause) => cause,
-            ApplySchemaError::ResourceNotFound(ref cause) => cause,
-            ApplySchemaError::RetryableConflict(ref cause) => cause,
-            ApplySchemaError::SchemaAlreadyExists(ref cause) => cause,
+            ApplySchemaError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ApplySchemaError::InternalService(ref cause) => write!(f, "{}", cause),
+            ApplySchemaError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ApplySchemaError::InvalidAttachment(ref cause) => write!(f, "{}", cause),
+            ApplySchemaError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ApplySchemaError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ApplySchemaError::RetryableConflict(ref cause) => write!(f, "{}", cause),
+            ApplySchemaError::SchemaAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ApplySchemaError {}
 /// Errors returned by AttachObject
 #[derive(Debug, PartialEq)]
 pub enum AttachObjectError {
@@ -3327,25 +3319,21 @@ impl AttachObjectError {
 }
 impl fmt::Display for AttachObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachObjectError {
-    fn description(&self) -> &str {
         match *self {
-            AttachObjectError::AccessDenied(ref cause) => cause,
-            AttachObjectError::DirectoryNotEnabled(ref cause) => cause,
-            AttachObjectError::FacetValidation(ref cause) => cause,
-            AttachObjectError::InternalService(ref cause) => cause,
-            AttachObjectError::InvalidArn(ref cause) => cause,
-            AttachObjectError::InvalidAttachment(ref cause) => cause,
-            AttachObjectError::LimitExceeded(ref cause) => cause,
-            AttachObjectError::LinkNameAlreadyInUse(ref cause) => cause,
-            AttachObjectError::ResourceNotFound(ref cause) => cause,
-            AttachObjectError::RetryableConflict(ref cause) => cause,
+            AttachObjectError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::InternalService(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::InvalidAttachment(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::LinkNameAlreadyInUse(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachObjectError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachObjectError {}
 /// Errors returned by AttachPolicy
 #[derive(Debug, PartialEq)]
 pub enum AttachPolicyError {
@@ -3404,23 +3392,19 @@ impl AttachPolicyError {
 }
 impl fmt::Display for AttachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            AttachPolicyError::AccessDenied(ref cause) => cause,
-            AttachPolicyError::DirectoryNotEnabled(ref cause) => cause,
-            AttachPolicyError::InternalService(ref cause) => cause,
-            AttachPolicyError::InvalidArn(ref cause) => cause,
-            AttachPolicyError::LimitExceeded(ref cause) => cause,
-            AttachPolicyError::NotPolicy(ref cause) => cause,
-            AttachPolicyError::ResourceNotFound(ref cause) => cause,
-            AttachPolicyError::RetryableConflict(ref cause) => cause,
+            AttachPolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::NotPolicy(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachPolicyError {}
 /// Errors returned by AttachToIndex
 #[derive(Debug, PartialEq)]
 pub enum AttachToIndexError {
@@ -3496,26 +3480,22 @@ impl AttachToIndexError {
 }
 impl fmt::Display for AttachToIndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachToIndexError {
-    fn description(&self) -> &str {
         match *self {
-            AttachToIndexError::AccessDenied(ref cause) => cause,
-            AttachToIndexError::DirectoryNotEnabled(ref cause) => cause,
-            AttachToIndexError::IndexedAttributeMissing(ref cause) => cause,
-            AttachToIndexError::InternalService(ref cause) => cause,
-            AttachToIndexError::InvalidArn(ref cause) => cause,
-            AttachToIndexError::InvalidAttachment(ref cause) => cause,
-            AttachToIndexError::LimitExceeded(ref cause) => cause,
-            AttachToIndexError::LinkNameAlreadyInUse(ref cause) => cause,
-            AttachToIndexError::NotIndex(ref cause) => cause,
-            AttachToIndexError::ResourceNotFound(ref cause) => cause,
-            AttachToIndexError::RetryableConflict(ref cause) => cause,
+            AttachToIndexError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::IndexedAttributeMissing(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::InternalService(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::InvalidAttachment(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::LinkNameAlreadyInUse(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::NotIndex(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachToIndexError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachToIndexError {}
 /// Errors returned by AttachTypedLink
 #[derive(Debug, PartialEq)]
 pub enum AttachTypedLinkError {
@@ -3579,24 +3559,20 @@ impl AttachTypedLinkError {
 }
 impl fmt::Display for AttachTypedLinkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachTypedLinkError {
-    fn description(&self) -> &str {
         match *self {
-            AttachTypedLinkError::AccessDenied(ref cause) => cause,
-            AttachTypedLinkError::DirectoryNotEnabled(ref cause) => cause,
-            AttachTypedLinkError::FacetValidation(ref cause) => cause,
-            AttachTypedLinkError::InternalService(ref cause) => cause,
-            AttachTypedLinkError::InvalidArn(ref cause) => cause,
-            AttachTypedLinkError::InvalidAttachment(ref cause) => cause,
-            AttachTypedLinkError::LimitExceeded(ref cause) => cause,
-            AttachTypedLinkError::ResourceNotFound(ref cause) => cause,
-            AttachTypedLinkError::RetryableConflict(ref cause) => cause,
+            AttachTypedLinkError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::InternalService(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::InvalidAttachment(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachTypedLinkError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachTypedLinkError {}
 /// Errors returned by BatchRead
 #[derive(Debug, PartialEq)]
 pub enum BatchReadError {
@@ -3645,21 +3621,17 @@ impl BatchReadError {
 }
 impl fmt::Display for BatchReadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchReadError {
-    fn description(&self) -> &str {
         match *self {
-            BatchReadError::AccessDenied(ref cause) => cause,
-            BatchReadError::DirectoryNotEnabled(ref cause) => cause,
-            BatchReadError::InternalService(ref cause) => cause,
-            BatchReadError::InvalidArn(ref cause) => cause,
-            BatchReadError::LimitExceeded(ref cause) => cause,
-            BatchReadError::RetryableConflict(ref cause) => cause,
+            BatchReadError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            BatchReadError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            BatchReadError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchReadError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            BatchReadError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchReadError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchReadError {}
 /// Errors returned by BatchWrite
 #[derive(Debug, PartialEq)]
 pub enum BatchWriteError {
@@ -3713,22 +3685,18 @@ impl BatchWriteError {
 }
 impl fmt::Display for BatchWriteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchWriteError {
-    fn description(&self) -> &str {
         match *self {
-            BatchWriteError::AccessDenied(ref cause) => cause,
-            BatchWriteError::BatchWrite(ref cause) => cause,
-            BatchWriteError::DirectoryNotEnabled(ref cause) => cause,
-            BatchWriteError::InternalService(ref cause) => cause,
-            BatchWriteError::InvalidArn(ref cause) => cause,
-            BatchWriteError::LimitExceeded(ref cause) => cause,
-            BatchWriteError::RetryableConflict(ref cause) => cause,
+            BatchWriteError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            BatchWriteError::BatchWrite(ref cause) => write!(f, "{}", cause),
+            BatchWriteError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            BatchWriteError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchWriteError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            BatchWriteError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchWriteError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchWriteError {}
 /// Errors returned by CreateDirectory
 #[derive(Debug, PartialEq)]
 pub enum CreateDirectoryError {
@@ -3784,22 +3752,18 @@ impl CreateDirectoryError {
 }
 impl fmt::Display for CreateDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDirectoryError::AccessDenied(ref cause) => cause,
-            CreateDirectoryError::DirectoryAlreadyExists(ref cause) => cause,
-            CreateDirectoryError::InternalService(ref cause) => cause,
-            CreateDirectoryError::InvalidArn(ref cause) => cause,
-            CreateDirectoryError::LimitExceeded(ref cause) => cause,
-            CreateDirectoryError::ResourceNotFound(ref cause) => cause,
-            CreateDirectoryError::RetryableConflict(ref cause) => cause,
+            CreateDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::DirectoryAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDirectoryError {}
 /// Errors returned by CreateFacet
 #[derive(Debug, PartialEq)]
 pub enum CreateFacetError {
@@ -3863,24 +3827,20 @@ impl CreateFacetError {
 }
 impl fmt::Display for CreateFacetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFacetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFacetError::AccessDenied(ref cause) => cause,
-            CreateFacetError::FacetAlreadyExists(ref cause) => cause,
-            CreateFacetError::FacetValidation(ref cause) => cause,
-            CreateFacetError::InternalService(ref cause) => cause,
-            CreateFacetError::InvalidArn(ref cause) => cause,
-            CreateFacetError::InvalidRule(ref cause) => cause,
-            CreateFacetError::LimitExceeded(ref cause) => cause,
-            CreateFacetError::ResourceNotFound(ref cause) => cause,
-            CreateFacetError::RetryableConflict(ref cause) => cause,
+            CreateFacetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::FacetAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::InvalidRule(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateFacetError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFacetError {}
 /// Errors returned by CreateIndex
 #[derive(Debug, PartialEq)]
 pub enum CreateIndexError {
@@ -3949,25 +3909,21 @@ impl CreateIndexError {
 }
 impl fmt::Display for CreateIndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIndexError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIndexError::AccessDenied(ref cause) => cause,
-            CreateIndexError::DirectoryNotEnabled(ref cause) => cause,
-            CreateIndexError::FacetValidation(ref cause) => cause,
-            CreateIndexError::InternalService(ref cause) => cause,
-            CreateIndexError::InvalidArn(ref cause) => cause,
-            CreateIndexError::LimitExceeded(ref cause) => cause,
-            CreateIndexError::LinkNameAlreadyInUse(ref cause) => cause,
-            CreateIndexError::ResourceNotFound(ref cause) => cause,
-            CreateIndexError::RetryableConflict(ref cause) => cause,
-            CreateIndexError::UnsupportedIndexType(ref cause) => cause,
+            CreateIndexError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::LinkNameAlreadyInUse(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::RetryableConflict(ref cause) => write!(f, "{}", cause),
+            CreateIndexError::UnsupportedIndexType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIndexError {}
 /// Errors returned by CreateObject
 #[derive(Debug, PartialEq)]
 pub enum CreateObjectError {
@@ -4036,25 +3992,21 @@ impl CreateObjectError {
 }
 impl fmt::Display for CreateObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateObjectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateObjectError::AccessDenied(ref cause) => cause,
-            CreateObjectError::DirectoryNotEnabled(ref cause) => cause,
-            CreateObjectError::FacetValidation(ref cause) => cause,
-            CreateObjectError::InternalService(ref cause) => cause,
-            CreateObjectError::InvalidArn(ref cause) => cause,
-            CreateObjectError::LimitExceeded(ref cause) => cause,
-            CreateObjectError::LinkNameAlreadyInUse(ref cause) => cause,
-            CreateObjectError::ResourceNotFound(ref cause) => cause,
-            CreateObjectError::RetryableConflict(ref cause) => cause,
-            CreateObjectError::UnsupportedIndexType(ref cause) => cause,
+            CreateObjectError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::LinkNameAlreadyInUse(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::RetryableConflict(ref cause) => write!(f, "{}", cause),
+            CreateObjectError::UnsupportedIndexType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateObjectError {}
 /// Errors returned by CreateSchema
 #[derive(Debug, PartialEq)]
 pub enum CreateSchemaError {
@@ -4103,21 +4055,17 @@ impl CreateSchemaError {
 }
 impl fmt::Display for CreateSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSchemaError::AccessDenied(ref cause) => cause,
-            CreateSchemaError::InternalService(ref cause) => cause,
-            CreateSchemaError::InvalidArn(ref cause) => cause,
-            CreateSchemaError::LimitExceeded(ref cause) => cause,
-            CreateSchemaError::RetryableConflict(ref cause) => cause,
-            CreateSchemaError::SchemaAlreadyExists(ref cause) => cause,
+            CreateSchemaError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateSchemaError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateSchemaError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateSchemaError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSchemaError::RetryableConflict(ref cause) => write!(f, "{}", cause),
+            CreateSchemaError::SchemaAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSchemaError {}
 /// Errors returned by CreateTypedLinkFacet
 #[derive(Debug, PartialEq)]
 pub enum CreateTypedLinkFacetError {
@@ -4191,24 +4139,20 @@ impl CreateTypedLinkFacetError {
 }
 impl fmt::Display for CreateTypedLinkFacetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTypedLinkFacetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTypedLinkFacetError::AccessDenied(ref cause) => cause,
-            CreateTypedLinkFacetError::FacetAlreadyExists(ref cause) => cause,
-            CreateTypedLinkFacetError::FacetValidation(ref cause) => cause,
-            CreateTypedLinkFacetError::InternalService(ref cause) => cause,
-            CreateTypedLinkFacetError::InvalidArn(ref cause) => cause,
-            CreateTypedLinkFacetError::InvalidRule(ref cause) => cause,
-            CreateTypedLinkFacetError::LimitExceeded(ref cause) => cause,
-            CreateTypedLinkFacetError::ResourceNotFound(ref cause) => cause,
-            CreateTypedLinkFacetError::RetryableConflict(ref cause) => cause,
+            CreateTypedLinkFacetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::FacetAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::InvalidRule(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTypedLinkFacetError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTypedLinkFacetError {}
 /// Errors returned by DeleteDirectory
 #[derive(Debug, PartialEq)]
 pub enum DeleteDirectoryError {
@@ -4269,23 +4213,19 @@ impl DeleteDirectoryError {
 }
 impl fmt::Display for DeleteDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDirectoryError::AccessDenied(ref cause) => cause,
-            DeleteDirectoryError::DirectoryDeleted(ref cause) => cause,
-            DeleteDirectoryError::DirectoryNotDisabled(ref cause) => cause,
-            DeleteDirectoryError::InternalService(ref cause) => cause,
-            DeleteDirectoryError::InvalidArn(ref cause) => cause,
-            DeleteDirectoryError::LimitExceeded(ref cause) => cause,
-            DeleteDirectoryError::ResourceNotFound(ref cause) => cause,
-            DeleteDirectoryError::RetryableConflict(ref cause) => cause,
+            DeleteDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::DirectoryDeleted(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::DirectoryNotDisabled(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDirectoryError {}
 /// Errors returned by DeleteFacet
 #[derive(Debug, PartialEq)]
 pub enum DeleteFacetError {
@@ -4344,23 +4284,19 @@ impl DeleteFacetError {
 }
 impl fmt::Display for DeleteFacetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFacetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFacetError::AccessDenied(ref cause) => cause,
-            DeleteFacetError::FacetInUse(ref cause) => cause,
-            DeleteFacetError::FacetNotFound(ref cause) => cause,
-            DeleteFacetError::InternalService(ref cause) => cause,
-            DeleteFacetError::InvalidArn(ref cause) => cause,
-            DeleteFacetError::LimitExceeded(ref cause) => cause,
-            DeleteFacetError::ResourceNotFound(ref cause) => cause,
-            DeleteFacetError::RetryableConflict(ref cause) => cause,
+            DeleteFacetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteFacetError::FacetInUse(ref cause) => write!(f, "{}", cause),
+            DeleteFacetError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFacetError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteFacetError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteFacetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteFacetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFacetError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFacetError {}
 /// Errors returned by DeleteObject
 #[derive(Debug, PartialEq)]
 pub enum DeleteObjectError {
@@ -4419,23 +4355,19 @@ impl DeleteObjectError {
 }
 impl fmt::Display for DeleteObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteObjectError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteObjectError::AccessDenied(ref cause) => cause,
-            DeleteObjectError::DirectoryNotEnabled(ref cause) => cause,
-            DeleteObjectError::InternalService(ref cause) => cause,
-            DeleteObjectError::InvalidArn(ref cause) => cause,
-            DeleteObjectError::LimitExceeded(ref cause) => cause,
-            DeleteObjectError::ObjectNotDetached(ref cause) => cause,
-            DeleteObjectError::ResourceNotFound(ref cause) => cause,
-            DeleteObjectError::RetryableConflict(ref cause) => cause,
+            DeleteObjectError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteObjectError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            DeleteObjectError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteObjectError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteObjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteObjectError::ObjectNotDetached(ref cause) => write!(f, "{}", cause),
+            DeleteObjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteObjectError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteObjectError {}
 /// Errors returned by DeleteSchema
 #[derive(Debug, PartialEq)]
 pub enum DeleteSchemaError {
@@ -4489,22 +4421,18 @@ impl DeleteSchemaError {
 }
 impl fmt::Display for DeleteSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSchemaError::AccessDenied(ref cause) => cause,
-            DeleteSchemaError::InternalService(ref cause) => cause,
-            DeleteSchemaError::InvalidArn(ref cause) => cause,
-            DeleteSchemaError::LimitExceeded(ref cause) => cause,
-            DeleteSchemaError::ResourceNotFound(ref cause) => cause,
-            DeleteSchemaError::RetryableConflict(ref cause) => cause,
-            DeleteSchemaError::StillContainsLinks(ref cause) => cause,
+            DeleteSchemaError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteSchemaError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteSchemaError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteSchemaError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteSchemaError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteSchemaError::RetryableConflict(ref cause) => write!(f, "{}", cause),
+            DeleteSchemaError::StillContainsLinks(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSchemaError {}
 /// Errors returned by DeleteTypedLinkFacet
 #[derive(Debug, PartialEq)]
 pub enum DeleteTypedLinkFacetError {
@@ -4564,22 +4492,18 @@ impl DeleteTypedLinkFacetError {
 }
 impl fmt::Display for DeleteTypedLinkFacetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTypedLinkFacetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTypedLinkFacetError::AccessDenied(ref cause) => cause,
-            DeleteTypedLinkFacetError::FacetNotFound(ref cause) => cause,
-            DeleteTypedLinkFacetError::InternalService(ref cause) => cause,
-            DeleteTypedLinkFacetError::InvalidArn(ref cause) => cause,
-            DeleteTypedLinkFacetError::LimitExceeded(ref cause) => cause,
-            DeleteTypedLinkFacetError::ResourceNotFound(ref cause) => cause,
-            DeleteTypedLinkFacetError::RetryableConflict(ref cause) => cause,
+            DeleteTypedLinkFacetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteTypedLinkFacetError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTypedLinkFacetError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteTypedLinkFacetError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteTypedLinkFacetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteTypedLinkFacetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTypedLinkFacetError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTypedLinkFacetError {}
 /// Errors returned by DetachFromIndex
 #[derive(Debug, PartialEq)]
 pub enum DetachFromIndexError {
@@ -4645,24 +4569,20 @@ impl DetachFromIndexError {
 }
 impl fmt::Display for DetachFromIndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachFromIndexError {
-    fn description(&self) -> &str {
         match *self {
-            DetachFromIndexError::AccessDenied(ref cause) => cause,
-            DetachFromIndexError::DirectoryNotEnabled(ref cause) => cause,
-            DetachFromIndexError::InternalService(ref cause) => cause,
-            DetachFromIndexError::InvalidArn(ref cause) => cause,
-            DetachFromIndexError::LimitExceeded(ref cause) => cause,
-            DetachFromIndexError::NotIndex(ref cause) => cause,
-            DetachFromIndexError::ObjectAlreadyDetached(ref cause) => cause,
-            DetachFromIndexError::ResourceNotFound(ref cause) => cause,
-            DetachFromIndexError::RetryableConflict(ref cause) => cause,
+            DetachFromIndexError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::InternalService(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::NotIndex(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::ObjectAlreadyDetached(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetachFromIndexError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachFromIndexError {}
 /// Errors returned by DetachObject
 #[derive(Debug, PartialEq)]
 pub enum DetachObjectError {
@@ -4721,23 +4641,19 @@ impl DetachObjectError {
 }
 impl fmt::Display for DetachObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachObjectError {
-    fn description(&self) -> &str {
         match *self {
-            DetachObjectError::AccessDenied(ref cause) => cause,
-            DetachObjectError::DirectoryNotEnabled(ref cause) => cause,
-            DetachObjectError::InternalService(ref cause) => cause,
-            DetachObjectError::InvalidArn(ref cause) => cause,
-            DetachObjectError::LimitExceeded(ref cause) => cause,
-            DetachObjectError::NotNode(ref cause) => cause,
-            DetachObjectError::ResourceNotFound(ref cause) => cause,
-            DetachObjectError::RetryableConflict(ref cause) => cause,
+            DetachObjectError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachObjectError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            DetachObjectError::InternalService(ref cause) => write!(f, "{}", cause),
+            DetachObjectError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DetachObjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachObjectError::NotNode(ref cause) => write!(f, "{}", cause),
+            DetachObjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetachObjectError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachObjectError {}
 /// Errors returned by DetachPolicy
 #[derive(Debug, PartialEq)]
 pub enum DetachPolicyError {
@@ -4796,23 +4712,19 @@ impl DetachPolicyError {
 }
 impl fmt::Display for DetachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DetachPolicyError::AccessDenied(ref cause) => cause,
-            DetachPolicyError::DirectoryNotEnabled(ref cause) => cause,
-            DetachPolicyError::InternalService(ref cause) => cause,
-            DetachPolicyError::InvalidArn(ref cause) => cause,
-            DetachPolicyError::LimitExceeded(ref cause) => cause,
-            DetachPolicyError::NotPolicy(ref cause) => cause,
-            DetachPolicyError::ResourceNotFound(ref cause) => cause,
-            DetachPolicyError::RetryableConflict(ref cause) => cause,
+            DetachPolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::NotPolicy(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachPolicyError {}
 /// Errors returned by DetachTypedLink
 #[derive(Debug, PartialEq)]
 pub enum DetachTypedLinkError {
@@ -4871,23 +4783,19 @@ impl DetachTypedLinkError {
 }
 impl fmt::Display for DetachTypedLinkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachTypedLinkError {
-    fn description(&self) -> &str {
         match *self {
-            DetachTypedLinkError::AccessDenied(ref cause) => cause,
-            DetachTypedLinkError::DirectoryNotEnabled(ref cause) => cause,
-            DetachTypedLinkError::FacetValidation(ref cause) => cause,
-            DetachTypedLinkError::InternalService(ref cause) => cause,
-            DetachTypedLinkError::InvalidArn(ref cause) => cause,
-            DetachTypedLinkError::LimitExceeded(ref cause) => cause,
-            DetachTypedLinkError::ResourceNotFound(ref cause) => cause,
-            DetachTypedLinkError::RetryableConflict(ref cause) => cause,
+            DetachTypedLinkError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachTypedLinkError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            DetachTypedLinkError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            DetachTypedLinkError::InternalService(ref cause) => write!(f, "{}", cause),
+            DetachTypedLinkError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DetachTypedLinkError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachTypedLinkError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetachTypedLinkError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachTypedLinkError {}
 /// Errors returned by DisableDirectory
 #[derive(Debug, PartialEq)]
 pub enum DisableDirectoryError {
@@ -4941,22 +4849,18 @@ impl DisableDirectoryError {
 }
 impl fmt::Display for DisableDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            DisableDirectoryError::AccessDenied(ref cause) => cause,
-            DisableDirectoryError::DirectoryDeleted(ref cause) => cause,
-            DisableDirectoryError::InternalService(ref cause) => cause,
-            DisableDirectoryError::InvalidArn(ref cause) => cause,
-            DisableDirectoryError::LimitExceeded(ref cause) => cause,
-            DisableDirectoryError::ResourceNotFound(ref cause) => cause,
-            DisableDirectoryError::RetryableConflict(ref cause) => cause,
+            DisableDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisableDirectoryError::DirectoryDeleted(ref cause) => write!(f, "{}", cause),
+            DisableDirectoryError::InternalService(ref cause) => write!(f, "{}", cause),
+            DisableDirectoryError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DisableDirectoryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DisableDirectoryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DisableDirectoryError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableDirectoryError {}
 /// Errors returned by EnableDirectory
 #[derive(Debug, PartialEq)]
 pub enum EnableDirectoryError {
@@ -5010,22 +4914,18 @@ impl EnableDirectoryError {
 }
 impl fmt::Display for EnableDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            EnableDirectoryError::AccessDenied(ref cause) => cause,
-            EnableDirectoryError::DirectoryDeleted(ref cause) => cause,
-            EnableDirectoryError::InternalService(ref cause) => cause,
-            EnableDirectoryError::InvalidArn(ref cause) => cause,
-            EnableDirectoryError::LimitExceeded(ref cause) => cause,
-            EnableDirectoryError::ResourceNotFound(ref cause) => cause,
-            EnableDirectoryError::RetryableConflict(ref cause) => cause,
+            EnableDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            EnableDirectoryError::DirectoryDeleted(ref cause) => write!(f, "{}", cause),
+            EnableDirectoryError::InternalService(ref cause) => write!(f, "{}", cause),
+            EnableDirectoryError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            EnableDirectoryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            EnableDirectoryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            EnableDirectoryError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableDirectoryError {}
 /// Errors returned by GetAppliedSchemaVersion
 #[derive(Debug, PartialEq)]
 pub enum GetAppliedSchemaVersionError {
@@ -5084,21 +4984,17 @@ impl GetAppliedSchemaVersionError {
 }
 impl fmt::Display for GetAppliedSchemaVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAppliedSchemaVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetAppliedSchemaVersionError::AccessDenied(ref cause) => cause,
-            GetAppliedSchemaVersionError::InternalService(ref cause) => cause,
-            GetAppliedSchemaVersionError::InvalidArn(ref cause) => cause,
-            GetAppliedSchemaVersionError::LimitExceeded(ref cause) => cause,
-            GetAppliedSchemaVersionError::ResourceNotFound(ref cause) => cause,
-            GetAppliedSchemaVersionError::RetryableConflict(ref cause) => cause,
+            GetAppliedSchemaVersionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetAppliedSchemaVersionError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetAppliedSchemaVersionError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetAppliedSchemaVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetAppliedSchemaVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetAppliedSchemaVersionError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAppliedSchemaVersionError {}
 /// Errors returned by GetDirectory
 #[derive(Debug, PartialEq)]
 pub enum GetDirectoryError {
@@ -5142,20 +5038,16 @@ impl GetDirectoryError {
 }
 impl fmt::Display for GetDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            GetDirectoryError::AccessDenied(ref cause) => cause,
-            GetDirectoryError::InternalService(ref cause) => cause,
-            GetDirectoryError::InvalidArn(ref cause) => cause,
-            GetDirectoryError::LimitExceeded(ref cause) => cause,
-            GetDirectoryError::RetryableConflict(ref cause) => cause,
+            GetDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDirectoryError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetDirectoryError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetDirectoryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetDirectoryError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDirectoryError {}
 /// Errors returned by GetFacet
 #[derive(Debug, PartialEq)]
 pub enum GetFacetError {
@@ -5209,22 +5101,18 @@ impl GetFacetError {
 }
 impl fmt::Display for GetFacetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFacetError {
-    fn description(&self) -> &str {
         match *self {
-            GetFacetError::AccessDenied(ref cause) => cause,
-            GetFacetError::FacetNotFound(ref cause) => cause,
-            GetFacetError::InternalService(ref cause) => cause,
-            GetFacetError::InvalidArn(ref cause) => cause,
-            GetFacetError::LimitExceeded(ref cause) => cause,
-            GetFacetError::ResourceNotFound(ref cause) => cause,
-            GetFacetError::RetryableConflict(ref cause) => cause,
+            GetFacetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetFacetError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            GetFacetError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetFacetError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetFacetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetFacetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetFacetError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFacetError {}
 /// Errors returned by GetLinkAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetLinkAttributesError {
@@ -5285,23 +5173,19 @@ impl GetLinkAttributesError {
 }
 impl fmt::Display for GetLinkAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLinkAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetLinkAttributesError::AccessDenied(ref cause) => cause,
-            GetLinkAttributesError::DirectoryNotEnabled(ref cause) => cause,
-            GetLinkAttributesError::FacetValidation(ref cause) => cause,
-            GetLinkAttributesError::InternalService(ref cause) => cause,
-            GetLinkAttributesError::InvalidArn(ref cause) => cause,
-            GetLinkAttributesError::LimitExceeded(ref cause) => cause,
-            GetLinkAttributesError::ResourceNotFound(ref cause) => cause,
-            GetLinkAttributesError::RetryableConflict(ref cause) => cause,
+            GetLinkAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetLinkAttributesError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            GetLinkAttributesError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            GetLinkAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetLinkAttributesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetLinkAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetLinkAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLinkAttributesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLinkAttributesError {}
 /// Errors returned by GetObjectAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetObjectAttributesError {
@@ -5366,23 +5250,19 @@ impl GetObjectAttributesError {
 }
 impl fmt::Display for GetObjectAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetObjectAttributesError::AccessDenied(ref cause) => cause,
-            GetObjectAttributesError::DirectoryNotEnabled(ref cause) => cause,
-            GetObjectAttributesError::FacetValidation(ref cause) => cause,
-            GetObjectAttributesError::InternalService(ref cause) => cause,
-            GetObjectAttributesError::InvalidArn(ref cause) => cause,
-            GetObjectAttributesError::LimitExceeded(ref cause) => cause,
-            GetObjectAttributesError::ResourceNotFound(ref cause) => cause,
-            GetObjectAttributesError::RetryableConflict(ref cause) => cause,
+            GetObjectAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetObjectAttributesError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            GetObjectAttributesError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            GetObjectAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetObjectAttributesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetObjectAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetObjectAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetObjectAttributesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetObjectAttributesError {}
 /// Errors returned by GetObjectInformation
 #[derive(Debug, PartialEq)]
 pub enum GetObjectInformationError {
@@ -5444,22 +5324,18 @@ impl GetObjectInformationError {
 }
 impl fmt::Display for GetObjectInformationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectInformationError {
-    fn description(&self) -> &str {
         match *self {
-            GetObjectInformationError::AccessDenied(ref cause) => cause,
-            GetObjectInformationError::DirectoryNotEnabled(ref cause) => cause,
-            GetObjectInformationError::InternalService(ref cause) => cause,
-            GetObjectInformationError::InvalidArn(ref cause) => cause,
-            GetObjectInformationError::LimitExceeded(ref cause) => cause,
-            GetObjectInformationError::ResourceNotFound(ref cause) => cause,
-            GetObjectInformationError::RetryableConflict(ref cause) => cause,
+            GetObjectInformationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetObjectInformationError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            GetObjectInformationError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetObjectInformationError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetObjectInformationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetObjectInformationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetObjectInformationError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetObjectInformationError {}
 /// Errors returned by GetSchemaAsJson
 #[derive(Debug, PartialEq)]
 pub enum GetSchemaAsJsonError {
@@ -5508,21 +5384,17 @@ impl GetSchemaAsJsonError {
 }
 impl fmt::Display for GetSchemaAsJsonError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSchemaAsJsonError {
-    fn description(&self) -> &str {
         match *self {
-            GetSchemaAsJsonError::AccessDenied(ref cause) => cause,
-            GetSchemaAsJsonError::InternalService(ref cause) => cause,
-            GetSchemaAsJsonError::InvalidArn(ref cause) => cause,
-            GetSchemaAsJsonError::LimitExceeded(ref cause) => cause,
-            GetSchemaAsJsonError::ResourceNotFound(ref cause) => cause,
-            GetSchemaAsJsonError::RetryableConflict(ref cause) => cause,
+            GetSchemaAsJsonError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetSchemaAsJsonError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetSchemaAsJsonError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetSchemaAsJsonError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetSchemaAsJsonError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetSchemaAsJsonError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSchemaAsJsonError {}
 /// Errors returned by GetTypedLinkFacetInformation
 #[derive(Debug, PartialEq)]
 pub enum GetTypedLinkFacetInformationError {
@@ -5599,23 +5471,25 @@ impl GetTypedLinkFacetInformationError {
 }
 impl fmt::Display for GetTypedLinkFacetInformationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTypedLinkFacetInformationError {
-    fn description(&self) -> &str {
         match *self {
-            GetTypedLinkFacetInformationError::AccessDenied(ref cause) => cause,
-            GetTypedLinkFacetInformationError::FacetNotFound(ref cause) => cause,
-            GetTypedLinkFacetInformationError::InternalService(ref cause) => cause,
-            GetTypedLinkFacetInformationError::InvalidArn(ref cause) => cause,
-            GetTypedLinkFacetInformationError::InvalidNextToken(ref cause) => cause,
-            GetTypedLinkFacetInformationError::LimitExceeded(ref cause) => cause,
-            GetTypedLinkFacetInformationError::ResourceNotFound(ref cause) => cause,
-            GetTypedLinkFacetInformationError::RetryableConflict(ref cause) => cause,
+            GetTypedLinkFacetInformationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetTypedLinkFacetInformationError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            GetTypedLinkFacetInformationError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTypedLinkFacetInformationError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetTypedLinkFacetInformationError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetTypedLinkFacetInformationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetTypedLinkFacetInformationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetTypedLinkFacetInformationError::RetryableConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetTypedLinkFacetInformationError {}
 /// Errors returned by ListAppliedSchemaArns
 #[derive(Debug, PartialEq)]
 pub enum ListAppliedSchemaArnsError {
@@ -5677,22 +5551,18 @@ impl ListAppliedSchemaArnsError {
 }
 impl fmt::Display for ListAppliedSchemaArnsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAppliedSchemaArnsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAppliedSchemaArnsError::AccessDenied(ref cause) => cause,
-            ListAppliedSchemaArnsError::InternalService(ref cause) => cause,
-            ListAppliedSchemaArnsError::InvalidArn(ref cause) => cause,
-            ListAppliedSchemaArnsError::InvalidNextToken(ref cause) => cause,
-            ListAppliedSchemaArnsError::LimitExceeded(ref cause) => cause,
-            ListAppliedSchemaArnsError::ResourceNotFound(ref cause) => cause,
-            ListAppliedSchemaArnsError::RetryableConflict(ref cause) => cause,
+            ListAppliedSchemaArnsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAppliedSchemaArnsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListAppliedSchemaArnsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListAppliedSchemaArnsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListAppliedSchemaArnsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListAppliedSchemaArnsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListAppliedSchemaArnsError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAppliedSchemaArnsError {}
 /// Errors returned by ListAttachedIndices
 #[derive(Debug, PartialEq)]
 pub enum ListAttachedIndicesError {
@@ -5752,22 +5622,18 @@ impl ListAttachedIndicesError {
 }
 impl fmt::Display for ListAttachedIndicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttachedIndicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttachedIndicesError::AccessDenied(ref cause) => cause,
-            ListAttachedIndicesError::DirectoryNotEnabled(ref cause) => cause,
-            ListAttachedIndicesError::InternalService(ref cause) => cause,
-            ListAttachedIndicesError::InvalidArn(ref cause) => cause,
-            ListAttachedIndicesError::LimitExceeded(ref cause) => cause,
-            ListAttachedIndicesError::ResourceNotFound(ref cause) => cause,
-            ListAttachedIndicesError::RetryableConflict(ref cause) => cause,
+            ListAttachedIndicesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAttachedIndicesError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListAttachedIndicesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListAttachedIndicesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListAttachedIndicesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListAttachedIndicesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListAttachedIndicesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttachedIndicesError {}
 /// Errors returned by ListDevelopmentSchemaArns
 #[derive(Debug, PartialEq)]
 pub enum ListDevelopmentSchemaArnsError {
@@ -5835,22 +5701,18 @@ impl ListDevelopmentSchemaArnsError {
 }
 impl fmt::Display for ListDevelopmentSchemaArnsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDevelopmentSchemaArnsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDevelopmentSchemaArnsError::AccessDenied(ref cause) => cause,
-            ListDevelopmentSchemaArnsError::InternalService(ref cause) => cause,
-            ListDevelopmentSchemaArnsError::InvalidArn(ref cause) => cause,
-            ListDevelopmentSchemaArnsError::InvalidNextToken(ref cause) => cause,
-            ListDevelopmentSchemaArnsError::LimitExceeded(ref cause) => cause,
-            ListDevelopmentSchemaArnsError::ResourceNotFound(ref cause) => cause,
-            ListDevelopmentSchemaArnsError::RetryableConflict(ref cause) => cause,
+            ListDevelopmentSchemaArnsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListDevelopmentSchemaArnsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListDevelopmentSchemaArnsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListDevelopmentSchemaArnsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListDevelopmentSchemaArnsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListDevelopmentSchemaArnsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListDevelopmentSchemaArnsError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDevelopmentSchemaArnsError {}
 /// Errors returned by ListDirectories
 #[derive(Debug, PartialEq)]
 pub enum ListDirectoriesError {
@@ -5899,21 +5761,17 @@ impl ListDirectoriesError {
 }
 impl fmt::Display for ListDirectoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDirectoriesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDirectoriesError::AccessDenied(ref cause) => cause,
-            ListDirectoriesError::InternalService(ref cause) => cause,
-            ListDirectoriesError::InvalidArn(ref cause) => cause,
-            ListDirectoriesError::InvalidNextToken(ref cause) => cause,
-            ListDirectoriesError::LimitExceeded(ref cause) => cause,
-            ListDirectoriesError::RetryableConflict(ref cause) => cause,
+            ListDirectoriesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListDirectoriesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListDirectoriesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListDirectoriesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListDirectoriesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListDirectoriesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDirectoriesError {}
 /// Errors returned by ListFacetAttributes
 #[derive(Debug, PartialEq)]
 pub enum ListFacetAttributesError {
@@ -5978,23 +5836,19 @@ impl ListFacetAttributesError {
 }
 impl fmt::Display for ListFacetAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFacetAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            ListFacetAttributesError::AccessDenied(ref cause) => cause,
-            ListFacetAttributesError::FacetNotFound(ref cause) => cause,
-            ListFacetAttributesError::InternalService(ref cause) => cause,
-            ListFacetAttributesError::InvalidArn(ref cause) => cause,
-            ListFacetAttributesError::InvalidNextToken(ref cause) => cause,
-            ListFacetAttributesError::LimitExceeded(ref cause) => cause,
-            ListFacetAttributesError::ResourceNotFound(ref cause) => cause,
-            ListFacetAttributesError::RetryableConflict(ref cause) => cause,
+            ListFacetAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListFacetAttributesError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            ListFacetAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListFacetAttributesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListFacetAttributesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListFacetAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListFacetAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListFacetAttributesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFacetAttributesError {}
 /// Errors returned by ListFacetNames
 #[derive(Debug, PartialEq)]
 pub enum ListFacetNamesError {
@@ -6048,22 +5902,18 @@ impl ListFacetNamesError {
 }
 impl fmt::Display for ListFacetNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFacetNamesError {
-    fn description(&self) -> &str {
         match *self {
-            ListFacetNamesError::AccessDenied(ref cause) => cause,
-            ListFacetNamesError::InternalService(ref cause) => cause,
-            ListFacetNamesError::InvalidArn(ref cause) => cause,
-            ListFacetNamesError::InvalidNextToken(ref cause) => cause,
-            ListFacetNamesError::LimitExceeded(ref cause) => cause,
-            ListFacetNamesError::ResourceNotFound(ref cause) => cause,
-            ListFacetNamesError::RetryableConflict(ref cause) => cause,
+            ListFacetNamesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListFacetNamesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListFacetNamesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListFacetNamesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListFacetNamesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListFacetNamesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListFacetNamesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFacetNamesError {}
 /// Errors returned by ListIncomingTypedLinks
 #[derive(Debug, PartialEq)]
 pub enum ListIncomingTypedLinksError {
@@ -6141,24 +5991,20 @@ impl ListIncomingTypedLinksError {
 }
 impl fmt::Display for ListIncomingTypedLinksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIncomingTypedLinksError {
-    fn description(&self) -> &str {
         match *self {
-            ListIncomingTypedLinksError::AccessDenied(ref cause) => cause,
-            ListIncomingTypedLinksError::DirectoryNotEnabled(ref cause) => cause,
-            ListIncomingTypedLinksError::FacetValidation(ref cause) => cause,
-            ListIncomingTypedLinksError::InternalService(ref cause) => cause,
-            ListIncomingTypedLinksError::InvalidArn(ref cause) => cause,
-            ListIncomingTypedLinksError::InvalidNextToken(ref cause) => cause,
-            ListIncomingTypedLinksError::LimitExceeded(ref cause) => cause,
-            ListIncomingTypedLinksError::ResourceNotFound(ref cause) => cause,
-            ListIncomingTypedLinksError::RetryableConflict(ref cause) => cause,
+            ListIncomingTypedLinksError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListIncomingTypedLinksError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIncomingTypedLinksError {}
 /// Errors returned by ListIndex
 #[derive(Debug, PartialEq)]
 pub enum ListIndexError {
@@ -6227,25 +6073,21 @@ impl ListIndexError {
 }
 impl fmt::Display for ListIndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIndexError {
-    fn description(&self) -> &str {
         match *self {
-            ListIndexError::AccessDenied(ref cause) => cause,
-            ListIndexError::DirectoryNotEnabled(ref cause) => cause,
-            ListIndexError::FacetValidation(ref cause) => cause,
-            ListIndexError::InternalService(ref cause) => cause,
-            ListIndexError::InvalidArn(ref cause) => cause,
-            ListIndexError::InvalidNextToken(ref cause) => cause,
-            ListIndexError::LimitExceeded(ref cause) => cause,
-            ListIndexError::NotIndex(ref cause) => cause,
-            ListIndexError::ResourceNotFound(ref cause) => cause,
-            ListIndexError::RetryableConflict(ref cause) => cause,
+            ListIndexError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListIndexError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListIndexError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            ListIndexError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListIndexError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListIndexError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListIndexError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListIndexError::NotIndex(ref cause) => write!(f, "{}", cause),
+            ListIndexError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListIndexError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIndexError {}
 /// Errors returned by ListManagedSchemaArns
 #[derive(Debug, PartialEq)]
 pub enum ListManagedSchemaArnsError {
@@ -6295,20 +6137,16 @@ impl ListManagedSchemaArnsError {
 }
 impl fmt::Display for ListManagedSchemaArnsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListManagedSchemaArnsError {
-    fn description(&self) -> &str {
         match *self {
-            ListManagedSchemaArnsError::AccessDenied(ref cause) => cause,
-            ListManagedSchemaArnsError::InternalService(ref cause) => cause,
-            ListManagedSchemaArnsError::InvalidArn(ref cause) => cause,
-            ListManagedSchemaArnsError::InvalidNextToken(ref cause) => cause,
-            ListManagedSchemaArnsError::ResourceNotFound(ref cause) => cause,
+            ListManagedSchemaArnsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListManagedSchemaArnsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListManagedSchemaArnsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListManagedSchemaArnsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListManagedSchemaArnsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListManagedSchemaArnsError {}
 /// Errors returned by ListObjectAttributes
 #[derive(Debug, PartialEq)]
 pub enum ListObjectAttributesError {
@@ -6384,24 +6222,20 @@ impl ListObjectAttributesError {
 }
 impl fmt::Display for ListObjectAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            ListObjectAttributesError::AccessDenied(ref cause) => cause,
-            ListObjectAttributesError::DirectoryNotEnabled(ref cause) => cause,
-            ListObjectAttributesError::FacetValidation(ref cause) => cause,
-            ListObjectAttributesError::InternalService(ref cause) => cause,
-            ListObjectAttributesError::InvalidArn(ref cause) => cause,
-            ListObjectAttributesError::InvalidNextToken(ref cause) => cause,
-            ListObjectAttributesError::LimitExceeded(ref cause) => cause,
-            ListObjectAttributesError::ResourceNotFound(ref cause) => cause,
-            ListObjectAttributesError::RetryableConflict(ref cause) => cause,
+            ListObjectAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListObjectAttributesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListObjectAttributesError {}
 /// Errors returned by ListObjectChildren
 #[derive(Debug, PartialEq)]
 pub enum ListObjectChildrenError {
@@ -6469,24 +6303,20 @@ impl ListObjectChildrenError {
 }
 impl fmt::Display for ListObjectChildrenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectChildrenError {
-    fn description(&self) -> &str {
         match *self {
-            ListObjectChildrenError::AccessDenied(ref cause) => cause,
-            ListObjectChildrenError::DirectoryNotEnabled(ref cause) => cause,
-            ListObjectChildrenError::InternalService(ref cause) => cause,
-            ListObjectChildrenError::InvalidArn(ref cause) => cause,
-            ListObjectChildrenError::InvalidNextToken(ref cause) => cause,
-            ListObjectChildrenError::LimitExceeded(ref cause) => cause,
-            ListObjectChildrenError::NotNode(ref cause) => cause,
-            ListObjectChildrenError::ResourceNotFound(ref cause) => cause,
-            ListObjectChildrenError::RetryableConflict(ref cause) => cause,
+            ListObjectChildrenError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::NotNode(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListObjectChildrenError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListObjectChildrenError {}
 /// Errors returned by ListObjectParentPaths
 #[derive(Debug, PartialEq)]
 pub enum ListObjectParentPathsError {
@@ -6555,23 +6385,19 @@ impl ListObjectParentPathsError {
 }
 impl fmt::Display for ListObjectParentPathsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectParentPathsError {
-    fn description(&self) -> &str {
         match *self {
-            ListObjectParentPathsError::AccessDenied(ref cause) => cause,
-            ListObjectParentPathsError::DirectoryNotEnabled(ref cause) => cause,
-            ListObjectParentPathsError::InternalService(ref cause) => cause,
-            ListObjectParentPathsError::InvalidArn(ref cause) => cause,
-            ListObjectParentPathsError::InvalidNextToken(ref cause) => cause,
-            ListObjectParentPathsError::LimitExceeded(ref cause) => cause,
-            ListObjectParentPathsError::ResourceNotFound(ref cause) => cause,
-            ListObjectParentPathsError::RetryableConflict(ref cause) => cause,
+            ListObjectParentPathsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListObjectParentPathsError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListObjectParentPathsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListObjectParentPathsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListObjectParentPathsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListObjectParentPathsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListObjectParentPathsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListObjectParentPathsError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListObjectParentPathsError {}
 /// Errors returned by ListObjectParents
 #[derive(Debug, PartialEq)]
 pub enum ListObjectParentsError {
@@ -6639,24 +6465,20 @@ impl ListObjectParentsError {
 }
 impl fmt::Display for ListObjectParentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectParentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListObjectParentsError::AccessDenied(ref cause) => cause,
-            ListObjectParentsError::CannotListParentOfRoot(ref cause) => cause,
-            ListObjectParentsError::DirectoryNotEnabled(ref cause) => cause,
-            ListObjectParentsError::InternalService(ref cause) => cause,
-            ListObjectParentsError::InvalidArn(ref cause) => cause,
-            ListObjectParentsError::InvalidNextToken(ref cause) => cause,
-            ListObjectParentsError::LimitExceeded(ref cause) => cause,
-            ListObjectParentsError::ResourceNotFound(ref cause) => cause,
-            ListObjectParentsError::RetryableConflict(ref cause) => cause,
+            ListObjectParentsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::CannotListParentOfRoot(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListObjectParentsError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListObjectParentsError {}
 /// Errors returned by ListObjectPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListObjectPoliciesError {
@@ -6719,23 +6541,19 @@ impl ListObjectPoliciesError {
 }
 impl fmt::Display for ListObjectPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListObjectPoliciesError::AccessDenied(ref cause) => cause,
-            ListObjectPoliciesError::DirectoryNotEnabled(ref cause) => cause,
-            ListObjectPoliciesError::InternalService(ref cause) => cause,
-            ListObjectPoliciesError::InvalidArn(ref cause) => cause,
-            ListObjectPoliciesError::InvalidNextToken(ref cause) => cause,
-            ListObjectPoliciesError::LimitExceeded(ref cause) => cause,
-            ListObjectPoliciesError::ResourceNotFound(ref cause) => cause,
-            ListObjectPoliciesError::RetryableConflict(ref cause) => cause,
+            ListObjectPoliciesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListObjectPoliciesError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListObjectPoliciesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListObjectPoliciesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListObjectPoliciesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListObjectPoliciesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListObjectPoliciesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListObjectPoliciesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListObjectPoliciesError {}
 /// Errors returned by ListOutgoingTypedLinks
 #[derive(Debug, PartialEq)]
 pub enum ListOutgoingTypedLinksError {
@@ -6813,24 +6631,20 @@ impl ListOutgoingTypedLinksError {
 }
 impl fmt::Display for ListOutgoingTypedLinksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOutgoingTypedLinksError {
-    fn description(&self) -> &str {
         match *self {
-            ListOutgoingTypedLinksError::AccessDenied(ref cause) => cause,
-            ListOutgoingTypedLinksError::DirectoryNotEnabled(ref cause) => cause,
-            ListOutgoingTypedLinksError::FacetValidation(ref cause) => cause,
-            ListOutgoingTypedLinksError::InternalService(ref cause) => cause,
-            ListOutgoingTypedLinksError::InvalidArn(ref cause) => cause,
-            ListOutgoingTypedLinksError::InvalidNextToken(ref cause) => cause,
-            ListOutgoingTypedLinksError::LimitExceeded(ref cause) => cause,
-            ListOutgoingTypedLinksError::ResourceNotFound(ref cause) => cause,
-            ListOutgoingTypedLinksError::RetryableConflict(ref cause) => cause,
+            ListOutgoingTypedLinksError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListOutgoingTypedLinksError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOutgoingTypedLinksError {}
 /// Errors returned by ListPolicyAttachments
 #[derive(Debug, PartialEq)]
 pub enum ListPolicyAttachmentsError {
@@ -6904,24 +6718,20 @@ impl ListPolicyAttachmentsError {
 }
 impl fmt::Display for ListPolicyAttachmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPolicyAttachmentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPolicyAttachmentsError::AccessDenied(ref cause) => cause,
-            ListPolicyAttachmentsError::DirectoryNotEnabled(ref cause) => cause,
-            ListPolicyAttachmentsError::InternalService(ref cause) => cause,
-            ListPolicyAttachmentsError::InvalidArn(ref cause) => cause,
-            ListPolicyAttachmentsError::InvalidNextToken(ref cause) => cause,
-            ListPolicyAttachmentsError::LimitExceeded(ref cause) => cause,
-            ListPolicyAttachmentsError::NotPolicy(ref cause) => cause,
-            ListPolicyAttachmentsError::ResourceNotFound(ref cause) => cause,
-            ListPolicyAttachmentsError::RetryableConflict(ref cause) => cause,
+            ListPolicyAttachmentsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::NotPolicy(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPolicyAttachmentsError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPolicyAttachmentsError {}
 /// Errors returned by ListPublishedSchemaArns
 #[derive(Debug, PartialEq)]
 pub enum ListPublishedSchemaArnsError {
@@ -6987,22 +6797,18 @@ impl ListPublishedSchemaArnsError {
 }
 impl fmt::Display for ListPublishedSchemaArnsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPublishedSchemaArnsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPublishedSchemaArnsError::AccessDenied(ref cause) => cause,
-            ListPublishedSchemaArnsError::InternalService(ref cause) => cause,
-            ListPublishedSchemaArnsError::InvalidArn(ref cause) => cause,
-            ListPublishedSchemaArnsError::InvalidNextToken(ref cause) => cause,
-            ListPublishedSchemaArnsError::LimitExceeded(ref cause) => cause,
-            ListPublishedSchemaArnsError::ResourceNotFound(ref cause) => cause,
-            ListPublishedSchemaArnsError::RetryableConflict(ref cause) => cause,
+            ListPublishedSchemaArnsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListPublishedSchemaArnsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListPublishedSchemaArnsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListPublishedSchemaArnsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListPublishedSchemaArnsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListPublishedSchemaArnsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPublishedSchemaArnsError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPublishedSchemaArnsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -7062,22 +6868,18 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AccessDenied(ref cause) => cause,
-            ListTagsForResourceError::InternalService(ref cause) => cause,
-            ListTagsForResourceError::InvalidArn(ref cause) => cause,
-            ListTagsForResourceError::InvalidTaggingRequest(ref cause) => cause,
-            ListTagsForResourceError::LimitExceeded(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::RetryableConflict(ref cause) => cause,
+            ListTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidTaggingRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTypedLinkFacetAttributes
 #[derive(Debug, PartialEq)]
 pub enum ListTypedLinkFacetAttributesError {
@@ -7154,23 +6956,25 @@ impl ListTypedLinkFacetAttributesError {
 }
 impl fmt::Display for ListTypedLinkFacetAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTypedLinkFacetAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTypedLinkFacetAttributesError::AccessDenied(ref cause) => cause,
-            ListTypedLinkFacetAttributesError::FacetNotFound(ref cause) => cause,
-            ListTypedLinkFacetAttributesError::InternalService(ref cause) => cause,
-            ListTypedLinkFacetAttributesError::InvalidArn(ref cause) => cause,
-            ListTypedLinkFacetAttributesError::InvalidNextToken(ref cause) => cause,
-            ListTypedLinkFacetAttributesError::LimitExceeded(ref cause) => cause,
-            ListTypedLinkFacetAttributesError::ResourceNotFound(ref cause) => cause,
-            ListTypedLinkFacetAttributesError::RetryableConflict(ref cause) => cause,
+            ListTypedLinkFacetAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetAttributesError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetAttributesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetAttributesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTypedLinkFacetAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetAttributesError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTypedLinkFacetAttributesError::RetryableConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListTypedLinkFacetAttributesError {}
 /// Errors returned by ListTypedLinkFacetNames
 #[derive(Debug, PartialEq)]
 pub enum ListTypedLinkFacetNamesError {
@@ -7236,22 +7040,18 @@ impl ListTypedLinkFacetNamesError {
 }
 impl fmt::Display for ListTypedLinkFacetNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTypedLinkFacetNamesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTypedLinkFacetNamesError::AccessDenied(ref cause) => cause,
-            ListTypedLinkFacetNamesError::InternalService(ref cause) => cause,
-            ListTypedLinkFacetNamesError::InvalidArn(ref cause) => cause,
-            ListTypedLinkFacetNamesError::InvalidNextToken(ref cause) => cause,
-            ListTypedLinkFacetNamesError::LimitExceeded(ref cause) => cause,
-            ListTypedLinkFacetNamesError::ResourceNotFound(ref cause) => cause,
-            ListTypedLinkFacetNamesError::RetryableConflict(ref cause) => cause,
+            ListTypedLinkFacetNamesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetNamesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetNamesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetNamesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetNamesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetNamesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTypedLinkFacetNamesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTypedLinkFacetNamesError {}
 /// Errors returned by LookupPolicy
 #[derive(Debug, PartialEq)]
 pub enum LookupPolicyError {
@@ -7310,23 +7110,19 @@ impl LookupPolicyError {
 }
 impl fmt::Display for LookupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for LookupPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            LookupPolicyError::AccessDenied(ref cause) => cause,
-            LookupPolicyError::DirectoryNotEnabled(ref cause) => cause,
-            LookupPolicyError::InternalService(ref cause) => cause,
-            LookupPolicyError::InvalidArn(ref cause) => cause,
-            LookupPolicyError::InvalidNextToken(ref cause) => cause,
-            LookupPolicyError::LimitExceeded(ref cause) => cause,
-            LookupPolicyError::ResourceNotFound(ref cause) => cause,
-            LookupPolicyError::RetryableConflict(ref cause) => cause,
+            LookupPolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            LookupPolicyError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            LookupPolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            LookupPolicyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            LookupPolicyError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            LookupPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            LookupPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            LookupPolicyError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for LookupPolicyError {}
 /// Errors returned by PublishSchema
 #[derive(Debug, PartialEq)]
 pub enum PublishSchemaError {
@@ -7382,22 +7178,18 @@ impl PublishSchemaError {
 }
 impl fmt::Display for PublishSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PublishSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            PublishSchemaError::AccessDenied(ref cause) => cause,
-            PublishSchemaError::InternalService(ref cause) => cause,
-            PublishSchemaError::InvalidArn(ref cause) => cause,
-            PublishSchemaError::LimitExceeded(ref cause) => cause,
-            PublishSchemaError::ResourceNotFound(ref cause) => cause,
-            PublishSchemaError::RetryableConflict(ref cause) => cause,
-            PublishSchemaError::SchemaAlreadyPublished(ref cause) => cause,
+            PublishSchemaError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            PublishSchemaError::InternalService(ref cause) => write!(f, "{}", cause),
+            PublishSchemaError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            PublishSchemaError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PublishSchemaError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PublishSchemaError::RetryableConflict(ref cause) => write!(f, "{}", cause),
+            PublishSchemaError::SchemaAlreadyPublished(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PublishSchemaError {}
 /// Errors returned by PutSchemaFromJson
 #[derive(Debug, PartialEq)]
 pub enum PutSchemaFromJsonError {
@@ -7451,22 +7243,18 @@ impl PutSchemaFromJsonError {
 }
 impl fmt::Display for PutSchemaFromJsonError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutSchemaFromJsonError {
-    fn description(&self) -> &str {
         match *self {
-            PutSchemaFromJsonError::AccessDenied(ref cause) => cause,
-            PutSchemaFromJsonError::InternalService(ref cause) => cause,
-            PutSchemaFromJsonError::InvalidArn(ref cause) => cause,
-            PutSchemaFromJsonError::InvalidRule(ref cause) => cause,
-            PutSchemaFromJsonError::InvalidSchemaDoc(ref cause) => cause,
-            PutSchemaFromJsonError::LimitExceeded(ref cause) => cause,
-            PutSchemaFromJsonError::RetryableConflict(ref cause) => cause,
+            PutSchemaFromJsonError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            PutSchemaFromJsonError::InternalService(ref cause) => write!(f, "{}", cause),
+            PutSchemaFromJsonError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            PutSchemaFromJsonError::InvalidRule(ref cause) => write!(f, "{}", cause),
+            PutSchemaFromJsonError::InvalidSchemaDoc(ref cause) => write!(f, "{}", cause),
+            PutSchemaFromJsonError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutSchemaFromJsonError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutSchemaFromJsonError {}
 /// Errors returned by RemoveFacetFromObject
 #[derive(Debug, PartialEq)]
 pub enum RemoveFacetFromObjectError {
@@ -7535,23 +7323,19 @@ impl RemoveFacetFromObjectError {
 }
 impl fmt::Display for RemoveFacetFromObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveFacetFromObjectError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveFacetFromObjectError::AccessDenied(ref cause) => cause,
-            RemoveFacetFromObjectError::DirectoryNotEnabled(ref cause) => cause,
-            RemoveFacetFromObjectError::FacetValidation(ref cause) => cause,
-            RemoveFacetFromObjectError::InternalService(ref cause) => cause,
-            RemoveFacetFromObjectError::InvalidArn(ref cause) => cause,
-            RemoveFacetFromObjectError::LimitExceeded(ref cause) => cause,
-            RemoveFacetFromObjectError::ResourceNotFound(ref cause) => cause,
-            RemoveFacetFromObjectError::RetryableConflict(ref cause) => cause,
+            RemoveFacetFromObjectError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RemoveFacetFromObjectError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            RemoveFacetFromObjectError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            RemoveFacetFromObjectError::InternalService(ref cause) => write!(f, "{}", cause),
+            RemoveFacetFromObjectError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RemoveFacetFromObjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RemoveFacetFromObjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveFacetFromObjectError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveFacetFromObjectError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -7605,22 +7389,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AccessDenied(ref cause) => cause,
-            TagResourceError::InternalService(ref cause) => cause,
-            TagResourceError::InvalidArn(ref cause) => cause,
-            TagResourceError::InvalidTaggingRequest(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::RetryableConflict(ref cause) => cause,
+            TagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidTaggingRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -7674,22 +7454,18 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AccessDenied(ref cause) => cause,
-            UntagResourceError::InternalService(ref cause) => cause,
-            UntagResourceError::InvalidArn(ref cause) => cause,
-            UntagResourceError::InvalidTaggingRequest(ref cause) => cause,
-            UntagResourceError::LimitExceeded(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::RetryableConflict(ref cause) => cause,
+            UntagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidTaggingRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateFacet
 #[derive(Debug, PartialEq)]
 pub enum UpdateFacetError {
@@ -7758,25 +7534,21 @@ impl UpdateFacetError {
 }
 impl fmt::Display for UpdateFacetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFacetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFacetError::AccessDenied(ref cause) => cause,
-            UpdateFacetError::FacetNotFound(ref cause) => cause,
-            UpdateFacetError::FacetValidation(ref cause) => cause,
-            UpdateFacetError::InternalService(ref cause) => cause,
-            UpdateFacetError::InvalidArn(ref cause) => cause,
-            UpdateFacetError::InvalidFacetUpdate(ref cause) => cause,
-            UpdateFacetError::InvalidRule(ref cause) => cause,
-            UpdateFacetError::LimitExceeded(ref cause) => cause,
-            UpdateFacetError::ResourceNotFound(ref cause) => cause,
-            UpdateFacetError::RetryableConflict(ref cause) => cause,
+            UpdateFacetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::InvalidFacetUpdate(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::InvalidRule(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFacetError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFacetError {}
 /// Errors returned by UpdateLinkAttributes
 #[derive(Debug, PartialEq)]
 pub enum UpdateLinkAttributesError {
@@ -7845,23 +7617,19 @@ impl UpdateLinkAttributesError {
 }
 impl fmt::Display for UpdateLinkAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLinkAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLinkAttributesError::AccessDenied(ref cause) => cause,
-            UpdateLinkAttributesError::DirectoryNotEnabled(ref cause) => cause,
-            UpdateLinkAttributesError::FacetValidation(ref cause) => cause,
-            UpdateLinkAttributesError::InternalService(ref cause) => cause,
-            UpdateLinkAttributesError::InvalidArn(ref cause) => cause,
-            UpdateLinkAttributesError::LimitExceeded(ref cause) => cause,
-            UpdateLinkAttributesError::ResourceNotFound(ref cause) => cause,
-            UpdateLinkAttributesError::RetryableConflict(ref cause) => cause,
+            UpdateLinkAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateLinkAttributesError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            UpdateLinkAttributesError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            UpdateLinkAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateLinkAttributesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateLinkAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateLinkAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateLinkAttributesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLinkAttributesError {}
 /// Errors returned by UpdateObjectAttributes
 #[derive(Debug, PartialEq)]
 pub enum UpdateObjectAttributesError {
@@ -7939,24 +7707,20 @@ impl UpdateObjectAttributesError {
 }
 impl fmt::Display for UpdateObjectAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateObjectAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateObjectAttributesError::AccessDenied(ref cause) => cause,
-            UpdateObjectAttributesError::DirectoryNotEnabled(ref cause) => cause,
-            UpdateObjectAttributesError::FacetValidation(ref cause) => cause,
-            UpdateObjectAttributesError::InternalService(ref cause) => cause,
-            UpdateObjectAttributesError::InvalidArn(ref cause) => cause,
-            UpdateObjectAttributesError::LimitExceeded(ref cause) => cause,
-            UpdateObjectAttributesError::LinkNameAlreadyInUse(ref cause) => cause,
-            UpdateObjectAttributesError::ResourceNotFound(ref cause) => cause,
-            UpdateObjectAttributesError::RetryableConflict(ref cause) => cause,
+            UpdateObjectAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::DirectoryNotEnabled(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::LinkNameAlreadyInUse(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateObjectAttributesError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateObjectAttributesError {}
 /// Errors returned by UpdateSchema
 #[derive(Debug, PartialEq)]
 pub enum UpdateSchemaError {
@@ -8005,21 +7769,17 @@ impl UpdateSchemaError {
 }
 impl fmt::Display for UpdateSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSchemaError::AccessDenied(ref cause) => cause,
-            UpdateSchemaError::InternalService(ref cause) => cause,
-            UpdateSchemaError::InvalidArn(ref cause) => cause,
-            UpdateSchemaError::LimitExceeded(ref cause) => cause,
-            UpdateSchemaError::ResourceNotFound(ref cause) => cause,
-            UpdateSchemaError::RetryableConflict(ref cause) => cause,
+            UpdateSchemaError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateSchemaError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateSchemaError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateSchemaError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSchemaError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateSchemaError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSchemaError {}
 /// Errors returned by UpdateTypedLinkFacet
 #[derive(Debug, PartialEq)]
 pub enum UpdateTypedLinkFacetError {
@@ -8098,25 +7858,21 @@ impl UpdateTypedLinkFacetError {
 }
 impl fmt::Display for UpdateTypedLinkFacetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTypedLinkFacetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTypedLinkFacetError::AccessDenied(ref cause) => cause,
-            UpdateTypedLinkFacetError::FacetNotFound(ref cause) => cause,
-            UpdateTypedLinkFacetError::FacetValidation(ref cause) => cause,
-            UpdateTypedLinkFacetError::InternalService(ref cause) => cause,
-            UpdateTypedLinkFacetError::InvalidArn(ref cause) => cause,
-            UpdateTypedLinkFacetError::InvalidFacetUpdate(ref cause) => cause,
-            UpdateTypedLinkFacetError::InvalidRule(ref cause) => cause,
-            UpdateTypedLinkFacetError::LimitExceeded(ref cause) => cause,
-            UpdateTypedLinkFacetError::ResourceNotFound(ref cause) => cause,
-            UpdateTypedLinkFacetError::RetryableConflict(ref cause) => cause,
+            UpdateTypedLinkFacetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::FacetNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::FacetValidation(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::InvalidFacetUpdate(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::InvalidRule(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTypedLinkFacetError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTypedLinkFacetError {}
 /// Errors returned by UpgradeAppliedSchema
 #[derive(Debug, PartialEq)]
 pub enum UpgradeAppliedSchemaError {
@@ -8187,23 +7943,19 @@ impl UpgradeAppliedSchemaError {
 }
 impl fmt::Display for UpgradeAppliedSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpgradeAppliedSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            UpgradeAppliedSchemaError::AccessDenied(ref cause) => cause,
-            UpgradeAppliedSchemaError::IncompatibleSchema(ref cause) => cause,
-            UpgradeAppliedSchemaError::InternalService(ref cause) => cause,
-            UpgradeAppliedSchemaError::InvalidArn(ref cause) => cause,
-            UpgradeAppliedSchemaError::InvalidAttachment(ref cause) => cause,
-            UpgradeAppliedSchemaError::ResourceNotFound(ref cause) => cause,
-            UpgradeAppliedSchemaError::RetryableConflict(ref cause) => cause,
-            UpgradeAppliedSchemaError::SchemaAlreadyExists(ref cause) => cause,
+            UpgradeAppliedSchemaError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpgradeAppliedSchemaError::IncompatibleSchema(ref cause) => write!(f, "{}", cause),
+            UpgradeAppliedSchemaError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpgradeAppliedSchemaError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpgradeAppliedSchemaError::InvalidAttachment(ref cause) => write!(f, "{}", cause),
+            UpgradeAppliedSchemaError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpgradeAppliedSchemaError::RetryableConflict(ref cause) => write!(f, "{}", cause),
+            UpgradeAppliedSchemaError::SchemaAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpgradeAppliedSchemaError {}
 /// Errors returned by UpgradePublishedSchema
 #[derive(Debug, PartialEq)]
 pub enum UpgradePublishedSchemaError {
@@ -8274,23 +8026,19 @@ impl UpgradePublishedSchemaError {
 }
 impl fmt::Display for UpgradePublishedSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpgradePublishedSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            UpgradePublishedSchemaError::AccessDenied(ref cause) => cause,
-            UpgradePublishedSchemaError::IncompatibleSchema(ref cause) => cause,
-            UpgradePublishedSchemaError::InternalService(ref cause) => cause,
-            UpgradePublishedSchemaError::InvalidArn(ref cause) => cause,
-            UpgradePublishedSchemaError::InvalidAttachment(ref cause) => cause,
-            UpgradePublishedSchemaError::LimitExceeded(ref cause) => cause,
-            UpgradePublishedSchemaError::ResourceNotFound(ref cause) => cause,
-            UpgradePublishedSchemaError::RetryableConflict(ref cause) => cause,
+            UpgradePublishedSchemaError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpgradePublishedSchemaError::IncompatibleSchema(ref cause) => write!(f, "{}", cause),
+            UpgradePublishedSchemaError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpgradePublishedSchemaError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpgradePublishedSchemaError::InvalidAttachment(ref cause) => write!(f, "{}", cause),
+            UpgradePublishedSchemaError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpgradePublishedSchemaError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpgradePublishedSchemaError::RetryableConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpgradePublishedSchemaError {}
 /// Trait representing the capabilities of the Amazon CloudDirectory API. Amazon CloudDirectory clients implement this trait.
 pub trait CloudDirectory {
     /// <p>Adds a new <a>Facet</a> to an object. An object can have more than one facet applied on it.</p>

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -8927,16 +8927,12 @@ impl CancelUpdateStackError {
 }
 impl fmt::Display for CancelUpdateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelUpdateStackError {
-    fn description(&self) -> &str {
         match *self {
-            CancelUpdateStackError::TokenAlreadyExists(ref cause) => cause,
+            CancelUpdateStackError::TokenAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelUpdateStackError {}
 /// Errors returned by ContinueUpdateRollback
 #[derive(Debug, PartialEq)]
 pub enum ContinueUpdateRollbackError {
@@ -8974,16 +8970,12 @@ impl ContinueUpdateRollbackError {
 }
 impl fmt::Display for ContinueUpdateRollbackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ContinueUpdateRollbackError {
-    fn description(&self) -> &str {
         match *self {
-            ContinueUpdateRollbackError::TokenAlreadyExists(ref cause) => cause,
+            ContinueUpdateRollbackError::TokenAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ContinueUpdateRollbackError {}
 /// Errors returned by CreateChangeSet
 #[derive(Debug, PartialEq)]
 pub enum CreateChangeSetError {
@@ -9035,18 +9027,14 @@ impl CreateChangeSetError {
 }
 impl fmt::Display for CreateChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateChangeSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateChangeSetError::AlreadyExists(ref cause) => cause,
-            CreateChangeSetError::InsufficientCapabilities(ref cause) => cause,
-            CreateChangeSetError::LimitExceeded(ref cause) => cause,
+            CreateChangeSetError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateChangeSetError::InsufficientCapabilities(ref cause) => write!(f, "{}", cause),
+            CreateChangeSetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateChangeSetError {}
 /// Errors returned by CreateStack
 #[derive(Debug, PartialEq)]
 pub enum CreateStackError {
@@ -9105,19 +9093,15 @@ impl CreateStackError {
 }
 impl fmt::Display for CreateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStackError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStackError::AlreadyExists(ref cause) => cause,
-            CreateStackError::InsufficientCapabilities(ref cause) => cause,
-            CreateStackError::LimitExceeded(ref cause) => cause,
-            CreateStackError::TokenAlreadyExists(ref cause) => cause,
+            CreateStackError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateStackError::InsufficientCapabilities(ref cause) => write!(f, "{}", cause),
+            CreateStackError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStackError::TokenAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStackError {}
 /// Errors returned by CreateStackInstances
 #[derive(Debug, PartialEq)]
 pub enum CreateStackInstancesError {
@@ -9192,21 +9176,19 @@ impl CreateStackInstancesError {
 }
 impl fmt::Display for CreateStackInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStackInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStackInstancesError::InvalidOperation(ref cause) => cause,
-            CreateStackInstancesError::LimitExceeded(ref cause) => cause,
-            CreateStackInstancesError::OperationIdAlreadyExists(ref cause) => cause,
-            CreateStackInstancesError::OperationInProgress(ref cause) => cause,
-            CreateStackInstancesError::StackSetNotFound(ref cause) => cause,
-            CreateStackInstancesError::StaleRequest(ref cause) => cause,
+            CreateStackInstancesError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            CreateStackInstancesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStackInstancesError::OperationIdAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStackInstancesError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            CreateStackInstancesError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
+            CreateStackInstancesError::StaleRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStackInstancesError {}
 /// Errors returned by CreateStackSet
 #[derive(Debug, PartialEq)]
 pub enum CreateStackSetError {
@@ -9258,18 +9240,14 @@ impl CreateStackSetError {
 }
 impl fmt::Display for CreateStackSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStackSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStackSetError::CreatedButModified(ref cause) => cause,
-            CreateStackSetError::LimitExceeded(ref cause) => cause,
-            CreateStackSetError::NameAlreadyExists(ref cause) => cause,
+            CreateStackSetError::CreatedButModified(ref cause) => write!(f, "{}", cause),
+            CreateStackSetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStackSetError::NameAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStackSetError {}
 /// Errors returned by DeleteChangeSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteChangeSetError {
@@ -9307,16 +9285,12 @@ impl DeleteChangeSetError {
 }
 impl fmt::Display for DeleteChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteChangeSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteChangeSetError::InvalidChangeSetStatus(ref cause) => cause,
+            DeleteChangeSetError::InvalidChangeSetStatus(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteChangeSetError {}
 /// Errors returned by DeleteStack
 #[derive(Debug, PartialEq)]
 pub enum DeleteStackError {
@@ -9354,16 +9328,12 @@ impl DeleteStackError {
 }
 impl fmt::Display for DeleteStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStackError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStackError::TokenAlreadyExists(ref cause) => cause,
+            DeleteStackError::TokenAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStackError {}
 /// Errors returned by DeleteStackInstances
 #[derive(Debug, PartialEq)]
 pub enum DeleteStackInstancesError {
@@ -9431,20 +9401,18 @@ impl DeleteStackInstancesError {
 }
 impl fmt::Display for DeleteStackInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStackInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStackInstancesError::InvalidOperation(ref cause) => cause,
-            DeleteStackInstancesError::OperationIdAlreadyExists(ref cause) => cause,
-            DeleteStackInstancesError::OperationInProgress(ref cause) => cause,
-            DeleteStackInstancesError::StackSetNotFound(ref cause) => cause,
-            DeleteStackInstancesError::StaleRequest(ref cause) => cause,
+            DeleteStackInstancesError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DeleteStackInstancesError::OperationIdAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteStackInstancesError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteStackInstancesError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteStackInstancesError::StaleRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStackInstancesError {}
 /// Errors returned by DeleteStackSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteStackSetError {
@@ -9489,17 +9457,13 @@ impl DeleteStackSetError {
 }
 impl fmt::Display for DeleteStackSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStackSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStackSetError::OperationInProgress(ref cause) => cause,
-            DeleteStackSetError::StackSetNotEmpty(ref cause) => cause,
+            DeleteStackSetError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteStackSetError::StackSetNotEmpty(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStackSetError {}
 /// Errors returned by DeregisterType
 #[derive(Debug, PartialEq)]
 pub enum DeregisterTypeError {
@@ -9544,17 +9508,13 @@ impl DeregisterTypeError {
 }
 impl fmt::Display for DeregisterTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterTypeError::CFNRegistry(ref cause) => cause,
-            DeregisterTypeError::TypeNotFound(ref cause) => cause,
+            DeregisterTypeError::CFNRegistry(ref cause) => write!(f, "{}", cause),
+            DeregisterTypeError::TypeNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterTypeError {}
 /// Errors returned by DescribeAccountLimits
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountLimitsError {}
@@ -9584,14 +9544,10 @@ impl DescribeAccountLimitsError {
 }
 impl fmt::Display for DescribeAccountLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountLimitsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAccountLimitsError {}
 /// Errors returned by DescribeChangeSet
 #[derive(Debug, PartialEq)]
 pub enum DescribeChangeSetError {
@@ -9629,16 +9585,12 @@ impl DescribeChangeSetError {
 }
 impl fmt::Display for DescribeChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeChangeSetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeChangeSetError::ChangeSetNotFound(ref cause) => cause,
+            DescribeChangeSetError::ChangeSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeChangeSetError {}
 /// Errors returned by DescribeStackDriftDetectionStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackDriftDetectionStatusError {}
@@ -9670,14 +9622,10 @@ impl DescribeStackDriftDetectionStatusError {
 }
 impl fmt::Display for DescribeStackDriftDetectionStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackDriftDetectionStatusError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeStackDriftDetectionStatusError {}
 /// Errors returned by DescribeStackEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackEventsError {}
@@ -9707,14 +9655,10 @@ impl DescribeStackEventsError {
 }
 impl fmt::Display for DescribeStackEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackEventsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeStackEventsError {}
 /// Errors returned by DescribeStackInstance
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackInstanceError {
@@ -9759,17 +9703,13 @@ impl DescribeStackInstanceError {
 }
 impl fmt::Display for DescribeStackInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStackInstanceError::StackInstanceNotFound(ref cause) => cause,
-            DescribeStackInstanceError::StackSetNotFound(ref cause) => cause,
+            DescribeStackInstanceError::StackInstanceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeStackInstanceError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStackInstanceError {}
 /// Errors returned by DescribeStackResource
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackResourceError {}
@@ -9799,14 +9739,10 @@ impl DescribeStackResourceError {
 }
 impl fmt::Display for DescribeStackResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackResourceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeStackResourceError {}
 /// Errors returned by DescribeStackResourceDrifts
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackResourceDriftsError {}
@@ -9838,14 +9774,10 @@ impl DescribeStackResourceDriftsError {
 }
 impl fmt::Display for DescribeStackResourceDriftsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackResourceDriftsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeStackResourceDriftsError {}
 /// Errors returned by DescribeStackResources
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackResourcesError {}
@@ -9875,14 +9807,10 @@ impl DescribeStackResourcesError {
 }
 impl fmt::Display for DescribeStackResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackResourcesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeStackResourcesError {}
 /// Errors returned by DescribeStackSet
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackSetError {
@@ -9920,16 +9848,12 @@ impl DescribeStackSetError {
 }
 impl fmt::Display for DescribeStackSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackSetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStackSetError::StackSetNotFound(ref cause) => cause,
+            DescribeStackSetError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStackSetError {}
 /// Errors returned by DescribeStackSetOperation
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackSetOperationError {
@@ -9974,17 +9898,13 @@ impl DescribeStackSetOperationError {
 }
 impl fmt::Display for DescribeStackSetOperationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackSetOperationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStackSetOperationError::OperationNotFound(ref cause) => cause,
-            DescribeStackSetOperationError::StackSetNotFound(ref cause) => cause,
+            DescribeStackSetOperationError::OperationNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeStackSetOperationError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStackSetOperationError {}
 /// Errors returned by DescribeStacks
 #[derive(Debug, PartialEq)]
 pub enum DescribeStacksError {}
@@ -10014,14 +9934,10 @@ impl DescribeStacksError {
 }
 impl fmt::Display for DescribeStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStacksError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeStacksError {}
 /// Errors returned by DescribeType
 #[derive(Debug, PartialEq)]
 pub enum DescribeTypeError {
@@ -10066,17 +9982,13 @@ impl DescribeTypeError {
 }
 impl fmt::Display for DescribeTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTypeError::CFNRegistry(ref cause) => cause,
-            DescribeTypeError::TypeNotFound(ref cause) => cause,
+            DescribeTypeError::CFNRegistry(ref cause) => write!(f, "{}", cause),
+            DescribeTypeError::TypeNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTypeError {}
 /// Errors returned by DescribeTypeRegistration
 #[derive(Debug, PartialEq)]
 pub enum DescribeTypeRegistrationError {
@@ -10114,16 +10026,12 @@ impl DescribeTypeRegistrationError {
 }
 impl fmt::Display for DescribeTypeRegistrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTypeRegistrationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTypeRegistrationError::CFNRegistry(ref cause) => cause,
+            DescribeTypeRegistrationError::CFNRegistry(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTypeRegistrationError {}
 /// Errors returned by DetectStackDrift
 #[derive(Debug, PartialEq)]
 pub enum DetectStackDriftError {}
@@ -10153,14 +10061,10 @@ impl DetectStackDriftError {
 }
 impl fmt::Display for DetectStackDriftError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectStackDriftError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DetectStackDriftError {}
 /// Errors returned by DetectStackResourceDrift
 #[derive(Debug, PartialEq)]
 pub enum DetectStackResourceDriftError {}
@@ -10190,14 +10094,10 @@ impl DetectStackResourceDriftError {
 }
 impl fmt::Display for DetectStackResourceDriftError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectStackResourceDriftError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DetectStackResourceDriftError {}
 /// Errors returned by DetectStackSetDrift
 #[derive(Debug, PartialEq)]
 pub enum DetectStackSetDriftError {
@@ -10249,18 +10149,14 @@ impl DetectStackSetDriftError {
 }
 impl fmt::Display for DetectStackSetDriftError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectStackSetDriftError {
-    fn description(&self) -> &str {
         match *self {
-            DetectStackSetDriftError::InvalidOperation(ref cause) => cause,
-            DetectStackSetDriftError::OperationInProgress(ref cause) => cause,
-            DetectStackSetDriftError::StackSetNotFound(ref cause) => cause,
+            DetectStackSetDriftError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DetectStackSetDriftError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            DetectStackSetDriftError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectStackSetDriftError {}
 /// Errors returned by EstimateTemplateCost
 #[derive(Debug, PartialEq)]
 pub enum EstimateTemplateCostError {}
@@ -10290,14 +10186,10 @@ impl EstimateTemplateCostError {
 }
 impl fmt::Display for EstimateTemplateCostError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EstimateTemplateCostError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for EstimateTemplateCostError {}
 /// Errors returned by ExecuteChangeSet
 #[derive(Debug, PartialEq)]
 pub enum ExecuteChangeSetError {
@@ -10356,19 +10248,15 @@ impl ExecuteChangeSetError {
 }
 impl fmt::Display for ExecuteChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExecuteChangeSetError {
-    fn description(&self) -> &str {
         match *self {
-            ExecuteChangeSetError::ChangeSetNotFound(ref cause) => cause,
-            ExecuteChangeSetError::InsufficientCapabilities(ref cause) => cause,
-            ExecuteChangeSetError::InvalidChangeSetStatus(ref cause) => cause,
-            ExecuteChangeSetError::TokenAlreadyExists(ref cause) => cause,
+            ExecuteChangeSetError::ChangeSetNotFound(ref cause) => write!(f, "{}", cause),
+            ExecuteChangeSetError::InsufficientCapabilities(ref cause) => write!(f, "{}", cause),
+            ExecuteChangeSetError::InvalidChangeSetStatus(ref cause) => write!(f, "{}", cause),
+            ExecuteChangeSetError::TokenAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExecuteChangeSetError {}
 /// Errors returned by GetStackPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetStackPolicyError {}
@@ -10398,14 +10286,10 @@ impl GetStackPolicyError {
 }
 impl fmt::Display for GetStackPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStackPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetStackPolicyError {}
 /// Errors returned by GetTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetTemplateError {
@@ -10443,16 +10327,12 @@ impl GetTemplateError {
 }
 impl fmt::Display for GetTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GetTemplateError::ChangeSetNotFound(ref cause) => cause,
+            GetTemplateError::ChangeSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTemplateError {}
 /// Errors returned by GetTemplateSummary
 #[derive(Debug, PartialEq)]
 pub enum GetTemplateSummaryError {
@@ -10490,16 +10370,12 @@ impl GetTemplateSummaryError {
 }
 impl fmt::Display for GetTemplateSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTemplateSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            GetTemplateSummaryError::StackSetNotFound(ref cause) => cause,
+            GetTemplateSummaryError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTemplateSummaryError {}
 /// Errors returned by ListChangeSets
 #[derive(Debug, PartialEq)]
 pub enum ListChangeSetsError {}
@@ -10529,14 +10405,10 @@ impl ListChangeSetsError {
 }
 impl fmt::Display for ListChangeSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListChangeSetsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListChangeSetsError {}
 /// Errors returned by ListExports
 #[derive(Debug, PartialEq)]
 pub enum ListExportsError {}
@@ -10566,14 +10438,10 @@ impl ListExportsError {
 }
 impl fmt::Display for ListExportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListExportsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListExportsError {}
 /// Errors returned by ListImports
 #[derive(Debug, PartialEq)]
 pub enum ListImportsError {}
@@ -10603,14 +10471,10 @@ impl ListImportsError {
 }
 impl fmt::Display for ListImportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListImportsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListImportsError {}
 /// Errors returned by ListStackInstances
 #[derive(Debug, PartialEq)]
 pub enum ListStackInstancesError {
@@ -10648,16 +10512,12 @@ impl ListStackInstancesError {
 }
 impl fmt::Display for ListStackInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStackInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListStackInstancesError::StackSetNotFound(ref cause) => cause,
+            ListStackInstancesError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStackInstancesError {}
 /// Errors returned by ListStackResources
 #[derive(Debug, PartialEq)]
 pub enum ListStackResourcesError {}
@@ -10687,14 +10547,10 @@ impl ListStackResourcesError {
 }
 impl fmt::Display for ListStackResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStackResourcesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListStackResourcesError {}
 /// Errors returned by ListStackSetOperationResults
 #[derive(Debug, PartialEq)]
 pub enum ListStackSetOperationResultsError {
@@ -10745,17 +10601,17 @@ impl ListStackSetOperationResultsError {
 }
 impl fmt::Display for ListStackSetOperationResultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStackSetOperationResultsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStackSetOperationResultsError::OperationNotFound(ref cause) => cause,
-            ListStackSetOperationResultsError::StackSetNotFound(ref cause) => cause,
+            ListStackSetOperationResultsError::OperationNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListStackSetOperationResultsError::StackSetNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListStackSetOperationResultsError {}
 /// Errors returned by ListStackSetOperations
 #[derive(Debug, PartialEq)]
 pub enum ListStackSetOperationsError {
@@ -10793,16 +10649,12 @@ impl ListStackSetOperationsError {
 }
 impl fmt::Display for ListStackSetOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStackSetOperationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStackSetOperationsError::StackSetNotFound(ref cause) => cause,
+            ListStackSetOperationsError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStackSetOperationsError {}
 /// Errors returned by ListStackSets
 #[derive(Debug, PartialEq)]
 pub enum ListStackSetsError {}
@@ -10832,14 +10684,10 @@ impl ListStackSetsError {
 }
 impl fmt::Display for ListStackSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStackSetsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListStackSetsError {}
 /// Errors returned by ListStacks
 #[derive(Debug, PartialEq)]
 pub enum ListStacksError {}
@@ -10869,14 +10717,10 @@ impl ListStacksError {
 }
 impl fmt::Display for ListStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStacksError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListStacksError {}
 /// Errors returned by ListTypeRegistrations
 #[derive(Debug, PartialEq)]
 pub enum ListTypeRegistrationsError {
@@ -10914,16 +10758,12 @@ impl ListTypeRegistrationsError {
 }
 impl fmt::Display for ListTypeRegistrationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTypeRegistrationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTypeRegistrationsError::CFNRegistry(ref cause) => cause,
+            ListTypeRegistrationsError::CFNRegistry(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTypeRegistrationsError {}
 /// Errors returned by ListTypeVersions
 #[derive(Debug, PartialEq)]
 pub enum ListTypeVersionsError {
@@ -10961,16 +10801,12 @@ impl ListTypeVersionsError {
 }
 impl fmt::Display for ListTypeVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTypeVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTypeVersionsError::CFNRegistry(ref cause) => cause,
+            ListTypeVersionsError::CFNRegistry(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTypeVersionsError {}
 /// Errors returned by ListTypes
 #[derive(Debug, PartialEq)]
 pub enum ListTypesError {
@@ -11008,16 +10844,12 @@ impl ListTypesError {
 }
 impl fmt::Display for ListTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTypesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTypesError::CFNRegistry(ref cause) => cause,
+            ListTypesError::CFNRegistry(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTypesError {}
 /// Errors returned by RecordHandlerProgress
 #[derive(Debug, PartialEq)]
 pub enum RecordHandlerProgressError {
@@ -11066,17 +10898,15 @@ impl RecordHandlerProgressError {
 }
 impl fmt::Display for RecordHandlerProgressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RecordHandlerProgressError {
-    fn description(&self) -> &str {
         match *self {
-            RecordHandlerProgressError::InvalidStateTransition(ref cause) => cause,
-            RecordHandlerProgressError::OperationStatusCheckFailed(ref cause) => cause,
+            RecordHandlerProgressError::InvalidStateTransition(ref cause) => write!(f, "{}", cause),
+            RecordHandlerProgressError::OperationStatusCheckFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RecordHandlerProgressError {}
 /// Errors returned by RegisterType
 #[derive(Debug, PartialEq)]
 pub enum RegisterTypeError {
@@ -11114,16 +10944,12 @@ impl RegisterTypeError {
 }
 impl fmt::Display for RegisterTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterTypeError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterTypeError::CFNRegistry(ref cause) => cause,
+            RegisterTypeError::CFNRegistry(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterTypeError {}
 /// Errors returned by SetStackPolicy
 #[derive(Debug, PartialEq)]
 pub enum SetStackPolicyError {}
@@ -11153,14 +10979,10 @@ impl SetStackPolicyError {
 }
 impl fmt::Display for SetStackPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetStackPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SetStackPolicyError {}
 /// Errors returned by SetTypeDefaultVersion
 #[derive(Debug, PartialEq)]
 pub enum SetTypeDefaultVersionError {
@@ -11205,17 +11027,13 @@ impl SetTypeDefaultVersionError {
 }
 impl fmt::Display for SetTypeDefaultVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetTypeDefaultVersionError {
-    fn description(&self) -> &str {
         match *self {
-            SetTypeDefaultVersionError::CFNRegistry(ref cause) => cause,
-            SetTypeDefaultVersionError::TypeNotFound(ref cause) => cause,
+            SetTypeDefaultVersionError::CFNRegistry(ref cause) => write!(f, "{}", cause),
+            SetTypeDefaultVersionError::TypeNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetTypeDefaultVersionError {}
 /// Errors returned by SignalResource
 #[derive(Debug, PartialEq)]
 pub enum SignalResourceError {}
@@ -11245,14 +11063,10 @@ impl SignalResourceError {
 }
 impl fmt::Display for SignalResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SignalResourceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SignalResourceError {}
 /// Errors returned by StopStackSetOperation
 #[derive(Debug, PartialEq)]
 pub enum StopStackSetOperationError {
@@ -11304,18 +11118,14 @@ impl StopStackSetOperationError {
 }
 impl fmt::Display for StopStackSetOperationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopStackSetOperationError {
-    fn description(&self) -> &str {
         match *self {
-            StopStackSetOperationError::InvalidOperation(ref cause) => cause,
-            StopStackSetOperationError::OperationNotFound(ref cause) => cause,
-            StopStackSetOperationError::StackSetNotFound(ref cause) => cause,
+            StopStackSetOperationError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            StopStackSetOperationError::OperationNotFound(ref cause) => write!(f, "{}", cause),
+            StopStackSetOperationError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopStackSetOperationError {}
 /// Errors returned by UpdateStack
 #[derive(Debug, PartialEq)]
 pub enum UpdateStackError {
@@ -11360,17 +11170,13 @@ impl UpdateStackError {
 }
 impl fmt::Display for UpdateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStackError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStackError::InsufficientCapabilities(ref cause) => cause,
-            UpdateStackError::TokenAlreadyExists(ref cause) => cause,
+            UpdateStackError::InsufficientCapabilities(ref cause) => write!(f, "{}", cause),
+            UpdateStackError::TokenAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStackError {}
 /// Errors returned by UpdateStackInstances
 #[derive(Debug, PartialEq)]
 pub enum UpdateStackInstancesError {
@@ -11445,21 +11251,19 @@ impl UpdateStackInstancesError {
 }
 impl fmt::Display for UpdateStackInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStackInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStackInstancesError::InvalidOperation(ref cause) => cause,
-            UpdateStackInstancesError::OperationIdAlreadyExists(ref cause) => cause,
-            UpdateStackInstancesError::OperationInProgress(ref cause) => cause,
-            UpdateStackInstancesError::StackInstanceNotFound(ref cause) => cause,
-            UpdateStackInstancesError::StackSetNotFound(ref cause) => cause,
-            UpdateStackInstancesError::StaleRequest(ref cause) => cause,
+            UpdateStackInstancesError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateStackInstancesError::OperationIdAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStackInstancesError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            UpdateStackInstancesError::StackInstanceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStackInstancesError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStackInstancesError::StaleRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStackInstancesError {}
 /// Errors returned by UpdateStackSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateStackSetError {
@@ -11532,21 +11336,17 @@ impl UpdateStackSetError {
 }
 impl fmt::Display for UpdateStackSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStackSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStackSetError::InvalidOperation(ref cause) => cause,
-            UpdateStackSetError::OperationIdAlreadyExists(ref cause) => cause,
-            UpdateStackSetError::OperationInProgress(ref cause) => cause,
-            UpdateStackSetError::StackInstanceNotFound(ref cause) => cause,
-            UpdateStackSetError::StackSetNotFound(ref cause) => cause,
-            UpdateStackSetError::StaleRequest(ref cause) => cause,
+            UpdateStackSetError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateStackSetError::OperationIdAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateStackSetError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            UpdateStackSetError::StackInstanceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStackSetError::StackSetNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStackSetError::StaleRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStackSetError {}
 /// Errors returned by UpdateTerminationProtection
 #[derive(Debug, PartialEq)]
 pub enum UpdateTerminationProtectionError {}
@@ -11578,14 +11378,10 @@ impl UpdateTerminationProtectionError {
 }
 impl fmt::Display for UpdateTerminationProtectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTerminationProtectionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UpdateTerminationProtectionError {}
 /// Errors returned by ValidateTemplate
 #[derive(Debug, PartialEq)]
 pub enum ValidateTemplateError {}
@@ -11615,14 +11411,10 @@ impl ValidateTemplateError {
 }
 impl fmt::Display for ValidateTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ValidateTemplateError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ValidateTemplateError {}
 /// Trait representing the capabilities of the AWS CloudFormation API. AWS CloudFormation clients implement this trait.
 pub trait CloudFormation {
     /// <p><p>Cancels an update on the specified stack. If the call completes successfully, the stack rolls back the update and reverts to the previous stack configuration.</p> <note> <p>You can cancel only stacks that are in the UPDATE<em>IN</em>PROGRESS state.</p> </note></p>

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -8402,20 +8402,16 @@ impl CreateCloudFrontOriginAccessIdentityError {
 }
 impl fmt::Display for CreateCloudFrontOriginAccessIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCloudFrontOriginAccessIdentityError {
-    fn description(&self) -> &str {
         match *self {
-                            CreateCloudFrontOriginAccessIdentityError::CloudFrontOriginAccessIdentityAlreadyExists(ref cause) => cause,
-CreateCloudFrontOriginAccessIdentityError::InconsistentQuantities(ref cause) => cause,
-CreateCloudFrontOriginAccessIdentityError::InvalidArgument(ref cause) => cause,
-CreateCloudFrontOriginAccessIdentityError::MissingBody(ref cause) => cause,
-CreateCloudFrontOriginAccessIdentityError::TooManyCloudFrontOriginAccessIdentities(ref cause) => cause
+                            CreateCloudFrontOriginAccessIdentityError::CloudFrontOriginAccessIdentityAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateCloudFrontOriginAccessIdentityError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+CreateCloudFrontOriginAccessIdentityError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+CreateCloudFrontOriginAccessIdentityError::MissingBody(ref cause) => write!(f, "{}", cause),
+CreateCloudFrontOriginAccessIdentityError::TooManyCloudFrontOriginAccessIdentities(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for CreateCloudFrontOriginAccessIdentityError {}
 /// Errors returned by CreateDistribution
 #[derive(Debug, PartialEq)]
 pub enum CreateDistributionError {
@@ -8534,59 +8530,55 @@ impl CreateDistributionError {
 }
 impl fmt::Display for CreateDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDistributionError {
-    fn description(&self) -> &str {
         match *self {
-                            CreateDistributionError::AccessDenied(ref cause) => cause,
-CreateDistributionError::CNAMEAlreadyExists(ref cause) => cause,
-CreateDistributionError::DistributionAlreadyExists(ref cause) => cause,
-CreateDistributionError::IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(ref cause) => cause,
-CreateDistributionError::InconsistentQuantities(ref cause) => cause,
-CreateDistributionError::InvalidArgument(ref cause) => cause,
-CreateDistributionError::InvalidDefaultRootObject(ref cause) => cause,
-CreateDistributionError::InvalidErrorCode(ref cause) => cause,
-CreateDistributionError::InvalidForwardCookies(ref cause) => cause,
-CreateDistributionError::InvalidGeoRestrictionParameter(ref cause) => cause,
-CreateDistributionError::InvalidHeadersForS3Origin(ref cause) => cause,
-CreateDistributionError::InvalidLambdaFunctionAssociation(ref cause) => cause,
-CreateDistributionError::InvalidLocationCode(ref cause) => cause,
-CreateDistributionError::InvalidMinimumProtocolVersion(ref cause) => cause,
-CreateDistributionError::InvalidOrigin(ref cause) => cause,
-CreateDistributionError::InvalidOriginAccessIdentity(ref cause) => cause,
-CreateDistributionError::InvalidOriginKeepaliveTimeout(ref cause) => cause,
-CreateDistributionError::InvalidOriginReadTimeout(ref cause) => cause,
-CreateDistributionError::InvalidProtocolSettings(ref cause) => cause,
-CreateDistributionError::InvalidQueryStringParameters(ref cause) => cause,
-CreateDistributionError::InvalidRelativePath(ref cause) => cause,
-CreateDistributionError::InvalidRequiredProtocol(ref cause) => cause,
-CreateDistributionError::InvalidResponseCode(ref cause) => cause,
-CreateDistributionError::InvalidTTLOrder(ref cause) => cause,
-CreateDistributionError::InvalidViewerCertificate(ref cause) => cause,
-CreateDistributionError::InvalidWebACLId(ref cause) => cause,
-CreateDistributionError::MissingBody(ref cause) => cause,
-CreateDistributionError::NoSuchFieldLevelEncryptionConfig(ref cause) => cause,
-CreateDistributionError::NoSuchOrigin(ref cause) => cause,
-CreateDistributionError::TooManyCacheBehaviors(ref cause) => cause,
-CreateDistributionError::TooManyCertificates(ref cause) => cause,
-CreateDistributionError::TooManyCookieNamesInWhiteList(ref cause) => cause,
-CreateDistributionError::TooManyDistributionCNAMEs(ref cause) => cause,
-CreateDistributionError::TooManyDistributions(ref cause) => cause,
-CreateDistributionError::TooManyDistributionsAssociatedToFieldLevelEncryptionConfig(ref cause) => cause,
-CreateDistributionError::TooManyDistributionsWithLambdaAssociations(ref cause) => cause,
-CreateDistributionError::TooManyHeadersInForwardedValues(ref cause) => cause,
-CreateDistributionError::TooManyLambdaFunctionAssociations(ref cause) => cause,
-CreateDistributionError::TooManyOriginCustomHeaders(ref cause) => cause,
-CreateDistributionError::TooManyOriginGroupsPerDistribution(ref cause) => cause,
-CreateDistributionError::TooManyOrigins(ref cause) => cause,
-CreateDistributionError::TooManyQueryStringParameters(ref cause) => cause,
-CreateDistributionError::TooManyTrustedSigners(ref cause) => cause,
-CreateDistributionError::TrustedSignerDoesNotExist(ref cause) => cause
+                            CreateDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::CNAMEAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::DistributionAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidDefaultRootObject(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidErrorCode(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidForwardCookies(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidGeoRestrictionParameter(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidHeadersForS3Origin(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidLambdaFunctionAssociation(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidLocationCode(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidMinimumProtocolVersion(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidOrigin(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidOriginAccessIdentity(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidOriginKeepaliveTimeout(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidOriginReadTimeout(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidProtocolSettings(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidQueryStringParameters(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidRelativePath(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidRequiredProtocol(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidResponseCode(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidTTLOrder(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidViewerCertificate(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::InvalidWebACLId(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::MissingBody(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::NoSuchFieldLevelEncryptionConfig(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::NoSuchOrigin(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyCacheBehaviors(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyCertificates(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyCookieNamesInWhiteList(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyDistributionCNAMEs(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyDistributions(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyDistributionsAssociatedToFieldLevelEncryptionConfig(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyDistributionsWithLambdaAssociations(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyHeadersInForwardedValues(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyLambdaFunctionAssociations(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyOriginCustomHeaders(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyOriginGroupsPerDistribution(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyOrigins(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyQueryStringParameters(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TooManyTrustedSigners(ref cause) => write!(f, "{}", cause),
+CreateDistributionError::TrustedSignerDoesNotExist(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for CreateDistributionError {}
 /// Errors returned by CreateDistributionWithTags
 #[derive(Debug, PartialEq)]
 pub enum CreateDistributionWithTagsError {
@@ -8709,60 +8701,56 @@ impl CreateDistributionWithTagsError {
 }
 impl fmt::Display for CreateDistributionWithTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDistributionWithTagsError {
-    fn description(&self) -> &str {
         match *self {
-                            CreateDistributionWithTagsError::AccessDenied(ref cause) => cause,
-CreateDistributionWithTagsError::CNAMEAlreadyExists(ref cause) => cause,
-CreateDistributionWithTagsError::DistributionAlreadyExists(ref cause) => cause,
-CreateDistributionWithTagsError::IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(ref cause) => cause,
-CreateDistributionWithTagsError::InconsistentQuantities(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidArgument(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidDefaultRootObject(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidErrorCode(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidForwardCookies(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidGeoRestrictionParameter(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidHeadersForS3Origin(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidLambdaFunctionAssociation(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidLocationCode(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidMinimumProtocolVersion(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidOrigin(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidOriginAccessIdentity(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidOriginKeepaliveTimeout(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidOriginReadTimeout(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidProtocolSettings(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidQueryStringParameters(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidRelativePath(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidRequiredProtocol(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidResponseCode(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidTTLOrder(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidTagging(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidViewerCertificate(ref cause) => cause,
-CreateDistributionWithTagsError::InvalidWebACLId(ref cause) => cause,
-CreateDistributionWithTagsError::MissingBody(ref cause) => cause,
-CreateDistributionWithTagsError::NoSuchFieldLevelEncryptionConfig(ref cause) => cause,
-CreateDistributionWithTagsError::NoSuchOrigin(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyCacheBehaviors(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyCertificates(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyCookieNamesInWhiteList(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyDistributionCNAMEs(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyDistributions(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyDistributionsAssociatedToFieldLevelEncryptionConfig(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyDistributionsWithLambdaAssociations(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyHeadersInForwardedValues(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyLambdaFunctionAssociations(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyOriginCustomHeaders(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyOriginGroupsPerDistribution(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyOrigins(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyQueryStringParameters(ref cause) => cause,
-CreateDistributionWithTagsError::TooManyTrustedSigners(ref cause) => cause,
-CreateDistributionWithTagsError::TrustedSignerDoesNotExist(ref cause) => cause
+                            CreateDistributionWithTagsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::CNAMEAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::DistributionAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidDefaultRootObject(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidErrorCode(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidForwardCookies(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidGeoRestrictionParameter(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidHeadersForS3Origin(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidLambdaFunctionAssociation(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidLocationCode(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidMinimumProtocolVersion(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidOrigin(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidOriginAccessIdentity(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidOriginKeepaliveTimeout(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidOriginReadTimeout(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidProtocolSettings(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidQueryStringParameters(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidRelativePath(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidRequiredProtocol(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidResponseCode(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidTTLOrder(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidTagging(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidViewerCertificate(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::InvalidWebACLId(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::MissingBody(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::NoSuchFieldLevelEncryptionConfig(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::NoSuchOrigin(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyCacheBehaviors(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyCertificates(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyCookieNamesInWhiteList(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyDistributionCNAMEs(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyDistributions(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyDistributionsAssociatedToFieldLevelEncryptionConfig(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyDistributionsWithLambdaAssociations(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyHeadersInForwardedValues(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyLambdaFunctionAssociations(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyOriginCustomHeaders(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyOriginGroupsPerDistribution(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyOrigins(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyQueryStringParameters(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TooManyTrustedSigners(ref cause) => write!(f, "{}", cause),
+CreateDistributionWithTagsError::TrustedSignerDoesNotExist(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for CreateDistributionWithTagsError {}
 /// Errors returned by CreateFieldLevelEncryptionConfig
 #[derive(Debug, PartialEq)]
 pub enum CreateFieldLevelEncryptionConfigError {
@@ -8811,23 +8799,19 @@ impl CreateFieldLevelEncryptionConfigError {
 }
 impl fmt::Display for CreateFieldLevelEncryptionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFieldLevelEncryptionConfigError {
-    fn description(&self) -> &str {
         match *self {
-                            CreateFieldLevelEncryptionConfigError::FieldLevelEncryptionConfigAlreadyExists(ref cause) => cause,
-CreateFieldLevelEncryptionConfigError::InconsistentQuantities(ref cause) => cause,
-CreateFieldLevelEncryptionConfigError::InvalidArgument(ref cause) => cause,
-CreateFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionProfile(ref cause) => cause,
-CreateFieldLevelEncryptionConfigError::QueryArgProfileEmpty(ref cause) => cause,
-CreateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionConfigs(ref cause) => cause,
-CreateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionContentTypeProfiles(ref cause) => cause,
-CreateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionQueryArgProfiles(ref cause) => cause
+                            CreateFieldLevelEncryptionConfigError::FieldLevelEncryptionConfigAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionConfigError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionConfigError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionProfile(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionConfigError::QueryArgProfileEmpty(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionConfigs(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionContentTypeProfiles(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionQueryArgProfiles(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for CreateFieldLevelEncryptionConfigError {}
 /// Errors returned by CreateFieldLevelEncryptionProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateFieldLevelEncryptionProfileError {
@@ -8876,23 +8860,19 @@ impl CreateFieldLevelEncryptionProfileError {
 }
 impl fmt::Display for CreateFieldLevelEncryptionProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFieldLevelEncryptionProfileError {
-    fn description(&self) -> &str {
         match *self {
-                            CreateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileAlreadyExists(ref cause) => cause,
-CreateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileSizeExceeded(ref cause) => cause,
-CreateFieldLevelEncryptionProfileError::InconsistentQuantities(ref cause) => cause,
-CreateFieldLevelEncryptionProfileError::InvalidArgument(ref cause) => cause,
-CreateFieldLevelEncryptionProfileError::NoSuchPublicKey(ref cause) => cause,
-CreateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionEncryptionEntities(ref cause) => cause,
-CreateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionFieldPatterns(ref cause) => cause,
-CreateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionProfiles(ref cause) => cause
+                            CreateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileSizeExceeded(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionProfileError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionProfileError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionProfileError::NoSuchPublicKey(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionEncryptionEntities(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionFieldPatterns(ref cause) => write!(f, "{}", cause),
+CreateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionProfiles(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for CreateFieldLevelEncryptionProfileError {}
 /// Errors returned by CreateInvalidation
 #[derive(Debug, PartialEq)]
 pub enum CreateInvalidationError {
@@ -8974,22 +8954,20 @@ impl CreateInvalidationError {
 }
 impl fmt::Display for CreateInvalidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInvalidationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInvalidationError::AccessDenied(ref cause) => cause,
-            CreateInvalidationError::BatchTooLarge(ref cause) => cause,
-            CreateInvalidationError::InconsistentQuantities(ref cause) => cause,
-            CreateInvalidationError::InvalidArgument(ref cause) => cause,
-            CreateInvalidationError::MissingBody(ref cause) => cause,
-            CreateInvalidationError::NoSuchDistribution(ref cause) => cause,
-            CreateInvalidationError::TooManyInvalidationsInProgress(ref cause) => cause,
+            CreateInvalidationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateInvalidationError::BatchTooLarge(ref cause) => write!(f, "{}", cause),
+            CreateInvalidationError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+            CreateInvalidationError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateInvalidationError::MissingBody(ref cause) => write!(f, "{}", cause),
+            CreateInvalidationError::NoSuchDistribution(ref cause) => write!(f, "{}", cause),
+            CreateInvalidationError::TooManyInvalidationsInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateInvalidationError {}
 /// Errors returned by CreatePublicKey
 #[derive(Debug, PartialEq)]
 pub enum CreatePublicKeyError {
@@ -9041,18 +9019,14 @@ impl CreatePublicKeyError {
 }
 impl fmt::Display for CreatePublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePublicKeyError::InvalidArgument(ref cause) => cause,
-            CreatePublicKeyError::PublicKeyAlreadyExists(ref cause) => cause,
-            CreatePublicKeyError::TooManyPublicKeys(ref cause) => cause,
+            CreatePublicKeyError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreatePublicKeyError::PublicKeyAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreatePublicKeyError::TooManyPublicKeys(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePublicKeyError {}
 /// Errors returned by CreateStreamingDistribution
 #[derive(Debug, PartialEq)]
 pub enum CreateStreamingDistributionError {
@@ -9185,31 +9159,39 @@ impl CreateStreamingDistributionError {
 }
 impl fmt::Display for CreateStreamingDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStreamingDistributionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStreamingDistributionError::AccessDenied(ref cause) => cause,
-            CreateStreamingDistributionError::CNAMEAlreadyExists(ref cause) => cause,
-            CreateStreamingDistributionError::InconsistentQuantities(ref cause) => cause,
-            CreateStreamingDistributionError::InvalidArgument(ref cause) => cause,
-            CreateStreamingDistributionError::InvalidOrigin(ref cause) => cause,
-            CreateStreamingDistributionError::InvalidOriginAccessIdentity(ref cause) => cause,
-            CreateStreamingDistributionError::MissingBody(ref cause) => cause,
+            CreateStreamingDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateStreamingDistributionError::CNAMEAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionError::InconsistentQuantities(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateStreamingDistributionError::InvalidOrigin(ref cause) => write!(f, "{}", cause),
+            CreateStreamingDistributionError::InvalidOriginAccessIdentity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionError::MissingBody(ref cause) => write!(f, "{}", cause),
             CreateStreamingDistributionError::StreamingDistributionAlreadyExists(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateStreamingDistributionError::TooManyStreamingDistributionCNAMEs(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateStreamingDistributionError::TooManyStreamingDistributions(ref cause) => cause,
-            CreateStreamingDistributionError::TooManyTrustedSigners(ref cause) => cause,
-            CreateStreamingDistributionError::TrustedSignerDoesNotExist(ref cause) => cause,
+            CreateStreamingDistributionError::TooManyStreamingDistributions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionError::TooManyTrustedSigners(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionError::TrustedSignerDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateStreamingDistributionError {}
 /// Errors returned by CreateStreamingDistributionWithTags
 #[derive(Debug, PartialEq)]
 pub enum CreateStreamingDistributionWithTagsError {
@@ -9268,36 +9250,50 @@ impl CreateStreamingDistributionWithTagsError {
 }
 impl fmt::Display for CreateStreamingDistributionWithTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStreamingDistributionWithTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStreamingDistributionWithTagsError::AccessDenied(ref cause) => cause,
-            CreateStreamingDistributionWithTagsError::CNAMEAlreadyExists(ref cause) => cause,
-            CreateStreamingDistributionWithTagsError::InconsistentQuantities(ref cause) => cause,
-            CreateStreamingDistributionWithTagsError::InvalidArgument(ref cause) => cause,
-            CreateStreamingDistributionWithTagsError::InvalidOrigin(ref cause) => cause,
-            CreateStreamingDistributionWithTagsError::InvalidOriginAccessIdentity(ref cause) => {
-                cause
+            CreateStreamingDistributionWithTagsError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
             }
-            CreateStreamingDistributionWithTagsError::InvalidTagging(ref cause) => cause,
-            CreateStreamingDistributionWithTagsError::MissingBody(ref cause) => cause,
+            CreateStreamingDistributionWithTagsError::CNAMEAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionWithTagsError::InconsistentQuantities(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionWithTagsError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionWithTagsError::InvalidOrigin(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionWithTagsError::InvalidOriginAccessIdentity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionWithTagsError::InvalidTagging(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionWithTagsError::MissingBody(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateStreamingDistributionWithTagsError::StreamingDistributionAlreadyExists(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateStreamingDistributionWithTagsError::TooManyStreamingDistributionCNAMEs(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateStreamingDistributionWithTagsError::TooManyStreamingDistributions(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateStreamingDistributionWithTagsError::TooManyTrustedSigners(ref cause) => cause,
-            CreateStreamingDistributionWithTagsError::TrustedSignerDoesNotExist(ref cause) => cause,
+            CreateStreamingDistributionWithTagsError::TooManyTrustedSigners(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamingDistributionWithTagsError::TrustedSignerDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateStreamingDistributionWithTagsError {}
 /// Errors returned by DeleteCloudFrontOriginAccessIdentity
 #[derive(Debug, PartialEq)]
 pub enum DeleteCloudFrontOriginAccessIdentityError {
@@ -9340,24 +9336,26 @@ impl DeleteCloudFrontOriginAccessIdentityError {
 }
 impl fmt::Display for DeleteCloudFrontOriginAccessIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCloudFrontOriginAccessIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCloudFrontOriginAccessIdentityError::AccessDenied(ref cause) => cause,
+            DeleteCloudFrontOriginAccessIdentityError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteCloudFrontOriginAccessIdentityError::CloudFrontOriginAccessIdentityInUse(
                 ref cause,
-            ) => cause,
-            DeleteCloudFrontOriginAccessIdentityError::InvalidIfMatchVersion(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DeleteCloudFrontOriginAccessIdentityError::InvalidIfMatchVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteCloudFrontOriginAccessIdentityError::NoSuchCloudFrontOriginAccessIdentity(
                 ref cause,
-            ) => cause,
-            DeleteCloudFrontOriginAccessIdentityError::PreconditionFailed(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DeleteCloudFrontOriginAccessIdentityError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCloudFrontOriginAccessIdentityError {}
 /// Errors returned by DeleteDistribution
 #[derive(Debug, PartialEq)]
 pub enum DeleteDistributionError {
@@ -9423,20 +9421,16 @@ impl DeleteDistributionError {
 }
 impl fmt::Display for DeleteDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDistributionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDistributionError::AccessDenied(ref cause) => cause,
-            DeleteDistributionError::DistributionNotDisabled(ref cause) => cause,
-            DeleteDistributionError::InvalidIfMatchVersion(ref cause) => cause,
-            DeleteDistributionError::NoSuchDistribution(ref cause) => cause,
-            DeleteDistributionError::PreconditionFailed(ref cause) => cause,
+            DeleteDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteDistributionError::DistributionNotDisabled(ref cause) => write!(f, "{}", cause),
+            DeleteDistributionError::InvalidIfMatchVersion(ref cause) => write!(f, "{}", cause),
+            DeleteDistributionError::NoSuchDistribution(ref cause) => write!(f, "{}", cause),
+            DeleteDistributionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDistributionError {}
 /// Errors returned by DeleteFieldLevelEncryptionConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteFieldLevelEncryptionConfigError {
@@ -9514,24 +9508,26 @@ impl DeleteFieldLevelEncryptionConfigError {
 }
 impl fmt::Display for DeleteFieldLevelEncryptionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFieldLevelEncryptionConfigError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFieldLevelEncryptionConfigError::AccessDenied(ref cause) => cause,
+            DeleteFieldLevelEncryptionConfigError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteFieldLevelEncryptionConfigError::FieldLevelEncryptionConfigInUse(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DeleteFieldLevelEncryptionConfigError::InvalidIfMatchVersion(ref cause) => cause,
+            DeleteFieldLevelEncryptionConfigError::InvalidIfMatchVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionConfig(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DeleteFieldLevelEncryptionConfigError::PreconditionFailed(ref cause) => cause,
+            DeleteFieldLevelEncryptionConfigError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteFieldLevelEncryptionConfigError {}
 /// Errors returned by DeleteFieldLevelEncryptionProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteFieldLevelEncryptionProfileError {
@@ -9605,24 +9601,26 @@ impl DeleteFieldLevelEncryptionProfileError {
 }
 impl fmt::Display for DeleteFieldLevelEncryptionProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFieldLevelEncryptionProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFieldLevelEncryptionProfileError::AccessDenied(ref cause) => cause,
-            DeleteFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileInUse(ref cause) => {
-                cause
+            DeleteFieldLevelEncryptionProfileError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
             }
-            DeleteFieldLevelEncryptionProfileError::InvalidIfMatchVersion(ref cause) => cause,
+            DeleteFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteFieldLevelEncryptionProfileError::InvalidIfMatchVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteFieldLevelEncryptionProfileError::NoSuchFieldLevelEncryptionProfile(
                 ref cause,
-            ) => cause,
-            DeleteFieldLevelEncryptionProfileError::PreconditionFailed(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DeleteFieldLevelEncryptionProfileError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteFieldLevelEncryptionProfileError {}
 /// Errors returned by DeletePublicKey
 #[derive(Debug, PartialEq)]
 pub enum DeletePublicKeyError {
@@ -9688,20 +9686,16 @@ impl DeletePublicKeyError {
 }
 impl fmt::Display for DeletePublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePublicKeyError::AccessDenied(ref cause) => cause,
-            DeletePublicKeyError::InvalidIfMatchVersion(ref cause) => cause,
-            DeletePublicKeyError::NoSuchPublicKey(ref cause) => cause,
-            DeletePublicKeyError::PreconditionFailed(ref cause) => cause,
-            DeletePublicKeyError::PublicKeyInUse(ref cause) => cause,
+            DeletePublicKeyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeletePublicKeyError::InvalidIfMatchVersion(ref cause) => write!(f, "{}", cause),
+            DeletePublicKeyError::NoSuchPublicKey(ref cause) => write!(f, "{}", cause),
+            DeletePublicKeyError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            DeletePublicKeyError::PublicKeyInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePublicKeyError {}
 /// Errors returned by DeleteStreamingDistribution
 #[derive(Debug, PartialEq)]
 pub enum DeleteStreamingDistributionError {
@@ -9777,20 +9771,24 @@ impl DeleteStreamingDistributionError {
 }
 impl fmt::Display for DeleteStreamingDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStreamingDistributionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStreamingDistributionError::AccessDenied(ref cause) => cause,
-            DeleteStreamingDistributionError::InvalidIfMatchVersion(ref cause) => cause,
-            DeleteStreamingDistributionError::NoSuchStreamingDistribution(ref cause) => cause,
-            DeleteStreamingDistributionError::PreconditionFailed(ref cause) => cause,
-            DeleteStreamingDistributionError::StreamingDistributionNotDisabled(ref cause) => cause,
+            DeleteStreamingDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteStreamingDistributionError::InvalidIfMatchVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteStreamingDistributionError::NoSuchStreamingDistribution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteStreamingDistributionError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteStreamingDistributionError::StreamingDistributionNotDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteStreamingDistributionError {}
 /// Errors returned by GetCloudFrontOriginAccessIdentity
 #[derive(Debug, PartialEq)]
 pub enum GetCloudFrontOriginAccessIdentityError {
@@ -9827,19 +9825,17 @@ impl GetCloudFrontOriginAccessIdentityError {
 }
 impl fmt::Display for GetCloudFrontOriginAccessIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCloudFrontOriginAccessIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            GetCloudFrontOriginAccessIdentityError::AccessDenied(ref cause) => cause,
+            GetCloudFrontOriginAccessIdentityError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetCloudFrontOriginAccessIdentityError::NoSuchCloudFrontOriginAccessIdentity(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCloudFrontOriginAccessIdentityError {}
 /// Errors returned by GetCloudFrontOriginAccessIdentityConfig
 #[derive(Debug, PartialEq)]
 pub enum GetCloudFrontOriginAccessIdentityConfigError {
@@ -9876,19 +9872,17 @@ impl GetCloudFrontOriginAccessIdentityConfigError {
 }
 impl fmt::Display for GetCloudFrontOriginAccessIdentityConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCloudFrontOriginAccessIdentityConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetCloudFrontOriginAccessIdentityConfigError::AccessDenied(ref cause) => cause,
+            GetCloudFrontOriginAccessIdentityConfigError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetCloudFrontOriginAccessIdentityConfigError::NoSuchCloudFrontOriginAccessIdentity(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCloudFrontOriginAccessIdentityConfigError {}
 /// Errors returned by GetDistribution
 #[derive(Debug, PartialEq)]
 pub enum GetDistributionError {
@@ -9933,17 +9927,13 @@ impl GetDistributionError {
 }
 impl fmt::Display for GetDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDistributionError {
-    fn description(&self) -> &str {
         match *self {
-            GetDistributionError::AccessDenied(ref cause) => cause,
-            GetDistributionError::NoSuchDistribution(ref cause) => cause,
+            GetDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDistributionError::NoSuchDistribution(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDistributionError {}
 /// Errors returned by GetDistributionConfig
 #[derive(Debug, PartialEq)]
 pub enum GetDistributionConfigError {
@@ -9988,17 +9978,13 @@ impl GetDistributionConfigError {
 }
 impl fmt::Display for GetDistributionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDistributionConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetDistributionConfigError::AccessDenied(ref cause) => cause,
-            GetDistributionConfigError::NoSuchDistribution(ref cause) => cause,
+            GetDistributionConfigError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDistributionConfigError::NoSuchDistribution(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDistributionConfigError {}
 /// Errors returned by GetFieldLevelEncryption
 #[derive(Debug, PartialEq)]
 pub enum GetFieldLevelEncryptionError {
@@ -10045,17 +10031,15 @@ impl GetFieldLevelEncryptionError {
 }
 impl fmt::Display for GetFieldLevelEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFieldLevelEncryptionError {
-    fn description(&self) -> &str {
         match *self {
-            GetFieldLevelEncryptionError::AccessDenied(ref cause) => cause,
-            GetFieldLevelEncryptionError::NoSuchFieldLevelEncryptionConfig(ref cause) => cause,
+            GetFieldLevelEncryptionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetFieldLevelEncryptionError::NoSuchFieldLevelEncryptionConfig(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetFieldLevelEncryptionError {}
 /// Errors returned by GetFieldLevelEncryptionConfig
 #[derive(Debug, PartialEq)]
 pub enum GetFieldLevelEncryptionConfigError {
@@ -10104,19 +10088,15 @@ impl GetFieldLevelEncryptionConfigError {
 }
 impl fmt::Display for GetFieldLevelEncryptionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFieldLevelEncryptionConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetFieldLevelEncryptionConfigError::AccessDenied(ref cause) => cause,
+            GetFieldLevelEncryptionConfigError::AccessDenied(ref cause) => write!(f, "{}", cause),
             GetFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionConfig(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GetFieldLevelEncryptionConfigError {}
 /// Errors returned by GetFieldLevelEncryptionProfile
 #[derive(Debug, PartialEq)]
 pub enum GetFieldLevelEncryptionProfileError {
@@ -10165,19 +10145,15 @@ impl GetFieldLevelEncryptionProfileError {
 }
 impl fmt::Display for GetFieldLevelEncryptionProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFieldLevelEncryptionProfileError {
-    fn description(&self) -> &str {
         match *self {
-            GetFieldLevelEncryptionProfileError::AccessDenied(ref cause) => cause,
+            GetFieldLevelEncryptionProfileError::AccessDenied(ref cause) => write!(f, "{}", cause),
             GetFieldLevelEncryptionProfileError::NoSuchFieldLevelEncryptionProfile(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GetFieldLevelEncryptionProfileError {}
 /// Errors returned by GetFieldLevelEncryptionProfileConfig
 #[derive(Debug, PartialEq)]
 pub enum GetFieldLevelEncryptionProfileConfigError {
@@ -10214,19 +10190,17 @@ impl GetFieldLevelEncryptionProfileConfigError {
 }
 impl fmt::Display for GetFieldLevelEncryptionProfileConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFieldLevelEncryptionProfileConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetFieldLevelEncryptionProfileConfigError::AccessDenied(ref cause) => cause,
+            GetFieldLevelEncryptionProfileConfigError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetFieldLevelEncryptionProfileConfigError::NoSuchFieldLevelEncryptionProfile(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFieldLevelEncryptionProfileConfigError {}
 /// Errors returned by GetInvalidation
 #[derive(Debug, PartialEq)]
 pub enum GetInvalidationError {
@@ -10278,18 +10252,14 @@ impl GetInvalidationError {
 }
 impl fmt::Display for GetInvalidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInvalidationError {
-    fn description(&self) -> &str {
         match *self {
-            GetInvalidationError::AccessDenied(ref cause) => cause,
-            GetInvalidationError::NoSuchDistribution(ref cause) => cause,
-            GetInvalidationError::NoSuchInvalidation(ref cause) => cause,
+            GetInvalidationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInvalidationError::NoSuchDistribution(ref cause) => write!(f, "{}", cause),
+            GetInvalidationError::NoSuchInvalidation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInvalidationError {}
 /// Errors returned by GetPublicKey
 #[derive(Debug, PartialEq)]
 pub enum GetPublicKeyError {
@@ -10334,17 +10304,13 @@ impl GetPublicKeyError {
 }
 impl fmt::Display for GetPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPublicKeyError::AccessDenied(ref cause) => cause,
-            GetPublicKeyError::NoSuchPublicKey(ref cause) => cause,
+            GetPublicKeyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::NoSuchPublicKey(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPublicKeyError {}
 /// Errors returned by GetPublicKeyConfig
 #[derive(Debug, PartialEq)]
 pub enum GetPublicKeyConfigError {
@@ -10389,17 +10355,13 @@ impl GetPublicKeyConfigError {
 }
 impl fmt::Display for GetPublicKeyConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPublicKeyConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetPublicKeyConfigError::AccessDenied(ref cause) => cause,
-            GetPublicKeyConfigError::NoSuchPublicKey(ref cause) => cause,
+            GetPublicKeyConfigError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyConfigError::NoSuchPublicKey(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPublicKeyConfigError {}
 /// Errors returned by GetStreamingDistribution
 #[derive(Debug, PartialEq)]
 pub enum GetStreamingDistributionError {
@@ -10446,17 +10408,15 @@ impl GetStreamingDistributionError {
 }
 impl fmt::Display for GetStreamingDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStreamingDistributionError {
-    fn description(&self) -> &str {
         match *self {
-            GetStreamingDistributionError::AccessDenied(ref cause) => cause,
-            GetStreamingDistributionError::NoSuchStreamingDistribution(ref cause) => cause,
+            GetStreamingDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetStreamingDistributionError::NoSuchStreamingDistribution(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetStreamingDistributionError {}
 /// Errors returned by GetStreamingDistributionConfig
 #[derive(Debug, PartialEq)]
 pub enum GetStreamingDistributionConfigError {
@@ -10505,17 +10465,15 @@ impl GetStreamingDistributionConfigError {
 }
 impl fmt::Display for GetStreamingDistributionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStreamingDistributionConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetStreamingDistributionConfigError::AccessDenied(ref cause) => cause,
-            GetStreamingDistributionConfigError::NoSuchStreamingDistribution(ref cause) => cause,
+            GetStreamingDistributionConfigError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetStreamingDistributionConfigError::NoSuchStreamingDistribution(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetStreamingDistributionConfigError {}
 /// Errors returned by ListCloudFrontOriginAccessIdentities
 #[derive(Debug, PartialEq)]
 pub enum ListCloudFrontOriginAccessIdentitiesError {
@@ -10557,16 +10515,14 @@ impl ListCloudFrontOriginAccessIdentitiesError {
 }
 impl fmt::Display for ListCloudFrontOriginAccessIdentitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCloudFrontOriginAccessIdentitiesError {
-    fn description(&self) -> &str {
         match *self {
-            ListCloudFrontOriginAccessIdentitiesError::InvalidArgument(ref cause) => cause,
+            ListCloudFrontOriginAccessIdentitiesError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListCloudFrontOriginAccessIdentitiesError {}
 /// Errors returned by ListDistributions
 #[derive(Debug, PartialEq)]
 pub enum ListDistributionsError {
@@ -10604,16 +10560,12 @@ impl ListDistributionsError {
 }
 impl fmt::Display for ListDistributionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDistributionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDistributionsError::InvalidArgument(ref cause) => cause,
+            ListDistributionsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDistributionsError {}
 /// Errors returned by ListDistributionsByWebACLId
 #[derive(Debug, PartialEq)]
 pub enum ListDistributionsByWebACLIdError {
@@ -10660,17 +10612,13 @@ impl ListDistributionsByWebACLIdError {
 }
 impl fmt::Display for ListDistributionsByWebACLIdError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDistributionsByWebACLIdError {
-    fn description(&self) -> &str {
         match *self {
-            ListDistributionsByWebACLIdError::InvalidArgument(ref cause) => cause,
-            ListDistributionsByWebACLIdError::InvalidWebACLId(ref cause) => cause,
+            ListDistributionsByWebACLIdError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListDistributionsByWebACLIdError::InvalidWebACLId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDistributionsByWebACLIdError {}
 /// Errors returned by ListFieldLevelEncryptionConfigs
 #[derive(Debug, PartialEq)]
 pub enum ListFieldLevelEncryptionConfigsError {
@@ -10712,16 +10660,14 @@ impl ListFieldLevelEncryptionConfigsError {
 }
 impl fmt::Display for ListFieldLevelEncryptionConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFieldLevelEncryptionConfigsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFieldLevelEncryptionConfigsError::InvalidArgument(ref cause) => cause,
+            ListFieldLevelEncryptionConfigsError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListFieldLevelEncryptionConfigsError {}
 /// Errors returned by ListFieldLevelEncryptionProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListFieldLevelEncryptionProfilesError {
@@ -10763,16 +10709,14 @@ impl ListFieldLevelEncryptionProfilesError {
 }
 impl fmt::Display for ListFieldLevelEncryptionProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFieldLevelEncryptionProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListFieldLevelEncryptionProfilesError::InvalidArgument(ref cause) => cause,
+            ListFieldLevelEncryptionProfilesError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListFieldLevelEncryptionProfilesError {}
 /// Errors returned by ListInvalidations
 #[derive(Debug, PartialEq)]
 pub enum ListInvalidationsError {
@@ -10824,18 +10768,14 @@ impl ListInvalidationsError {
 }
 impl fmt::Display for ListInvalidationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInvalidationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListInvalidationsError::AccessDenied(ref cause) => cause,
-            ListInvalidationsError::InvalidArgument(ref cause) => cause,
-            ListInvalidationsError::NoSuchDistribution(ref cause) => cause,
+            ListInvalidationsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListInvalidationsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListInvalidationsError::NoSuchDistribution(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInvalidationsError {}
 /// Errors returned by ListPublicKeys
 #[derive(Debug, PartialEq)]
 pub enum ListPublicKeysError {
@@ -10873,16 +10813,12 @@ impl ListPublicKeysError {
 }
 impl fmt::Display for ListPublicKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPublicKeysError {
-    fn description(&self) -> &str {
         match *self {
-            ListPublicKeysError::InvalidArgument(ref cause) => cause,
+            ListPublicKeysError::InvalidArgument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPublicKeysError {}
 /// Errors returned by ListStreamingDistributions
 #[derive(Debug, PartialEq)]
 pub enum ListStreamingDistributionsError {
@@ -10922,16 +10858,12 @@ impl ListStreamingDistributionsError {
 }
 impl fmt::Display for ListStreamingDistributionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStreamingDistributionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStreamingDistributionsError::InvalidArgument(ref cause) => cause,
+            ListStreamingDistributionsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStreamingDistributionsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -10990,19 +10922,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AccessDenied(ref cause) => cause,
-            ListTagsForResourceError::InvalidArgument(ref cause) => cause,
-            ListTagsForResourceError::InvalidTagging(ref cause) => cause,
-            ListTagsForResourceError::NoSuchResource(ref cause) => cause,
+            ListTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidTagging(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NoSuchResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -11061,19 +10989,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AccessDenied(ref cause) => cause,
-            TagResourceError::InvalidArgument(ref cause) => cause,
-            TagResourceError::InvalidTagging(ref cause) => cause,
-            TagResourceError::NoSuchResource(ref cause) => cause,
+            TagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidTagging(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NoSuchResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -11132,19 +11056,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AccessDenied(ref cause) => cause,
-            UntagResourceError::InvalidArgument(ref cause) => cause,
-            UntagResourceError::InvalidTagging(ref cause) => cause,
-            UntagResourceError::NoSuchResource(ref cause) => cause,
+            UntagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidTagging(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NoSuchResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateCloudFrontOriginAccessIdentity
 #[derive(Debug, PartialEq)]
 pub enum UpdateCloudFrontOriginAccessIdentityError {
@@ -11193,25 +11113,35 @@ impl UpdateCloudFrontOriginAccessIdentityError {
 }
 impl fmt::Display for UpdateCloudFrontOriginAccessIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCloudFrontOriginAccessIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCloudFrontOriginAccessIdentityError::AccessDenied(ref cause) => cause,
-            UpdateCloudFrontOriginAccessIdentityError::IllegalUpdate(ref cause) => cause,
-            UpdateCloudFrontOriginAccessIdentityError::InconsistentQuantities(ref cause) => cause,
-            UpdateCloudFrontOriginAccessIdentityError::InvalidArgument(ref cause) => cause,
-            UpdateCloudFrontOriginAccessIdentityError::InvalidIfMatchVersion(ref cause) => cause,
-            UpdateCloudFrontOriginAccessIdentityError::MissingBody(ref cause) => cause,
+            UpdateCloudFrontOriginAccessIdentityError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCloudFrontOriginAccessIdentityError::IllegalUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCloudFrontOriginAccessIdentityError::InconsistentQuantities(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCloudFrontOriginAccessIdentityError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCloudFrontOriginAccessIdentityError::InvalidIfMatchVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCloudFrontOriginAccessIdentityError::MissingBody(ref cause) => {
+                write!(f, "{}", cause)
+            }
             UpdateCloudFrontOriginAccessIdentityError::NoSuchCloudFrontOriginAccessIdentity(
                 ref cause,
-            ) => cause,
-            UpdateCloudFrontOriginAccessIdentityError::PreconditionFailed(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            UpdateCloudFrontOriginAccessIdentityError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateCloudFrontOriginAccessIdentityError {}
 /// Errors returned by UpdateDistribution
 #[derive(Debug, PartialEq)]
 pub enum UpdateDistributionError {
@@ -11330,59 +11260,55 @@ impl UpdateDistributionError {
 }
 impl fmt::Display for UpdateDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDistributionError {
-    fn description(&self) -> &str {
         match *self {
-                            UpdateDistributionError::AccessDenied(ref cause) => cause,
-UpdateDistributionError::CNAMEAlreadyExists(ref cause) => cause,
-UpdateDistributionError::IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(ref cause) => cause,
-UpdateDistributionError::IllegalUpdate(ref cause) => cause,
-UpdateDistributionError::InconsistentQuantities(ref cause) => cause,
-UpdateDistributionError::InvalidArgument(ref cause) => cause,
-UpdateDistributionError::InvalidDefaultRootObject(ref cause) => cause,
-UpdateDistributionError::InvalidErrorCode(ref cause) => cause,
-UpdateDistributionError::InvalidForwardCookies(ref cause) => cause,
-UpdateDistributionError::InvalidGeoRestrictionParameter(ref cause) => cause,
-UpdateDistributionError::InvalidHeadersForS3Origin(ref cause) => cause,
-UpdateDistributionError::InvalidIfMatchVersion(ref cause) => cause,
-UpdateDistributionError::InvalidLambdaFunctionAssociation(ref cause) => cause,
-UpdateDistributionError::InvalidLocationCode(ref cause) => cause,
-UpdateDistributionError::InvalidMinimumProtocolVersion(ref cause) => cause,
-UpdateDistributionError::InvalidOriginAccessIdentity(ref cause) => cause,
-UpdateDistributionError::InvalidOriginKeepaliveTimeout(ref cause) => cause,
-UpdateDistributionError::InvalidOriginReadTimeout(ref cause) => cause,
-UpdateDistributionError::InvalidQueryStringParameters(ref cause) => cause,
-UpdateDistributionError::InvalidRelativePath(ref cause) => cause,
-UpdateDistributionError::InvalidRequiredProtocol(ref cause) => cause,
-UpdateDistributionError::InvalidResponseCode(ref cause) => cause,
-UpdateDistributionError::InvalidTTLOrder(ref cause) => cause,
-UpdateDistributionError::InvalidViewerCertificate(ref cause) => cause,
-UpdateDistributionError::InvalidWebACLId(ref cause) => cause,
-UpdateDistributionError::MissingBody(ref cause) => cause,
-UpdateDistributionError::NoSuchDistribution(ref cause) => cause,
-UpdateDistributionError::NoSuchFieldLevelEncryptionConfig(ref cause) => cause,
-UpdateDistributionError::NoSuchOrigin(ref cause) => cause,
-UpdateDistributionError::PreconditionFailed(ref cause) => cause,
-UpdateDistributionError::TooManyCacheBehaviors(ref cause) => cause,
-UpdateDistributionError::TooManyCertificates(ref cause) => cause,
-UpdateDistributionError::TooManyCookieNamesInWhiteList(ref cause) => cause,
-UpdateDistributionError::TooManyDistributionCNAMEs(ref cause) => cause,
-UpdateDistributionError::TooManyDistributionsAssociatedToFieldLevelEncryptionConfig(ref cause) => cause,
-UpdateDistributionError::TooManyDistributionsWithLambdaAssociations(ref cause) => cause,
-UpdateDistributionError::TooManyHeadersInForwardedValues(ref cause) => cause,
-UpdateDistributionError::TooManyLambdaFunctionAssociations(ref cause) => cause,
-UpdateDistributionError::TooManyOriginCustomHeaders(ref cause) => cause,
-UpdateDistributionError::TooManyOriginGroupsPerDistribution(ref cause) => cause,
-UpdateDistributionError::TooManyOrigins(ref cause) => cause,
-UpdateDistributionError::TooManyQueryStringParameters(ref cause) => cause,
-UpdateDistributionError::TooManyTrustedSigners(ref cause) => cause,
-UpdateDistributionError::TrustedSignerDoesNotExist(ref cause) => cause
+                            UpdateDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::CNAMEAlreadyExists(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::IllegalUpdate(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidDefaultRootObject(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidErrorCode(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidForwardCookies(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidGeoRestrictionParameter(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidHeadersForS3Origin(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidIfMatchVersion(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidLambdaFunctionAssociation(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidLocationCode(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidMinimumProtocolVersion(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidOriginAccessIdentity(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidOriginKeepaliveTimeout(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidOriginReadTimeout(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidQueryStringParameters(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidRelativePath(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidRequiredProtocol(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidResponseCode(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidTTLOrder(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidViewerCertificate(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::InvalidWebACLId(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::MissingBody(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::NoSuchDistribution(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::NoSuchFieldLevelEncryptionConfig(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::NoSuchOrigin(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyCacheBehaviors(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyCertificates(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyCookieNamesInWhiteList(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyDistributionCNAMEs(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyDistributionsAssociatedToFieldLevelEncryptionConfig(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyDistributionsWithLambdaAssociations(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyHeadersInForwardedValues(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyLambdaFunctionAssociations(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyOriginCustomHeaders(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyOriginGroupsPerDistribution(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyOrigins(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyQueryStringParameters(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TooManyTrustedSigners(ref cause) => write!(f, "{}", cause),
+UpdateDistributionError::TrustedSignerDoesNotExist(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for UpdateDistributionError {}
 /// Errors returned by UpdateFieldLevelEncryptionConfig
 #[derive(Debug, PartialEq)]
 pub enum UpdateFieldLevelEncryptionConfigError {
@@ -11437,26 +11363,22 @@ impl UpdateFieldLevelEncryptionConfigError {
 }
 impl fmt::Display for UpdateFieldLevelEncryptionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFieldLevelEncryptionConfigError {
-    fn description(&self) -> &str {
         match *self {
-                            UpdateFieldLevelEncryptionConfigError::AccessDenied(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::IllegalUpdate(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::InconsistentQuantities(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::InvalidArgument(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::InvalidIfMatchVersion(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionConfig(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionProfile(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::PreconditionFailed(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::QueryArgProfileEmpty(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionContentTypeProfiles(ref cause) => cause,
-UpdateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionQueryArgProfiles(ref cause) => cause
+                            UpdateFieldLevelEncryptionConfigError::AccessDenied(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::IllegalUpdate(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::InvalidIfMatchVersion(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionConfig(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::NoSuchFieldLevelEncryptionProfile(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::QueryArgProfileEmpty(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionContentTypeProfiles(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionConfigError::TooManyFieldLevelEncryptionQueryArgProfiles(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for UpdateFieldLevelEncryptionConfigError {}
 /// Errors returned by UpdateFieldLevelEncryptionProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateFieldLevelEncryptionProfileError {
@@ -11513,27 +11435,23 @@ impl UpdateFieldLevelEncryptionProfileError {
 }
 impl fmt::Display for UpdateFieldLevelEncryptionProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFieldLevelEncryptionProfileError {
-    fn description(&self) -> &str {
         match *self {
-                            UpdateFieldLevelEncryptionProfileError::AccessDenied(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileAlreadyExists(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileSizeExceeded(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::IllegalUpdate(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::InconsistentQuantities(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::InvalidArgument(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::InvalidIfMatchVersion(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::NoSuchFieldLevelEncryptionProfile(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::NoSuchPublicKey(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::PreconditionFailed(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionEncryptionEntities(ref cause) => cause,
-UpdateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionFieldPatterns(ref cause) => cause
+                            UpdateFieldLevelEncryptionProfileError::AccessDenied(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileAlreadyExists(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::FieldLevelEncryptionProfileSizeExceeded(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::IllegalUpdate(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::InconsistentQuantities(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::InvalidIfMatchVersion(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::NoSuchFieldLevelEncryptionProfile(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::NoSuchPublicKey(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionEncryptionEntities(ref cause) => write!(f, "{}", cause),
+UpdateFieldLevelEncryptionProfileError::TooManyFieldLevelEncryptionFieldPatterns(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for UpdateFieldLevelEncryptionProfileError {}
 /// Errors returned by UpdatePublicKey
 #[derive(Debug, PartialEq)]
 pub enum UpdatePublicKeyError {
@@ -11615,22 +11533,20 @@ impl UpdatePublicKeyError {
 }
 impl fmt::Display for UpdatePublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePublicKeyError::AccessDenied(ref cause) => cause,
-            UpdatePublicKeyError::CannotChangeImmutablePublicKeyFields(ref cause) => cause,
-            UpdatePublicKeyError::IllegalUpdate(ref cause) => cause,
-            UpdatePublicKeyError::InvalidArgument(ref cause) => cause,
-            UpdatePublicKeyError::InvalidIfMatchVersion(ref cause) => cause,
-            UpdatePublicKeyError::NoSuchPublicKey(ref cause) => cause,
-            UpdatePublicKeyError::PreconditionFailed(ref cause) => cause,
+            UpdatePublicKeyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdatePublicKeyError::CannotChangeImmutablePublicKeyFields(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePublicKeyError::IllegalUpdate(ref cause) => write!(f, "{}", cause),
+            UpdatePublicKeyError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdatePublicKeyError::InvalidIfMatchVersion(ref cause) => write!(f, "{}", cause),
+            UpdatePublicKeyError::NoSuchPublicKey(ref cause) => write!(f, "{}", cause),
+            UpdatePublicKeyError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePublicKeyError {}
 /// Errors returned by UpdateStreamingDistribution
 #[derive(Debug, PartialEq)]
 pub enum UpdateStreamingDistributionError {
@@ -11772,30 +11688,42 @@ impl UpdateStreamingDistributionError {
 }
 impl fmt::Display for UpdateStreamingDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStreamingDistributionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStreamingDistributionError::AccessDenied(ref cause) => cause,
-            UpdateStreamingDistributionError::CNAMEAlreadyExists(ref cause) => cause,
-            UpdateStreamingDistributionError::IllegalUpdate(ref cause) => cause,
-            UpdateStreamingDistributionError::InconsistentQuantities(ref cause) => cause,
-            UpdateStreamingDistributionError::InvalidArgument(ref cause) => cause,
-            UpdateStreamingDistributionError::InvalidIfMatchVersion(ref cause) => cause,
-            UpdateStreamingDistributionError::InvalidOriginAccessIdentity(ref cause) => cause,
-            UpdateStreamingDistributionError::MissingBody(ref cause) => cause,
-            UpdateStreamingDistributionError::NoSuchStreamingDistribution(ref cause) => cause,
-            UpdateStreamingDistributionError::PreconditionFailed(ref cause) => cause,
-            UpdateStreamingDistributionError::TooManyStreamingDistributionCNAMEs(ref cause) => {
-                cause
+            UpdateStreamingDistributionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateStreamingDistributionError::CNAMEAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
             }
-            UpdateStreamingDistributionError::TooManyTrustedSigners(ref cause) => cause,
-            UpdateStreamingDistributionError::TrustedSignerDoesNotExist(ref cause) => cause,
+            UpdateStreamingDistributionError::IllegalUpdate(ref cause) => write!(f, "{}", cause),
+            UpdateStreamingDistributionError::InconsistentQuantities(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStreamingDistributionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateStreamingDistributionError::InvalidIfMatchVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStreamingDistributionError::InvalidOriginAccessIdentity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStreamingDistributionError::MissingBody(ref cause) => write!(f, "{}", cause),
+            UpdateStreamingDistributionError::NoSuchStreamingDistribution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStreamingDistributionError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStreamingDistributionError::TooManyStreamingDistributionCNAMEs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStreamingDistributionError::TooManyTrustedSigners(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStreamingDistributionError::TrustedSignerDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateStreamingDistributionError {}
 /// Trait representing the capabilities of the CloudFront API. CloudFront clients implement this trait.
 pub trait CloudFront {
     /// <p>Creates a new origin access identity. If you're using Amazon S3 for your origin, you can use an origin access identity to require users to access your content using a CloudFront URL instead of the Amazon S3 URL. For more information about how to use origin access identities, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -624,18 +624,14 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::CloudHsmInternal(ref cause) => cause,
-            AddTagsToResourceError::CloudHsmService(ref cause) => cause,
-            AddTagsToResourceError::InvalidRequest(ref cause) => cause,
+            AddTagsToResourceError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by CreateHapg
 #[derive(Debug, PartialEq)]
 pub enum CreateHapgError {
@@ -669,18 +665,14 @@ impl CreateHapgError {
 }
 impl fmt::Display for CreateHapgError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHapgError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHapgError::CloudHsmInternal(ref cause) => cause,
-            CreateHapgError::CloudHsmService(ref cause) => cause,
-            CreateHapgError::InvalidRequest(ref cause) => cause,
+            CreateHapgError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            CreateHapgError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            CreateHapgError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHapgError {}
 /// Errors returned by CreateHsm
 #[derive(Debug, PartialEq)]
 pub enum CreateHsmError {
@@ -714,18 +706,14 @@ impl CreateHsmError {
 }
 impl fmt::Display for CreateHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHsmError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHsmError::CloudHsmInternal(ref cause) => cause,
-            CreateHsmError::CloudHsmService(ref cause) => cause,
-            CreateHsmError::InvalidRequest(ref cause) => cause,
+            CreateHsmError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            CreateHsmError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            CreateHsmError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHsmError {}
 /// Errors returned by CreateLunaClient
 #[derive(Debug, PartialEq)]
 pub enum CreateLunaClientError {
@@ -759,18 +747,14 @@ impl CreateLunaClientError {
 }
 impl fmt::Display for CreateLunaClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLunaClientError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLunaClientError::CloudHsmInternal(ref cause) => cause,
-            CreateLunaClientError::CloudHsmService(ref cause) => cause,
-            CreateLunaClientError::InvalidRequest(ref cause) => cause,
+            CreateLunaClientError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            CreateLunaClientError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            CreateLunaClientError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLunaClientError {}
 /// Errors returned by DeleteHapg
 #[derive(Debug, PartialEq)]
 pub enum DeleteHapgError {
@@ -804,18 +788,14 @@ impl DeleteHapgError {
 }
 impl fmt::Display for DeleteHapgError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHapgError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHapgError::CloudHsmInternal(ref cause) => cause,
-            DeleteHapgError::CloudHsmService(ref cause) => cause,
-            DeleteHapgError::InvalidRequest(ref cause) => cause,
+            DeleteHapgError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            DeleteHapgError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            DeleteHapgError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteHapgError {}
 /// Errors returned by DeleteHsm
 #[derive(Debug, PartialEq)]
 pub enum DeleteHsmError {
@@ -849,18 +829,14 @@ impl DeleteHsmError {
 }
 impl fmt::Display for DeleteHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHsmError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHsmError::CloudHsmInternal(ref cause) => cause,
-            DeleteHsmError::CloudHsmService(ref cause) => cause,
-            DeleteHsmError::InvalidRequest(ref cause) => cause,
+            DeleteHsmError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            DeleteHsmError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            DeleteHsmError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteHsmError {}
 /// Errors returned by DeleteLunaClient
 #[derive(Debug, PartialEq)]
 pub enum DeleteLunaClientError {
@@ -894,18 +870,14 @@ impl DeleteLunaClientError {
 }
 impl fmt::Display for DeleteLunaClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLunaClientError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLunaClientError::CloudHsmInternal(ref cause) => cause,
-            DeleteLunaClientError::CloudHsmService(ref cause) => cause,
-            DeleteLunaClientError::InvalidRequest(ref cause) => cause,
+            DeleteLunaClientError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            DeleteLunaClientError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            DeleteLunaClientError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLunaClientError {}
 /// Errors returned by DescribeHapg
 #[derive(Debug, PartialEq)]
 pub enum DescribeHapgError {
@@ -939,18 +911,14 @@ impl DescribeHapgError {
 }
 impl fmt::Display for DescribeHapgError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHapgError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHapgError::CloudHsmInternal(ref cause) => cause,
-            DescribeHapgError::CloudHsmService(ref cause) => cause,
-            DescribeHapgError::InvalidRequest(ref cause) => cause,
+            DescribeHapgError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            DescribeHapgError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            DescribeHapgError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeHapgError {}
 /// Errors returned by DescribeHsm
 #[derive(Debug, PartialEq)]
 pub enum DescribeHsmError {
@@ -984,18 +952,14 @@ impl DescribeHsmError {
 }
 impl fmt::Display for DescribeHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHsmError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHsmError::CloudHsmInternal(ref cause) => cause,
-            DescribeHsmError::CloudHsmService(ref cause) => cause,
-            DescribeHsmError::InvalidRequest(ref cause) => cause,
+            DescribeHsmError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            DescribeHsmError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            DescribeHsmError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeHsmError {}
 /// Errors returned by DescribeLunaClient
 #[derive(Debug, PartialEq)]
 pub enum DescribeLunaClientError {
@@ -1029,18 +993,14 @@ impl DescribeLunaClientError {
 }
 impl fmt::Display for DescribeLunaClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLunaClientError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLunaClientError::CloudHsmInternal(ref cause) => cause,
-            DescribeLunaClientError::CloudHsmService(ref cause) => cause,
-            DescribeLunaClientError::InvalidRequest(ref cause) => cause,
+            DescribeLunaClientError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            DescribeLunaClientError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            DescribeLunaClientError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLunaClientError {}
 /// Errors returned by GetConfig
 #[derive(Debug, PartialEq)]
 pub enum GetConfigError {
@@ -1074,18 +1034,14 @@ impl GetConfigError {
 }
 impl fmt::Display for GetConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetConfigError::CloudHsmInternal(ref cause) => cause,
-            GetConfigError::CloudHsmService(ref cause) => cause,
-            GetConfigError::InvalidRequest(ref cause) => cause,
+            GetConfigError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            GetConfigError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            GetConfigError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConfigError {}
 /// Errors returned by ListAvailableZones
 #[derive(Debug, PartialEq)]
 pub enum ListAvailableZonesError {
@@ -1119,18 +1075,14 @@ impl ListAvailableZonesError {
 }
 impl fmt::Display for ListAvailableZonesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAvailableZonesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAvailableZonesError::CloudHsmInternal(ref cause) => cause,
-            ListAvailableZonesError::CloudHsmService(ref cause) => cause,
-            ListAvailableZonesError::InvalidRequest(ref cause) => cause,
+            ListAvailableZonesError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            ListAvailableZonesError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            ListAvailableZonesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAvailableZonesError {}
 /// Errors returned by ListHapgs
 #[derive(Debug, PartialEq)]
 pub enum ListHapgsError {
@@ -1164,18 +1116,14 @@ impl ListHapgsError {
 }
 impl fmt::Display for ListHapgsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHapgsError {
-    fn description(&self) -> &str {
         match *self {
-            ListHapgsError::CloudHsmInternal(ref cause) => cause,
-            ListHapgsError::CloudHsmService(ref cause) => cause,
-            ListHapgsError::InvalidRequest(ref cause) => cause,
+            ListHapgsError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            ListHapgsError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            ListHapgsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHapgsError {}
 /// Errors returned by ListHsms
 #[derive(Debug, PartialEq)]
 pub enum ListHsmsError {
@@ -1209,18 +1157,14 @@ impl ListHsmsError {
 }
 impl fmt::Display for ListHsmsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHsmsError {
-    fn description(&self) -> &str {
         match *self {
-            ListHsmsError::CloudHsmInternal(ref cause) => cause,
-            ListHsmsError::CloudHsmService(ref cause) => cause,
-            ListHsmsError::InvalidRequest(ref cause) => cause,
+            ListHsmsError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            ListHsmsError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            ListHsmsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHsmsError {}
 /// Errors returned by ListLunaClients
 #[derive(Debug, PartialEq)]
 pub enum ListLunaClientsError {
@@ -1254,18 +1198,14 @@ impl ListLunaClientsError {
 }
 impl fmt::Display for ListLunaClientsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLunaClientsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLunaClientsError::CloudHsmInternal(ref cause) => cause,
-            ListLunaClientsError::CloudHsmService(ref cause) => cause,
-            ListLunaClientsError::InvalidRequest(ref cause) => cause,
+            ListLunaClientsError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            ListLunaClientsError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            ListLunaClientsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLunaClientsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1301,18 +1241,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::CloudHsmInternal(ref cause) => cause,
-            ListTagsForResourceError::CloudHsmService(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
+            ListTagsForResourceError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ModifyHapg
 #[derive(Debug, PartialEq)]
 pub enum ModifyHapgError {
@@ -1346,18 +1282,14 @@ impl ModifyHapgError {
 }
 impl fmt::Display for ModifyHapgError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyHapgError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyHapgError::CloudHsmInternal(ref cause) => cause,
-            ModifyHapgError::CloudHsmService(ref cause) => cause,
-            ModifyHapgError::InvalidRequest(ref cause) => cause,
+            ModifyHapgError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            ModifyHapgError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            ModifyHapgError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyHapgError {}
 /// Errors returned by ModifyHsm
 #[derive(Debug, PartialEq)]
 pub enum ModifyHsmError {
@@ -1391,18 +1323,14 @@ impl ModifyHsmError {
 }
 impl fmt::Display for ModifyHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyHsmError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyHsmError::CloudHsmInternal(ref cause) => cause,
-            ModifyHsmError::CloudHsmService(ref cause) => cause,
-            ModifyHsmError::InvalidRequest(ref cause) => cause,
+            ModifyHsmError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            ModifyHsmError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            ModifyHsmError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyHsmError {}
 /// Errors returned by ModifyLunaClient
 #[derive(Debug, PartialEq)]
 pub enum ModifyLunaClientError {
@@ -1426,16 +1354,12 @@ impl ModifyLunaClientError {
 }
 impl fmt::Display for ModifyLunaClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyLunaClientError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyLunaClientError::CloudHsmService(ref cause) => cause,
+            ModifyLunaClientError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyLunaClientError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -1475,18 +1399,14 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::CloudHsmInternal(ref cause) => cause,
-            RemoveTagsFromResourceError::CloudHsmService(ref cause) => cause,
-            RemoveTagsFromResourceError::InvalidRequest(ref cause) => cause,
+            RemoveTagsFromResourceError::CloudHsmInternal(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::CloudHsmService(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Trait representing the capabilities of the CloudHSM API. CloudHSM clients implement this trait.
 pub trait CloudHsm {
     /// <p>This is documentation for <b>AWS CloudHSM Classic</b>. For more information, see <a href="http://aws.amazon.com/cloudhsm/faqs-classic/">AWS CloudHSM Classic FAQs</a>, the <a href="http://docs.aws.amazon.com/cloudhsm/classic/userguide/">AWS CloudHSM Classic User Guide</a>, and the <a href="http://docs.aws.amazon.com/cloudhsm/classic/APIReference/">AWS CloudHSM Classic API Reference</a>.</p> <p> <b>For information about the current version of AWS CloudHSM</b>, see <a href="http://aws.amazon.com/cloudhsm/">AWS CloudHSM</a>, the <a href="http://docs.aws.amazon.com/cloudhsm/latest/userguide/">AWS CloudHSM User Guide</a>, and the <a href="http://docs.aws.amazon.com/cloudhsm/latest/APIReference/">AWS CloudHSM API Reference</a>.</p> <p>Adds or overwrites one or more tags for the specified AWS CloudHSM resource.</p> <p>Each tag consists of a key and a value. Tag keys must be unique to each resource.</p>

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -543,20 +543,16 @@ impl CopyBackupToRegionError {
 }
 impl fmt::Display for CopyBackupToRegionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyBackupToRegionError {
-    fn description(&self) -> &str {
         match *self {
-            CopyBackupToRegionError::CloudHsmAccessDenied(ref cause) => cause,
-            CopyBackupToRegionError::CloudHsmInternalFailure(ref cause) => cause,
-            CopyBackupToRegionError::CloudHsmInvalidRequest(ref cause) => cause,
-            CopyBackupToRegionError::CloudHsmResourceNotFound(ref cause) => cause,
-            CopyBackupToRegionError::CloudHsmService(ref cause) => cause,
+            CopyBackupToRegionError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            CopyBackupToRegionError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            CopyBackupToRegionError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            CopyBackupToRegionError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CopyBackupToRegionError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopyBackupToRegionError {}
 /// Errors returned by CreateCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterError {
@@ -606,20 +602,16 @@ impl CreateClusterError {
 }
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterError::CloudHsmAccessDenied(ref cause) => cause,
-            CreateClusterError::CloudHsmInternalFailure(ref cause) => cause,
-            CreateClusterError::CloudHsmInvalidRequest(ref cause) => cause,
-            CreateClusterError::CloudHsmResourceNotFound(ref cause) => cause,
-            CreateClusterError::CloudHsmService(ref cause) => cause,
+            CreateClusterError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterError {}
 /// Errors returned by CreateHsm
 #[derive(Debug, PartialEq)]
 pub enum CreateHsmError {
@@ -663,20 +655,16 @@ impl CreateHsmError {
 }
 impl fmt::Display for CreateHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHsmError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHsmError::CloudHsmAccessDenied(ref cause) => cause,
-            CreateHsmError::CloudHsmInternalFailure(ref cause) => cause,
-            CreateHsmError::CloudHsmInvalidRequest(ref cause) => cause,
-            CreateHsmError::CloudHsmResourceNotFound(ref cause) => cause,
-            CreateHsmError::CloudHsmService(ref cause) => cause,
+            CreateHsmError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateHsmError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateHsmError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateHsmError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateHsmError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHsmError {}
 /// Errors returned by DeleteBackup
 #[derive(Debug, PartialEq)]
 pub enum DeleteBackupError {
@@ -724,20 +712,16 @@ impl DeleteBackupError {
 }
 impl fmt::Display for DeleteBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBackupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBackupError::CloudHsmAccessDenied(ref cause) => cause,
-            DeleteBackupError::CloudHsmInternalFailure(ref cause) => cause,
-            DeleteBackupError::CloudHsmInvalidRequest(ref cause) => cause,
-            DeleteBackupError::CloudHsmResourceNotFound(ref cause) => cause,
-            DeleteBackupError::CloudHsmService(ref cause) => cause,
+            DeleteBackupError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBackupError {}
 /// Errors returned by DeleteCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterError {
@@ -787,20 +771,16 @@ impl DeleteClusterError {
 }
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterError::CloudHsmAccessDenied(ref cause) => cause,
-            DeleteClusterError::CloudHsmInternalFailure(ref cause) => cause,
-            DeleteClusterError::CloudHsmInvalidRequest(ref cause) => cause,
-            DeleteClusterError::CloudHsmResourceNotFound(ref cause) => cause,
-            DeleteClusterError::CloudHsmService(ref cause) => cause,
+            DeleteClusterError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClusterError {}
 /// Errors returned by DeleteHsm
 #[derive(Debug, PartialEq)]
 pub enum DeleteHsmError {
@@ -844,20 +824,16 @@ impl DeleteHsmError {
 }
 impl fmt::Display for DeleteHsmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHsmError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHsmError::CloudHsmAccessDenied(ref cause) => cause,
-            DeleteHsmError::CloudHsmInternalFailure(ref cause) => cause,
-            DeleteHsmError::CloudHsmInvalidRequest(ref cause) => cause,
-            DeleteHsmError::CloudHsmResourceNotFound(ref cause) => cause,
-            DeleteHsmError::CloudHsmService(ref cause) => cause,
+            DeleteHsmError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteHsmError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteHsmError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteHsmError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteHsmError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteHsmError {}
 /// Errors returned by DescribeBackups
 #[derive(Debug, PartialEq)]
 pub enum DescribeBackupsError {
@@ -909,20 +885,16 @@ impl DescribeBackupsError {
 }
 impl fmt::Display for DescribeBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBackupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBackupsError::CloudHsmAccessDenied(ref cause) => cause,
-            DescribeBackupsError::CloudHsmInternalFailure(ref cause) => cause,
-            DescribeBackupsError::CloudHsmInvalidRequest(ref cause) => cause,
-            DescribeBackupsError::CloudHsmResourceNotFound(ref cause) => cause,
-            DescribeBackupsError::CloudHsmService(ref cause) => cause,
+            DescribeBackupsError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBackupsError {}
 /// Errors returned by DescribeClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeClustersError {
@@ -967,19 +939,15 @@ impl DescribeClustersError {
 }
 impl fmt::Display for DescribeClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClustersError::CloudHsmAccessDenied(ref cause) => cause,
-            DescribeClustersError::CloudHsmInternalFailure(ref cause) => cause,
-            DescribeClustersError::CloudHsmInvalidRequest(ref cause) => cause,
-            DescribeClustersError::CloudHsmService(ref cause) => cause,
+            DescribeClustersError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClustersError {}
 /// Errors returned by InitializeCluster
 #[derive(Debug, PartialEq)]
 pub enum InitializeClusterError {
@@ -1031,20 +999,16 @@ impl InitializeClusterError {
 }
 impl fmt::Display for InitializeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitializeClusterError {
-    fn description(&self) -> &str {
         match *self {
-            InitializeClusterError::CloudHsmAccessDenied(ref cause) => cause,
-            InitializeClusterError::CloudHsmInternalFailure(ref cause) => cause,
-            InitializeClusterError::CloudHsmInvalidRequest(ref cause) => cause,
-            InitializeClusterError::CloudHsmResourceNotFound(ref cause) => cause,
-            InitializeClusterError::CloudHsmService(ref cause) => cause,
+            InitializeClusterError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            InitializeClusterError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            InitializeClusterError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            InitializeClusterError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            InitializeClusterError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InitializeClusterError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -1088,20 +1052,16 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::CloudHsmAccessDenied(ref cause) => cause,
-            ListTagsError::CloudHsmInternalFailure(ref cause) => cause,
-            ListTagsError::CloudHsmInvalidRequest(ref cause) => cause,
-            ListTagsError::CloudHsmResourceNotFound(ref cause) => cause,
-            ListTagsError::CloudHsmService(ref cause) => cause,
+            ListTagsError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTagsError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by RestoreBackup
 #[derive(Debug, PartialEq)]
 pub enum RestoreBackupError {
@@ -1151,20 +1111,16 @@ impl RestoreBackupError {
 }
 impl fmt::Display for RestoreBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreBackupError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreBackupError::CloudHsmAccessDenied(ref cause) => cause,
-            RestoreBackupError::CloudHsmInternalFailure(ref cause) => cause,
-            RestoreBackupError::CloudHsmInvalidRequest(ref cause) => cause,
-            RestoreBackupError::CloudHsmResourceNotFound(ref cause) => cause,
-            RestoreBackupError::CloudHsmService(ref cause) => cause,
+            RestoreBackupError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            RestoreBackupError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            RestoreBackupError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            RestoreBackupError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RestoreBackupError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreBackupError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1210,20 +1166,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::CloudHsmAccessDenied(ref cause) => cause,
-            TagResourceError::CloudHsmInternalFailure(ref cause) => cause,
-            TagResourceError::CloudHsmInvalidRequest(ref cause) => cause,
-            TagResourceError::CloudHsmResourceNotFound(ref cause) => cause,
-            TagResourceError::CloudHsmService(ref cause) => cause,
+            TagResourceError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1273,20 +1225,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::CloudHsmAccessDenied(ref cause) => cause,
-            UntagResourceError::CloudHsmInternalFailure(ref cause) => cause,
-            UntagResourceError::CloudHsmInvalidRequest(ref cause) => cause,
-            UntagResourceError::CloudHsmResourceNotFound(ref cause) => cause,
-            UntagResourceError::CloudHsmService(ref cause) => cause,
+            UntagResourceError::CloudHsmAccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::CloudHsmInternalFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::CloudHsmInvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::CloudHsmResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::CloudHsmService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the CloudHSM V2 API. CloudHSM V2 clients implement this trait.
 pub trait CloudHsmv2 {
     /// <p>Copy an AWS CloudHSM cluster backup to a different region.</p>

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -4043,18 +4043,14 @@ impl BuildSuggestersError {
 }
 impl fmt::Display for BuildSuggestersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BuildSuggestersError {
-    fn description(&self) -> &str {
         match *self {
-            BuildSuggestersError::Base(ref cause) => cause,
-            BuildSuggestersError::Internal(ref cause) => cause,
-            BuildSuggestersError::ResourceNotFound(ref cause) => cause,
+            BuildSuggestersError::Base(ref cause) => write!(f, "{}", cause),
+            BuildSuggestersError::Internal(ref cause) => write!(f, "{}", cause),
+            BuildSuggestersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BuildSuggestersError {}
 /// Errors returned by CreateDomain
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainError {
@@ -4104,18 +4100,14 @@ impl CreateDomainError {
 }
 impl fmt::Display for CreateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainError::Base(ref cause) => cause,
-            CreateDomainError::Internal(ref cause) => cause,
-            CreateDomainError::LimitExceeded(ref cause) => cause,
+            CreateDomainError::Base(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainError {}
 /// Errors returned by DefineAnalysisScheme
 #[derive(Debug, PartialEq)]
 pub enum DefineAnalysisSchemeError {
@@ -4181,20 +4173,16 @@ impl DefineAnalysisSchemeError {
 }
 impl fmt::Display for DefineAnalysisSchemeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DefineAnalysisSchemeError {
-    fn description(&self) -> &str {
         match *self {
-            DefineAnalysisSchemeError::Base(ref cause) => cause,
-            DefineAnalysisSchemeError::Internal(ref cause) => cause,
-            DefineAnalysisSchemeError::InvalidType(ref cause) => cause,
-            DefineAnalysisSchemeError::LimitExceeded(ref cause) => cause,
-            DefineAnalysisSchemeError::ResourceNotFound(ref cause) => cause,
+            DefineAnalysisSchemeError::Base(ref cause) => write!(f, "{}", cause),
+            DefineAnalysisSchemeError::Internal(ref cause) => write!(f, "{}", cause),
+            DefineAnalysisSchemeError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DefineAnalysisSchemeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DefineAnalysisSchemeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DefineAnalysisSchemeError {}
 /// Errors returned by DefineExpression
 #[derive(Debug, PartialEq)]
 pub enum DefineExpressionError {
@@ -4260,20 +4248,16 @@ impl DefineExpressionError {
 }
 impl fmt::Display for DefineExpressionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DefineExpressionError {
-    fn description(&self) -> &str {
         match *self {
-            DefineExpressionError::Base(ref cause) => cause,
-            DefineExpressionError::Internal(ref cause) => cause,
-            DefineExpressionError::InvalidType(ref cause) => cause,
-            DefineExpressionError::LimitExceeded(ref cause) => cause,
-            DefineExpressionError::ResourceNotFound(ref cause) => cause,
+            DefineExpressionError::Base(ref cause) => write!(f, "{}", cause),
+            DefineExpressionError::Internal(ref cause) => write!(f, "{}", cause),
+            DefineExpressionError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DefineExpressionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DefineExpressionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DefineExpressionError {}
 /// Errors returned by DefineIndexField
 #[derive(Debug, PartialEq)]
 pub enum DefineIndexFieldError {
@@ -4339,20 +4323,16 @@ impl DefineIndexFieldError {
 }
 impl fmt::Display for DefineIndexFieldError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DefineIndexFieldError {
-    fn description(&self) -> &str {
         match *self {
-            DefineIndexFieldError::Base(ref cause) => cause,
-            DefineIndexFieldError::Internal(ref cause) => cause,
-            DefineIndexFieldError::InvalidType(ref cause) => cause,
-            DefineIndexFieldError::LimitExceeded(ref cause) => cause,
-            DefineIndexFieldError::ResourceNotFound(ref cause) => cause,
+            DefineIndexFieldError::Base(ref cause) => write!(f, "{}", cause),
+            DefineIndexFieldError::Internal(ref cause) => write!(f, "{}", cause),
+            DefineIndexFieldError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DefineIndexFieldError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DefineIndexFieldError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DefineIndexFieldError {}
 /// Errors returned by DefineSuggester
 #[derive(Debug, PartialEq)]
 pub enum DefineSuggesterError {
@@ -4418,20 +4398,16 @@ impl DefineSuggesterError {
 }
 impl fmt::Display for DefineSuggesterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DefineSuggesterError {
-    fn description(&self) -> &str {
         match *self {
-            DefineSuggesterError::Base(ref cause) => cause,
-            DefineSuggesterError::Internal(ref cause) => cause,
-            DefineSuggesterError::InvalidType(ref cause) => cause,
-            DefineSuggesterError::LimitExceeded(ref cause) => cause,
-            DefineSuggesterError::ResourceNotFound(ref cause) => cause,
+            DefineSuggesterError::Base(ref cause) => write!(f, "{}", cause),
+            DefineSuggesterError::Internal(ref cause) => write!(f, "{}", cause),
+            DefineSuggesterError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DefineSuggesterError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DefineSuggesterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DefineSuggesterError {}
 /// Errors returned by DeleteAnalysisScheme
 #[derive(Debug, PartialEq)]
 pub enum DeleteAnalysisSchemeError {
@@ -4490,19 +4466,15 @@ impl DeleteAnalysisSchemeError {
 }
 impl fmt::Display for DeleteAnalysisSchemeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAnalysisSchemeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAnalysisSchemeError::Base(ref cause) => cause,
-            DeleteAnalysisSchemeError::Internal(ref cause) => cause,
-            DeleteAnalysisSchemeError::InvalidType(ref cause) => cause,
-            DeleteAnalysisSchemeError::ResourceNotFound(ref cause) => cause,
+            DeleteAnalysisSchemeError::Base(ref cause) => write!(f, "{}", cause),
+            DeleteAnalysisSchemeError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteAnalysisSchemeError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DeleteAnalysisSchemeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAnalysisSchemeError {}
 /// Errors returned by DeleteDomain
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainError {
@@ -4545,17 +4517,13 @@ impl DeleteDomainError {
 }
 impl fmt::Display for DeleteDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainError::Base(ref cause) => cause,
-            DeleteDomainError::Internal(ref cause) => cause,
+            DeleteDomainError::Base(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainError {}
 /// Errors returned by DeleteExpression
 #[derive(Debug, PartialEq)]
 pub enum DeleteExpressionError {
@@ -4614,19 +4582,15 @@ impl DeleteExpressionError {
 }
 impl fmt::Display for DeleteExpressionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteExpressionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteExpressionError::Base(ref cause) => cause,
-            DeleteExpressionError::Internal(ref cause) => cause,
-            DeleteExpressionError::InvalidType(ref cause) => cause,
-            DeleteExpressionError::ResourceNotFound(ref cause) => cause,
+            DeleteExpressionError::Base(ref cause) => write!(f, "{}", cause),
+            DeleteExpressionError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteExpressionError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DeleteExpressionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteExpressionError {}
 /// Errors returned by DeleteIndexField
 #[derive(Debug, PartialEq)]
 pub enum DeleteIndexFieldError {
@@ -4685,19 +4649,15 @@ impl DeleteIndexFieldError {
 }
 impl fmt::Display for DeleteIndexFieldError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIndexFieldError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIndexFieldError::Base(ref cause) => cause,
-            DeleteIndexFieldError::Internal(ref cause) => cause,
-            DeleteIndexFieldError::InvalidType(ref cause) => cause,
-            DeleteIndexFieldError::ResourceNotFound(ref cause) => cause,
+            DeleteIndexFieldError::Base(ref cause) => write!(f, "{}", cause),
+            DeleteIndexFieldError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteIndexFieldError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DeleteIndexFieldError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIndexFieldError {}
 /// Errors returned by DeleteSuggester
 #[derive(Debug, PartialEq)]
 pub enum DeleteSuggesterError {
@@ -4756,19 +4716,15 @@ impl DeleteSuggesterError {
 }
 impl fmt::Display for DeleteSuggesterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSuggesterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSuggesterError::Base(ref cause) => cause,
-            DeleteSuggesterError::Internal(ref cause) => cause,
-            DeleteSuggesterError::InvalidType(ref cause) => cause,
-            DeleteSuggesterError::ResourceNotFound(ref cause) => cause,
+            DeleteSuggesterError::Base(ref cause) => write!(f, "{}", cause),
+            DeleteSuggesterError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteSuggesterError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DeleteSuggesterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSuggesterError {}
 /// Errors returned by DescribeAnalysisSchemes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAnalysisSchemesError {
@@ -4820,18 +4776,14 @@ impl DescribeAnalysisSchemesError {
 }
 impl fmt::Display for DescribeAnalysisSchemesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAnalysisSchemesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAnalysisSchemesError::Base(ref cause) => cause,
-            DescribeAnalysisSchemesError::Internal(ref cause) => cause,
-            DescribeAnalysisSchemesError::ResourceNotFound(ref cause) => cause,
+            DescribeAnalysisSchemesError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeAnalysisSchemesError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeAnalysisSchemesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAnalysisSchemesError {}
 /// Errors returned by DescribeAvailabilityOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeAvailabilityOptionsError {
@@ -4910,21 +4862,19 @@ impl DescribeAvailabilityOptionsError {
 }
 impl fmt::Display for DescribeAvailabilityOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAvailabilityOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAvailabilityOptionsError::Base(ref cause) => cause,
-            DescribeAvailabilityOptionsError::DisabledOperation(ref cause) => cause,
-            DescribeAvailabilityOptionsError::Internal(ref cause) => cause,
-            DescribeAvailabilityOptionsError::InvalidType(ref cause) => cause,
-            DescribeAvailabilityOptionsError::LimitExceeded(ref cause) => cause,
-            DescribeAvailabilityOptionsError::ResourceNotFound(ref cause) => cause,
+            DescribeAvailabilityOptionsError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeAvailabilityOptionsError::DisabledOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAvailabilityOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeAvailabilityOptionsError::InvalidType(ref cause) => write!(f, "{}", cause),
+            DescribeAvailabilityOptionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeAvailabilityOptionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAvailabilityOptionsError {}
 /// Errors returned by DescribeDomainEndpointOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeDomainEndpointOptionsError {
@@ -4996,20 +4946,20 @@ impl DescribeDomainEndpointOptionsError {
 }
 impl fmt::Display for DescribeDomainEndpointOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDomainEndpointOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDomainEndpointOptionsError::Base(ref cause) => cause,
-            DescribeDomainEndpointOptionsError::DisabledOperation(ref cause) => cause,
-            DescribeDomainEndpointOptionsError::Internal(ref cause) => cause,
-            DescribeDomainEndpointOptionsError::LimitExceeded(ref cause) => cause,
-            DescribeDomainEndpointOptionsError::ResourceNotFound(ref cause) => cause,
+            DescribeDomainEndpointOptionsError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeDomainEndpointOptionsError::DisabledOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDomainEndpointOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeDomainEndpointOptionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeDomainEndpointOptionsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDomainEndpointOptionsError {}
 /// Errors returned by DescribeDomains
 #[derive(Debug, PartialEq)]
 pub enum DescribeDomainsError {
@@ -5054,17 +5004,13 @@ impl DescribeDomainsError {
 }
 impl fmt::Display for DescribeDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDomainsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDomainsError::Base(ref cause) => cause,
-            DescribeDomainsError::Internal(ref cause) => cause,
+            DescribeDomainsError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeDomainsError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDomainsError {}
 /// Errors returned by DescribeExpressions
 #[derive(Debug, PartialEq)]
 pub enum DescribeExpressionsError {
@@ -5116,18 +5062,14 @@ impl DescribeExpressionsError {
 }
 impl fmt::Display for DescribeExpressionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeExpressionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeExpressionsError::Base(ref cause) => cause,
-            DescribeExpressionsError::Internal(ref cause) => cause,
-            DescribeExpressionsError::ResourceNotFound(ref cause) => cause,
+            DescribeExpressionsError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeExpressionsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeExpressionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeExpressionsError {}
 /// Errors returned by DescribeIndexFields
 #[derive(Debug, PartialEq)]
 pub enum DescribeIndexFieldsError {
@@ -5179,18 +5121,14 @@ impl DescribeIndexFieldsError {
 }
 impl fmt::Display for DescribeIndexFieldsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIndexFieldsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIndexFieldsError::Base(ref cause) => cause,
-            DescribeIndexFieldsError::Internal(ref cause) => cause,
-            DescribeIndexFieldsError::ResourceNotFound(ref cause) => cause,
+            DescribeIndexFieldsError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeIndexFieldsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeIndexFieldsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIndexFieldsError {}
 /// Errors returned by DescribeScalingParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingParametersError {
@@ -5242,18 +5180,14 @@ impl DescribeScalingParametersError {
 }
 impl fmt::Display for DescribeScalingParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingParametersError::Base(ref cause) => cause,
-            DescribeScalingParametersError::Internal(ref cause) => cause,
-            DescribeScalingParametersError::ResourceNotFound(ref cause) => cause,
+            DescribeScalingParametersError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeScalingParametersError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeScalingParametersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScalingParametersError {}
 /// Errors returned by DescribeServiceAccessPolicies
 #[derive(Debug, PartialEq)]
 pub enum DescribeServiceAccessPoliciesError {
@@ -5309,18 +5243,16 @@ impl DescribeServiceAccessPoliciesError {
 }
 impl fmt::Display for DescribeServiceAccessPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServiceAccessPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServiceAccessPoliciesError::Base(ref cause) => cause,
-            DescribeServiceAccessPoliciesError::Internal(ref cause) => cause,
-            DescribeServiceAccessPoliciesError::ResourceNotFound(ref cause) => cause,
+            DescribeServiceAccessPoliciesError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeServiceAccessPoliciesError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeServiceAccessPoliciesError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeServiceAccessPoliciesError {}
 /// Errors returned by DescribeSuggesters
 #[derive(Debug, PartialEq)]
 pub enum DescribeSuggestersError {
@@ -5372,18 +5304,14 @@ impl DescribeSuggestersError {
 }
 impl fmt::Display for DescribeSuggestersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSuggestersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSuggestersError::Base(ref cause) => cause,
-            DescribeSuggestersError::Internal(ref cause) => cause,
-            DescribeSuggestersError::ResourceNotFound(ref cause) => cause,
+            DescribeSuggestersError::Base(ref cause) => write!(f, "{}", cause),
+            DescribeSuggestersError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeSuggestersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSuggestersError {}
 /// Errors returned by IndexDocuments
 #[derive(Debug, PartialEq)]
 pub enum IndexDocumentsError {
@@ -5435,18 +5363,14 @@ impl IndexDocumentsError {
 }
 impl fmt::Display for IndexDocumentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for IndexDocumentsError {
-    fn description(&self) -> &str {
         match *self {
-            IndexDocumentsError::Base(ref cause) => cause,
-            IndexDocumentsError::Internal(ref cause) => cause,
-            IndexDocumentsError::ResourceNotFound(ref cause) => cause,
+            IndexDocumentsError::Base(ref cause) => write!(f, "{}", cause),
+            IndexDocumentsError::Internal(ref cause) => write!(f, "{}", cause),
+            IndexDocumentsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for IndexDocumentsError {}
 /// Errors returned by ListDomainNames
 #[derive(Debug, PartialEq)]
 pub enum ListDomainNamesError {
@@ -5484,16 +5408,12 @@ impl ListDomainNamesError {
 }
 impl fmt::Display for ListDomainNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainNamesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDomainNamesError::Base(ref cause) => cause,
+            ListDomainNamesError::Base(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDomainNamesError {}
 /// Errors returned by UpdateAvailabilityOptions
 #[derive(Debug, PartialEq)]
 pub enum UpdateAvailabilityOptionsError {
@@ -5573,22 +5493,18 @@ impl UpdateAvailabilityOptionsError {
 }
 impl fmt::Display for UpdateAvailabilityOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAvailabilityOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAvailabilityOptionsError::Base(ref cause) => cause,
-            UpdateAvailabilityOptionsError::DisabledOperation(ref cause) => cause,
-            UpdateAvailabilityOptionsError::Internal(ref cause) => cause,
-            UpdateAvailabilityOptionsError::InvalidType(ref cause) => cause,
-            UpdateAvailabilityOptionsError::LimitExceeded(ref cause) => cause,
-            UpdateAvailabilityOptionsError::ResourceNotFound(ref cause) => cause,
-            UpdateAvailabilityOptionsError::Validation(ref cause) => cause,
+            UpdateAvailabilityOptionsError::Base(ref cause) => write!(f, "{}", cause),
+            UpdateAvailabilityOptionsError::DisabledOperation(ref cause) => write!(f, "{}", cause),
+            UpdateAvailabilityOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateAvailabilityOptionsError::InvalidType(ref cause) => write!(f, "{}", cause),
+            UpdateAvailabilityOptionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateAvailabilityOptionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAvailabilityOptionsError::Validation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAvailabilityOptionsError {}
 /// Errors returned by UpdateDomainEndpointOptions
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainEndpointOptionsError {
@@ -5674,22 +5590,20 @@ impl UpdateDomainEndpointOptionsError {
 }
 impl fmt::Display for UpdateDomainEndpointOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainEndpointOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainEndpointOptionsError::Base(ref cause) => cause,
-            UpdateDomainEndpointOptionsError::DisabledOperation(ref cause) => cause,
-            UpdateDomainEndpointOptionsError::Internal(ref cause) => cause,
-            UpdateDomainEndpointOptionsError::InvalidType(ref cause) => cause,
-            UpdateDomainEndpointOptionsError::LimitExceeded(ref cause) => cause,
-            UpdateDomainEndpointOptionsError::ResourceNotFound(ref cause) => cause,
-            UpdateDomainEndpointOptionsError::Validation(ref cause) => cause,
+            UpdateDomainEndpointOptionsError::Base(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEndpointOptionsError::DisabledOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDomainEndpointOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEndpointOptionsError::InvalidType(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEndpointOptionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEndpointOptionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEndpointOptionsError::Validation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainEndpointOptionsError {}
 /// Errors returned by UpdateScalingParameters
 #[derive(Debug, PartialEq)]
 pub enum UpdateScalingParametersError {
@@ -5755,20 +5669,16 @@ impl UpdateScalingParametersError {
 }
 impl fmt::Display for UpdateScalingParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateScalingParametersError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateScalingParametersError::Base(ref cause) => cause,
-            UpdateScalingParametersError::Internal(ref cause) => cause,
-            UpdateScalingParametersError::InvalidType(ref cause) => cause,
-            UpdateScalingParametersError::LimitExceeded(ref cause) => cause,
-            UpdateScalingParametersError::ResourceNotFound(ref cause) => cause,
+            UpdateScalingParametersError::Base(ref cause) => write!(f, "{}", cause),
+            UpdateScalingParametersError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateScalingParametersError::InvalidType(ref cause) => write!(f, "{}", cause),
+            UpdateScalingParametersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateScalingParametersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateScalingParametersError {}
 /// Errors returned by UpdateServiceAccessPolicies
 #[derive(Debug, PartialEq)]
 pub enum UpdateServiceAccessPoliciesError {
@@ -5838,20 +5748,16 @@ impl UpdateServiceAccessPoliciesError {
 }
 impl fmt::Display for UpdateServiceAccessPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServiceAccessPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServiceAccessPoliciesError::Base(ref cause) => cause,
-            UpdateServiceAccessPoliciesError::Internal(ref cause) => cause,
-            UpdateServiceAccessPoliciesError::InvalidType(ref cause) => cause,
-            UpdateServiceAccessPoliciesError::LimitExceeded(ref cause) => cause,
-            UpdateServiceAccessPoliciesError::ResourceNotFound(ref cause) => cause,
+            UpdateServiceAccessPoliciesError::Base(ref cause) => write!(f, "{}", cause),
+            UpdateServiceAccessPoliciesError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateServiceAccessPoliciesError::InvalidType(ref cause) => write!(f, "{}", cause),
+            UpdateServiceAccessPoliciesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateServiceAccessPoliciesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServiceAccessPoliciesError {}
 /// Trait representing the capabilities of the Amazon CloudSearch API. Amazon CloudSearch clients implement this trait.
 pub trait CloudSearch {
     /// <p>Indexes the search suggestions. For more information, see <a href="http://docs.aws.amazon.com/cloudsearch/latest/developerguide/getting-suggestions.html#configuring-suggesters">Configuring Suggesters</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -373,16 +373,12 @@ impl SearchError {
 }
 impl fmt::Display for SearchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchError {
-    fn description(&self) -> &str {
         match *self {
-            SearchError::Search(ref cause) => cause,
+            SearchError::Search(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchError {}
 /// Errors returned by Suggest
 #[derive(Debug, PartialEq)]
 pub enum SuggestError {
@@ -404,16 +400,12 @@ impl SuggestError {
 }
 impl fmt::Display for SuggestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SuggestError {
-    fn description(&self) -> &str {
         match *self {
-            SuggestError::Search(ref cause) => cause,
+            SuggestError::Search(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SuggestError {}
 /// Errors returned by UploadDocuments
 #[derive(Debug, PartialEq)]
 pub enum UploadDocumentsError {
@@ -437,16 +429,12 @@ impl UploadDocumentsError {
 }
 impl fmt::Display for UploadDocumentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadDocumentsError {
-    fn description(&self) -> &str {
         match *self {
-            UploadDocumentsError::DocumentService(ref cause) => cause,
+            UploadDocumentsError::DocumentService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UploadDocumentsError {}
 /// Trait representing the capabilities of the Amazon CloudSearch Domain API. Amazon CloudSearch Domain clients implement this trait.
 pub trait CloudSearchDomain {
     /// <p>Retrieves a list of documents that match the specified search criteria. How you specify the search criteria depends on which query parser you use. Amazon CloudSearch supports four query parsers:</p> <ul> <li><code>simple</code>: search all <code>text</code> and <code>text-array</code> fields for the specified string. Search for phrases, individual terms, and prefixes. </li> <li><code>structured</code>: search specific fields, construct compound queries using Boolean operators, and use advanced features such as term boosting and proximity searching.</li> <li><code>lucene</code>: specify search criteria using the Apache Lucene query parser syntax.</li> <li><code>dismax</code>: specify search criteria using the simplified subset of the Apache Lucene query parser syntax defined by the DisMax query parser.</li> </ul> <p>For more information, see <a href="http://docs.aws.amazon.com/cloudsearch/latest/developerguide/searching.html">Searching Your Data</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p> <p>The endpoint for submitting <code>Search</code> requests is domain-specific. You submit search requests to a domain's search endpoint. To get the search endpoint for your domain, use the Amazon CloudSearch configuration service <code>DescribeDomains</code> action. A domain's endpoints are also displayed on the domain dashboard in the Amazon CloudSearch console. </p>

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -941,24 +941,20 @@ impl AddTagsError {
 }
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsError::CloudTrailARNInvalid(ref cause) => cause,
-            AddTagsError::InvalidTagParameter(ref cause) => cause,
-            AddTagsError::InvalidTrailName(ref cause) => cause,
-            AddTagsError::NotOrganizationMasterAccount(ref cause) => cause,
-            AddTagsError::OperationNotPermitted(ref cause) => cause,
-            AddTagsError::ResourceNotFound(ref cause) => cause,
-            AddTagsError::ResourceTypeNotSupported(ref cause) => cause,
-            AddTagsError::TagsLimitExceeded(ref cause) => cause,
-            AddTagsError::UnsupportedOperation(ref cause) => cause,
+            AddTagsError::CloudTrailARNInvalid(ref cause) => write!(f, "{}", cause),
+            AddTagsError::InvalidTagParameter(ref cause) => write!(f, "{}", cause),
+            AddTagsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            AddTagsError::NotOrganizationMasterAccount(ref cause) => write!(f, "{}", cause),
+            AddTagsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            AddTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddTagsError::ResourceTypeNotSupported(ref cause) => write!(f, "{}", cause),
+            AddTagsError::TagsLimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddTagsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsError {}
 /// Errors returned by CreateTrail
 #[derive(Debug, PartialEq)]
 pub enum CreateTrailError {
@@ -1134,42 +1130,42 @@ impl CreateTrailError {
 }
 impl fmt::Display for CreateTrailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrailError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrailError::CloudTrailAccessNotEnabled(ref cause) => cause,
-            CreateTrailError::CloudWatchLogsDeliveryUnavailable(ref cause) => cause,
-            CreateTrailError::InsufficientDependencyServiceAccessPermission(ref cause) => cause,
-            CreateTrailError::InsufficientEncryptionPolicy(ref cause) => cause,
-            CreateTrailError::InsufficientS3BucketPolicy(ref cause) => cause,
-            CreateTrailError::InsufficientSnsTopicPolicy(ref cause) => cause,
-            CreateTrailError::InvalidCloudWatchLogsLogGroupArn(ref cause) => cause,
-            CreateTrailError::InvalidCloudWatchLogsRoleArn(ref cause) => cause,
-            CreateTrailError::InvalidKmsKeyId(ref cause) => cause,
-            CreateTrailError::InvalidParameterCombination(ref cause) => cause,
-            CreateTrailError::InvalidS3BucketName(ref cause) => cause,
-            CreateTrailError::InvalidS3Prefix(ref cause) => cause,
-            CreateTrailError::InvalidSnsTopicName(ref cause) => cause,
-            CreateTrailError::InvalidTagParameter(ref cause) => cause,
-            CreateTrailError::InvalidTrailName(ref cause) => cause,
-            CreateTrailError::Kms(ref cause) => cause,
-            CreateTrailError::KmsKeyDisabled(ref cause) => cause,
-            CreateTrailError::KmsKeyNotFound(ref cause) => cause,
-            CreateTrailError::MaximumNumberOfTrailsExceeded(ref cause) => cause,
-            CreateTrailError::NotOrganizationMasterAccount(ref cause) => cause,
-            CreateTrailError::OperationNotPermitted(ref cause) => cause,
-            CreateTrailError::OrganizationNotInAllFeaturesMode(ref cause) => cause,
-            CreateTrailError::OrganizationsNotInUse(ref cause) => cause,
-            CreateTrailError::S3BucketDoesNotExist(ref cause) => cause,
-            CreateTrailError::TrailAlreadyExists(ref cause) => cause,
-            CreateTrailError::TrailNotProvided(ref cause) => cause,
-            CreateTrailError::UnsupportedOperation(ref cause) => cause,
+            CreateTrailError::CloudTrailAccessNotEnabled(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::CloudWatchLogsDeliveryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTrailError::InsufficientDependencyServiceAccessPermission(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTrailError::InsufficientEncryptionPolicy(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InsufficientS3BucketPolicy(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InsufficientSnsTopicPolicy(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidCloudWatchLogsLogGroupArn(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidCloudWatchLogsRoleArn(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidKmsKeyId(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidS3BucketName(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidS3Prefix(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidSnsTopicName(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidTagParameter(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::Kms(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::KmsKeyDisabled(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::KmsKeyNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::MaximumNumberOfTrailsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::NotOrganizationMasterAccount(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::OrganizationNotInAllFeaturesMode(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::OrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::S3BucketDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::TrailAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::TrailNotProvided(ref cause) => write!(f, "{}", cause),
+            CreateTrailError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTrailError {}
 /// Errors returned by DeleteTrail
 #[derive(Debug, PartialEq)]
 pub enum DeleteTrailError {
@@ -1227,22 +1223,20 @@ impl DeleteTrailError {
 }
 impl fmt::Display for DeleteTrailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTrailError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTrailError::InsufficientDependencyServiceAccessPermission(ref cause) => cause,
-            DeleteTrailError::InvalidHomeRegion(ref cause) => cause,
-            DeleteTrailError::InvalidTrailName(ref cause) => cause,
-            DeleteTrailError::NotOrganizationMasterAccount(ref cause) => cause,
-            DeleteTrailError::OperationNotPermitted(ref cause) => cause,
-            DeleteTrailError::TrailNotFound(ref cause) => cause,
-            DeleteTrailError::UnsupportedOperation(ref cause) => cause,
+            DeleteTrailError::InsufficientDependencyServiceAccessPermission(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteTrailError::InvalidHomeRegion(ref cause) => write!(f, "{}", cause),
+            DeleteTrailError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            DeleteTrailError::NotOrganizationMasterAccount(ref cause) => write!(f, "{}", cause),
+            DeleteTrailError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteTrailError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTrailError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTrailError {}
 /// Errors returned by DescribeTrails
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrailsError {
@@ -1278,18 +1272,14 @@ impl DescribeTrailsError {
 }
 impl fmt::Display for DescribeTrailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrailsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrailsError::InvalidTrailName(ref cause) => cause,
-            DescribeTrailsError::OperationNotPermitted(ref cause) => cause,
-            DescribeTrailsError::UnsupportedOperation(ref cause) => cause,
+            DescribeTrailsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            DescribeTrailsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DescribeTrailsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTrailsError {}
 /// Errors returned by GetEventSelectors
 #[derive(Debug, PartialEq)]
 pub enum GetEventSelectorsError {
@@ -1332,19 +1322,15 @@ impl GetEventSelectorsError {
 }
 impl fmt::Display for GetEventSelectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEventSelectorsError {
-    fn description(&self) -> &str {
         match *self {
-            GetEventSelectorsError::InvalidTrailName(ref cause) => cause,
-            GetEventSelectorsError::OperationNotPermitted(ref cause) => cause,
-            GetEventSelectorsError::TrailNotFound(ref cause) => cause,
-            GetEventSelectorsError::UnsupportedOperation(ref cause) => cause,
+            GetEventSelectorsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            GetEventSelectorsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GetEventSelectorsError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            GetEventSelectorsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEventSelectorsError {}
 /// Errors returned by GetInsightSelectors
 #[derive(Debug, PartialEq)]
 pub enum GetInsightSelectorsError {
@@ -1396,20 +1382,16 @@ impl GetInsightSelectorsError {
 }
 impl fmt::Display for GetInsightSelectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInsightSelectorsError {
-    fn description(&self) -> &str {
         match *self {
-            GetInsightSelectorsError::InsightNotEnabled(ref cause) => cause,
-            GetInsightSelectorsError::InvalidTrailName(ref cause) => cause,
-            GetInsightSelectorsError::OperationNotPermitted(ref cause) => cause,
-            GetInsightSelectorsError::TrailNotFound(ref cause) => cause,
-            GetInsightSelectorsError::UnsupportedOperation(ref cause) => cause,
+            GetInsightSelectorsError::InsightNotEnabled(ref cause) => write!(f, "{}", cause),
+            GetInsightSelectorsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            GetInsightSelectorsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GetInsightSelectorsError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            GetInsightSelectorsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInsightSelectorsError {}
 /// Errors returned by GetTrail
 #[derive(Debug, PartialEq)]
 pub enum GetTrailError {
@@ -1448,19 +1430,15 @@ impl GetTrailError {
 }
 impl fmt::Display for GetTrailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTrailError {
-    fn description(&self) -> &str {
         match *self {
-            GetTrailError::InvalidTrailName(ref cause) => cause,
-            GetTrailError::OperationNotPermitted(ref cause) => cause,
-            GetTrailError::TrailNotFound(ref cause) => cause,
-            GetTrailError::UnsupportedOperation(ref cause) => cause,
+            GetTrailError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            GetTrailError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GetTrailError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            GetTrailError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTrailError {}
 /// Errors returned by GetTrailStatus
 #[derive(Debug, PartialEq)]
 pub enum GetTrailStatusError {
@@ -1501,19 +1479,15 @@ impl GetTrailStatusError {
 }
 impl fmt::Display for GetTrailStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTrailStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetTrailStatusError::InvalidTrailName(ref cause) => cause,
-            GetTrailStatusError::OperationNotPermitted(ref cause) => cause,
-            GetTrailStatusError::TrailNotFound(ref cause) => cause,
-            GetTrailStatusError::UnsupportedOperation(ref cause) => cause,
+            GetTrailStatusError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            GetTrailStatusError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GetTrailStatusError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            GetTrailStatusError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTrailStatusError {}
 /// Errors returned by ListPublicKeys
 #[derive(Debug, PartialEq)]
 pub enum ListPublicKeysError {
@@ -1554,19 +1528,15 @@ impl ListPublicKeysError {
 }
 impl fmt::Display for ListPublicKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPublicKeysError {
-    fn description(&self) -> &str {
         match *self {
-            ListPublicKeysError::InvalidTimeRange(ref cause) => cause,
-            ListPublicKeysError::InvalidToken(ref cause) => cause,
-            ListPublicKeysError::OperationNotPermitted(ref cause) => cause,
-            ListPublicKeysError::UnsupportedOperation(ref cause) => cause,
+            ListPublicKeysError::InvalidTimeRange(ref cause) => write!(f, "{}", cause),
+            ListPublicKeysError::InvalidToken(ref cause) => write!(f, "{}", cause),
+            ListPublicKeysError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ListPublicKeysError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPublicKeysError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -1620,22 +1590,18 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::CloudTrailARNInvalid(ref cause) => cause,
-            ListTagsError::InvalidToken(ref cause) => cause,
-            ListTagsError::InvalidTrailName(ref cause) => cause,
-            ListTagsError::OperationNotPermitted(ref cause) => cause,
-            ListTagsError::ResourceNotFound(ref cause) => cause,
-            ListTagsError::ResourceTypeNotSupported(ref cause) => cause,
-            ListTagsError::UnsupportedOperation(ref cause) => cause,
+            ListTagsError::CloudTrailARNInvalid(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InvalidToken(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            ListTagsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ListTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsError::ResourceTypeNotSupported(ref cause) => write!(f, "{}", cause),
+            ListTagsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by ListTrails
 #[derive(Debug, PartialEq)]
 pub enum ListTrailsError {
@@ -1664,17 +1630,13 @@ impl ListTrailsError {
 }
 impl fmt::Display for ListTrailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrailsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTrailsError::OperationNotPermitted(ref cause) => cause,
-            ListTrailsError::UnsupportedOperation(ref cause) => cause,
+            ListTrailsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ListTrailsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTrailsError {}
 /// Errors returned by LookupEvents
 #[derive(Debug, PartialEq)]
 pub enum LookupEventsError {
@@ -1730,22 +1692,18 @@ impl LookupEventsError {
 }
 impl fmt::Display for LookupEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for LookupEventsError {
-    fn description(&self) -> &str {
         match *self {
-            LookupEventsError::InvalidEventCategory(ref cause) => cause,
-            LookupEventsError::InvalidLookupAttributes(ref cause) => cause,
-            LookupEventsError::InvalidMaxResults(ref cause) => cause,
-            LookupEventsError::InvalidNextToken(ref cause) => cause,
-            LookupEventsError::InvalidTimeRange(ref cause) => cause,
-            LookupEventsError::OperationNotPermitted(ref cause) => cause,
-            LookupEventsError::UnsupportedOperation(ref cause) => cause,
+            LookupEventsError::InvalidEventCategory(ref cause) => write!(f, "{}", cause),
+            LookupEventsError::InvalidLookupAttributes(ref cause) => write!(f, "{}", cause),
+            LookupEventsError::InvalidMaxResults(ref cause) => write!(f, "{}", cause),
+            LookupEventsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            LookupEventsError::InvalidTimeRange(ref cause) => write!(f, "{}", cause),
+            LookupEventsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            LookupEventsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for LookupEventsError {}
 /// Errors returned by PutEventSelectors
 #[derive(Debug, PartialEq)]
 pub enum PutEventSelectorsError {
@@ -1816,25 +1774,23 @@ impl PutEventSelectorsError {
 }
 impl fmt::Display for PutEventSelectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutEventSelectorsError {
-    fn description(&self) -> &str {
         match *self {
             PutEventSelectorsError::InsufficientDependencyServiceAccessPermission(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            PutEventSelectorsError::InvalidEventSelectors(ref cause) => cause,
-            PutEventSelectorsError::InvalidHomeRegion(ref cause) => cause,
-            PutEventSelectorsError::InvalidTrailName(ref cause) => cause,
-            PutEventSelectorsError::NotOrganizationMasterAccount(ref cause) => cause,
-            PutEventSelectorsError::OperationNotPermitted(ref cause) => cause,
-            PutEventSelectorsError::TrailNotFound(ref cause) => cause,
-            PutEventSelectorsError::UnsupportedOperation(ref cause) => cause,
+            PutEventSelectorsError::InvalidEventSelectors(ref cause) => write!(f, "{}", cause),
+            PutEventSelectorsError::InvalidHomeRegion(ref cause) => write!(f, "{}", cause),
+            PutEventSelectorsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            PutEventSelectorsError::NotOrganizationMasterAccount(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutEventSelectorsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            PutEventSelectorsError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            PutEventSelectorsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutEventSelectorsError {}
 /// Errors returned by PutInsightSelectors
 #[derive(Debug, PartialEq)]
 pub enum PutInsightSelectorsError {
@@ -1914,24 +1870,26 @@ impl PutInsightSelectorsError {
 }
 impl fmt::Display for PutInsightSelectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutInsightSelectorsError {
-    fn description(&self) -> &str {
         match *self {
-            PutInsightSelectorsError::InsufficientEncryptionPolicy(ref cause) => cause,
-            PutInsightSelectorsError::InsufficientS3BucketPolicy(ref cause) => cause,
-            PutInsightSelectorsError::InvalidHomeRegion(ref cause) => cause,
-            PutInsightSelectorsError::InvalidInsightSelectors(ref cause) => cause,
-            PutInsightSelectorsError::InvalidTrailName(ref cause) => cause,
-            PutInsightSelectorsError::NotOrganizationMasterAccount(ref cause) => cause,
-            PutInsightSelectorsError::OperationNotPermitted(ref cause) => cause,
-            PutInsightSelectorsError::TrailNotFound(ref cause) => cause,
-            PutInsightSelectorsError::UnsupportedOperation(ref cause) => cause,
+            PutInsightSelectorsError::InsufficientEncryptionPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutInsightSelectorsError::InsufficientS3BucketPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutInsightSelectorsError::InvalidHomeRegion(ref cause) => write!(f, "{}", cause),
+            PutInsightSelectorsError::InvalidInsightSelectors(ref cause) => write!(f, "{}", cause),
+            PutInsightSelectorsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            PutInsightSelectorsError::NotOrganizationMasterAccount(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutInsightSelectorsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            PutInsightSelectorsError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            PutInsightSelectorsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutInsightSelectorsError {}
 /// Errors returned by RemoveTags
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsError {
@@ -1992,23 +1950,19 @@ impl RemoveTagsError {
 }
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsError::CloudTrailARNInvalid(ref cause) => cause,
-            RemoveTagsError::InvalidTagParameter(ref cause) => cause,
-            RemoveTagsError::InvalidTrailName(ref cause) => cause,
-            RemoveTagsError::NotOrganizationMasterAccount(ref cause) => cause,
-            RemoveTagsError::OperationNotPermitted(ref cause) => cause,
-            RemoveTagsError::ResourceNotFound(ref cause) => cause,
-            RemoveTagsError::ResourceTypeNotSupported(ref cause) => cause,
-            RemoveTagsError::UnsupportedOperation(ref cause) => cause,
+            RemoveTagsError::CloudTrailARNInvalid(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::InvalidTagParameter(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::NotOrganizationMasterAccount(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::ResourceTypeNotSupported(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsError {}
 /// Errors returned by StartLogging
 #[derive(Debug, PartialEq)]
 pub enum StartLoggingError {
@@ -2066,22 +2020,20 @@ impl StartLoggingError {
 }
 impl fmt::Display for StartLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartLoggingError {
-    fn description(&self) -> &str {
         match *self {
-            StartLoggingError::InsufficientDependencyServiceAccessPermission(ref cause) => cause,
-            StartLoggingError::InvalidHomeRegion(ref cause) => cause,
-            StartLoggingError::InvalidTrailName(ref cause) => cause,
-            StartLoggingError::NotOrganizationMasterAccount(ref cause) => cause,
-            StartLoggingError::OperationNotPermitted(ref cause) => cause,
-            StartLoggingError::TrailNotFound(ref cause) => cause,
-            StartLoggingError::UnsupportedOperation(ref cause) => cause,
+            StartLoggingError::InsufficientDependencyServiceAccessPermission(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartLoggingError::InvalidHomeRegion(ref cause) => write!(f, "{}", cause),
+            StartLoggingError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            StartLoggingError::NotOrganizationMasterAccount(ref cause) => write!(f, "{}", cause),
+            StartLoggingError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StartLoggingError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            StartLoggingError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartLoggingError {}
 /// Errors returned by StopLogging
 #[derive(Debug, PartialEq)]
 pub enum StopLoggingError {
@@ -2139,22 +2091,20 @@ impl StopLoggingError {
 }
 impl fmt::Display for StopLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopLoggingError {
-    fn description(&self) -> &str {
         match *self {
-            StopLoggingError::InsufficientDependencyServiceAccessPermission(ref cause) => cause,
-            StopLoggingError::InvalidHomeRegion(ref cause) => cause,
-            StopLoggingError::InvalidTrailName(ref cause) => cause,
-            StopLoggingError::NotOrganizationMasterAccount(ref cause) => cause,
-            StopLoggingError::OperationNotPermitted(ref cause) => cause,
-            StopLoggingError::TrailNotFound(ref cause) => cause,
-            StopLoggingError::UnsupportedOperation(ref cause) => cause,
+            StopLoggingError::InsufficientDependencyServiceAccessPermission(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopLoggingError::InvalidHomeRegion(ref cause) => write!(f, "{}", cause),
+            StopLoggingError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            StopLoggingError::NotOrganizationMasterAccount(ref cause) => write!(f, "{}", cause),
+            StopLoggingError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StopLoggingError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            StopLoggingError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopLoggingError {}
 /// Errors returned by UpdateTrail
 #[derive(Debug, PartialEq)]
 pub enum UpdateTrailError {
@@ -2328,42 +2278,42 @@ impl UpdateTrailError {
 }
 impl fmt::Display for UpdateTrailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTrailError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTrailError::CloudTrailAccessNotEnabled(ref cause) => cause,
-            UpdateTrailError::CloudWatchLogsDeliveryUnavailable(ref cause) => cause,
-            UpdateTrailError::InsufficientDependencyServiceAccessPermission(ref cause) => cause,
-            UpdateTrailError::InsufficientEncryptionPolicy(ref cause) => cause,
-            UpdateTrailError::InsufficientS3BucketPolicy(ref cause) => cause,
-            UpdateTrailError::InsufficientSnsTopicPolicy(ref cause) => cause,
-            UpdateTrailError::InvalidCloudWatchLogsLogGroupArn(ref cause) => cause,
-            UpdateTrailError::InvalidCloudWatchLogsRoleArn(ref cause) => cause,
-            UpdateTrailError::InvalidEventSelectors(ref cause) => cause,
-            UpdateTrailError::InvalidHomeRegion(ref cause) => cause,
-            UpdateTrailError::InvalidKmsKeyId(ref cause) => cause,
-            UpdateTrailError::InvalidParameterCombination(ref cause) => cause,
-            UpdateTrailError::InvalidS3BucketName(ref cause) => cause,
-            UpdateTrailError::InvalidS3Prefix(ref cause) => cause,
-            UpdateTrailError::InvalidSnsTopicName(ref cause) => cause,
-            UpdateTrailError::InvalidTrailName(ref cause) => cause,
-            UpdateTrailError::Kms(ref cause) => cause,
-            UpdateTrailError::KmsKeyDisabled(ref cause) => cause,
-            UpdateTrailError::KmsKeyNotFound(ref cause) => cause,
-            UpdateTrailError::NotOrganizationMasterAccount(ref cause) => cause,
-            UpdateTrailError::OperationNotPermitted(ref cause) => cause,
-            UpdateTrailError::OrganizationNotInAllFeaturesMode(ref cause) => cause,
-            UpdateTrailError::OrganizationsNotInUse(ref cause) => cause,
-            UpdateTrailError::S3BucketDoesNotExist(ref cause) => cause,
-            UpdateTrailError::TrailNotFound(ref cause) => cause,
-            UpdateTrailError::TrailNotProvided(ref cause) => cause,
-            UpdateTrailError::UnsupportedOperation(ref cause) => cause,
+            UpdateTrailError::CloudTrailAccessNotEnabled(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::CloudWatchLogsDeliveryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTrailError::InsufficientDependencyServiceAccessPermission(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTrailError::InsufficientEncryptionPolicy(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InsufficientS3BucketPolicy(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InsufficientSnsTopicPolicy(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidCloudWatchLogsLogGroupArn(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidCloudWatchLogsRoleArn(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidEventSelectors(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidHomeRegion(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidKmsKeyId(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidS3BucketName(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidS3Prefix(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidSnsTopicName(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::InvalidTrailName(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::Kms(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::KmsKeyDisabled(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::KmsKeyNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::NotOrganizationMasterAccount(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::OrganizationNotInAllFeaturesMode(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::OrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::S3BucketDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::TrailNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::TrailNotProvided(ref cause) => write!(f, "{}", cause),
+            UpdateTrailError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTrailError {}
 /// Trait representing the capabilities of the CloudTrail API. CloudTrail clients implement this trait.
 pub trait CloudTrail {
     /// <p>Adds one or more tags to a trail, up to a limit of 50. Overwrites an existing tag's value when a new value is specified for an existing tag key. Tag key names must be unique for a trail; you cannot have two keys with the same name but different values. If you specify a key without a value, the tag will be created with the specified key and a value of null. You can tag a trail that applies to all AWS Regions only from the Region in which the trail was created (also known as its home region).</p>

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -4453,16 +4453,12 @@ impl DeleteAlarmsError {
 }
 impl fmt::Display for DeleteAlarmsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAlarmsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAlarmsError::ResourceNotFound(ref cause) => cause,
+            DeleteAlarmsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAlarmsError {}
 /// Errors returned by DeleteAnomalyDetector
 #[derive(Debug, PartialEq)]
 pub enum DeleteAnomalyDetectorError {
@@ -4523,19 +4519,17 @@ impl DeleteAnomalyDetectorError {
 }
 impl fmt::Display for DeleteAnomalyDetectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAnomalyDetectorError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAnomalyDetectorError::InternalServiceFault(ref cause) => cause,
-            DeleteAnomalyDetectorError::InvalidParameterValue(ref cause) => cause,
-            DeleteAnomalyDetectorError::MissingRequiredParameter(ref cause) => cause,
-            DeleteAnomalyDetectorError::ResourceNotFound(ref cause) => cause,
+            DeleteAnomalyDetectorError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            DeleteAnomalyDetectorError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteAnomalyDetectorError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAnomalyDetectorError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAnomalyDetectorError {}
 /// Errors returned by DeleteDashboards
 #[derive(Debug, PartialEq)]
 pub enum DeleteDashboardsError {
@@ -4587,18 +4581,14 @@ impl DeleteDashboardsError {
 }
 impl fmt::Display for DeleteDashboardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDashboardsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDashboardsError::DashboardNotFoundError(ref cause) => cause,
-            DeleteDashboardsError::InternalServiceFault(ref cause) => cause,
-            DeleteDashboardsError::InvalidParameterValue(ref cause) => cause,
+            DeleteDashboardsError::DashboardNotFoundError(ref cause) => write!(f, "{}", cause),
+            DeleteDashboardsError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            DeleteDashboardsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDashboardsError {}
 /// Errors returned by DeleteInsightRules
 #[derive(Debug, PartialEq)]
 pub enum DeleteInsightRulesError {
@@ -4643,17 +4633,13 @@ impl DeleteInsightRulesError {
 }
 impl fmt::Display for DeleteInsightRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInsightRulesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInsightRulesError::InvalidParameterValue(ref cause) => cause,
-            DeleteInsightRulesError::MissingRequiredParameter(ref cause) => cause,
+            DeleteInsightRulesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteInsightRulesError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInsightRulesError {}
 /// Errors returned by DescribeAlarmHistory
 #[derive(Debug, PartialEq)]
 pub enum DescribeAlarmHistoryError {
@@ -4691,16 +4677,12 @@ impl DescribeAlarmHistoryError {
 }
 impl fmt::Display for DescribeAlarmHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAlarmHistoryError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAlarmHistoryError::InvalidNextToken(ref cause) => cause,
+            DescribeAlarmHistoryError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAlarmHistoryError {}
 /// Errors returned by DescribeAlarms
 #[derive(Debug, PartialEq)]
 pub enum DescribeAlarmsError {
@@ -4738,16 +4720,12 @@ impl DescribeAlarmsError {
 }
 impl fmt::Display for DescribeAlarmsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAlarmsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAlarmsError::InvalidNextToken(ref cause) => cause,
+            DescribeAlarmsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAlarmsError {}
 /// Errors returned by DescribeAlarmsForMetric
 #[derive(Debug, PartialEq)]
 pub enum DescribeAlarmsForMetricError {}
@@ -4777,14 +4755,10 @@ impl DescribeAlarmsForMetricError {
 }
 impl fmt::Display for DescribeAlarmsForMetricError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAlarmsForMetricError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAlarmsForMetricError {}
 /// Errors returned by DescribeAnomalyDetectors
 #[derive(Debug, PartialEq)]
 pub enum DescribeAnomalyDetectorsError {
@@ -4840,18 +4814,18 @@ impl DescribeAnomalyDetectorsError {
 }
 impl fmt::Display for DescribeAnomalyDetectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAnomalyDetectorsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAnomalyDetectorsError::InternalServiceFault(ref cause) => cause,
-            DescribeAnomalyDetectorsError::InvalidNextToken(ref cause) => cause,
-            DescribeAnomalyDetectorsError::InvalidParameterValue(ref cause) => cause,
+            DescribeAnomalyDetectorsError::InternalServiceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAnomalyDetectorsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeAnomalyDetectorsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAnomalyDetectorsError {}
 /// Errors returned by DescribeInsightRules
 #[derive(Debug, PartialEq)]
 pub enum DescribeInsightRulesError {
@@ -4889,16 +4863,12 @@ impl DescribeInsightRulesError {
 }
 impl fmt::Display for DescribeInsightRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInsightRulesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInsightRulesError::InvalidNextToken(ref cause) => cause,
+            DescribeInsightRulesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInsightRulesError {}
 /// Errors returned by DisableAlarmActions
 #[derive(Debug, PartialEq)]
 pub enum DisableAlarmActionsError {}
@@ -4928,14 +4898,10 @@ impl DisableAlarmActionsError {
 }
 impl fmt::Display for DisableAlarmActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableAlarmActionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DisableAlarmActionsError {}
 /// Errors returned by DisableInsightRules
 #[derive(Debug, PartialEq)]
 pub enum DisableInsightRulesError {
@@ -4982,17 +4948,13 @@ impl DisableInsightRulesError {
 }
 impl fmt::Display for DisableInsightRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableInsightRulesError {
-    fn description(&self) -> &str {
         match *self {
-            DisableInsightRulesError::InvalidParameterValue(ref cause) => cause,
-            DisableInsightRulesError::MissingRequiredParameter(ref cause) => cause,
+            DisableInsightRulesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DisableInsightRulesError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableInsightRulesError {}
 /// Errors returned by EnableAlarmActions
 #[derive(Debug, PartialEq)]
 pub enum EnableAlarmActionsError {}
@@ -5022,14 +4984,10 @@ impl EnableAlarmActionsError {
 }
 impl fmt::Display for EnableAlarmActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableAlarmActionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for EnableAlarmActionsError {}
 /// Errors returned by EnableInsightRules
 #[derive(Debug, PartialEq)]
 pub enum EnableInsightRulesError {
@@ -5081,18 +5039,14 @@ impl EnableInsightRulesError {
 }
 impl fmt::Display for EnableInsightRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableInsightRulesError {
-    fn description(&self) -> &str {
         match *self {
-            EnableInsightRulesError::InvalidParameterValue(ref cause) => cause,
-            EnableInsightRulesError::LimitExceeded(ref cause) => cause,
-            EnableInsightRulesError::MissingRequiredParameter(ref cause) => cause,
+            EnableInsightRulesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            EnableInsightRulesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            EnableInsightRulesError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableInsightRulesError {}
 /// Errors returned by GetDashboard
 #[derive(Debug, PartialEq)]
 pub enum GetDashboardError {
@@ -5144,18 +5098,14 @@ impl GetDashboardError {
 }
 impl fmt::Display for GetDashboardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDashboardError {
-    fn description(&self) -> &str {
         match *self {
-            GetDashboardError::DashboardNotFoundError(ref cause) => cause,
-            GetDashboardError::InternalServiceFault(ref cause) => cause,
-            GetDashboardError::InvalidParameterValue(ref cause) => cause,
+            GetDashboardError::DashboardNotFoundError(ref cause) => write!(f, "{}", cause),
+            GetDashboardError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            GetDashboardError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDashboardError {}
 /// Errors returned by GetInsightRuleReport
 #[derive(Debug, PartialEq)]
 pub enum GetInsightRuleReportError {
@@ -5209,18 +5159,16 @@ impl GetInsightRuleReportError {
 }
 impl fmt::Display for GetInsightRuleReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInsightRuleReportError {
-    fn description(&self) -> &str {
         match *self {
-            GetInsightRuleReportError::InvalidParameterValue(ref cause) => cause,
-            GetInsightRuleReportError::MissingRequiredParameter(ref cause) => cause,
-            GetInsightRuleReportError::ResourceNotFound(ref cause) => cause,
+            GetInsightRuleReportError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetInsightRuleReportError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetInsightRuleReportError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInsightRuleReportError {}
 /// Errors returned by GetMetricData
 #[derive(Debug, PartialEq)]
 pub enum GetMetricDataError {
@@ -5258,16 +5206,12 @@ impl GetMetricDataError {
 }
 impl fmt::Display for GetMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMetricDataError {
-    fn description(&self) -> &str {
         match *self {
-            GetMetricDataError::InvalidNextToken(ref cause) => cause,
+            GetMetricDataError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMetricDataError {}
 /// Errors returned by GetMetricStatistics
 #[derive(Debug, PartialEq)]
 pub enum GetMetricStatisticsError {
@@ -5330,19 +5274,17 @@ impl GetMetricStatisticsError {
 }
 impl fmt::Display for GetMetricStatisticsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMetricStatisticsError {
-    fn description(&self) -> &str {
         match *self {
-            GetMetricStatisticsError::InternalServiceFault(ref cause) => cause,
-            GetMetricStatisticsError::InvalidParameterCombination(ref cause) => cause,
-            GetMetricStatisticsError::InvalidParameterValue(ref cause) => cause,
-            GetMetricStatisticsError::MissingRequiredParameter(ref cause) => cause,
+            GetMetricStatisticsError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            GetMetricStatisticsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMetricStatisticsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetMetricStatisticsError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMetricStatisticsError {}
 /// Errors returned by GetMetricWidgetImage
 #[derive(Debug, PartialEq)]
 pub enum GetMetricWidgetImageError {}
@@ -5372,14 +5314,10 @@ impl GetMetricWidgetImageError {
 }
 impl fmt::Display for GetMetricWidgetImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMetricWidgetImageError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetMetricWidgetImageError {}
 /// Errors returned by ListDashboards
 #[derive(Debug, PartialEq)]
 pub enum ListDashboardsError {
@@ -5424,17 +5362,13 @@ impl ListDashboardsError {
 }
 impl fmt::Display for ListDashboardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDashboardsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDashboardsError::InternalServiceFault(ref cause) => cause,
-            ListDashboardsError::InvalidParameterValue(ref cause) => cause,
+            ListDashboardsError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            ListDashboardsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDashboardsError {}
 /// Errors returned by ListMetrics
 #[derive(Debug, PartialEq)]
 pub enum ListMetricsError {
@@ -5479,17 +5413,13 @@ impl ListMetricsError {
 }
 impl fmt::Display for ListMetricsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMetricsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMetricsError::InternalServiceFault(ref cause) => cause,
-            ListMetricsError::InvalidParameterValue(ref cause) => cause,
+            ListMetricsError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            ListMetricsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMetricsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -5541,18 +5471,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalServiceFault(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameterValue(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PutAnomalyDetector
 #[derive(Debug, PartialEq)]
 pub enum PutAnomalyDetectorError {
@@ -5611,19 +5537,15 @@ impl PutAnomalyDetectorError {
 }
 impl fmt::Display for PutAnomalyDetectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAnomalyDetectorError {
-    fn description(&self) -> &str {
         match *self {
-            PutAnomalyDetectorError::InternalServiceFault(ref cause) => cause,
-            PutAnomalyDetectorError::InvalidParameterValue(ref cause) => cause,
-            PutAnomalyDetectorError::LimitExceeded(ref cause) => cause,
-            PutAnomalyDetectorError::MissingRequiredParameter(ref cause) => cause,
+            PutAnomalyDetectorError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            PutAnomalyDetectorError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutAnomalyDetectorError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutAnomalyDetectorError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutAnomalyDetectorError {}
 /// Errors returned by PutDashboard
 #[derive(Debug, PartialEq)]
 pub enum PutDashboardError {
@@ -5668,17 +5590,13 @@ impl PutDashboardError {
 }
 impl fmt::Display for PutDashboardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutDashboardError {
-    fn description(&self) -> &str {
         match *self {
-            PutDashboardError::DashboardInvalidInputError(ref cause) => cause,
-            PutDashboardError::InternalServiceFault(ref cause) => cause,
+            PutDashboardError::DashboardInvalidInputError(ref cause) => write!(f, "{}", cause),
+            PutDashboardError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutDashboardError {}
 /// Errors returned by PutInsightRule
 #[derive(Debug, PartialEq)]
 pub enum PutInsightRuleError {
@@ -5730,18 +5648,14 @@ impl PutInsightRuleError {
 }
 impl fmt::Display for PutInsightRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutInsightRuleError {
-    fn description(&self) -> &str {
         match *self {
-            PutInsightRuleError::InvalidParameterValue(ref cause) => cause,
-            PutInsightRuleError::LimitExceeded(ref cause) => cause,
-            PutInsightRuleError::MissingRequiredParameter(ref cause) => cause,
+            PutInsightRuleError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutInsightRuleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutInsightRuleError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutInsightRuleError {}
 /// Errors returned by PutMetricAlarm
 #[derive(Debug, PartialEq)]
 pub enum PutMetricAlarmError {
@@ -5779,16 +5693,12 @@ impl PutMetricAlarmError {
 }
 impl fmt::Display for PutMetricAlarmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutMetricAlarmError {
-    fn description(&self) -> &str {
         match *self {
-            PutMetricAlarmError::LimitExceededFault(ref cause) => cause,
+            PutMetricAlarmError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutMetricAlarmError {}
 /// Errors returned by PutMetricData
 #[derive(Debug, PartialEq)]
 pub enum PutMetricDataError {
@@ -5847,19 +5757,15 @@ impl PutMetricDataError {
 }
 impl fmt::Display for PutMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutMetricDataError {
-    fn description(&self) -> &str {
         match *self {
-            PutMetricDataError::InternalServiceFault(ref cause) => cause,
-            PutMetricDataError::InvalidParameterCombination(ref cause) => cause,
-            PutMetricDataError::InvalidParameterValue(ref cause) => cause,
-            PutMetricDataError::MissingRequiredParameter(ref cause) => cause,
+            PutMetricDataError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            PutMetricDataError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            PutMetricDataError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutMetricDataError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutMetricDataError {}
 /// Errors returned by SetAlarmState
 #[derive(Debug, PartialEq)]
 pub enum SetAlarmStateError {
@@ -5904,17 +5810,13 @@ impl SetAlarmStateError {
 }
 impl fmt::Display for SetAlarmStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetAlarmStateError {
-    fn description(&self) -> &str {
         match *self {
-            SetAlarmStateError::InvalidFormatFault(ref cause) => cause,
-            SetAlarmStateError::ResourceNotFound(ref cause) => cause,
+            SetAlarmStateError::InvalidFormatFault(ref cause) => write!(f, "{}", cause),
+            SetAlarmStateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetAlarmStateError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5973,19 +5875,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ConcurrentModification(ref cause) => cause,
-            TagResourceError::InternalServiceFault(ref cause) => cause,
-            TagResourceError::InvalidParameterValue(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -6044,19 +5942,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ConcurrentModification(ref cause) => cause,
-            UntagResourceError::InternalServiceFault(ref cause) => cause,
-            UntagResourceError::InvalidParameterValue(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServiceFault(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the CloudWatch API. CloudWatch clients implement this trait.
 pub trait CloudWatch {
     /// <p>Deletes the specified alarms. You can delete up to 50 alarms in one operation. In the event of an error, no alarms are deleted.</p>

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -1829,16 +1829,12 @@ impl BatchDeleteBuildsError {
 }
 impl fmt::Display for BatchDeleteBuildsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteBuildsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeleteBuildsError::InvalidInput(ref cause) => cause,
+            BatchDeleteBuildsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeleteBuildsError {}
 /// Errors returned by BatchGetBuilds
 #[derive(Debug, PartialEq)]
 pub enum BatchGetBuildsError {
@@ -1862,16 +1858,12 @@ impl BatchGetBuildsError {
 }
 impl fmt::Display for BatchGetBuildsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetBuildsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetBuildsError::InvalidInput(ref cause) => cause,
+            BatchGetBuildsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetBuildsError {}
 /// Errors returned by BatchGetProjects
 #[derive(Debug, PartialEq)]
 pub enum BatchGetProjectsError {
@@ -1895,16 +1887,12 @@ impl BatchGetProjectsError {
 }
 impl fmt::Display for BatchGetProjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetProjectsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetProjectsError::InvalidInput(ref cause) => cause,
+            BatchGetProjectsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetProjectsError {}
 /// Errors returned by BatchGetReportGroups
 #[derive(Debug, PartialEq)]
 pub enum BatchGetReportGroupsError {
@@ -1928,16 +1916,12 @@ impl BatchGetReportGroupsError {
 }
 impl fmt::Display for BatchGetReportGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetReportGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetReportGroupsError::InvalidInput(ref cause) => cause,
+            BatchGetReportGroupsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetReportGroupsError {}
 /// Errors returned by BatchGetReports
 #[derive(Debug, PartialEq)]
 pub enum BatchGetReportsError {
@@ -1961,16 +1945,12 @@ impl BatchGetReportsError {
 }
 impl fmt::Display for BatchGetReportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetReportsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetReportsError::InvalidInput(ref cause) => cause,
+            BatchGetReportsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetReportsError {}
 /// Errors returned by CreateProject
 #[derive(Debug, PartialEq)]
 pub enum CreateProjectError {
@@ -2004,18 +1984,14 @@ impl CreateProjectError {
 }
 impl fmt::Display for CreateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProjectError::AccountLimitExceeded(ref cause) => cause,
-            CreateProjectError::InvalidInput(ref cause) => cause,
-            CreateProjectError::ResourceAlreadyExists(ref cause) => cause,
+            CreateProjectError::AccountLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProjectError {}
 /// Errors returned by CreateReportGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateReportGroupError {
@@ -2053,18 +2029,14 @@ impl CreateReportGroupError {
 }
 impl fmt::Display for CreateReportGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReportGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReportGroupError::AccountLimitExceeded(ref cause) => cause,
-            CreateReportGroupError::InvalidInput(ref cause) => cause,
-            CreateReportGroupError::ResourceAlreadyExists(ref cause) => cause,
+            CreateReportGroupError::AccountLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateReportGroupError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateReportGroupError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateReportGroupError {}
 /// Errors returned by CreateWebhook
 #[derive(Debug, PartialEq)]
 pub enum CreateWebhookError {
@@ -2103,19 +2075,15 @@ impl CreateWebhookError {
 }
 impl fmt::Display for CreateWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWebhookError::InvalidInput(ref cause) => cause,
-            CreateWebhookError::OAuthProvider(ref cause) => cause,
-            CreateWebhookError::ResourceAlreadyExists(ref cause) => cause,
-            CreateWebhookError::ResourceNotFound(ref cause) => cause,
+            CreateWebhookError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::OAuthProvider(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateWebhookError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWebhookError {}
 /// Errors returned by DeleteProject
 #[derive(Debug, PartialEq)]
 pub enum DeleteProjectError {
@@ -2139,16 +2107,12 @@ impl DeleteProjectError {
 }
 impl fmt::Display for DeleteProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProjectError::InvalidInput(ref cause) => cause,
+            DeleteProjectError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProjectError {}
 /// Errors returned by DeleteReport
 #[derive(Debug, PartialEq)]
 pub enum DeleteReportError {
@@ -2172,16 +2136,12 @@ impl DeleteReportError {
 }
 impl fmt::Display for DeleteReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReportError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReportError::InvalidInput(ref cause) => cause,
+            DeleteReportError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReportError {}
 /// Errors returned by DeleteReportGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteReportGroupError {
@@ -2205,16 +2165,12 @@ impl DeleteReportGroupError {
 }
 impl fmt::Display for DeleteReportGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReportGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReportGroupError::InvalidInput(ref cause) => cause,
+            DeleteReportGroupError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReportGroupError {}
 /// Errors returned by DeleteSourceCredentials
 #[derive(Debug, PartialEq)]
 pub enum DeleteSourceCredentialsError {
@@ -2247,17 +2203,13 @@ impl DeleteSourceCredentialsError {
 }
 impl fmt::Display for DeleteSourceCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSourceCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSourceCredentialsError::InvalidInput(ref cause) => cause,
-            DeleteSourceCredentialsError::ResourceNotFound(ref cause) => cause,
+            DeleteSourceCredentialsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteSourceCredentialsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSourceCredentialsError {}
 /// Errors returned by DeleteWebhook
 #[derive(Debug, PartialEq)]
 pub enum DeleteWebhookError {
@@ -2291,18 +2243,14 @@ impl DeleteWebhookError {
 }
 impl fmt::Display for DeleteWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWebhookError::InvalidInput(ref cause) => cause,
-            DeleteWebhookError::OAuthProvider(ref cause) => cause,
-            DeleteWebhookError::ResourceNotFound(ref cause) => cause,
+            DeleteWebhookError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteWebhookError::OAuthProvider(ref cause) => write!(f, "{}", cause),
+            DeleteWebhookError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWebhookError {}
 /// Errors returned by DescribeTestCases
 #[derive(Debug, PartialEq)]
 pub enum DescribeTestCasesError {
@@ -2331,17 +2279,13 @@ impl DescribeTestCasesError {
 }
 impl fmt::Display for DescribeTestCasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTestCasesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTestCasesError::InvalidInput(ref cause) => cause,
-            DescribeTestCasesError::ResourceNotFound(ref cause) => cause,
+            DescribeTestCasesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeTestCasesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTestCasesError {}
 /// Errors returned by ImportSourceCredentials
 #[derive(Debug, PartialEq)]
 pub enum ImportSourceCredentialsError {
@@ -2381,18 +2325,16 @@ impl ImportSourceCredentialsError {
 }
 impl fmt::Display for ImportSourceCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportSourceCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            ImportSourceCredentialsError::AccountLimitExceeded(ref cause) => cause,
-            ImportSourceCredentialsError::InvalidInput(ref cause) => cause,
-            ImportSourceCredentialsError::ResourceAlreadyExists(ref cause) => cause,
+            ImportSourceCredentialsError::AccountLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ImportSourceCredentialsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ImportSourceCredentialsError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ImportSourceCredentialsError {}
 /// Errors returned by InvalidateProjectCache
 #[derive(Debug, PartialEq)]
 pub enum InvalidateProjectCacheError {
@@ -2423,17 +2365,13 @@ impl InvalidateProjectCacheError {
 }
 impl fmt::Display for InvalidateProjectCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InvalidateProjectCacheError {
-    fn description(&self) -> &str {
         match *self {
-            InvalidateProjectCacheError::InvalidInput(ref cause) => cause,
-            InvalidateProjectCacheError::ResourceNotFound(ref cause) => cause,
+            InvalidateProjectCacheError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            InvalidateProjectCacheError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InvalidateProjectCacheError {}
 /// Errors returned by ListBuilds
 #[derive(Debug, PartialEq)]
 pub enum ListBuildsError {
@@ -2457,16 +2395,12 @@ impl ListBuildsError {
 }
 impl fmt::Display for ListBuildsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBuildsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBuildsError::InvalidInput(ref cause) => cause,
+            ListBuildsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBuildsError {}
 /// Errors returned by ListBuildsForProject
 #[derive(Debug, PartialEq)]
 pub enum ListBuildsForProjectError {
@@ -2497,17 +2431,13 @@ impl ListBuildsForProjectError {
 }
 impl fmt::Display for ListBuildsForProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBuildsForProjectError {
-    fn description(&self) -> &str {
         match *self {
-            ListBuildsForProjectError::InvalidInput(ref cause) => cause,
-            ListBuildsForProjectError::ResourceNotFound(ref cause) => cause,
+            ListBuildsForProjectError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListBuildsForProjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBuildsForProjectError {}
 /// Errors returned by ListCuratedEnvironmentImages
 #[derive(Debug, PartialEq)]
 pub enum ListCuratedEnvironmentImagesError {}
@@ -2527,14 +2457,10 @@ impl ListCuratedEnvironmentImagesError {
 }
 impl fmt::Display for ListCuratedEnvironmentImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCuratedEnvironmentImagesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListCuratedEnvironmentImagesError {}
 /// Errors returned by ListProjects
 #[derive(Debug, PartialEq)]
 pub enum ListProjectsError {
@@ -2558,16 +2484,12 @@ impl ListProjectsError {
 }
 impl fmt::Display for ListProjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProjectsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProjectsError::InvalidInput(ref cause) => cause,
+            ListProjectsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProjectsError {}
 /// Errors returned by ListReportGroups
 #[derive(Debug, PartialEq)]
 pub enum ListReportGroupsError {
@@ -2591,16 +2513,12 @@ impl ListReportGroupsError {
 }
 impl fmt::Display for ListReportGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReportGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListReportGroupsError::InvalidInput(ref cause) => cause,
+            ListReportGroupsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListReportGroupsError {}
 /// Errors returned by ListReports
 #[derive(Debug, PartialEq)]
 pub enum ListReportsError {
@@ -2624,16 +2542,12 @@ impl ListReportsError {
 }
 impl fmt::Display for ListReportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReportsError {
-    fn description(&self) -> &str {
         match *self {
-            ListReportsError::InvalidInput(ref cause) => cause,
+            ListReportsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListReportsError {}
 /// Errors returned by ListReportsForReportGroup
 #[derive(Debug, PartialEq)]
 pub enum ListReportsForReportGroupError {
@@ -2666,17 +2580,13 @@ impl ListReportsForReportGroupError {
 }
 impl fmt::Display for ListReportsForReportGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReportsForReportGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ListReportsForReportGroupError::InvalidInput(ref cause) => cause,
-            ListReportsForReportGroupError::ResourceNotFound(ref cause) => cause,
+            ListReportsForReportGroupError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListReportsForReportGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListReportsForReportGroupError {}
 /// Errors returned by ListSourceCredentials
 #[derive(Debug, PartialEq)]
 pub enum ListSourceCredentialsError {}
@@ -2694,14 +2604,10 @@ impl ListSourceCredentialsError {
 }
 impl fmt::Display for ListSourceCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSourceCredentialsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListSourceCredentialsError {}
 /// Errors returned by StartBuild
 #[derive(Debug, PartialEq)]
 pub enum StartBuildError {
@@ -2735,18 +2641,14 @@ impl StartBuildError {
 }
 impl fmt::Display for StartBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartBuildError {
-    fn description(&self) -> &str {
         match *self {
-            StartBuildError::AccountLimitExceeded(ref cause) => cause,
-            StartBuildError::InvalidInput(ref cause) => cause,
-            StartBuildError::ResourceNotFound(ref cause) => cause,
+            StartBuildError::AccountLimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartBuildError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartBuildError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartBuildError {}
 /// Errors returned by StopBuild
 #[derive(Debug, PartialEq)]
 pub enum StopBuildError {
@@ -2775,17 +2677,13 @@ impl StopBuildError {
 }
 impl fmt::Display for StopBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopBuildError {
-    fn description(&self) -> &str {
         match *self {
-            StopBuildError::InvalidInput(ref cause) => cause,
-            StopBuildError::ResourceNotFound(ref cause) => cause,
+            StopBuildError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StopBuildError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopBuildError {}
 /// Errors returned by UpdateProject
 #[derive(Debug, PartialEq)]
 pub enum UpdateProjectError {
@@ -2814,17 +2712,13 @@ impl UpdateProjectError {
 }
 impl fmt::Display for UpdateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProjectError::InvalidInput(ref cause) => cause,
-            UpdateProjectError::ResourceNotFound(ref cause) => cause,
+            UpdateProjectError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProjectError {}
 /// Errors returned by UpdateReportGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateReportGroupError {
@@ -2853,17 +2747,13 @@ impl UpdateReportGroupError {
 }
 impl fmt::Display for UpdateReportGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateReportGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateReportGroupError::InvalidInput(ref cause) => cause,
-            UpdateReportGroupError::ResourceNotFound(ref cause) => cause,
+            UpdateReportGroupError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateReportGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateReportGroupError {}
 /// Errors returned by UpdateWebhook
 #[derive(Debug, PartialEq)]
 pub enum UpdateWebhookError {
@@ -2897,18 +2787,14 @@ impl UpdateWebhookError {
 }
 impl fmt::Display for UpdateWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateWebhookError::InvalidInput(ref cause) => cause,
-            UpdateWebhookError::OAuthProvider(ref cause) => cause,
-            UpdateWebhookError::ResourceNotFound(ref cause) => cause,
+            UpdateWebhookError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateWebhookError::OAuthProvider(ref cause) => write!(f, "{}", cause),
+            UpdateWebhookError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateWebhookError {}
 /// Trait representing the capabilities of the AWS CodeBuild API. AWS CodeBuild clients implement this trait.
 pub trait CodeBuild {
     /// <p>Deletes one or more builds.</p>

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -3412,27 +3412,23 @@ _ => {}
 }
 impl fmt::Display for AssociateApprovalRuleTemplateWithRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateApprovalRuleTemplateWithRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-                            AssociateApprovalRuleTemplateWithRepositoryError::ApprovalRuleTemplateDoesNotExist(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::ApprovalRuleTemplateNameRequired(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyAccessDenied(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyDisabled(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyNotFound(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyUnavailable(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::InvalidApprovalRuleTemplateName(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::InvalidRepositoryName(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::MaximumRuleTemplatesAssociatedWithRepository(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::RepositoryDoesNotExist(ref cause) => cause,
-AssociateApprovalRuleTemplateWithRepositoryError::RepositoryNameRequired(ref cause) => cause
+                            AssociateApprovalRuleTemplateWithRepositoryError::ApprovalRuleTemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::ApprovalRuleTemplateNameRequired(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::InvalidApprovalRuleTemplateName(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::MaximumRuleTemplatesAssociatedWithRepository(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+AssociateApprovalRuleTemplateWithRepositoryError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for AssociateApprovalRuleTemplateWithRepositoryError {}
 /// Errors returned by BatchAssociateApprovalRuleTemplateWithRepositories
 #[derive(Debug, PartialEq)]
 pub enum BatchAssociateApprovalRuleTemplateWithRepositoriesError {
@@ -3483,25 +3479,21 @@ _ => {}
 }
 impl fmt::Display for BatchAssociateApprovalRuleTemplateWithRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchAssociateApprovalRuleTemplateWithRepositoriesError {
-    fn description(&self) -> &str {
         match *self {
-                            BatchAssociateApprovalRuleTemplateWithRepositoriesError::ApprovalRuleTemplateDoesNotExist(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::ApprovalRuleTemplateNameRequired(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyAccessDenied(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyDisabled(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyNotFound(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyUnavailable(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::InvalidApprovalRuleTemplateName(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::MaximumRepositoryNamesExceeded(ref cause) => cause,
-BatchAssociateApprovalRuleTemplateWithRepositoriesError::RepositoryNamesRequired(ref cause) => cause
+                            BatchAssociateApprovalRuleTemplateWithRepositoriesError::ApprovalRuleTemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::ApprovalRuleTemplateNameRequired(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::InvalidApprovalRuleTemplateName(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::MaximumRepositoryNamesExceeded(ref cause) => write!(f, "{}", cause),
+BatchAssociateApprovalRuleTemplateWithRepositoriesError::RepositoryNamesRequired(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for BatchAssociateApprovalRuleTemplateWithRepositoriesError {}
 /// Errors returned by BatchDescribeMergeConflicts
 #[derive(Debug, PartialEq)]
 pub enum BatchDescribeMergeConflictsError {
@@ -3671,36 +3663,70 @@ impl BatchDescribeMergeConflictsError {
 }
 impl fmt::Display for BatchDescribeMergeConflictsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDescribeMergeConflictsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDescribeMergeConflictsError::CommitDoesNotExist(ref cause) => cause,
-            BatchDescribeMergeConflictsError::CommitRequired(ref cause) => cause,
-            BatchDescribeMergeConflictsError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            BatchDescribeMergeConflictsError::EncryptionKeyAccessDenied(ref cause) => cause,
-            BatchDescribeMergeConflictsError::EncryptionKeyDisabled(ref cause) => cause,
-            BatchDescribeMergeConflictsError::EncryptionKeyNotFound(ref cause) => cause,
-            BatchDescribeMergeConflictsError::EncryptionKeyUnavailable(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidCommit(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidConflictDetailLevel(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidContinuationToken(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidMaxConflictFiles(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidMaxMergeHunks(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidMergeOption(ref cause) => cause,
-            BatchDescribeMergeConflictsError::InvalidRepositoryName(ref cause) => cause,
-            BatchDescribeMergeConflictsError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            BatchDescribeMergeConflictsError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            BatchDescribeMergeConflictsError::MergeOptionRequired(ref cause) => cause,
-            BatchDescribeMergeConflictsError::RepositoryDoesNotExist(ref cause) => cause,
-            BatchDescribeMergeConflictsError::RepositoryNameRequired(ref cause) => cause,
-            BatchDescribeMergeConflictsError::TipsDivergenceExceeded(ref cause) => cause,
+            BatchDescribeMergeConflictsError::CommitDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            BatchDescribeMergeConflictsError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            BatchDescribeMergeConflictsError::InvalidConflictDetailLevel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::InvalidContinuationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::InvalidMaxConflictFiles(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::InvalidMaxMergeHunks(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::InvalidMergeOption(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::MergeOptionRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDescribeMergeConflictsError::TipsDivergenceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchDescribeMergeConflictsError {}
 /// Errors returned by BatchDisassociateApprovalRuleTemplateFromRepositories
 #[derive(Debug, PartialEq)]
 pub enum BatchDisassociateApprovalRuleTemplateFromRepositoriesError {
@@ -3751,25 +3777,21 @@ _ => {}
 }
 impl fmt::Display for BatchDisassociateApprovalRuleTemplateFromRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDisassociateApprovalRuleTemplateFromRepositoriesError {
-    fn description(&self) -> &str {
         match *self {
-                            BatchDisassociateApprovalRuleTemplateFromRepositoriesError::ApprovalRuleTemplateDoesNotExist(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::ApprovalRuleTemplateNameRequired(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyAccessDenied(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyDisabled(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyNotFound(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyUnavailable(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::InvalidApprovalRuleTemplateName(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::MaximumRepositoryNamesExceeded(ref cause) => cause,
-BatchDisassociateApprovalRuleTemplateFromRepositoriesError::RepositoryNamesRequired(ref cause) => cause
+                            BatchDisassociateApprovalRuleTemplateFromRepositoriesError::ApprovalRuleTemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::ApprovalRuleTemplateNameRequired(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::InvalidApprovalRuleTemplateName(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::MaximumRepositoryNamesExceeded(ref cause) => write!(f, "{}", cause),
+BatchDisassociateApprovalRuleTemplateFromRepositoriesError::RepositoryNamesRequired(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for BatchDisassociateApprovalRuleTemplateFromRepositoriesError {}
 /// Errors returned by BatchGetCommits
 #[derive(Debug, PartialEq)]
 pub enum BatchGetCommitsError {
@@ -3858,25 +3880,23 @@ impl BatchGetCommitsError {
 }
 impl fmt::Display for BatchGetCommitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetCommitsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetCommitsError::CommitIdsLimitExceeded(ref cause) => cause,
-            BatchGetCommitsError::CommitIdsListRequired(ref cause) => cause,
-            BatchGetCommitsError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            BatchGetCommitsError::EncryptionKeyAccessDenied(ref cause) => cause,
-            BatchGetCommitsError::EncryptionKeyDisabled(ref cause) => cause,
-            BatchGetCommitsError::EncryptionKeyNotFound(ref cause) => cause,
-            BatchGetCommitsError::EncryptionKeyUnavailable(ref cause) => cause,
-            BatchGetCommitsError::InvalidRepositoryName(ref cause) => cause,
-            BatchGetCommitsError::RepositoryDoesNotExist(ref cause) => cause,
-            BatchGetCommitsError::RepositoryNameRequired(ref cause) => cause,
+            BatchGetCommitsError::CommitIdsLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::CommitIdsListRequired(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetCommitsError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            BatchGetCommitsError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetCommitsError {}
 /// Errors returned by BatchGetRepositories
 #[derive(Debug, PartialEq)]
 pub enum BatchGetRepositoriesError {
@@ -3951,23 +3971,27 @@ impl BatchGetRepositoriesError {
 }
 impl fmt::Display for BatchGetRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetRepositoriesError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetRepositoriesError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            BatchGetRepositoriesError::EncryptionKeyAccessDenied(ref cause) => cause,
-            BatchGetRepositoriesError::EncryptionKeyDisabled(ref cause) => cause,
-            BatchGetRepositoriesError::EncryptionKeyNotFound(ref cause) => cause,
-            BatchGetRepositoriesError::EncryptionKeyUnavailable(ref cause) => cause,
-            BatchGetRepositoriesError::InvalidRepositoryName(ref cause) => cause,
-            BatchGetRepositoriesError::MaximumRepositoryNamesExceeded(ref cause) => cause,
-            BatchGetRepositoriesError::RepositoryNamesRequired(ref cause) => cause,
+            BatchGetRepositoriesError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetRepositoriesError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetRepositoriesError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            BatchGetRepositoriesError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            BatchGetRepositoriesError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetRepositoriesError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            BatchGetRepositoriesError::MaximumRepositoryNamesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetRepositoriesError::RepositoryNamesRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetRepositoriesError {}
 /// Errors returned by CreateApprovalRuleTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateApprovalRuleTemplateError {
@@ -4045,28 +4069,32 @@ impl CreateApprovalRuleTemplateError {
 }
 impl fmt::Display for CreateApprovalRuleTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApprovalRuleTemplateError {
-    fn description(&self) -> &str {
         match *self {
             CreateApprovalRuleTemplateError::ApprovalRuleTemplateContentRequired(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateApprovalRuleTemplateError::ApprovalRuleTemplateNameAlreadyExists(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateApprovalRuleTemplateError::ApprovalRuleTemplateNameRequired(ref cause) => cause,
-            CreateApprovalRuleTemplateError::InvalidApprovalRuleTemplateContent(ref cause) => cause,
+            CreateApprovalRuleTemplateError::ApprovalRuleTemplateNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateApprovalRuleTemplateError::InvalidApprovalRuleTemplateContent(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateApprovalRuleTemplateError::InvalidApprovalRuleTemplateDescription(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateApprovalRuleTemplateError::InvalidApprovalRuleTemplateName(ref cause) => cause,
-            CreateApprovalRuleTemplateError::NumberOfRuleTemplatesExceeded(ref cause) => cause,
+            CreateApprovalRuleTemplateError::InvalidApprovalRuleTemplateName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateApprovalRuleTemplateError::NumberOfRuleTemplatesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateApprovalRuleTemplateError {}
 /// Errors returned by CreateBranch
 #[derive(Debug, PartialEq)]
 pub enum CreateBranchError {
@@ -4161,29 +4189,25 @@ impl CreateBranchError {
 }
 impl fmt::Display for CreateBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBranchError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBranchError::BranchNameExists(ref cause) => cause,
-            CreateBranchError::BranchNameRequired(ref cause) => cause,
-            CreateBranchError::CommitDoesNotExist(ref cause) => cause,
-            CreateBranchError::CommitIdRequired(ref cause) => cause,
-            CreateBranchError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            CreateBranchError::EncryptionKeyAccessDenied(ref cause) => cause,
-            CreateBranchError::EncryptionKeyDisabled(ref cause) => cause,
-            CreateBranchError::EncryptionKeyNotFound(ref cause) => cause,
-            CreateBranchError::EncryptionKeyUnavailable(ref cause) => cause,
-            CreateBranchError::InvalidBranchName(ref cause) => cause,
-            CreateBranchError::InvalidCommitId(ref cause) => cause,
-            CreateBranchError::InvalidRepositoryName(ref cause) => cause,
-            CreateBranchError::RepositoryDoesNotExist(ref cause) => cause,
-            CreateBranchError::RepositoryNameRequired(ref cause) => cause,
+            CreateBranchError::BranchNameExists(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::CommitIdRequired(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateBranchError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBranchError {}
 /// Errors returned by CreateCommit
 #[derive(Debug, PartialEq)]
 pub enum CreateCommitError {
@@ -4420,53 +4444,57 @@ impl CreateCommitError {
 }
 impl fmt::Display for CreateCommitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCommitError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCommitError::BranchDoesNotExist(ref cause) => cause,
-            CreateCommitError::BranchNameIsTagName(ref cause) => cause,
-            CreateCommitError::BranchNameRequired(ref cause) => cause,
-            CreateCommitError::CommitMessageLengthExceeded(ref cause) => cause,
-            CreateCommitError::DirectoryNameConflictsWithFileName(ref cause) => cause,
-            CreateCommitError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            CreateCommitError::EncryptionKeyAccessDenied(ref cause) => cause,
-            CreateCommitError::EncryptionKeyDisabled(ref cause) => cause,
-            CreateCommitError::EncryptionKeyNotFound(ref cause) => cause,
-            CreateCommitError::EncryptionKeyUnavailable(ref cause) => cause,
-            CreateCommitError::FileContentAndSourceFileSpecified(ref cause) => cause,
-            CreateCommitError::FileContentSizeLimitExceeded(ref cause) => cause,
-            CreateCommitError::FileDoesNotExist(ref cause) => cause,
-            CreateCommitError::FileEntryRequired(ref cause) => cause,
-            CreateCommitError::FileModeRequired(ref cause) => cause,
-            CreateCommitError::FileNameConflictsWithDirectoryName(ref cause) => cause,
-            CreateCommitError::FilePathConflictsWithSubmodulePath(ref cause) => cause,
-            CreateCommitError::FolderContentSizeLimitExceeded(ref cause) => cause,
-            CreateCommitError::InvalidBranchName(ref cause) => cause,
-            CreateCommitError::InvalidDeletionParameter(ref cause) => cause,
-            CreateCommitError::InvalidEmail(ref cause) => cause,
-            CreateCommitError::InvalidFileMode(ref cause) => cause,
-            CreateCommitError::InvalidParentCommitId(ref cause) => cause,
-            CreateCommitError::InvalidPath(ref cause) => cause,
-            CreateCommitError::InvalidRepositoryName(ref cause) => cause,
-            CreateCommitError::MaximumFileEntriesExceeded(ref cause) => cause,
-            CreateCommitError::NameLengthExceeded(ref cause) => cause,
-            CreateCommitError::NoChange(ref cause) => cause,
-            CreateCommitError::ParentCommitDoesNotExist(ref cause) => cause,
-            CreateCommitError::ParentCommitIdOutdated(ref cause) => cause,
-            CreateCommitError::ParentCommitIdRequired(ref cause) => cause,
-            CreateCommitError::PathRequired(ref cause) => cause,
-            CreateCommitError::PutFileEntryConflict(ref cause) => cause,
-            CreateCommitError::RepositoryDoesNotExist(ref cause) => cause,
-            CreateCommitError::RepositoryNameRequired(ref cause) => cause,
-            CreateCommitError::RestrictedSourceFile(ref cause) => cause,
-            CreateCommitError::SamePathRequest(ref cause) => cause,
-            CreateCommitError::SourceFileOrContentRequired(ref cause) => cause,
+            CreateCommitError::BranchDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::BranchNameIsTagName(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::CommitMessageLengthExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::DirectoryNameConflictsWithFileName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCommitError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::FileContentAndSourceFileSpecified(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCommitError::FileContentSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::FileDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::FileEntryRequired(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::FileModeRequired(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::FileNameConflictsWithDirectoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCommitError::FilePathConflictsWithSubmodulePath(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCommitError::FolderContentSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::InvalidDeletionParameter(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::InvalidFileMode(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::InvalidParentCommitId(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::MaximumFileEntriesExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::NameLengthExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::NoChange(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::ParentCommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::ParentCommitIdOutdated(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::ParentCommitIdRequired(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::PathRequired(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::PutFileEntryConflict(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::RestrictedSourceFile(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::SamePathRequest(ref cause) => write!(f, "{}", cause),
+            CreateCommitError::SourceFileOrContentRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCommitError {}
 /// Errors returned by CreatePullRequest
 #[derive(Debug, PartialEq)]
 pub enum CreatePullRequestError {
@@ -4648,40 +4676,46 @@ impl CreatePullRequestError {
 }
 impl fmt::Display for CreatePullRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePullRequestError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePullRequestError::ClientRequestTokenRequired(ref cause) => cause,
-            CreatePullRequestError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            CreatePullRequestError::EncryptionKeyAccessDenied(ref cause) => cause,
-            CreatePullRequestError::EncryptionKeyDisabled(ref cause) => cause,
-            CreatePullRequestError::EncryptionKeyNotFound(ref cause) => cause,
-            CreatePullRequestError::EncryptionKeyUnavailable(ref cause) => cause,
-            CreatePullRequestError::IdempotencyParameterMismatch(ref cause) => cause,
-            CreatePullRequestError::InvalidClientRequestToken(ref cause) => cause,
-            CreatePullRequestError::InvalidDescription(ref cause) => cause,
-            CreatePullRequestError::InvalidReferenceName(ref cause) => cause,
-            CreatePullRequestError::InvalidRepositoryName(ref cause) => cause,
-            CreatePullRequestError::InvalidTarget(ref cause) => cause,
-            CreatePullRequestError::InvalidTargets(ref cause) => cause,
-            CreatePullRequestError::InvalidTitle(ref cause) => cause,
-            CreatePullRequestError::MaximumOpenPullRequestsExceeded(ref cause) => cause,
-            CreatePullRequestError::MultipleRepositoriesInPullRequest(ref cause) => cause,
-            CreatePullRequestError::ReferenceDoesNotExist(ref cause) => cause,
-            CreatePullRequestError::ReferenceNameRequired(ref cause) => cause,
-            CreatePullRequestError::ReferenceTypeNotSupported(ref cause) => cause,
-            CreatePullRequestError::RepositoryDoesNotExist(ref cause) => cause,
-            CreatePullRequestError::RepositoryNameRequired(ref cause) => cause,
-            CreatePullRequestError::SourceAndDestinationAreSame(ref cause) => cause,
-            CreatePullRequestError::TargetRequired(ref cause) => cause,
-            CreatePullRequestError::TargetsRequired(ref cause) => cause,
-            CreatePullRequestError::TitleRequired(ref cause) => cause,
+            CreatePullRequestError::ClientRequestTokenRequired(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::IdempotencyParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestError::InvalidClientRequestToken(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::InvalidDescription(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::InvalidReferenceName(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::InvalidTargets(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::InvalidTitle(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::MaximumOpenPullRequestsExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestError::MultipleRepositoriesInPullRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestError::ReferenceDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::ReferenceNameRequired(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::ReferenceTypeNotSupported(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::SourceAndDestinationAreSame(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestError::TargetRequired(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::TargetsRequired(ref cause) => write!(f, "{}", cause),
+            CreatePullRequestError::TitleRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePullRequestError {}
 /// Errors returned by CreatePullRequestApprovalRule
 #[derive(Debug, PartialEq)]
 pub enum CreatePullRequestApprovalRuleError {
@@ -4809,30 +4843,56 @@ impl CreatePullRequestApprovalRuleError {
 }
 impl fmt::Display for CreatePullRequestApprovalRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePullRequestApprovalRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePullRequestApprovalRuleError::ApprovalRuleContentRequired(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::ApprovalRuleNameAlreadyExists(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::ApprovalRuleNameRequired(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::EncryptionKeyAccessDenied(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::EncryptionKeyDisabled(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::EncryptionKeyNotFound(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::EncryptionKeyUnavailable(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::InvalidApprovalRuleContent(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::InvalidApprovalRuleName(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::InvalidPullRequestId(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::NumberOfRulesExceeded(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::PullRequestAlreadyClosed(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::PullRequestDoesNotExist(ref cause) => cause,
-            CreatePullRequestApprovalRuleError::PullRequestIdRequired(ref cause) => cause,
+            CreatePullRequestApprovalRuleError::ApprovalRuleContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::ApprovalRuleNameAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::ApprovalRuleNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::InvalidApprovalRuleContent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::InvalidApprovalRuleName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::NumberOfRulesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePullRequestApprovalRuleError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreatePullRequestApprovalRuleError {}
 /// Errors returned by CreateRepository
 #[derive(Debug, PartialEq)]
 pub enum CreateRepositoryError {
@@ -4943,29 +5003,29 @@ impl CreateRepositoryError {
 }
 impl fmt::Display for CreateRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            CreateRepositoryError::EncryptionKeyAccessDenied(ref cause) => cause,
-            CreateRepositoryError::EncryptionKeyDisabled(ref cause) => cause,
-            CreateRepositoryError::EncryptionKeyNotFound(ref cause) => cause,
-            CreateRepositoryError::EncryptionKeyUnavailable(ref cause) => cause,
-            CreateRepositoryError::InvalidRepositoryDescription(ref cause) => cause,
-            CreateRepositoryError::InvalidRepositoryName(ref cause) => cause,
-            CreateRepositoryError::InvalidSystemTagUsage(ref cause) => cause,
-            CreateRepositoryError::InvalidTagsMap(ref cause) => cause,
-            CreateRepositoryError::RepositoryLimitExceeded(ref cause) => cause,
-            CreateRepositoryError::RepositoryNameExists(ref cause) => cause,
-            CreateRepositoryError::RepositoryNameRequired(ref cause) => cause,
-            CreateRepositoryError::TagPolicy(ref cause) => cause,
-            CreateRepositoryError::TooManyTags(ref cause) => cause,
+            CreateRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRepositoryError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::InvalidRepositoryDescription(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRepositoryError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::InvalidSystemTagUsage(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::InvalidTagsMap(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::RepositoryLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::RepositoryNameExists(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRepositoryError {}
 /// Errors returned by CreateUnreferencedMergeCommit
 #[derive(Debug, PartialEq)]
 pub enum CreateUnreferencedMergeCommitError {
@@ -5246,59 +5306,109 @@ impl CreateUnreferencedMergeCommitError {
 }
 impl fmt::Display for CreateUnreferencedMergeCommitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUnreferencedMergeCommitError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUnreferencedMergeCommitError::CommitDoesNotExist(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::CommitMessageLengthExceeded(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::CommitRequired(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::ConcurrentReferenceUpdate(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::EncryptionKeyAccessDenied(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::EncryptionKeyDisabled(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::EncryptionKeyNotFound(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::EncryptionKeyUnavailable(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::FileContentSizeLimitExceeded(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::FileModeRequired(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::FolderContentSizeLimitExceeded(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidCommit(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidConflictDetailLevel(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidConflictResolution(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidConflictResolutionStrategy(ref cause) => {
-                cause
+            CreateUnreferencedMergeCommitError::CommitDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
             }
-            CreateUnreferencedMergeCommitError::InvalidEmail(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidFileMode(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidMergeOption(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidPath(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidReplacementContent(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidReplacementType(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::InvalidRepositoryName(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::ManualMergeRequired(ref cause) => cause,
+            CreateUnreferencedMergeCommitError::CommitMessageLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            CreateUnreferencedMergeCommitError::ConcurrentReferenceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::FileContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::FileModeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::FolderContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            CreateUnreferencedMergeCommitError::InvalidConflictDetailLevel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidConflictResolution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            CreateUnreferencedMergeCommitError::InvalidFileMode(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidMergeOption(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            CreateUnreferencedMergeCommitError::InvalidReplacementContent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidReplacementType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::ManualMergeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateUnreferencedMergeCommitError::MaximumConflictResolutionEntriesExceeded(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateUnreferencedMergeCommitError::MaximumFileContentToLoadExceeded(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateUnreferencedMergeCommitError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::MergeOptionRequired(ref cause) => cause,
+            CreateUnreferencedMergeCommitError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::MergeOptionRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateUnreferencedMergeCommitError::MultipleConflictResolutionEntries(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateUnreferencedMergeCommitError::NameLengthExceeded(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::PathRequired(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::ReplacementContentRequired(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::ReplacementTypeRequired(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::RepositoryDoesNotExist(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::RepositoryNameRequired(ref cause) => cause,
-            CreateUnreferencedMergeCommitError::TipsDivergenceExceeded(ref cause) => cause,
+            CreateUnreferencedMergeCommitError::NameLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::PathRequired(ref cause) => write!(f, "{}", cause),
+            CreateUnreferencedMergeCommitError::ReplacementContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::ReplacementTypeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUnreferencedMergeCommitError::TipsDivergenceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateUnreferencedMergeCommitError {}
 /// Errors returned by DeleteApprovalRuleTemplate
 #[derive(Debug, PartialEq)]
 pub enum DeleteApprovalRuleTemplateError {
@@ -5340,18 +5450,20 @@ impl DeleteApprovalRuleTemplateError {
 }
 impl fmt::Display for DeleteApprovalRuleTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApprovalRuleTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApprovalRuleTemplateError::ApprovalRuleTemplateInUse(ref cause) => cause,
-            DeleteApprovalRuleTemplateError::ApprovalRuleTemplateNameRequired(ref cause) => cause,
-            DeleteApprovalRuleTemplateError::InvalidApprovalRuleTemplateName(ref cause) => cause,
+            DeleteApprovalRuleTemplateError::ApprovalRuleTemplateInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApprovalRuleTemplateError::ApprovalRuleTemplateNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApprovalRuleTemplateError::InvalidApprovalRuleTemplateName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteApprovalRuleTemplateError {}
 /// Errors returned by DeleteBranch
 #[derive(Debug, PartialEq)]
 pub enum DeleteBranchError {
@@ -5433,26 +5545,22 @@ impl DeleteBranchError {
 }
 impl fmt::Display for DeleteBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBranchError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBranchError::BranchNameRequired(ref cause) => cause,
-            DeleteBranchError::DefaultBranchCannotBeDeleted(ref cause) => cause,
-            DeleteBranchError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            DeleteBranchError::EncryptionKeyAccessDenied(ref cause) => cause,
-            DeleteBranchError::EncryptionKeyDisabled(ref cause) => cause,
-            DeleteBranchError::EncryptionKeyNotFound(ref cause) => cause,
-            DeleteBranchError::EncryptionKeyUnavailable(ref cause) => cause,
-            DeleteBranchError::InvalidBranchName(ref cause) => cause,
-            DeleteBranchError::InvalidRepositoryName(ref cause) => cause,
-            DeleteBranchError::RepositoryDoesNotExist(ref cause) => cause,
-            DeleteBranchError::RepositoryNameRequired(ref cause) => cause,
+            DeleteBranchError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::DefaultBranchCannotBeDeleted(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteBranchError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBranchError {}
 /// Errors returned by DeleteCommentContent
 #[derive(Debug, PartialEq)]
 pub enum DeleteCommentContentError {
@@ -5497,19 +5605,15 @@ impl DeleteCommentContentError {
 }
 impl fmt::Display for DeleteCommentContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCommentContentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCommentContentError::CommentDeleted(ref cause) => cause,
-            DeleteCommentContentError::CommentDoesNotExist(ref cause) => cause,
-            DeleteCommentContentError::CommentIdRequired(ref cause) => cause,
-            DeleteCommentContentError::InvalidCommentId(ref cause) => cause,
+            DeleteCommentContentError::CommentDeleted(ref cause) => write!(f, "{}", cause),
+            DeleteCommentContentError::CommentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteCommentContentError::CommentIdRequired(ref cause) => write!(f, "{}", cause),
+            DeleteCommentContentError::InvalidCommentId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCommentContentError {}
 /// Errors returned by DeleteFile
 #[derive(Debug, PartialEq)]
 pub enum DeleteFileError {
@@ -5644,37 +5748,33 @@ impl DeleteFileError {
 }
 impl fmt::Display for DeleteFileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFileError::BranchDoesNotExist(ref cause) => cause,
-            DeleteFileError::BranchNameIsTagName(ref cause) => cause,
-            DeleteFileError::BranchNameRequired(ref cause) => cause,
-            DeleteFileError::CommitMessageLengthExceeded(ref cause) => cause,
-            DeleteFileError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            DeleteFileError::EncryptionKeyAccessDenied(ref cause) => cause,
-            DeleteFileError::EncryptionKeyDisabled(ref cause) => cause,
-            DeleteFileError::EncryptionKeyNotFound(ref cause) => cause,
-            DeleteFileError::EncryptionKeyUnavailable(ref cause) => cause,
-            DeleteFileError::FileDoesNotExist(ref cause) => cause,
-            DeleteFileError::InvalidBranchName(ref cause) => cause,
-            DeleteFileError::InvalidEmail(ref cause) => cause,
-            DeleteFileError::InvalidParentCommitId(ref cause) => cause,
-            DeleteFileError::InvalidPath(ref cause) => cause,
-            DeleteFileError::InvalidRepositoryName(ref cause) => cause,
-            DeleteFileError::NameLengthExceeded(ref cause) => cause,
-            DeleteFileError::ParentCommitDoesNotExist(ref cause) => cause,
-            DeleteFileError::ParentCommitIdOutdated(ref cause) => cause,
-            DeleteFileError::ParentCommitIdRequired(ref cause) => cause,
-            DeleteFileError::PathRequired(ref cause) => cause,
-            DeleteFileError::RepositoryDoesNotExist(ref cause) => cause,
-            DeleteFileError::RepositoryNameRequired(ref cause) => cause,
+            DeleteFileError::BranchDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::BranchNameIsTagName(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::CommitMessageLengthExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::FileDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::InvalidParentCommitId(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::NameLengthExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::ParentCommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::ParentCommitIdOutdated(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::ParentCommitIdRequired(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::PathRequired(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteFileError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFileError {}
 /// Errors returned by DeletePullRequestApprovalRule
 #[derive(Debug, PartialEq)]
 pub enum DeletePullRequestApprovalRuleError {
@@ -5783,29 +5883,47 @@ impl DeletePullRequestApprovalRuleError {
 }
 impl fmt::Display for DeletePullRequestApprovalRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePullRequestApprovalRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePullRequestApprovalRuleError::ApprovalRuleNameRequired(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::CannotDeleteApprovalRuleFromTemplate(ref cause) => {
-                cause
+            DeletePullRequestApprovalRuleError::ApprovalRuleNameRequired(ref cause) => {
+                write!(f, "{}", cause)
             }
-            DeletePullRequestApprovalRuleError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::EncryptionKeyAccessDenied(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::EncryptionKeyDisabled(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::EncryptionKeyNotFound(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::EncryptionKeyUnavailable(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::InvalidApprovalRuleName(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::InvalidPullRequestId(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::PullRequestAlreadyClosed(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::PullRequestDoesNotExist(ref cause) => cause,
-            DeletePullRequestApprovalRuleError::PullRequestIdRequired(ref cause) => cause,
+            DeletePullRequestApprovalRuleError::CannotDeleteApprovalRuleFromTemplate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::InvalidApprovalRuleName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePullRequestApprovalRuleError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeletePullRequestApprovalRuleError {}
 /// Errors returned by DeleteRepository
 #[derive(Debug, PartialEq)]
 pub enum DeleteRepositoryError {
@@ -5873,22 +5991,20 @@ impl DeleteRepositoryError {
 }
 impl fmt::Display for DeleteRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            DeleteRepositoryError::EncryptionKeyAccessDenied(ref cause) => cause,
-            DeleteRepositoryError::EncryptionKeyDisabled(ref cause) => cause,
-            DeleteRepositoryError::EncryptionKeyNotFound(ref cause) => cause,
-            DeleteRepositoryError::EncryptionKeyUnavailable(ref cause) => cause,
-            DeleteRepositoryError::InvalidRepositoryName(ref cause) => cause,
-            DeleteRepositoryError::RepositoryNameRequired(ref cause) => cause,
+            DeleteRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRepositoryError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRepositoryError {}
 /// Errors returned by DescribeMergeConflicts
 #[derive(Debug, PartialEq)]
 pub enum DescribeMergeConflictsError {
@@ -6064,38 +6180,56 @@ impl DescribeMergeConflictsError {
 }
 impl fmt::Display for DescribeMergeConflictsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMergeConflictsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMergeConflictsError::CommitDoesNotExist(ref cause) => cause,
-            DescribeMergeConflictsError::CommitRequired(ref cause) => cause,
-            DescribeMergeConflictsError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            DescribeMergeConflictsError::EncryptionKeyAccessDenied(ref cause) => cause,
-            DescribeMergeConflictsError::EncryptionKeyDisabled(ref cause) => cause,
-            DescribeMergeConflictsError::EncryptionKeyNotFound(ref cause) => cause,
-            DescribeMergeConflictsError::EncryptionKeyUnavailable(ref cause) => cause,
-            DescribeMergeConflictsError::FileDoesNotExist(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidCommit(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidConflictDetailLevel(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidContinuationToken(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidMaxMergeHunks(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidMergeOption(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidPath(ref cause) => cause,
-            DescribeMergeConflictsError::InvalidRepositoryName(ref cause) => cause,
-            DescribeMergeConflictsError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            DescribeMergeConflictsError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            DescribeMergeConflictsError::MergeOptionRequired(ref cause) => cause,
-            DescribeMergeConflictsError::PathRequired(ref cause) => cause,
-            DescribeMergeConflictsError::RepositoryDoesNotExist(ref cause) => cause,
-            DescribeMergeConflictsError::RepositoryNameRequired(ref cause) => cause,
-            DescribeMergeConflictsError::TipsDivergenceExceeded(ref cause) => cause,
+            DescribeMergeConflictsError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::FileDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::InvalidConflictDetailLevel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::InvalidContinuationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::InvalidMaxMergeHunks(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::InvalidMergeOption(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::MergeOptionRequired(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::PathRequired(ref cause) => write!(f, "{}", cause),
+            DescribeMergeConflictsError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMergeConflictsError::TipsDivergenceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMergeConflictsError {}
 /// Errors returned by DescribePullRequestEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribePullRequestEventsError {
@@ -6205,28 +6339,44 @@ impl DescribePullRequestEventsError {
 }
 impl fmt::Display for DescribePullRequestEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePullRequestEventsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePullRequestEventsError::ActorDoesNotExist(ref cause) => cause,
-            DescribePullRequestEventsError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            DescribePullRequestEventsError::EncryptionKeyAccessDenied(ref cause) => cause,
-            DescribePullRequestEventsError::EncryptionKeyDisabled(ref cause) => cause,
-            DescribePullRequestEventsError::EncryptionKeyNotFound(ref cause) => cause,
-            DescribePullRequestEventsError::EncryptionKeyUnavailable(ref cause) => cause,
-            DescribePullRequestEventsError::InvalidActorArn(ref cause) => cause,
-            DescribePullRequestEventsError::InvalidContinuationToken(ref cause) => cause,
-            DescribePullRequestEventsError::InvalidMaxResults(ref cause) => cause,
-            DescribePullRequestEventsError::InvalidPullRequestEventType(ref cause) => cause,
-            DescribePullRequestEventsError::InvalidPullRequestId(ref cause) => cause,
-            DescribePullRequestEventsError::PullRequestDoesNotExist(ref cause) => cause,
-            DescribePullRequestEventsError::PullRequestIdRequired(ref cause) => cause,
+            DescribePullRequestEventsError::ActorDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribePullRequestEventsError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::InvalidActorArn(ref cause) => write!(f, "{}", cause),
+            DescribePullRequestEventsError::InvalidContinuationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::InvalidMaxResults(ref cause) => write!(f, "{}", cause),
+            DescribePullRequestEventsError::InvalidPullRequestEventType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePullRequestEventsError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePullRequestEventsError {}
 /// Errors returned by DisassociateApprovalRuleTemplateFromRepository
 #[derive(Debug, PartialEq)]
 pub enum DisassociateApprovalRuleTemplateFromRepositoryError {
@@ -6280,26 +6430,22 @@ _ => {}
 }
 impl fmt::Display for DisassociateApprovalRuleTemplateFromRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateApprovalRuleTemplateFromRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-                            DisassociateApprovalRuleTemplateFromRepositoryError::ApprovalRuleTemplateDoesNotExist(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::ApprovalRuleTemplateNameRequired(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyAccessDenied(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyDisabled(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyNotFound(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyUnavailable(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::InvalidApprovalRuleTemplateName(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::InvalidRepositoryName(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::RepositoryDoesNotExist(ref cause) => cause,
-DisassociateApprovalRuleTemplateFromRepositoryError::RepositoryNameRequired(ref cause) => cause
+                            DisassociateApprovalRuleTemplateFromRepositoryError::ApprovalRuleTemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::ApprovalRuleTemplateNameRequired(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::InvalidApprovalRuleTemplateName(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+DisassociateApprovalRuleTemplateFromRepositoryError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for DisassociateApprovalRuleTemplateFromRepositoryError {}
 /// Errors returned by EvaluatePullRequestApprovalRules
 #[derive(Debug, PartialEq)]
 pub enum EvaluatePullRequestApprovalRulesError {
@@ -6399,28 +6545,44 @@ impl EvaluatePullRequestApprovalRulesError {
 }
 impl fmt::Display for EvaluatePullRequestApprovalRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EvaluatePullRequestApprovalRulesError {
-    fn description(&self) -> &str {
         match *self {
             EvaluatePullRequestApprovalRulesError::EncryptionIntegrityChecksFailed(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            EvaluatePullRequestApprovalRulesError::EncryptionKeyAccessDenied(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::EncryptionKeyDisabled(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::EncryptionKeyNotFound(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::EncryptionKeyUnavailable(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::InvalidPullRequestId(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::InvalidRevisionId(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::PullRequestDoesNotExist(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::PullRequestIdRequired(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::RevisionIdRequired(ref cause) => cause,
-            EvaluatePullRequestApprovalRulesError::RevisionNotCurrent(ref cause) => cause,
+            EvaluatePullRequestApprovalRulesError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::InvalidRevisionId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::RevisionIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EvaluatePullRequestApprovalRulesError::RevisionNotCurrent(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for EvaluatePullRequestApprovalRulesError {}
 /// Errors returned by GetApprovalRuleTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetApprovalRuleTemplateError {
@@ -6460,18 +6622,20 @@ impl GetApprovalRuleTemplateError {
 }
 impl fmt::Display for GetApprovalRuleTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApprovalRuleTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GetApprovalRuleTemplateError::ApprovalRuleTemplateDoesNotExist(ref cause) => cause,
-            GetApprovalRuleTemplateError::ApprovalRuleTemplateNameRequired(ref cause) => cause,
-            GetApprovalRuleTemplateError::InvalidApprovalRuleTemplateName(ref cause) => cause,
+            GetApprovalRuleTemplateError::ApprovalRuleTemplateDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetApprovalRuleTemplateError::ApprovalRuleTemplateNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetApprovalRuleTemplateError::InvalidApprovalRuleTemplateName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetApprovalRuleTemplateError {}
 /// Errors returned by GetBlob
 #[derive(Debug, PartialEq)]
 pub enum GetBlobError {
@@ -6552,27 +6716,23 @@ impl GetBlobError {
 }
 impl fmt::Display for GetBlobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBlobError {
-    fn description(&self) -> &str {
         match *self {
-            GetBlobError::BlobIdDoesNotExist(ref cause) => cause,
-            GetBlobError::BlobIdRequired(ref cause) => cause,
-            GetBlobError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetBlobError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetBlobError::EncryptionKeyDisabled(ref cause) => cause,
-            GetBlobError::EncryptionKeyNotFound(ref cause) => cause,
-            GetBlobError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetBlobError::FileTooLarge(ref cause) => cause,
-            GetBlobError::InvalidBlobId(ref cause) => cause,
-            GetBlobError::InvalidRepositoryName(ref cause) => cause,
-            GetBlobError::RepositoryDoesNotExist(ref cause) => cause,
-            GetBlobError::RepositoryNameRequired(ref cause) => cause,
+            GetBlobError::BlobIdDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetBlobError::BlobIdRequired(ref cause) => write!(f, "{}", cause),
+            GetBlobError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            GetBlobError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetBlobError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetBlobError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetBlobError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetBlobError::FileTooLarge(ref cause) => write!(f, "{}", cause),
+            GetBlobError::InvalidBlobId(ref cause) => write!(f, "{}", cause),
+            GetBlobError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetBlobError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetBlobError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBlobError {}
 /// Errors returned by GetBranch
 #[derive(Debug, PartialEq)]
 pub enum GetBranchError {
@@ -6648,26 +6808,22 @@ impl GetBranchError {
 }
 impl fmt::Display for GetBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBranchError {
-    fn description(&self) -> &str {
         match *self {
-            GetBranchError::BranchDoesNotExist(ref cause) => cause,
-            GetBranchError::BranchNameRequired(ref cause) => cause,
-            GetBranchError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetBranchError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetBranchError::EncryptionKeyDisabled(ref cause) => cause,
-            GetBranchError::EncryptionKeyNotFound(ref cause) => cause,
-            GetBranchError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetBranchError::InvalidBranchName(ref cause) => cause,
-            GetBranchError::InvalidRepositoryName(ref cause) => cause,
-            GetBranchError::RepositoryDoesNotExist(ref cause) => cause,
-            GetBranchError::RepositoryNameRequired(ref cause) => cause,
+            GetBranchError::BranchDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetBranchError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            GetBranchError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            GetBranchError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetBranchError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetBranchError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetBranchError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetBranchError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            GetBranchError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetBranchError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetBranchError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBranchError {}
 /// Errors returned by GetComment
 #[derive(Debug, PartialEq)]
 pub enum GetCommentError {
@@ -6706,19 +6862,15 @@ impl GetCommentError {
 }
 impl fmt::Display for GetCommentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCommentError {
-    fn description(&self) -> &str {
         match *self {
-            GetCommentError::CommentDeleted(ref cause) => cause,
-            GetCommentError::CommentDoesNotExist(ref cause) => cause,
-            GetCommentError::CommentIdRequired(ref cause) => cause,
-            GetCommentError::InvalidCommentId(ref cause) => cause,
+            GetCommentError::CommentDeleted(ref cause) => write!(f, "{}", cause),
+            GetCommentError::CommentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetCommentError::CommentIdRequired(ref cause) => write!(f, "{}", cause),
+            GetCommentError::InvalidCommentId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCommentError {}
 /// Errors returned by GetCommentsForComparedCommit
 #[derive(Debug, PartialEq)]
 pub enum GetCommentsForComparedCommitError {
@@ -6830,28 +6982,48 @@ impl GetCommentsForComparedCommitError {
 }
 impl fmt::Display for GetCommentsForComparedCommitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCommentsForComparedCommitError {
-    fn description(&self) -> &str {
         match *self {
-            GetCommentsForComparedCommitError::CommitDoesNotExist(ref cause) => cause,
-            GetCommentsForComparedCommitError::CommitIdRequired(ref cause) => cause,
-            GetCommentsForComparedCommitError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetCommentsForComparedCommitError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetCommentsForComparedCommitError::EncryptionKeyDisabled(ref cause) => cause,
-            GetCommentsForComparedCommitError::EncryptionKeyNotFound(ref cause) => cause,
-            GetCommentsForComparedCommitError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetCommentsForComparedCommitError::InvalidCommitId(ref cause) => cause,
-            GetCommentsForComparedCommitError::InvalidContinuationToken(ref cause) => cause,
-            GetCommentsForComparedCommitError::InvalidMaxResults(ref cause) => cause,
-            GetCommentsForComparedCommitError::InvalidRepositoryName(ref cause) => cause,
-            GetCommentsForComparedCommitError::RepositoryDoesNotExist(ref cause) => cause,
-            GetCommentsForComparedCommitError::RepositoryNameRequired(ref cause) => cause,
+            GetCommentsForComparedCommitError::CommitDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::CommitIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            GetCommentsForComparedCommitError::InvalidContinuationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::InvalidMaxResults(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForComparedCommitError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetCommentsForComparedCommitError {}
 /// Errors returned by GetCommentsForPullRequest
 #[derive(Debug, PartialEq)]
 pub enum GetCommentsForPullRequestError {
@@ -6991,34 +7163,54 @@ impl GetCommentsForPullRequestError {
 }
 impl fmt::Display for GetCommentsForPullRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCommentsForPullRequestError {
-    fn description(&self) -> &str {
         match *self {
-            GetCommentsForPullRequestError::CommitDoesNotExist(ref cause) => cause,
-            GetCommentsForPullRequestError::CommitIdRequired(ref cause) => cause,
-            GetCommentsForPullRequestError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetCommentsForPullRequestError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetCommentsForPullRequestError::EncryptionKeyDisabled(ref cause) => cause,
-            GetCommentsForPullRequestError::EncryptionKeyNotFound(ref cause) => cause,
-            GetCommentsForPullRequestError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetCommentsForPullRequestError::InvalidCommitId(ref cause) => cause,
-            GetCommentsForPullRequestError::InvalidContinuationToken(ref cause) => cause,
-            GetCommentsForPullRequestError::InvalidMaxResults(ref cause) => cause,
-            GetCommentsForPullRequestError::InvalidPullRequestId(ref cause) => cause,
-            GetCommentsForPullRequestError::InvalidRepositoryName(ref cause) => cause,
-            GetCommentsForPullRequestError::PullRequestDoesNotExist(ref cause) => cause,
-            GetCommentsForPullRequestError::PullRequestIdRequired(ref cause) => cause,
-            GetCommentsForPullRequestError::RepositoryDoesNotExist(ref cause) => cause,
-            GetCommentsForPullRequestError::RepositoryNameRequired(ref cause) => cause,
+            GetCommentsForPullRequestError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetCommentsForPullRequestError::CommitIdRequired(ref cause) => write!(f, "{}", cause),
+            GetCommentsForPullRequestError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            GetCommentsForPullRequestError::InvalidContinuationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::InvalidMaxResults(ref cause) => write!(f, "{}", cause),
+            GetCommentsForPullRequestError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCommentsForPullRequestError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetCommentsForPullRequestError::RepositoryNotAssociatedWithPullRequest(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GetCommentsForPullRequestError {}
 /// Errors returned by GetCommit
 #[derive(Debug, PartialEq)]
 pub enum GetCommitError {
@@ -7094,26 +7286,22 @@ impl GetCommitError {
 }
 impl fmt::Display for GetCommitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCommitError {
-    fn description(&self) -> &str {
         match *self {
-            GetCommitError::CommitIdDoesNotExist(ref cause) => cause,
-            GetCommitError::CommitIdRequired(ref cause) => cause,
-            GetCommitError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetCommitError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetCommitError::EncryptionKeyDisabled(ref cause) => cause,
-            GetCommitError::EncryptionKeyNotFound(ref cause) => cause,
-            GetCommitError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetCommitError::InvalidCommitId(ref cause) => cause,
-            GetCommitError::InvalidRepositoryName(ref cause) => cause,
-            GetCommitError::RepositoryDoesNotExist(ref cause) => cause,
-            GetCommitError::RepositoryNameRequired(ref cause) => cause,
+            GetCommitError::CommitIdDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetCommitError::CommitIdRequired(ref cause) => write!(f, "{}", cause),
+            GetCommitError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            GetCommitError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetCommitError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetCommitError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetCommitError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetCommitError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            GetCommitError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetCommitError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetCommitError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCommitError {}
 /// Errors returned by GetDifferences
 #[derive(Debug, PartialEq)]
 pub enum GetDifferencesError {
@@ -7230,31 +7418,29 @@ impl GetDifferencesError {
 }
 impl fmt::Display for GetDifferencesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDifferencesError {
-    fn description(&self) -> &str {
         match *self {
-            GetDifferencesError::CommitDoesNotExist(ref cause) => cause,
-            GetDifferencesError::CommitRequired(ref cause) => cause,
-            GetDifferencesError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetDifferencesError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetDifferencesError::EncryptionKeyDisabled(ref cause) => cause,
-            GetDifferencesError::EncryptionKeyNotFound(ref cause) => cause,
-            GetDifferencesError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetDifferencesError::InvalidCommit(ref cause) => cause,
-            GetDifferencesError::InvalidCommitId(ref cause) => cause,
-            GetDifferencesError::InvalidContinuationToken(ref cause) => cause,
-            GetDifferencesError::InvalidMaxResults(ref cause) => cause,
-            GetDifferencesError::InvalidPath(ref cause) => cause,
-            GetDifferencesError::InvalidRepositoryName(ref cause) => cause,
-            GetDifferencesError::PathDoesNotExist(ref cause) => cause,
-            GetDifferencesError::RepositoryDoesNotExist(ref cause) => cause,
-            GetDifferencesError::RepositoryNameRequired(ref cause) => cause,
+            GetDifferencesError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDifferencesError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::InvalidContinuationToken(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::InvalidMaxResults(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::PathDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDifferencesError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDifferencesError {}
 /// Errors returned by GetFile
 #[derive(Debug, PartialEq)]
 pub enum GetFileError {
@@ -7345,29 +7531,25 @@ impl GetFileError {
 }
 impl fmt::Display for GetFileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFileError {
-    fn description(&self) -> &str {
         match *self {
-            GetFileError::CommitDoesNotExist(ref cause) => cause,
-            GetFileError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetFileError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetFileError::EncryptionKeyDisabled(ref cause) => cause,
-            GetFileError::EncryptionKeyNotFound(ref cause) => cause,
-            GetFileError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetFileError::FileDoesNotExist(ref cause) => cause,
-            GetFileError::FileTooLarge(ref cause) => cause,
-            GetFileError::InvalidCommit(ref cause) => cause,
-            GetFileError::InvalidPath(ref cause) => cause,
-            GetFileError::InvalidRepositoryName(ref cause) => cause,
-            GetFileError::PathRequired(ref cause) => cause,
-            GetFileError::RepositoryDoesNotExist(ref cause) => cause,
-            GetFileError::RepositoryNameRequired(ref cause) => cause,
+            GetFileError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetFileError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            GetFileError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetFileError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetFileError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetFileError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetFileError::FileDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetFileError::FileTooLarge(ref cause) => write!(f, "{}", cause),
+            GetFileError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            GetFileError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            GetFileError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetFileError::PathRequired(ref cause) => write!(f, "{}", cause),
+            GetFileError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetFileError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFileError {}
 /// Errors returned by GetFolder
 #[derive(Debug, PartialEq)]
 pub enum GetFolderError {
@@ -7453,28 +7635,24 @@ impl GetFolderError {
 }
 impl fmt::Display for GetFolderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFolderError {
-    fn description(&self) -> &str {
         match *self {
-            GetFolderError::CommitDoesNotExist(ref cause) => cause,
-            GetFolderError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetFolderError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetFolderError::EncryptionKeyDisabled(ref cause) => cause,
-            GetFolderError::EncryptionKeyNotFound(ref cause) => cause,
-            GetFolderError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetFolderError::FolderDoesNotExist(ref cause) => cause,
-            GetFolderError::InvalidCommit(ref cause) => cause,
-            GetFolderError::InvalidPath(ref cause) => cause,
-            GetFolderError::InvalidRepositoryName(ref cause) => cause,
-            GetFolderError::PathRequired(ref cause) => cause,
-            GetFolderError::RepositoryDoesNotExist(ref cause) => cause,
-            GetFolderError::RepositoryNameRequired(ref cause) => cause,
+            GetFolderError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetFolderError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            GetFolderError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetFolderError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetFolderError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetFolderError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetFolderError::FolderDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetFolderError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            GetFolderError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            GetFolderError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetFolderError::PathRequired(ref cause) => write!(f, "{}", cause),
+            GetFolderError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetFolderError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFolderError {}
 /// Errors returned by GetMergeCommit
 #[derive(Debug, PartialEq)]
 pub enum GetMergeCommitError {
@@ -7578,28 +7756,28 @@ impl GetMergeCommitError {
 }
 impl fmt::Display for GetMergeCommitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMergeCommitError {
-    fn description(&self) -> &str {
         match *self {
-            GetMergeCommitError::CommitDoesNotExist(ref cause) => cause,
-            GetMergeCommitError::CommitRequired(ref cause) => cause,
-            GetMergeCommitError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetMergeCommitError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetMergeCommitError::EncryptionKeyDisabled(ref cause) => cause,
-            GetMergeCommitError::EncryptionKeyNotFound(ref cause) => cause,
-            GetMergeCommitError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetMergeCommitError::InvalidCommit(ref cause) => cause,
-            GetMergeCommitError::InvalidConflictDetailLevel(ref cause) => cause,
-            GetMergeCommitError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            GetMergeCommitError::InvalidRepositoryName(ref cause) => cause,
-            GetMergeCommitError::RepositoryDoesNotExist(ref cause) => cause,
-            GetMergeCommitError::RepositoryNameRequired(ref cause) => cause,
+            GetMergeCommitError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeCommitError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::InvalidConflictDetailLevel(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeCommitError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMergeCommitError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMergeCommitError {}
 /// Errors returned by GetMergeConflicts
 #[derive(Debug, PartialEq)]
 pub enum GetMergeConflictsError {
@@ -7768,37 +7946,45 @@ impl GetMergeConflictsError {
 }
 impl fmt::Display for GetMergeConflictsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMergeConflictsError {
-    fn description(&self) -> &str {
         match *self {
-            GetMergeConflictsError::CommitDoesNotExist(ref cause) => cause,
-            GetMergeConflictsError::CommitRequired(ref cause) => cause,
-            GetMergeConflictsError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetMergeConflictsError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetMergeConflictsError::EncryptionKeyDisabled(ref cause) => cause,
-            GetMergeConflictsError::EncryptionKeyNotFound(ref cause) => cause,
-            GetMergeConflictsError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetMergeConflictsError::InvalidCommit(ref cause) => cause,
-            GetMergeConflictsError::InvalidConflictDetailLevel(ref cause) => cause,
-            GetMergeConflictsError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            GetMergeConflictsError::InvalidContinuationToken(ref cause) => cause,
-            GetMergeConflictsError::InvalidDestinationCommitSpecifier(ref cause) => cause,
-            GetMergeConflictsError::InvalidMaxConflictFiles(ref cause) => cause,
-            GetMergeConflictsError::InvalidMergeOption(ref cause) => cause,
-            GetMergeConflictsError::InvalidRepositoryName(ref cause) => cause,
-            GetMergeConflictsError::InvalidSourceCommitSpecifier(ref cause) => cause,
-            GetMergeConflictsError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            GetMergeConflictsError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            GetMergeConflictsError::MergeOptionRequired(ref cause) => cause,
-            GetMergeConflictsError::RepositoryDoesNotExist(ref cause) => cause,
-            GetMergeConflictsError::RepositoryNameRequired(ref cause) => cause,
-            GetMergeConflictsError::TipsDivergenceExceeded(ref cause) => cause,
+            GetMergeConflictsError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeConflictsError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::InvalidConflictDetailLevel(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeConflictsError::InvalidContinuationToken(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::InvalidDestinationCommitSpecifier(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeConflictsError::InvalidMaxConflictFiles(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::InvalidMergeOption(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::InvalidSourceCommitSpecifier(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeConflictsError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeConflictsError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeConflictsError::MergeOptionRequired(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            GetMergeConflictsError::TipsDivergenceExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMergeConflictsError {}
 /// Errors returned by GetMergeOptions
 #[derive(Debug, PartialEq)]
 pub enum GetMergeOptionsError {
@@ -7923,31 +8109,35 @@ impl GetMergeOptionsError {
 }
 impl fmt::Display for GetMergeOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMergeOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetMergeOptionsError::CommitDoesNotExist(ref cause) => cause,
-            GetMergeOptionsError::CommitRequired(ref cause) => cause,
-            GetMergeOptionsError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetMergeOptionsError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetMergeOptionsError::EncryptionKeyDisabled(ref cause) => cause,
-            GetMergeOptionsError::EncryptionKeyNotFound(ref cause) => cause,
-            GetMergeOptionsError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetMergeOptionsError::InvalidCommit(ref cause) => cause,
-            GetMergeOptionsError::InvalidConflictDetailLevel(ref cause) => cause,
-            GetMergeOptionsError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            GetMergeOptionsError::InvalidRepositoryName(ref cause) => cause,
-            GetMergeOptionsError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            GetMergeOptionsError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            GetMergeOptionsError::RepositoryDoesNotExist(ref cause) => cause,
-            GetMergeOptionsError::RepositoryNameRequired(ref cause) => cause,
-            GetMergeOptionsError::TipsDivergenceExceeded(ref cause) => cause,
+            GetMergeOptionsError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeOptionsError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::InvalidConflictDetailLevel(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeOptionsError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeOptionsError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMergeOptionsError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            GetMergeOptionsError::TipsDivergenceExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMergeOptionsError {}
 /// Errors returned by GetPullRequest
 #[derive(Debug, PartialEq)]
 pub enum GetPullRequestError {
@@ -8020,23 +8210,21 @@ impl GetPullRequestError {
 }
 impl fmt::Display for GetPullRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPullRequestError {
-    fn description(&self) -> &str {
         match *self {
-            GetPullRequestError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetPullRequestError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetPullRequestError::EncryptionKeyDisabled(ref cause) => cause,
-            GetPullRequestError::EncryptionKeyNotFound(ref cause) => cause,
-            GetPullRequestError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetPullRequestError::InvalidPullRequestId(ref cause) => cause,
-            GetPullRequestError::PullRequestDoesNotExist(ref cause) => cause,
-            GetPullRequestError::PullRequestIdRequired(ref cause) => cause,
+            GetPullRequestError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetPullRequestError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetPullRequestError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetPullRequestError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPullRequestError::InvalidPullRequestId(ref cause) => write!(f, "{}", cause),
+            GetPullRequestError::PullRequestDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetPullRequestError::PullRequestIdRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPullRequestError {}
 /// Errors returned by GetPullRequestApprovalStates
 #[derive(Debug, PartialEq)]
 pub enum GetPullRequestApprovalStatesError {
@@ -8127,25 +8315,41 @@ impl GetPullRequestApprovalStatesError {
 }
 impl fmt::Display for GetPullRequestApprovalStatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPullRequestApprovalStatesError {
-    fn description(&self) -> &str {
         match *self {
-            GetPullRequestApprovalStatesError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetPullRequestApprovalStatesError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetPullRequestApprovalStatesError::EncryptionKeyDisabled(ref cause) => cause,
-            GetPullRequestApprovalStatesError::EncryptionKeyNotFound(ref cause) => cause,
-            GetPullRequestApprovalStatesError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetPullRequestApprovalStatesError::InvalidPullRequestId(ref cause) => cause,
-            GetPullRequestApprovalStatesError::InvalidRevisionId(ref cause) => cause,
-            GetPullRequestApprovalStatesError::PullRequestDoesNotExist(ref cause) => cause,
-            GetPullRequestApprovalStatesError::PullRequestIdRequired(ref cause) => cause,
-            GetPullRequestApprovalStatesError::RevisionIdRequired(ref cause) => cause,
+            GetPullRequestApprovalStatesError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::InvalidRevisionId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestApprovalStatesError::RevisionIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetPullRequestApprovalStatesError {}
 /// Errors returned by GetPullRequestOverrideState
 #[derive(Debug, PartialEq)]
 pub enum GetPullRequestOverrideStateError {
@@ -8236,25 +8440,41 @@ impl GetPullRequestOverrideStateError {
 }
 impl fmt::Display for GetPullRequestOverrideStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPullRequestOverrideStateError {
-    fn description(&self) -> &str {
         match *self {
-            GetPullRequestOverrideStateError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetPullRequestOverrideStateError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetPullRequestOverrideStateError::EncryptionKeyDisabled(ref cause) => cause,
-            GetPullRequestOverrideStateError::EncryptionKeyNotFound(ref cause) => cause,
-            GetPullRequestOverrideStateError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetPullRequestOverrideStateError::InvalidPullRequestId(ref cause) => cause,
-            GetPullRequestOverrideStateError::InvalidRevisionId(ref cause) => cause,
-            GetPullRequestOverrideStateError::PullRequestDoesNotExist(ref cause) => cause,
-            GetPullRequestOverrideStateError::PullRequestIdRequired(ref cause) => cause,
-            GetPullRequestOverrideStateError::RevisionIdRequired(ref cause) => cause,
+            GetPullRequestOverrideStateError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::InvalidRevisionId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPullRequestOverrideStateError::RevisionIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetPullRequestOverrideStateError {}
 /// Errors returned by GetRepository
 #[derive(Debug, PartialEq)]
 pub enum GetRepositoryError {
@@ -8323,23 +8543,21 @@ impl GetRepositoryError {
 }
 impl fmt::Display for GetRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-            GetRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetRepositoryError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetRepositoryError::EncryptionKeyDisabled(ref cause) => cause,
-            GetRepositoryError::EncryptionKeyNotFound(ref cause) => cause,
-            GetRepositoryError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetRepositoryError::InvalidRepositoryName(ref cause) => cause,
-            GetRepositoryError::RepositoryDoesNotExist(ref cause) => cause,
-            GetRepositoryError::RepositoryNameRequired(ref cause) => cause,
+            GetRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRepositoryError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRepositoryError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetRepositoryError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetRepositoryError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetRepositoryError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetRepositoryError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetRepositoryError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRepositoryError {}
 /// Errors returned by GetRepositoryTriggers
 #[derive(Debug, PartialEq)]
 pub enum GetRepositoryTriggersError {
@@ -8414,23 +8632,25 @@ impl GetRepositoryTriggersError {
 }
 impl fmt::Display for GetRepositoryTriggersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRepositoryTriggersError {
-    fn description(&self) -> &str {
         match *self {
-            GetRepositoryTriggersError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            GetRepositoryTriggersError::EncryptionKeyAccessDenied(ref cause) => cause,
-            GetRepositoryTriggersError::EncryptionKeyDisabled(ref cause) => cause,
-            GetRepositoryTriggersError::EncryptionKeyNotFound(ref cause) => cause,
-            GetRepositoryTriggersError::EncryptionKeyUnavailable(ref cause) => cause,
-            GetRepositoryTriggersError::InvalidRepositoryName(ref cause) => cause,
-            GetRepositoryTriggersError::RepositoryDoesNotExist(ref cause) => cause,
-            GetRepositoryTriggersError::RepositoryNameRequired(ref cause) => cause,
+            GetRepositoryTriggersError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRepositoryTriggersError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRepositoryTriggersError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            GetRepositoryTriggersError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            GetRepositoryTriggersError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRepositoryTriggersError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            GetRepositoryTriggersError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetRepositoryTriggersError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRepositoryTriggersError {}
 /// Errors returned by ListApprovalRuleTemplates
 #[derive(Debug, PartialEq)]
 pub enum ListApprovalRuleTemplatesError {
@@ -8463,17 +8683,15 @@ impl ListApprovalRuleTemplatesError {
 }
 impl fmt::Display for ListApprovalRuleTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApprovalRuleTemplatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListApprovalRuleTemplatesError::InvalidContinuationToken(ref cause) => cause,
-            ListApprovalRuleTemplatesError::InvalidMaxResults(ref cause) => cause,
+            ListApprovalRuleTemplatesError::InvalidContinuationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApprovalRuleTemplatesError::InvalidMaxResults(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListApprovalRuleTemplatesError {}
 /// Errors returned by ListAssociatedApprovalRuleTemplatesForRepository
 #[derive(Debug, PartialEq)]
 pub enum ListAssociatedApprovalRuleTemplatesForRepositoryError {
@@ -8524,25 +8742,21 @@ _ => {}
 }
 impl fmt::Display for ListAssociatedApprovalRuleTemplatesForRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssociatedApprovalRuleTemplatesForRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-                            ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyAccessDenied(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyDisabled(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyNotFound(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyUnavailable(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::InvalidContinuationToken(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::InvalidMaxResults(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::InvalidRepositoryName(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::RepositoryDoesNotExist(ref cause) => cause,
-ListAssociatedApprovalRuleTemplatesForRepositoryError::RepositoryNameRequired(ref cause) => cause
+                            ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::InvalidContinuationToken(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::InvalidMaxResults(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+ListAssociatedApprovalRuleTemplatesForRepositoryError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for ListAssociatedApprovalRuleTemplatesForRepositoryError {}
 /// Errors returned by ListBranches
 #[derive(Debug, PartialEq)]
 pub enum ListBranchesError {
@@ -8614,24 +8828,20 @@ impl ListBranchesError {
 }
 impl fmt::Display for ListBranchesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBranchesError {
-    fn description(&self) -> &str {
         match *self {
-            ListBranchesError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            ListBranchesError::EncryptionKeyAccessDenied(ref cause) => cause,
-            ListBranchesError::EncryptionKeyDisabled(ref cause) => cause,
-            ListBranchesError::EncryptionKeyNotFound(ref cause) => cause,
-            ListBranchesError::EncryptionKeyUnavailable(ref cause) => cause,
-            ListBranchesError::InvalidContinuationToken(ref cause) => cause,
-            ListBranchesError::InvalidRepositoryName(ref cause) => cause,
-            ListBranchesError::RepositoryDoesNotExist(ref cause) => cause,
-            ListBranchesError::RepositoryNameRequired(ref cause) => cause,
+            ListBranchesError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::InvalidContinuationToken(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListBranchesError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBranchesError {}
 /// Errors returned by ListPullRequests
 #[derive(Debug, PartialEq)]
 pub enum ListPullRequestsError {
@@ -8735,28 +8945,26 @@ impl ListPullRequestsError {
 }
 impl fmt::Display for ListPullRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPullRequestsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPullRequestsError::AuthorDoesNotExist(ref cause) => cause,
-            ListPullRequestsError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            ListPullRequestsError::EncryptionKeyAccessDenied(ref cause) => cause,
-            ListPullRequestsError::EncryptionKeyDisabled(ref cause) => cause,
-            ListPullRequestsError::EncryptionKeyNotFound(ref cause) => cause,
-            ListPullRequestsError::EncryptionKeyUnavailable(ref cause) => cause,
-            ListPullRequestsError::InvalidAuthorArn(ref cause) => cause,
-            ListPullRequestsError::InvalidContinuationToken(ref cause) => cause,
-            ListPullRequestsError::InvalidMaxResults(ref cause) => cause,
-            ListPullRequestsError::InvalidPullRequestStatus(ref cause) => cause,
-            ListPullRequestsError::InvalidRepositoryName(ref cause) => cause,
-            ListPullRequestsError::RepositoryDoesNotExist(ref cause) => cause,
-            ListPullRequestsError::RepositoryNameRequired(ref cause) => cause,
+            ListPullRequestsError::AuthorDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListPullRequestsError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::InvalidAuthorArn(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::InvalidContinuationToken(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::InvalidMaxResults(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::InvalidPullRequestStatus(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListPullRequestsError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPullRequestsError {}
 /// Errors returned by ListRepositories
 #[derive(Debug, PartialEq)]
 pub enum ListRepositoriesError {
@@ -8792,18 +9000,14 @@ impl ListRepositoriesError {
 }
 impl fmt::Display for ListRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRepositoriesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRepositoriesError::InvalidContinuationToken(ref cause) => cause,
-            ListRepositoriesError::InvalidOrder(ref cause) => cause,
-            ListRepositoriesError::InvalidSortBy(ref cause) => cause,
+            ListRepositoriesError::InvalidContinuationToken(ref cause) => write!(f, "{}", cause),
+            ListRepositoriesError::InvalidOrder(ref cause) => write!(f, "{}", cause),
+            ListRepositoriesError::InvalidSortBy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRepositoriesError {}
 /// Errors returned by ListRepositoriesForApprovalRuleTemplate
 #[derive(Debug, PartialEq)]
 pub enum ListRepositoriesForApprovalRuleTemplateError {
@@ -8904,39 +9108,41 @@ impl ListRepositoriesForApprovalRuleTemplateError {
 }
 impl fmt::Display for ListRepositoriesForApprovalRuleTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRepositoriesForApprovalRuleTemplateError {
-    fn description(&self) -> &str {
         match *self {
             ListRepositoriesForApprovalRuleTemplateError::ApprovalRuleTemplateDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ListRepositoriesForApprovalRuleTemplateError::ApprovalRuleTemplateNameRequired(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ListRepositoriesForApprovalRuleTemplateError::EncryptionIntegrityChecksFailed(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ListRepositoriesForApprovalRuleTemplateError::EncryptionKeyAccessDenied(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            ListRepositoriesForApprovalRuleTemplateError::EncryptionKeyDisabled(ref cause) => cause,
-            ListRepositoriesForApprovalRuleTemplateError::EncryptionKeyNotFound(ref cause) => cause,
+            ListRepositoriesForApprovalRuleTemplateError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListRepositoriesForApprovalRuleTemplateError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ListRepositoriesForApprovalRuleTemplateError::EncryptionKeyUnavailable(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             ListRepositoriesForApprovalRuleTemplateError::InvalidApprovalRuleTemplateName(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ListRepositoriesForApprovalRuleTemplateError::InvalidContinuationToken(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            ListRepositoriesForApprovalRuleTemplateError::InvalidMaxResults(ref cause) => cause,
+            ListRepositoriesForApprovalRuleTemplateError::InvalidMaxResults(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListRepositoriesForApprovalRuleTemplateError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -8983,19 +9189,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InvalidRepositoryName(ref cause) => cause,
-            ListTagsForResourceError::InvalidResourceArn(ref cause) => cause,
-            ListTagsForResourceError::RepositoryDoesNotExist(ref cause) => cause,
-            ListTagsForResourceError::ResourceArnRequired(ref cause) => cause,
+            ListTagsForResourceError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidResourceArn(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceArnRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by MergeBranchesByFastForward
 #[derive(Debug, PartialEq)]
 pub enum MergeBranchesByFastForwardError {
@@ -9149,34 +9351,62 @@ impl MergeBranchesByFastForwardError {
 }
 impl fmt::Display for MergeBranchesByFastForwardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergeBranchesByFastForwardError {
-    fn description(&self) -> &str {
         match *self {
-            MergeBranchesByFastForwardError::BranchDoesNotExist(ref cause) => cause,
-            MergeBranchesByFastForwardError::BranchNameIsTagName(ref cause) => cause,
-            MergeBranchesByFastForwardError::BranchNameRequired(ref cause) => cause,
-            MergeBranchesByFastForwardError::CommitDoesNotExist(ref cause) => cause,
-            MergeBranchesByFastForwardError::CommitRequired(ref cause) => cause,
-            MergeBranchesByFastForwardError::ConcurrentReferenceUpdate(ref cause) => cause,
-            MergeBranchesByFastForwardError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            MergeBranchesByFastForwardError::EncryptionKeyAccessDenied(ref cause) => cause,
-            MergeBranchesByFastForwardError::EncryptionKeyDisabled(ref cause) => cause,
-            MergeBranchesByFastForwardError::EncryptionKeyNotFound(ref cause) => cause,
-            MergeBranchesByFastForwardError::EncryptionKeyUnavailable(ref cause) => cause,
-            MergeBranchesByFastForwardError::InvalidBranchName(ref cause) => cause,
-            MergeBranchesByFastForwardError::InvalidCommit(ref cause) => cause,
-            MergeBranchesByFastForwardError::InvalidRepositoryName(ref cause) => cause,
-            MergeBranchesByFastForwardError::InvalidTargetBranch(ref cause) => cause,
-            MergeBranchesByFastForwardError::ManualMergeRequired(ref cause) => cause,
-            MergeBranchesByFastForwardError::RepositoryDoesNotExist(ref cause) => cause,
-            MergeBranchesByFastForwardError::RepositoryNameRequired(ref cause) => cause,
-            MergeBranchesByFastForwardError::TipsDivergenceExceeded(ref cause) => cause,
+            MergeBranchesByFastForwardError::BranchDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::BranchNameIsTagName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::BranchNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::CommitDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByFastForwardError::ConcurrentReferenceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByFastForwardError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByFastForwardError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::InvalidTargetBranch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::ManualMergeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByFastForwardError::TipsDivergenceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for MergeBranchesByFastForwardError {}
 /// Errors returned by MergeBranchesBySquash
 #[derive(Debug, PartialEq)]
 pub enum MergeBranchesBySquashError {
@@ -9462,56 +9692,84 @@ impl MergeBranchesBySquashError {
 }
 impl fmt::Display for MergeBranchesBySquashError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergeBranchesBySquashError {
-    fn description(&self) -> &str {
         match *self {
-            MergeBranchesBySquashError::BranchDoesNotExist(ref cause) => cause,
-            MergeBranchesBySquashError::BranchNameIsTagName(ref cause) => cause,
-            MergeBranchesBySquashError::BranchNameRequired(ref cause) => cause,
-            MergeBranchesBySquashError::CommitDoesNotExist(ref cause) => cause,
-            MergeBranchesBySquashError::CommitMessageLengthExceeded(ref cause) => cause,
-            MergeBranchesBySquashError::CommitRequired(ref cause) => cause,
-            MergeBranchesBySquashError::ConcurrentReferenceUpdate(ref cause) => cause,
-            MergeBranchesBySquashError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            MergeBranchesBySquashError::EncryptionKeyAccessDenied(ref cause) => cause,
-            MergeBranchesBySquashError::EncryptionKeyDisabled(ref cause) => cause,
-            MergeBranchesBySquashError::EncryptionKeyNotFound(ref cause) => cause,
-            MergeBranchesBySquashError::EncryptionKeyUnavailable(ref cause) => cause,
-            MergeBranchesBySquashError::FileContentSizeLimitExceeded(ref cause) => cause,
-            MergeBranchesBySquashError::FileModeRequired(ref cause) => cause,
-            MergeBranchesBySquashError::FolderContentSizeLimitExceeded(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidBranchName(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidCommit(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidConflictDetailLevel(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidConflictResolution(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidEmail(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidFileMode(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidPath(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidReplacementContent(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidReplacementType(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidRepositoryName(ref cause) => cause,
-            MergeBranchesBySquashError::InvalidTargetBranch(ref cause) => cause,
-            MergeBranchesBySquashError::ManualMergeRequired(ref cause) => cause,
-            MergeBranchesBySquashError::MaximumConflictResolutionEntriesExceeded(ref cause) => {
-                cause
+            MergeBranchesBySquashError::BranchDoesNotExist(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::BranchNameIsTagName(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::CommitMessageLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
             }
-            MergeBranchesBySquashError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            MergeBranchesBySquashError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            MergeBranchesBySquashError::MultipleConflictResolutionEntries(ref cause) => cause,
-            MergeBranchesBySquashError::NameLengthExceeded(ref cause) => cause,
-            MergeBranchesBySquashError::PathRequired(ref cause) => cause,
-            MergeBranchesBySquashError::ReplacementContentRequired(ref cause) => cause,
-            MergeBranchesBySquashError::ReplacementTypeRequired(ref cause) => cause,
-            MergeBranchesBySquashError::RepositoryDoesNotExist(ref cause) => cause,
-            MergeBranchesBySquashError::RepositoryNameRequired(ref cause) => cause,
-            MergeBranchesBySquashError::TipsDivergenceExceeded(ref cause) => cause,
+            MergeBranchesBySquashError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::ConcurrentReferenceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::FileContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::FileModeRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::FolderContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::InvalidConflictDetailLevel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::InvalidConflictResolution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::InvalidFileMode(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::InvalidReplacementContent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::InvalidReplacementType(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::InvalidTargetBranch(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::ManualMergeRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::MaximumConflictResolutionEntriesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::MultipleConflictResolutionEntries(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::NameLengthExceeded(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::PathRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::ReplacementContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::ReplacementTypeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesBySquashError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesBySquashError::TipsDivergenceExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for MergeBranchesBySquashError {}
 /// Errors returned by MergeBranchesByThreeWay
 #[derive(Debug, PartialEq)]
 pub enum MergeBranchesByThreeWayError {
@@ -9803,56 +10061,98 @@ impl MergeBranchesByThreeWayError {
 }
 impl fmt::Display for MergeBranchesByThreeWayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergeBranchesByThreeWayError {
-    fn description(&self) -> &str {
         match *self {
-            MergeBranchesByThreeWayError::BranchDoesNotExist(ref cause) => cause,
-            MergeBranchesByThreeWayError::BranchNameIsTagName(ref cause) => cause,
-            MergeBranchesByThreeWayError::BranchNameRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::CommitDoesNotExist(ref cause) => cause,
-            MergeBranchesByThreeWayError::CommitMessageLengthExceeded(ref cause) => cause,
-            MergeBranchesByThreeWayError::CommitRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::ConcurrentReferenceUpdate(ref cause) => cause,
-            MergeBranchesByThreeWayError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            MergeBranchesByThreeWayError::EncryptionKeyAccessDenied(ref cause) => cause,
-            MergeBranchesByThreeWayError::EncryptionKeyDisabled(ref cause) => cause,
-            MergeBranchesByThreeWayError::EncryptionKeyNotFound(ref cause) => cause,
-            MergeBranchesByThreeWayError::EncryptionKeyUnavailable(ref cause) => cause,
-            MergeBranchesByThreeWayError::FileContentSizeLimitExceeded(ref cause) => cause,
-            MergeBranchesByThreeWayError::FileModeRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::FolderContentSizeLimitExceeded(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidBranchName(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidCommit(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidConflictDetailLevel(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidConflictResolution(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidEmail(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidFileMode(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidPath(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidReplacementContent(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidReplacementType(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidRepositoryName(ref cause) => cause,
-            MergeBranchesByThreeWayError::InvalidTargetBranch(ref cause) => cause,
-            MergeBranchesByThreeWayError::ManualMergeRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::MaximumConflictResolutionEntriesExceeded(ref cause) => {
-                cause
+            MergeBranchesByThreeWayError::BranchDoesNotExist(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::BranchNameIsTagName(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::CommitMessageLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
             }
-            MergeBranchesByThreeWayError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            MergeBranchesByThreeWayError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            MergeBranchesByThreeWayError::MultipleConflictResolutionEntries(ref cause) => cause,
-            MergeBranchesByThreeWayError::NameLengthExceeded(ref cause) => cause,
-            MergeBranchesByThreeWayError::PathRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::ReplacementContentRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::ReplacementTypeRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::RepositoryDoesNotExist(ref cause) => cause,
-            MergeBranchesByThreeWayError::RepositoryNameRequired(ref cause) => cause,
-            MergeBranchesByThreeWayError::TipsDivergenceExceeded(ref cause) => cause,
+            MergeBranchesByThreeWayError::CommitRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::ConcurrentReferenceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::FileContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::FileModeRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::FolderContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::InvalidCommit(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::InvalidConflictDetailLevel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::InvalidConflictResolution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::InvalidFileMode(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::InvalidReplacementContent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::InvalidReplacementType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::InvalidTargetBranch(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::ManualMergeRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::MaximumConflictResolutionEntriesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::MultipleConflictResolutionEntries(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::NameLengthExceeded(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::PathRequired(ref cause) => write!(f, "{}", cause),
+            MergeBranchesByThreeWayError::ReplacementContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::ReplacementTypeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergeBranchesByThreeWayError::TipsDivergenceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for MergeBranchesByThreeWayError {}
 /// Errors returned by MergePullRequestByFastForward
 #[derive(Debug, PartialEq)]
 pub enum MergePullRequestByFastForwardError {
@@ -10014,38 +10314,68 @@ impl MergePullRequestByFastForwardError {
 }
 impl fmt::Display for MergePullRequestByFastForwardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergePullRequestByFastForwardError {
-    fn description(&self) -> &str {
         match *self {
-            MergePullRequestByFastForwardError::ConcurrentReferenceUpdate(ref cause) => cause,
-            MergePullRequestByFastForwardError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            MergePullRequestByFastForwardError::EncryptionKeyAccessDenied(ref cause) => cause,
-            MergePullRequestByFastForwardError::EncryptionKeyDisabled(ref cause) => cause,
-            MergePullRequestByFastForwardError::EncryptionKeyNotFound(ref cause) => cause,
-            MergePullRequestByFastForwardError::EncryptionKeyUnavailable(ref cause) => cause,
-            MergePullRequestByFastForwardError::InvalidCommitId(ref cause) => cause,
-            MergePullRequestByFastForwardError::InvalidPullRequestId(ref cause) => cause,
-            MergePullRequestByFastForwardError::InvalidRepositoryName(ref cause) => cause,
-            MergePullRequestByFastForwardError::ManualMergeRequired(ref cause) => cause,
-            MergePullRequestByFastForwardError::PullRequestAlreadyClosed(ref cause) => cause,
-            MergePullRequestByFastForwardError::PullRequestApprovalRulesNotSatisfied(ref cause) => {
-                cause
+            MergePullRequestByFastForwardError::ConcurrentReferenceUpdate(ref cause) => {
+                write!(f, "{}", cause)
             }
-            MergePullRequestByFastForwardError::PullRequestDoesNotExist(ref cause) => cause,
-            MergePullRequestByFastForwardError::PullRequestIdRequired(ref cause) => cause,
-            MergePullRequestByFastForwardError::ReferenceDoesNotExist(ref cause) => cause,
-            MergePullRequestByFastForwardError::RepositoryDoesNotExist(ref cause) => cause,
-            MergePullRequestByFastForwardError::RepositoryNameRequired(ref cause) => cause,
+            MergePullRequestByFastForwardError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::InvalidCommitId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::ManualMergeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::PullRequestApprovalRulesNotSatisfied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::ReferenceDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByFastForwardError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             MergePullRequestByFastForwardError::RepositoryNotAssociatedWithPullRequest(
                 ref cause,
-            ) => cause,
-            MergePullRequestByFastForwardError::TipOfSourceReferenceIsDifferent(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            MergePullRequestByFastForwardError::TipOfSourceReferenceIsDifferent(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for MergePullRequestByFastForwardError {}
 /// Errors returned by MergePullRequestBySquash
 #[derive(Debug, PartialEq)]
 pub enum MergePullRequestBySquashError {
@@ -10336,57 +10666,111 @@ impl MergePullRequestBySquashError {
 }
 impl fmt::Display for MergePullRequestBySquashError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergePullRequestBySquashError {
-    fn description(&self) -> &str {
         match *self {
-            MergePullRequestBySquashError::CommitMessageLengthExceeded(ref cause) => cause,
-            MergePullRequestBySquashError::ConcurrentReferenceUpdate(ref cause) => cause,
-            MergePullRequestBySquashError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            MergePullRequestBySquashError::EncryptionKeyAccessDenied(ref cause) => cause,
-            MergePullRequestBySquashError::EncryptionKeyDisabled(ref cause) => cause,
-            MergePullRequestBySquashError::EncryptionKeyNotFound(ref cause) => cause,
-            MergePullRequestBySquashError::EncryptionKeyUnavailable(ref cause) => cause,
-            MergePullRequestBySquashError::FileContentSizeLimitExceeded(ref cause) => cause,
-            MergePullRequestBySquashError::FolderContentSizeLimitExceeded(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidCommitId(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidConflictDetailLevel(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidConflictResolution(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidEmail(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidFileMode(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidPath(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidPullRequestId(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidReplacementContent(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidReplacementType(ref cause) => cause,
-            MergePullRequestBySquashError::InvalidRepositoryName(ref cause) => cause,
-            MergePullRequestBySquashError::ManualMergeRequired(ref cause) => cause,
+            MergePullRequestBySquashError::CommitMessageLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::ConcurrentReferenceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::FileContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::FolderContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            MergePullRequestBySquashError::InvalidConflictDetailLevel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::InvalidConflictResolution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            MergePullRequestBySquashError::InvalidFileMode(ref cause) => write!(f, "{}", cause),
+            MergePullRequestBySquashError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            MergePullRequestBySquashError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::InvalidReplacementContent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::InvalidReplacementType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::ManualMergeRequired(ref cause) => write!(f, "{}", cause),
             MergePullRequestBySquashError::MaximumConflictResolutionEntriesExceeded(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            MergePullRequestBySquashError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            MergePullRequestBySquashError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            MergePullRequestBySquashError::MultipleConflictResolutionEntries(ref cause) => cause,
-            MergePullRequestBySquashError::NameLengthExceeded(ref cause) => cause,
-            MergePullRequestBySquashError::PathRequired(ref cause) => cause,
-            MergePullRequestBySquashError::PullRequestAlreadyClosed(ref cause) => cause,
-            MergePullRequestBySquashError::PullRequestApprovalRulesNotSatisfied(ref cause) => cause,
-            MergePullRequestBySquashError::PullRequestDoesNotExist(ref cause) => cause,
-            MergePullRequestBySquashError::PullRequestIdRequired(ref cause) => cause,
-            MergePullRequestBySquashError::ReplacementContentRequired(ref cause) => cause,
-            MergePullRequestBySquashError::ReplacementTypeRequired(ref cause) => cause,
-            MergePullRequestBySquashError::RepositoryDoesNotExist(ref cause) => cause,
-            MergePullRequestBySquashError::RepositoryNameRequired(ref cause) => cause,
+            MergePullRequestBySquashError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::MultipleConflictResolutionEntries(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::NameLengthExceeded(ref cause) => write!(f, "{}", cause),
+            MergePullRequestBySquashError::PathRequired(ref cause) => write!(f, "{}", cause),
+            MergePullRequestBySquashError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::PullRequestApprovalRulesNotSatisfied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::ReplacementContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::ReplacementTypeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             MergePullRequestBySquashError::RepositoryNotAssociatedWithPullRequest(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            MergePullRequestBySquashError::TipOfSourceReferenceIsDifferent(ref cause) => cause,
-            MergePullRequestBySquashError::TipsDivergenceExceeded(ref cause) => cause,
+            MergePullRequestBySquashError::TipOfSourceReferenceIsDifferent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestBySquashError::TipsDivergenceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for MergePullRequestBySquashError {}
 /// Errors returned by MergePullRequestByThreeWay
 #[derive(Debug, PartialEq)]
 pub enum MergePullRequestByThreeWayError {
@@ -10679,59 +11063,115 @@ impl MergePullRequestByThreeWayError {
 }
 impl fmt::Display for MergePullRequestByThreeWayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergePullRequestByThreeWayError {
-    fn description(&self) -> &str {
         match *self {
-            MergePullRequestByThreeWayError::CommitMessageLengthExceeded(ref cause) => cause,
-            MergePullRequestByThreeWayError::ConcurrentReferenceUpdate(ref cause) => cause,
-            MergePullRequestByThreeWayError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            MergePullRequestByThreeWayError::EncryptionKeyAccessDenied(ref cause) => cause,
-            MergePullRequestByThreeWayError::EncryptionKeyDisabled(ref cause) => cause,
-            MergePullRequestByThreeWayError::EncryptionKeyNotFound(ref cause) => cause,
-            MergePullRequestByThreeWayError::EncryptionKeyUnavailable(ref cause) => cause,
-            MergePullRequestByThreeWayError::FileContentSizeLimitExceeded(ref cause) => cause,
-            MergePullRequestByThreeWayError::FolderContentSizeLimitExceeded(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidCommitId(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidConflictDetailLevel(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidConflictResolution(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidConflictResolutionStrategy(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidEmail(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidFileMode(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidPath(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidPullRequestId(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidReplacementContent(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidReplacementType(ref cause) => cause,
-            MergePullRequestByThreeWayError::InvalidRepositoryName(ref cause) => cause,
-            MergePullRequestByThreeWayError::ManualMergeRequired(ref cause) => cause,
+            MergePullRequestByThreeWayError::CommitMessageLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::ConcurrentReferenceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::FileContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::FolderContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            MergePullRequestByThreeWayError::InvalidConflictDetailLevel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::InvalidConflictResolution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::InvalidConflictResolutionStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            MergePullRequestByThreeWayError::InvalidFileMode(ref cause) => write!(f, "{}", cause),
+            MergePullRequestByThreeWayError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            MergePullRequestByThreeWayError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::InvalidReplacementContent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::InvalidReplacementType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::ManualMergeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             MergePullRequestByThreeWayError::MaximumConflictResolutionEntriesExceeded(
                 ref cause,
-            ) => cause,
-            MergePullRequestByThreeWayError::MaximumFileContentToLoadExceeded(ref cause) => cause,
-            MergePullRequestByThreeWayError::MaximumItemsToCompareExceeded(ref cause) => cause,
-            MergePullRequestByThreeWayError::MultipleConflictResolutionEntries(ref cause) => cause,
-            MergePullRequestByThreeWayError::NameLengthExceeded(ref cause) => cause,
-            MergePullRequestByThreeWayError::PathRequired(ref cause) => cause,
-            MergePullRequestByThreeWayError::PullRequestAlreadyClosed(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            MergePullRequestByThreeWayError::MaximumFileContentToLoadExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::MaximumItemsToCompareExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::MultipleConflictResolutionEntries(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::NameLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::PathRequired(ref cause) => write!(f, "{}", cause),
+            MergePullRequestByThreeWayError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
             MergePullRequestByThreeWayError::PullRequestApprovalRulesNotSatisfied(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            MergePullRequestByThreeWayError::PullRequestDoesNotExist(ref cause) => cause,
-            MergePullRequestByThreeWayError::PullRequestIdRequired(ref cause) => cause,
-            MergePullRequestByThreeWayError::ReplacementContentRequired(ref cause) => cause,
-            MergePullRequestByThreeWayError::ReplacementTypeRequired(ref cause) => cause,
-            MergePullRequestByThreeWayError::RepositoryDoesNotExist(ref cause) => cause,
-            MergePullRequestByThreeWayError::RepositoryNameRequired(ref cause) => cause,
+            MergePullRequestByThreeWayError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::ReplacementContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::ReplacementTypeRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             MergePullRequestByThreeWayError::RepositoryNotAssociatedWithPullRequest(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            MergePullRequestByThreeWayError::TipOfSourceReferenceIsDifferent(ref cause) => cause,
-            MergePullRequestByThreeWayError::TipsDivergenceExceeded(ref cause) => cause,
+            MergePullRequestByThreeWayError::TipOfSourceReferenceIsDifferent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            MergePullRequestByThreeWayError::TipsDivergenceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for MergePullRequestByThreeWayError {}
 /// Errors returned by OverridePullRequestApprovalRules
 #[derive(Debug, PartialEq)]
 pub enum OverridePullRequestApprovalRulesError {
@@ -10859,32 +11299,56 @@ impl OverridePullRequestApprovalRulesError {
 }
 impl fmt::Display for OverridePullRequestApprovalRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for OverridePullRequestApprovalRulesError {
-    fn description(&self) -> &str {
         match *self {
             OverridePullRequestApprovalRulesError::EncryptionIntegrityChecksFailed(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            OverridePullRequestApprovalRulesError::EncryptionKeyAccessDenied(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::EncryptionKeyDisabled(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::EncryptionKeyNotFound(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::EncryptionKeyUnavailable(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::InvalidOverrideStatus(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::InvalidPullRequestId(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::InvalidRevisionId(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::OverrideAlreadySet(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::OverrideStatusRequired(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::PullRequestAlreadyClosed(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::PullRequestDoesNotExist(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::PullRequestIdRequired(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::RevisionIdRequired(ref cause) => cause,
-            OverridePullRequestApprovalRulesError::RevisionNotCurrent(ref cause) => cause,
+            OverridePullRequestApprovalRulesError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::InvalidOverrideStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::InvalidRevisionId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::OverrideAlreadySet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::OverrideStatusRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::RevisionIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OverridePullRequestApprovalRulesError::RevisionNotCurrent(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for OverridePullRequestApprovalRulesError {}
 /// Errors returned by PostCommentForComparedCommit
 #[derive(Debug, PartialEq)]
 pub enum PostCommentForComparedCommitError {
@@ -11068,40 +11532,74 @@ impl PostCommentForComparedCommitError {
 }
 impl fmt::Display for PostCommentForComparedCommitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PostCommentForComparedCommitError {
-    fn description(&self) -> &str {
         match *self {
             PostCommentForComparedCommitError::BeforeCommitIdAndAfterCommitIdAreSame(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            PostCommentForComparedCommitError::ClientRequestTokenRequired(ref cause) => cause,
-            PostCommentForComparedCommitError::CommentContentRequired(ref cause) => cause,
-            PostCommentForComparedCommitError::CommentContentSizeLimitExceeded(ref cause) => cause,
-            PostCommentForComparedCommitError::CommitDoesNotExist(ref cause) => cause,
-            PostCommentForComparedCommitError::CommitIdRequired(ref cause) => cause,
-            PostCommentForComparedCommitError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            PostCommentForComparedCommitError::EncryptionKeyAccessDenied(ref cause) => cause,
-            PostCommentForComparedCommitError::EncryptionKeyDisabled(ref cause) => cause,
-            PostCommentForComparedCommitError::EncryptionKeyNotFound(ref cause) => cause,
-            PostCommentForComparedCommitError::EncryptionKeyUnavailable(ref cause) => cause,
-            PostCommentForComparedCommitError::IdempotencyParameterMismatch(ref cause) => cause,
-            PostCommentForComparedCommitError::InvalidClientRequestToken(ref cause) => cause,
-            PostCommentForComparedCommitError::InvalidCommitId(ref cause) => cause,
-            PostCommentForComparedCommitError::InvalidFileLocation(ref cause) => cause,
-            PostCommentForComparedCommitError::InvalidFilePosition(ref cause) => cause,
-            PostCommentForComparedCommitError::InvalidPath(ref cause) => cause,
-            PostCommentForComparedCommitError::InvalidRelativeFileVersionEnum(ref cause) => cause,
-            PostCommentForComparedCommitError::InvalidRepositoryName(ref cause) => cause,
-            PostCommentForComparedCommitError::PathDoesNotExist(ref cause) => cause,
-            PostCommentForComparedCommitError::PathRequired(ref cause) => cause,
-            PostCommentForComparedCommitError::RepositoryDoesNotExist(ref cause) => cause,
-            PostCommentForComparedCommitError::RepositoryNameRequired(ref cause) => cause,
+            PostCommentForComparedCommitError::ClientRequestTokenRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::CommentContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::CommentContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::CommitDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::CommitIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::IdempotencyParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::InvalidClientRequestToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            PostCommentForComparedCommitError::InvalidFileLocation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::InvalidFilePosition(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            PostCommentForComparedCommitError::InvalidRelativeFileVersionEnum(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::PathDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::PathRequired(ref cause) => write!(f, "{}", cause),
+            PostCommentForComparedCommitError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForComparedCommitError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PostCommentForComparedCommitError {}
 /// Errors returned by PostCommentForPullRequest
 #[derive(Debug, PartialEq)]
 pub enum PostCommentForPullRequestError {
@@ -11313,46 +11811,80 @@ impl PostCommentForPullRequestError {
 }
 impl fmt::Display for PostCommentForPullRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PostCommentForPullRequestError {
-    fn description(&self) -> &str {
         match *self {
             PostCommentForPullRequestError::BeforeCommitIdAndAfterCommitIdAreSame(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            PostCommentForPullRequestError::ClientRequestTokenRequired(ref cause) => cause,
-            PostCommentForPullRequestError::CommentContentRequired(ref cause) => cause,
-            PostCommentForPullRequestError::CommentContentSizeLimitExceeded(ref cause) => cause,
-            PostCommentForPullRequestError::CommitDoesNotExist(ref cause) => cause,
-            PostCommentForPullRequestError::CommitIdRequired(ref cause) => cause,
-            PostCommentForPullRequestError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            PostCommentForPullRequestError::EncryptionKeyAccessDenied(ref cause) => cause,
-            PostCommentForPullRequestError::EncryptionKeyDisabled(ref cause) => cause,
-            PostCommentForPullRequestError::EncryptionKeyNotFound(ref cause) => cause,
-            PostCommentForPullRequestError::EncryptionKeyUnavailable(ref cause) => cause,
-            PostCommentForPullRequestError::IdempotencyParameterMismatch(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidClientRequestToken(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidCommitId(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidFileLocation(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidFilePosition(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidPath(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidPullRequestId(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidRelativeFileVersionEnum(ref cause) => cause,
-            PostCommentForPullRequestError::InvalidRepositoryName(ref cause) => cause,
-            PostCommentForPullRequestError::PathDoesNotExist(ref cause) => cause,
-            PostCommentForPullRequestError::PathRequired(ref cause) => cause,
-            PostCommentForPullRequestError::PullRequestDoesNotExist(ref cause) => cause,
-            PostCommentForPullRequestError::PullRequestIdRequired(ref cause) => cause,
-            PostCommentForPullRequestError::RepositoryDoesNotExist(ref cause) => cause,
-            PostCommentForPullRequestError::RepositoryNameRequired(ref cause) => cause,
+            PostCommentForPullRequestError::ClientRequestTokenRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::CommentContentRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::CommentContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::CommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PostCommentForPullRequestError::CommitIdRequired(ref cause) => write!(f, "{}", cause),
+            PostCommentForPullRequestError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::IdempotencyParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::InvalidClientRequestToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::InvalidCommitId(ref cause) => write!(f, "{}", cause),
+            PostCommentForPullRequestError::InvalidFileLocation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::InvalidFilePosition(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            PostCommentForPullRequestError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::InvalidRelativeFileVersionEnum(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::PathDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PostCommentForPullRequestError::PathRequired(ref cause) => write!(f, "{}", cause),
+            PostCommentForPullRequestError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentForPullRequestError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             PostCommentForPullRequestError::RepositoryNotAssociatedWithPullRequest(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for PostCommentForPullRequestError {}
 /// Errors returned by PostCommentReply
 #[derive(Debug, PartialEq)]
 pub enum PostCommentReplyError {
@@ -11423,23 +11955,23 @@ impl PostCommentReplyError {
 }
 impl fmt::Display for PostCommentReplyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PostCommentReplyError {
-    fn description(&self) -> &str {
         match *self {
-            PostCommentReplyError::ClientRequestTokenRequired(ref cause) => cause,
-            PostCommentReplyError::CommentContentRequired(ref cause) => cause,
-            PostCommentReplyError::CommentContentSizeLimitExceeded(ref cause) => cause,
-            PostCommentReplyError::CommentDoesNotExist(ref cause) => cause,
-            PostCommentReplyError::CommentIdRequired(ref cause) => cause,
-            PostCommentReplyError::IdempotencyParameterMismatch(ref cause) => cause,
-            PostCommentReplyError::InvalidClientRequestToken(ref cause) => cause,
-            PostCommentReplyError::InvalidCommentId(ref cause) => cause,
+            PostCommentReplyError::ClientRequestTokenRequired(ref cause) => write!(f, "{}", cause),
+            PostCommentReplyError::CommentContentRequired(ref cause) => write!(f, "{}", cause),
+            PostCommentReplyError::CommentContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentReplyError::CommentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PostCommentReplyError::CommentIdRequired(ref cause) => write!(f, "{}", cause),
+            PostCommentReplyError::IdempotencyParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PostCommentReplyError::InvalidClientRequestToken(ref cause) => write!(f, "{}", cause),
+            PostCommentReplyError::InvalidCommentId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PostCommentReplyError {}
 /// Errors returned by PutFile
 #[derive(Debug, PartialEq)]
 pub enum PutFileError {
@@ -11620,45 +12152,41 @@ impl PutFileError {
 }
 impl fmt::Display for PutFileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutFileError {
-    fn description(&self) -> &str {
         match *self {
-            PutFileError::BranchDoesNotExist(ref cause) => cause,
-            PutFileError::BranchNameIsTagName(ref cause) => cause,
-            PutFileError::BranchNameRequired(ref cause) => cause,
-            PutFileError::CommitMessageLengthExceeded(ref cause) => cause,
-            PutFileError::DirectoryNameConflictsWithFileName(ref cause) => cause,
-            PutFileError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            PutFileError::EncryptionKeyAccessDenied(ref cause) => cause,
-            PutFileError::EncryptionKeyDisabled(ref cause) => cause,
-            PutFileError::EncryptionKeyNotFound(ref cause) => cause,
-            PutFileError::EncryptionKeyUnavailable(ref cause) => cause,
-            PutFileError::FileContentRequired(ref cause) => cause,
-            PutFileError::FileContentSizeLimitExceeded(ref cause) => cause,
-            PutFileError::FileNameConflictsWithDirectoryName(ref cause) => cause,
-            PutFileError::FilePathConflictsWithSubmodulePath(ref cause) => cause,
-            PutFileError::FolderContentSizeLimitExceeded(ref cause) => cause,
-            PutFileError::InvalidBranchName(ref cause) => cause,
-            PutFileError::InvalidDeletionParameter(ref cause) => cause,
-            PutFileError::InvalidEmail(ref cause) => cause,
-            PutFileError::InvalidFileMode(ref cause) => cause,
-            PutFileError::InvalidParentCommitId(ref cause) => cause,
-            PutFileError::InvalidPath(ref cause) => cause,
-            PutFileError::InvalidRepositoryName(ref cause) => cause,
-            PutFileError::NameLengthExceeded(ref cause) => cause,
-            PutFileError::ParentCommitDoesNotExist(ref cause) => cause,
-            PutFileError::ParentCommitIdOutdated(ref cause) => cause,
-            PutFileError::ParentCommitIdRequired(ref cause) => cause,
-            PutFileError::PathRequired(ref cause) => cause,
-            PutFileError::RepositoryDoesNotExist(ref cause) => cause,
-            PutFileError::RepositoryNameRequired(ref cause) => cause,
-            PutFileError::SameFileContent(ref cause) => cause,
+            PutFileError::BranchDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PutFileError::BranchNameIsTagName(ref cause) => write!(f, "{}", cause),
+            PutFileError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            PutFileError::CommitMessageLengthExceeded(ref cause) => write!(f, "{}", cause),
+            PutFileError::DirectoryNameConflictsWithFileName(ref cause) => write!(f, "{}", cause),
+            PutFileError::EncryptionIntegrityChecksFailed(ref cause) => write!(f, "{}", cause),
+            PutFileError::EncryptionKeyAccessDenied(ref cause) => write!(f, "{}", cause),
+            PutFileError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            PutFileError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            PutFileError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            PutFileError::FileContentRequired(ref cause) => write!(f, "{}", cause),
+            PutFileError::FileContentSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutFileError::FileNameConflictsWithDirectoryName(ref cause) => write!(f, "{}", cause),
+            PutFileError::FilePathConflictsWithSubmodulePath(ref cause) => write!(f, "{}", cause),
+            PutFileError::FolderContentSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutFileError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            PutFileError::InvalidDeletionParameter(ref cause) => write!(f, "{}", cause),
+            PutFileError::InvalidEmail(ref cause) => write!(f, "{}", cause),
+            PutFileError::InvalidFileMode(ref cause) => write!(f, "{}", cause),
+            PutFileError::InvalidParentCommitId(ref cause) => write!(f, "{}", cause),
+            PutFileError::InvalidPath(ref cause) => write!(f, "{}", cause),
+            PutFileError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            PutFileError::NameLengthExceeded(ref cause) => write!(f, "{}", cause),
+            PutFileError::ParentCommitDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PutFileError::ParentCommitIdOutdated(ref cause) => write!(f, "{}", cause),
+            PutFileError::ParentCommitIdRequired(ref cause) => write!(f, "{}", cause),
+            PutFileError::PathRequired(ref cause) => write!(f, "{}", cause),
+            PutFileError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PutFileError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            PutFileError::SameFileContent(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutFileError {}
 /// Errors returned by PutRepositoryTriggers
 #[derive(Debug, PartialEq)]
 pub enum PutRepositoryTriggersError {
@@ -11828,36 +12356,64 @@ impl PutRepositoryTriggersError {
 }
 impl fmt::Display for PutRepositoryTriggersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRepositoryTriggersError {
-    fn description(&self) -> &str {
         match *self {
-            PutRepositoryTriggersError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            PutRepositoryTriggersError::EncryptionKeyAccessDenied(ref cause) => cause,
-            PutRepositoryTriggersError::EncryptionKeyDisabled(ref cause) => cause,
-            PutRepositoryTriggersError::EncryptionKeyNotFound(ref cause) => cause,
-            PutRepositoryTriggersError::EncryptionKeyUnavailable(ref cause) => cause,
-            PutRepositoryTriggersError::InvalidRepositoryName(ref cause) => cause,
-            PutRepositoryTriggersError::InvalidRepositoryTriggerBranchName(ref cause) => cause,
-            PutRepositoryTriggersError::InvalidRepositoryTriggerCustomData(ref cause) => cause,
-            PutRepositoryTriggersError::InvalidRepositoryTriggerDestinationArn(ref cause) => cause,
-            PutRepositoryTriggersError::InvalidRepositoryTriggerEvents(ref cause) => cause,
-            PutRepositoryTriggersError::InvalidRepositoryTriggerName(ref cause) => cause,
-            PutRepositoryTriggersError::InvalidRepositoryTriggerRegion(ref cause) => cause,
-            PutRepositoryTriggersError::MaximumBranchesExceeded(ref cause) => cause,
-            PutRepositoryTriggersError::MaximumRepositoryTriggersExceeded(ref cause) => cause,
-            PutRepositoryTriggersError::RepositoryDoesNotExist(ref cause) => cause,
-            PutRepositoryTriggersError::RepositoryNameRequired(ref cause) => cause,
-            PutRepositoryTriggersError::RepositoryTriggerBranchNameListRequired(ref cause) => cause,
-            PutRepositoryTriggersError::RepositoryTriggerDestinationArnRequired(ref cause) => cause,
-            PutRepositoryTriggersError::RepositoryTriggerEventsListRequired(ref cause) => cause,
-            PutRepositoryTriggersError::RepositoryTriggerNameRequired(ref cause) => cause,
-            PutRepositoryTriggersError::RepositoryTriggersListRequired(ref cause) => cause,
+            PutRepositoryTriggersError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            PutRepositoryTriggersError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            PutRepositoryTriggersError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            PutRepositoryTriggersError::InvalidRepositoryTriggerBranchName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::InvalidRepositoryTriggerCustomData(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::InvalidRepositoryTriggerDestinationArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::InvalidRepositoryTriggerEvents(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::InvalidRepositoryTriggerName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::InvalidRepositoryTriggerRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::MaximumBranchesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::MaximumRepositoryTriggersExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PutRepositoryTriggersError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
+            PutRepositoryTriggersError::RepositoryTriggerBranchNameListRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::RepositoryTriggerDestinationArnRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::RepositoryTriggerEventsListRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::RepositoryTriggerNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRepositoryTriggersError::RepositoryTriggersListRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutRepositoryTriggersError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -11921,24 +12477,20 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidRepositoryName(ref cause) => cause,
-            TagResourceError::InvalidResourceArn(ref cause) => cause,
-            TagResourceError::InvalidSystemTagUsage(ref cause) => cause,
-            TagResourceError::InvalidTagsMap(ref cause) => cause,
-            TagResourceError::RepositoryDoesNotExist(ref cause) => cause,
-            TagResourceError::ResourceArnRequired(ref cause) => cause,
-            TagResourceError::TagPolicy(ref cause) => cause,
-            TagResourceError::TagsMapRequired(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidResourceArn(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidSystemTagUsage(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidTagsMap(ref cause) => write!(f, "{}", cause),
+            TagResourceError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceArnRequired(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagsMapRequired(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TestRepositoryTriggers
 #[derive(Debug, PartialEq)]
 pub enum TestRepositoryTriggersError {
@@ -12110,40 +12662,68 @@ impl TestRepositoryTriggersError {
 }
 impl fmt::Display for TestRepositoryTriggersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestRepositoryTriggersError {
-    fn description(&self) -> &str {
         match *self {
-            TestRepositoryTriggersError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            TestRepositoryTriggersError::EncryptionKeyAccessDenied(ref cause) => cause,
-            TestRepositoryTriggersError::EncryptionKeyDisabled(ref cause) => cause,
-            TestRepositoryTriggersError::EncryptionKeyNotFound(ref cause) => cause,
-            TestRepositoryTriggersError::EncryptionKeyUnavailable(ref cause) => cause,
-            TestRepositoryTriggersError::InvalidRepositoryName(ref cause) => cause,
-            TestRepositoryTriggersError::InvalidRepositoryTriggerBranchName(ref cause) => cause,
-            TestRepositoryTriggersError::InvalidRepositoryTriggerCustomData(ref cause) => cause,
-            TestRepositoryTriggersError::InvalidRepositoryTriggerDestinationArn(ref cause) => cause,
-            TestRepositoryTriggersError::InvalidRepositoryTriggerEvents(ref cause) => cause,
-            TestRepositoryTriggersError::InvalidRepositoryTriggerName(ref cause) => cause,
-            TestRepositoryTriggersError::InvalidRepositoryTriggerRegion(ref cause) => cause,
-            TestRepositoryTriggersError::MaximumBranchesExceeded(ref cause) => cause,
-            TestRepositoryTriggersError::MaximumRepositoryTriggersExceeded(ref cause) => cause,
-            TestRepositoryTriggersError::RepositoryDoesNotExist(ref cause) => cause,
-            TestRepositoryTriggersError::RepositoryNameRequired(ref cause) => cause,
+            TestRepositoryTriggersError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            TestRepositoryTriggersError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            TestRepositoryTriggersError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            TestRepositoryTriggersError::InvalidRepositoryTriggerBranchName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::InvalidRepositoryTriggerCustomData(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::InvalidRepositoryTriggerDestinationArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::InvalidRepositoryTriggerEvents(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::InvalidRepositoryTriggerName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::InvalidRepositoryTriggerRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::MaximumBranchesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::MaximumRepositoryTriggersExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             TestRepositoryTriggersError::RepositoryTriggerBranchNameListRequired(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             TestRepositoryTriggersError::RepositoryTriggerDestinationArnRequired(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            TestRepositoryTriggersError::RepositoryTriggerEventsListRequired(ref cause) => cause,
-            TestRepositoryTriggersError::RepositoryTriggerNameRequired(ref cause) => cause,
-            TestRepositoryTriggersError::RepositoryTriggersListRequired(ref cause) => cause,
+            TestRepositoryTriggersError::RepositoryTriggerEventsListRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::RepositoryTriggerNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestRepositoryTriggersError::RepositoryTriggersListRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for TestRepositoryTriggersError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -12209,24 +12789,20 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InvalidRepositoryName(ref cause) => cause,
-            UntagResourceError::InvalidResourceArn(ref cause) => cause,
-            UntagResourceError::InvalidSystemTagUsage(ref cause) => cause,
-            UntagResourceError::InvalidTagKeysList(ref cause) => cause,
-            UntagResourceError::RepositoryDoesNotExist(ref cause) => cause,
-            UntagResourceError::ResourceArnRequired(ref cause) => cause,
-            UntagResourceError::TagKeysListRequired(ref cause) => cause,
-            UntagResourceError::TagPolicy(ref cause) => cause,
-            UntagResourceError::TooManyTags(ref cause) => cause,
+            UntagResourceError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidResourceArn(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidSystemTagUsage(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidTagKeysList(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceArnRequired(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TagKeysListRequired(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateApprovalRuleTemplateContent
 #[derive(Debug, PartialEq)]
 pub enum UpdateApprovalRuleTemplateContentError {
@@ -12299,31 +12875,29 @@ impl UpdateApprovalRuleTemplateContentError {
 }
 impl fmt::Display for UpdateApprovalRuleTemplateContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApprovalRuleTemplateContentError {
-    fn description(&self) -> &str {
         match *self {
             UpdateApprovalRuleTemplateContentError::ApprovalRuleTemplateContentRequired(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateApprovalRuleTemplateContentError::ApprovalRuleTemplateDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             UpdateApprovalRuleTemplateContentError::ApprovalRuleTemplateNameRequired(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             UpdateApprovalRuleTemplateContentError::InvalidApprovalRuleTemplateContent(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateApprovalRuleTemplateContentError::InvalidApprovalRuleTemplateName(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdateApprovalRuleTemplateContentError::InvalidRuleContentSha256(ref cause) => cause,
+            UpdateApprovalRuleTemplateContentError::InvalidRuleContentSha256(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateApprovalRuleTemplateContentError {}
 /// Errors returned by UpdateApprovalRuleTemplateDescription
 #[derive(Debug, PartialEq)]
 pub enum UpdateApprovalRuleTemplateDescriptionError {
@@ -12356,27 +12930,23 @@ _ => {}
 }
 impl fmt::Display for UpdateApprovalRuleTemplateDescriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApprovalRuleTemplateDescriptionError {
-    fn description(&self) -> &str {
         match *self {
             UpdateApprovalRuleTemplateDescriptionError::ApprovalRuleTemplateDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateApprovalRuleTemplateDescriptionError::ApprovalRuleTemplateNameRequired(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateApprovalRuleTemplateDescriptionError::InvalidApprovalRuleTemplateDescription(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateApprovalRuleTemplateDescriptionError::InvalidApprovalRuleTemplateName(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApprovalRuleTemplateDescriptionError {}
 /// Errors returned by UpdateApprovalRuleTemplateName
 #[derive(Debug, PartialEq)]
 pub enum UpdateApprovalRuleTemplateNameError {
@@ -12433,27 +13003,23 @@ impl UpdateApprovalRuleTemplateNameError {
 }
 impl fmt::Display for UpdateApprovalRuleTemplateNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApprovalRuleTemplateNameError {
-    fn description(&self) -> &str {
         match *self {
             UpdateApprovalRuleTemplateNameError::ApprovalRuleTemplateDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             UpdateApprovalRuleTemplateNameError::ApprovalRuleTemplateNameAlreadyExists(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateApprovalRuleTemplateNameError::ApprovalRuleTemplateNameRequired(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             UpdateApprovalRuleTemplateNameError::InvalidApprovalRuleTemplateName(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for UpdateApprovalRuleTemplateNameError {}
 /// Errors returned by UpdateComment
 #[derive(Debug, PartialEq)]
 pub enum UpdateCommentError {
@@ -12513,22 +13079,20 @@ impl UpdateCommentError {
 }
 impl fmt::Display for UpdateCommentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCommentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCommentError::CommentContentRequired(ref cause) => cause,
-            UpdateCommentError::CommentContentSizeLimitExceeded(ref cause) => cause,
-            UpdateCommentError::CommentDeleted(ref cause) => cause,
-            UpdateCommentError::CommentDoesNotExist(ref cause) => cause,
-            UpdateCommentError::CommentIdRequired(ref cause) => cause,
-            UpdateCommentError::CommentNotCreatedByCaller(ref cause) => cause,
-            UpdateCommentError::InvalidCommentId(ref cause) => cause,
+            UpdateCommentError::CommentContentRequired(ref cause) => write!(f, "{}", cause),
+            UpdateCommentError::CommentContentSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCommentError::CommentDeleted(ref cause) => write!(f, "{}", cause),
+            UpdateCommentError::CommentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateCommentError::CommentIdRequired(ref cause) => write!(f, "{}", cause),
+            UpdateCommentError::CommentNotCreatedByCaller(ref cause) => write!(f, "{}", cause),
+            UpdateCommentError::InvalidCommentId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCommentError {}
 /// Errors returned by UpdateDefaultBranch
 #[derive(Debug, PartialEq)]
 pub enum UpdateDefaultBranchError {
@@ -12624,26 +13188,26 @@ impl UpdateDefaultBranchError {
 }
 impl fmt::Display for UpdateDefaultBranchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDefaultBranchError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDefaultBranchError::BranchDoesNotExist(ref cause) => cause,
-            UpdateDefaultBranchError::BranchNameRequired(ref cause) => cause,
-            UpdateDefaultBranchError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            UpdateDefaultBranchError::EncryptionKeyAccessDenied(ref cause) => cause,
-            UpdateDefaultBranchError::EncryptionKeyDisabled(ref cause) => cause,
-            UpdateDefaultBranchError::EncryptionKeyNotFound(ref cause) => cause,
-            UpdateDefaultBranchError::EncryptionKeyUnavailable(ref cause) => cause,
-            UpdateDefaultBranchError::InvalidBranchName(ref cause) => cause,
-            UpdateDefaultBranchError::InvalidRepositoryName(ref cause) => cause,
-            UpdateDefaultBranchError::RepositoryDoesNotExist(ref cause) => cause,
-            UpdateDefaultBranchError::RepositoryNameRequired(ref cause) => cause,
+            UpdateDefaultBranchError::BranchDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::BranchNameRequired(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDefaultBranchError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDefaultBranchError::EncryptionKeyDisabled(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::EncryptionKeyNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::EncryptionKeyUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::InvalidBranchName(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateDefaultBranchError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDefaultBranchError {}
 /// Errors returned by UpdatePullRequestApprovalRuleContent
 #[derive(Debug, PartialEq)]
 pub enum UpdatePullRequestApprovalRuleContentError {
@@ -12794,41 +13358,59 @@ impl UpdatePullRequestApprovalRuleContentError {
 }
 impl fmt::Display for UpdatePullRequestApprovalRuleContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePullRequestApprovalRuleContentError {
-    fn description(&self) -> &str {
         match *self {
             UpdatePullRequestApprovalRuleContentError::ApprovalRuleContentRequired(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdatePullRequestApprovalRuleContentError::ApprovalRuleDoesNotExist(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::ApprovalRuleNameRequired(ref cause) => cause,
+            UpdatePullRequestApprovalRuleContentError::ApprovalRuleDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::ApprovalRuleNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             UpdatePullRequestApprovalRuleContentError::CannotModifyApprovalRuleFromTemplate(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdatePullRequestApprovalRuleContentError::EncryptionIntegrityChecksFailed(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdatePullRequestApprovalRuleContentError::EncryptionKeyAccessDenied(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdatePullRequestApprovalRuleContentError::EncryptionKeyDisabled(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::EncryptionKeyNotFound(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::EncryptionKeyUnavailable(ref cause) => cause,
+            UpdatePullRequestApprovalRuleContentError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
             UpdatePullRequestApprovalRuleContentError::InvalidApprovalRuleContent(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdatePullRequestApprovalRuleContentError::InvalidApprovalRuleName(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::InvalidPullRequestId(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::InvalidRuleContentSha256(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::PullRequestAlreadyClosed(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::PullRequestDoesNotExist(ref cause) => cause,
-            UpdatePullRequestApprovalRuleContentError::PullRequestIdRequired(ref cause) => cause,
+            UpdatePullRequestApprovalRuleContentError::InvalidApprovalRuleName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::InvalidRuleContentSha256(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalRuleContentError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdatePullRequestApprovalRuleContentError {}
 /// Errors returned by UpdatePullRequestApprovalState
 #[derive(Debug, PartialEq)]
 pub enum UpdatePullRequestApprovalStateError {
@@ -12967,37 +13549,59 @@ impl UpdatePullRequestApprovalStateError {
 }
 impl fmt::Display for UpdatePullRequestApprovalStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePullRequestApprovalStateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePullRequestApprovalStateError::ApprovalStateRequired(ref cause) => cause,
+            UpdatePullRequestApprovalStateError::ApprovalStateRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
             UpdatePullRequestApprovalStateError::EncryptionIntegrityChecksFailed(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdatePullRequestApprovalStateError::EncryptionKeyAccessDenied(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::EncryptionKeyDisabled(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::EncryptionKeyNotFound(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::EncryptionKeyUnavailable(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::InvalidApprovalState(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::InvalidPullRequestId(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::InvalidRevisionId(ref cause) => cause,
+            UpdatePullRequestApprovalStateError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::InvalidApprovalState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::InvalidRevisionId(ref cause) => {
+                write!(f, "{}", cause)
+            }
             UpdatePullRequestApprovalStateError::MaximumNumberOfApprovalsExceeded(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdatePullRequestApprovalStateError::PullRequestAlreadyClosed(ref cause) => cause,
+            UpdatePullRequestApprovalStateError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
             UpdatePullRequestApprovalStateError::PullRequestCannotBeApprovedByAuthor(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdatePullRequestApprovalStateError::PullRequestDoesNotExist(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::PullRequestIdRequired(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::RevisionIdRequired(ref cause) => cause,
-            UpdatePullRequestApprovalStateError::RevisionNotCurrent(ref cause) => cause,
+            UpdatePullRequestApprovalStateError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::RevisionIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestApprovalStateError::RevisionNotCurrent(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdatePullRequestApprovalStateError {}
 /// Errors returned by UpdatePullRequestDescription
 #[derive(Debug, PartialEq)]
 pub enum UpdatePullRequestDescriptionError {
@@ -13053,20 +13657,26 @@ impl UpdatePullRequestDescriptionError {
 }
 impl fmt::Display for UpdatePullRequestDescriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePullRequestDescriptionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePullRequestDescriptionError::InvalidDescription(ref cause) => cause,
-            UpdatePullRequestDescriptionError::InvalidPullRequestId(ref cause) => cause,
-            UpdatePullRequestDescriptionError::PullRequestAlreadyClosed(ref cause) => cause,
-            UpdatePullRequestDescriptionError::PullRequestDoesNotExist(ref cause) => cause,
-            UpdatePullRequestDescriptionError::PullRequestIdRequired(ref cause) => cause,
+            UpdatePullRequestDescriptionError::InvalidDescription(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestDescriptionError::InvalidPullRequestId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestDescriptionError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestDescriptionError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestDescriptionError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdatePullRequestDescriptionError {}
 /// Errors returned by UpdatePullRequestStatus
 #[derive(Debug, PartialEq)]
 pub enum UpdatePullRequestStatusError {
@@ -13162,26 +13772,42 @@ impl UpdatePullRequestStatusError {
 }
 impl fmt::Display for UpdatePullRequestStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePullRequestStatusError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePullRequestStatusError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            UpdatePullRequestStatusError::EncryptionKeyAccessDenied(ref cause) => cause,
-            UpdatePullRequestStatusError::EncryptionKeyDisabled(ref cause) => cause,
-            UpdatePullRequestStatusError::EncryptionKeyNotFound(ref cause) => cause,
-            UpdatePullRequestStatusError::EncryptionKeyUnavailable(ref cause) => cause,
-            UpdatePullRequestStatusError::InvalidPullRequestId(ref cause) => cause,
-            UpdatePullRequestStatusError::InvalidPullRequestStatus(ref cause) => cause,
-            UpdatePullRequestStatusError::InvalidPullRequestStatusUpdate(ref cause) => cause,
-            UpdatePullRequestStatusError::PullRequestDoesNotExist(ref cause) => cause,
-            UpdatePullRequestStatusError::PullRequestIdRequired(ref cause) => cause,
-            UpdatePullRequestStatusError::PullRequestStatusRequired(ref cause) => cause,
+            UpdatePullRequestStatusError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::InvalidPullRequestId(ref cause) => write!(f, "{}", cause),
+            UpdatePullRequestStatusError::InvalidPullRequestStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::InvalidPullRequestStatusUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::PullRequestIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestStatusError::PullRequestStatusRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdatePullRequestStatusError {}
 /// Errors returned by UpdatePullRequestTitle
 #[derive(Debug, PartialEq)]
 pub enum UpdatePullRequestTitleError {
@@ -13240,21 +13866,21 @@ impl UpdatePullRequestTitleError {
 }
 impl fmt::Display for UpdatePullRequestTitleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePullRequestTitleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePullRequestTitleError::InvalidPullRequestId(ref cause) => cause,
-            UpdatePullRequestTitleError::InvalidTitle(ref cause) => cause,
-            UpdatePullRequestTitleError::PullRequestAlreadyClosed(ref cause) => cause,
-            UpdatePullRequestTitleError::PullRequestDoesNotExist(ref cause) => cause,
-            UpdatePullRequestTitleError::PullRequestIdRequired(ref cause) => cause,
-            UpdatePullRequestTitleError::TitleRequired(ref cause) => cause,
+            UpdatePullRequestTitleError::InvalidPullRequestId(ref cause) => write!(f, "{}", cause),
+            UpdatePullRequestTitleError::InvalidTitle(ref cause) => write!(f, "{}", cause),
+            UpdatePullRequestTitleError::PullRequestAlreadyClosed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestTitleError::PullRequestDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePullRequestTitleError::PullRequestIdRequired(ref cause) => write!(f, "{}", cause),
+            UpdatePullRequestTitleError::TitleRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePullRequestTitleError {}
 /// Errors returned by UpdateRepositoryDescription
 #[derive(Debug, PartialEq)]
 pub enum UpdateRepositoryDescriptionError {
@@ -13338,24 +13964,38 @@ impl UpdateRepositoryDescriptionError {
 }
 impl fmt::Display for UpdateRepositoryDescriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRepositoryDescriptionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRepositoryDescriptionError::EncryptionIntegrityChecksFailed(ref cause) => cause,
-            UpdateRepositoryDescriptionError::EncryptionKeyAccessDenied(ref cause) => cause,
-            UpdateRepositoryDescriptionError::EncryptionKeyDisabled(ref cause) => cause,
-            UpdateRepositoryDescriptionError::EncryptionKeyNotFound(ref cause) => cause,
-            UpdateRepositoryDescriptionError::EncryptionKeyUnavailable(ref cause) => cause,
-            UpdateRepositoryDescriptionError::InvalidRepositoryDescription(ref cause) => cause,
-            UpdateRepositoryDescriptionError::InvalidRepositoryName(ref cause) => cause,
-            UpdateRepositoryDescriptionError::RepositoryDoesNotExist(ref cause) => cause,
-            UpdateRepositoryDescriptionError::RepositoryNameRequired(ref cause) => cause,
+            UpdateRepositoryDescriptionError::EncryptionIntegrityChecksFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::EncryptionKeyAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::EncryptionKeyDisabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::EncryptionKeyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::EncryptionKeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::InvalidRepositoryDescription(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::InvalidRepositoryName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::RepositoryDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRepositoryDescriptionError::RepositoryNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateRepositoryDescriptionError {}
 /// Errors returned by UpdateRepositoryName
 #[derive(Debug, PartialEq)]
 pub enum UpdateRepositoryNameError {
@@ -13402,19 +14042,15 @@ impl UpdateRepositoryNameError {
 }
 impl fmt::Display for UpdateRepositoryNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRepositoryNameError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRepositoryNameError::InvalidRepositoryName(ref cause) => cause,
-            UpdateRepositoryNameError::RepositoryDoesNotExist(ref cause) => cause,
-            UpdateRepositoryNameError::RepositoryNameExists(ref cause) => cause,
-            UpdateRepositoryNameError::RepositoryNameRequired(ref cause) => cause,
+            UpdateRepositoryNameError::InvalidRepositoryName(ref cause) => write!(f, "{}", cause),
+            UpdateRepositoryNameError::RepositoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateRepositoryNameError::RepositoryNameExists(ref cause) => write!(f, "{}", cause),
+            UpdateRepositoryNameError::RepositoryNameRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRepositoryNameError {}
 /// Trait representing the capabilities of the CodeCommit API. CodeCommit clients implement this trait.
 pub trait CodeCommit {
     /// <p>Creates an association between an approval rule template and a specified repository. Then, the next time a pull request is created in the repository where the destination reference (if specified) matches the destination reference (branch) for the pull request, an approval rule that matches the template conditions is automatically created for that pull request. If no destination references are specified in the template, an approval rule that matches the template contents is created for all pull requests in that repository.</p>

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -2349,22 +2349,28 @@ impl AddTagsToOnPremisesInstancesError {
 }
 impl fmt::Display for AddTagsToOnPremisesInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToOnPremisesInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToOnPremisesInstancesError::InstanceLimitExceeded(ref cause) => cause,
-            AddTagsToOnPremisesInstancesError::InstanceNameRequired(ref cause) => cause,
-            AddTagsToOnPremisesInstancesError::InstanceNotRegistered(ref cause) => cause,
-            AddTagsToOnPremisesInstancesError::InvalidInstanceName(ref cause) => cause,
-            AddTagsToOnPremisesInstancesError::InvalidTag(ref cause) => cause,
-            AddTagsToOnPremisesInstancesError::TagLimitExceeded(ref cause) => cause,
-            AddTagsToOnPremisesInstancesError::TagRequired(ref cause) => cause,
+            AddTagsToOnPremisesInstancesError::InstanceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddTagsToOnPremisesInstancesError::InstanceNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddTagsToOnPremisesInstancesError::InstanceNotRegistered(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddTagsToOnPremisesInstancesError::InvalidInstanceName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddTagsToOnPremisesInstancesError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            AddTagsToOnPremisesInstancesError::TagLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddTagsToOnPremisesInstancesError::TagRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToOnPremisesInstancesError {}
 /// Errors returned by BatchGetApplicationRevisions
 #[derive(Debug, PartialEq)]
 pub enum BatchGetApplicationRevisionsError {
@@ -2427,21 +2433,27 @@ impl BatchGetApplicationRevisionsError {
 }
 impl fmt::Display for BatchGetApplicationRevisionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetApplicationRevisionsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetApplicationRevisionsError::ApplicationDoesNotExist(ref cause) => cause,
-            BatchGetApplicationRevisionsError::ApplicationNameRequired(ref cause) => cause,
-            BatchGetApplicationRevisionsError::BatchLimitExceeded(ref cause) => cause,
-            BatchGetApplicationRevisionsError::InvalidApplicationName(ref cause) => cause,
-            BatchGetApplicationRevisionsError::InvalidRevision(ref cause) => cause,
-            BatchGetApplicationRevisionsError::RevisionRequired(ref cause) => cause,
+            BatchGetApplicationRevisionsError::ApplicationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetApplicationRevisionsError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetApplicationRevisionsError::BatchLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetApplicationRevisionsError::InvalidApplicationName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetApplicationRevisionsError::InvalidRevision(ref cause) => write!(f, "{}", cause),
+            BatchGetApplicationRevisionsError::RevisionRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchGetApplicationRevisionsError {}
 /// Errors returned by BatchGetApplications
 #[derive(Debug, PartialEq)]
 pub enum BatchGetApplicationsError {
@@ -2488,19 +2500,15 @@ impl BatchGetApplicationsError {
 }
 impl fmt::Display for BatchGetApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetApplicationsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetApplicationsError::ApplicationDoesNotExist(ref cause) => cause,
-            BatchGetApplicationsError::ApplicationNameRequired(ref cause) => cause,
-            BatchGetApplicationsError::BatchLimitExceeded(ref cause) => cause,
-            BatchGetApplicationsError::InvalidApplicationName(ref cause) => cause,
+            BatchGetApplicationsError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            BatchGetApplicationsError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            BatchGetApplicationsError::BatchLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchGetApplicationsError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetApplicationsError {}
 /// Errors returned by BatchGetDeploymentGroups
 #[derive(Debug, PartialEq)]
 pub enum BatchGetDeploymentGroupsError {
@@ -2568,22 +2576,30 @@ impl BatchGetDeploymentGroupsError {
 }
 impl fmt::Display for BatchGetDeploymentGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetDeploymentGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetDeploymentGroupsError::ApplicationDoesNotExist(ref cause) => cause,
-            BatchGetDeploymentGroupsError::ApplicationNameRequired(ref cause) => cause,
-            BatchGetDeploymentGroupsError::BatchLimitExceeded(ref cause) => cause,
-            BatchGetDeploymentGroupsError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            BatchGetDeploymentGroupsError::DeploymentGroupNameRequired(ref cause) => cause,
-            BatchGetDeploymentGroupsError::InvalidApplicationName(ref cause) => cause,
-            BatchGetDeploymentGroupsError::InvalidDeploymentGroupName(ref cause) => cause,
+            BatchGetDeploymentGroupsError::ApplicationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentGroupsError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentGroupsError::BatchLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchGetDeploymentGroupsError::DeploymentConfigDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentGroupsError::DeploymentGroupNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentGroupsError::InvalidApplicationName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentGroupsError::InvalidDeploymentGroupName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchGetDeploymentGroupsError {}
 /// Errors returned by BatchGetDeploymentInstances
 #[derive(Debug, PartialEq)]
 pub enum BatchGetDeploymentInstancesError {
@@ -2653,22 +2669,32 @@ impl BatchGetDeploymentInstancesError {
 }
 impl fmt::Display for BatchGetDeploymentInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetDeploymentInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetDeploymentInstancesError::BatchLimitExceeded(ref cause) => cause,
-            BatchGetDeploymentInstancesError::DeploymentDoesNotExist(ref cause) => cause,
-            BatchGetDeploymentInstancesError::DeploymentIdRequired(ref cause) => cause,
-            BatchGetDeploymentInstancesError::InstanceIdRequired(ref cause) => cause,
-            BatchGetDeploymentInstancesError::InvalidComputePlatform(ref cause) => cause,
-            BatchGetDeploymentInstancesError::InvalidDeploymentId(ref cause) => cause,
-            BatchGetDeploymentInstancesError::InvalidInstanceName(ref cause) => cause,
+            BatchGetDeploymentInstancesError::BatchLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentInstancesError::DeploymentDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentInstancesError::DeploymentIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentInstancesError::InstanceIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentInstancesError::InvalidComputePlatform(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentInstancesError::InvalidDeploymentId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentInstancesError::InvalidInstanceName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchGetDeploymentInstancesError {}
 /// Errors returned by BatchGetDeploymentTargets
 #[derive(Debug, PartialEq)]
 pub enum BatchGetDeploymentTargetsError {
@@ -2743,23 +2769,35 @@ impl BatchGetDeploymentTargetsError {
 }
 impl fmt::Display for BatchGetDeploymentTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetDeploymentTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetDeploymentTargetsError::DeploymentDoesNotExist(ref cause) => cause,
-            BatchGetDeploymentTargetsError::DeploymentIdRequired(ref cause) => cause,
-            BatchGetDeploymentTargetsError::DeploymentNotStarted(ref cause) => cause,
-            BatchGetDeploymentTargetsError::DeploymentTargetDoesNotExist(ref cause) => cause,
-            BatchGetDeploymentTargetsError::DeploymentTargetIdRequired(ref cause) => cause,
-            BatchGetDeploymentTargetsError::DeploymentTargetListSizeExceeded(ref cause) => cause,
-            BatchGetDeploymentTargetsError::InvalidDeploymentId(ref cause) => cause,
-            BatchGetDeploymentTargetsError::InvalidDeploymentTargetId(ref cause) => cause,
+            BatchGetDeploymentTargetsError::DeploymentDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentTargetsError::DeploymentIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentTargetsError::DeploymentNotStarted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentTargetsError::DeploymentTargetDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentTargetsError::DeploymentTargetIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentTargetsError::DeploymentTargetListSizeExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentTargetsError::InvalidDeploymentId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetDeploymentTargetsError::InvalidDeploymentTargetId(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchGetDeploymentTargetsError {}
 /// Errors returned by BatchGetDeployments
 #[derive(Debug, PartialEq)]
 pub enum BatchGetDeploymentsError {
@@ -2799,18 +2837,14 @@ impl BatchGetDeploymentsError {
 }
 impl fmt::Display for BatchGetDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetDeploymentsError::BatchLimitExceeded(ref cause) => cause,
-            BatchGetDeploymentsError::DeploymentIdRequired(ref cause) => cause,
-            BatchGetDeploymentsError::InvalidDeploymentId(ref cause) => cause,
+            BatchGetDeploymentsError::BatchLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchGetDeploymentsError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            BatchGetDeploymentsError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetDeploymentsError {}
 /// Errors returned by BatchGetOnPremisesInstances
 #[derive(Debug, PartialEq)]
 pub enum BatchGetOnPremisesInstancesError {
@@ -2852,18 +2886,20 @@ impl BatchGetOnPremisesInstancesError {
 }
 impl fmt::Display for BatchGetOnPremisesInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetOnPremisesInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetOnPremisesInstancesError::BatchLimitExceeded(ref cause) => cause,
-            BatchGetOnPremisesInstancesError::InstanceNameRequired(ref cause) => cause,
-            BatchGetOnPremisesInstancesError::InvalidInstanceName(ref cause) => cause,
+            BatchGetOnPremisesInstancesError::BatchLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetOnPremisesInstancesError::InstanceNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchGetOnPremisesInstancesError::InvalidInstanceName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchGetOnPremisesInstancesError {}
 /// Errors returned by ContinueDeployment
 #[derive(Debug, PartialEq)]
 pub enum ContinueDeploymentError {
@@ -2938,23 +2974,25 @@ impl ContinueDeploymentError {
 }
 impl fmt::Display for ContinueDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ContinueDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            ContinueDeploymentError::DeploymentAlreadyCompleted(ref cause) => cause,
-            ContinueDeploymentError::DeploymentDoesNotExist(ref cause) => cause,
-            ContinueDeploymentError::DeploymentIdRequired(ref cause) => cause,
-            ContinueDeploymentError::DeploymentIsNotInReadyState(ref cause) => cause,
-            ContinueDeploymentError::InvalidDeploymentId(ref cause) => cause,
-            ContinueDeploymentError::InvalidDeploymentStatus(ref cause) => cause,
-            ContinueDeploymentError::InvalidDeploymentWaitType(ref cause) => cause,
-            ContinueDeploymentError::UnsupportedActionForDeploymentType(ref cause) => cause,
+            ContinueDeploymentError::DeploymentAlreadyCompleted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ContinueDeploymentError::DeploymentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ContinueDeploymentError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            ContinueDeploymentError::DeploymentIsNotInReadyState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ContinueDeploymentError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
+            ContinueDeploymentError::InvalidDeploymentStatus(ref cause) => write!(f, "{}", cause),
+            ContinueDeploymentError::InvalidDeploymentWaitType(ref cause) => write!(f, "{}", cause),
+            ContinueDeploymentError::UnsupportedActionForDeploymentType(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ContinueDeploymentError {}
 /// Errors returned by CreateApplication
 #[derive(Debug, PartialEq)]
 pub enum CreateApplicationError {
@@ -3013,21 +3051,17 @@ impl CreateApplicationError {
 }
 impl fmt::Display for CreateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApplicationError::ApplicationAlreadyExists(ref cause) => cause,
-            CreateApplicationError::ApplicationLimitExceeded(ref cause) => cause,
-            CreateApplicationError::ApplicationNameRequired(ref cause) => cause,
-            CreateApplicationError::InvalidApplicationName(ref cause) => cause,
-            CreateApplicationError::InvalidComputePlatform(ref cause) => cause,
-            CreateApplicationError::InvalidTagsToAdd(ref cause) => cause,
+            CreateApplicationError::ApplicationAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::ApplicationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::InvalidComputePlatform(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::InvalidTagsToAdd(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApplicationError {}
 /// Errors returned by CreateDeployment
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentError {
@@ -3197,38 +3231,40 @@ impl CreateDeploymentError {
 }
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentError::ApplicationDoesNotExist(ref cause) => cause,
-            CreateDeploymentError::ApplicationNameRequired(ref cause) => cause,
-            CreateDeploymentError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            CreateDeploymentError::DeploymentGroupDoesNotExist(ref cause) => cause,
-            CreateDeploymentError::DeploymentGroupNameRequired(ref cause) => cause,
-            CreateDeploymentError::DeploymentLimitExceeded(ref cause) => cause,
-            CreateDeploymentError::DescriptionTooLong(ref cause) => cause,
-            CreateDeploymentError::InvalidApplicationName(ref cause) => cause,
-            CreateDeploymentError::InvalidAutoRollbackConfig(ref cause) => cause,
-            CreateDeploymentError::InvalidAutoScalingGroup(ref cause) => cause,
-            CreateDeploymentError::InvalidDeploymentConfigName(ref cause) => cause,
-            CreateDeploymentError::InvalidDeploymentGroupName(ref cause) => cause,
-            CreateDeploymentError::InvalidFileExistsBehavior(ref cause) => cause,
-            CreateDeploymentError::InvalidGitHubAccountToken(ref cause) => cause,
-            CreateDeploymentError::InvalidIgnoreApplicationStopFailuresValue(ref cause) => cause,
-            CreateDeploymentError::InvalidLoadBalancerInfo(ref cause) => cause,
-            CreateDeploymentError::InvalidRevision(ref cause) => cause,
-            CreateDeploymentError::InvalidRole(ref cause) => cause,
-            CreateDeploymentError::InvalidTargetInstances(ref cause) => cause,
-            CreateDeploymentError::InvalidUpdateOutdatedInstancesOnlyValue(ref cause) => cause,
-            CreateDeploymentError::RevisionDoesNotExist(ref cause) => cause,
-            CreateDeploymentError::RevisionRequired(ref cause) => cause,
-            CreateDeploymentError::Throttling(ref cause) => cause,
+            CreateDeploymentError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::DeploymentConfigDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentError::DeploymentGroupDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::DeploymentGroupNameRequired(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::DeploymentLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::DescriptionTooLong(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidAutoRollbackConfig(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidAutoScalingGroup(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidDeploymentConfigName(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidDeploymentGroupName(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidFileExistsBehavior(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidGitHubAccountToken(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidIgnoreApplicationStopFailuresValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentError::InvalidLoadBalancerInfo(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidRevision(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidTargetInstances(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::InvalidUpdateOutdatedInstancesOnlyValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentError::RevisionDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::RevisionRequired(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeploymentError {}
 /// Errors returned by CreateDeploymentConfig
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentConfigError {
@@ -3296,22 +3332,32 @@ impl CreateDeploymentConfigError {
 }
 impl fmt::Display for CreateDeploymentConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentConfigError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentConfigError::DeploymentConfigAlreadyExists(ref cause) => cause,
-            CreateDeploymentConfigError::DeploymentConfigLimitExceeded(ref cause) => cause,
-            CreateDeploymentConfigError::DeploymentConfigNameRequired(ref cause) => cause,
-            CreateDeploymentConfigError::InvalidComputePlatform(ref cause) => cause,
-            CreateDeploymentConfigError::InvalidDeploymentConfigName(ref cause) => cause,
-            CreateDeploymentConfigError::InvalidMinimumHealthyHostValue(ref cause) => cause,
-            CreateDeploymentConfigError::InvalidTrafficRoutingConfiguration(ref cause) => cause,
+            CreateDeploymentConfigError::DeploymentConfigAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentConfigError::DeploymentConfigLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentConfigError::DeploymentConfigNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentConfigError::InvalidComputePlatform(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentConfigError::InvalidDeploymentConfigName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentConfigError::InvalidMinimumHealthyHostValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentConfigError::InvalidTrafficRoutingConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDeploymentConfigError {}
 /// Errors returned by CreateDeploymentGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentGroupError {
@@ -3544,47 +3590,79 @@ impl CreateDeploymentGroupError {
 }
 impl fmt::Display for CreateDeploymentGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentGroupError::AlarmsLimitExceeded(ref cause) => cause,
-            CreateDeploymentGroupError::ApplicationDoesNotExist(ref cause) => cause,
-            CreateDeploymentGroupError::ApplicationNameRequired(ref cause) => cause,
-            CreateDeploymentGroupError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            CreateDeploymentGroupError::DeploymentGroupAlreadyExists(ref cause) => cause,
-            CreateDeploymentGroupError::DeploymentGroupLimitExceeded(ref cause) => cause,
-            CreateDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => cause,
-            CreateDeploymentGroupError::ECSServiceMappingLimitExceeded(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidAlarmConfig(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidApplicationName(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidAutoRollbackConfig(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidAutoScalingGroup(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidBlueGreenDeploymentConfiguration(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidDeploymentConfigName(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidDeploymentStyle(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidEC2TagCombination(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidEC2Tag(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidECSService(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidInput(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidLoadBalancerInfo(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidOnPremisesTagCombination(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidRole(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidTag(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidTagsToAdd(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidTargetGroupPair(ref cause) => cause,
-            CreateDeploymentGroupError::InvalidTriggerConfig(ref cause) => cause,
-            CreateDeploymentGroupError::LifecycleHookLimitExceeded(ref cause) => cause,
-            CreateDeploymentGroupError::RoleRequired(ref cause) => cause,
-            CreateDeploymentGroupError::TagSetListLimitExceeded(ref cause) => cause,
-            CreateDeploymentGroupError::Throttling(ref cause) => cause,
-            CreateDeploymentGroupError::TriggerTargetsLimitExceeded(ref cause) => cause,
+            CreateDeploymentGroupError::AlarmsLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::ApplicationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::DeploymentConfigDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::DeploymentGroupAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::DeploymentGroupLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::ECSServiceMappingLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidAlarmConfig(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidAutoRollbackConfig(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidAutoScalingGroup(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidBlueGreenDeploymentConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidDeploymentConfigName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidDeploymentStyle(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidEC2TagCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidEC2Tag(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidECSService(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidLoadBalancerInfo(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidOnPremisesTagCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidTagsToAdd(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidTargetGroupPair(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::InvalidTriggerConfig(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::LifecycleHookLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::RoleRequired(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::TagSetListLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDeploymentGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateDeploymentGroupError::TriggerTargetsLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDeploymentGroupError {}
 /// Errors returned by DeleteApplication
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationError {
@@ -3622,18 +3700,14 @@ impl DeleteApplicationError {
 }
 impl fmt::Display for DeleteApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationError::ApplicationNameRequired(ref cause) => cause,
-            DeleteApplicationError::InvalidApplicationName(ref cause) => cause,
-            DeleteApplicationError::InvalidRole(ref cause) => cause,
+            DeleteApplicationError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::InvalidRole(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApplicationError {}
 /// Errors returned by DeleteDeploymentConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeploymentConfigError {
@@ -3680,19 +3754,19 @@ impl DeleteDeploymentConfigError {
 }
 impl fmt::Display for DeleteDeploymentConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeploymentConfigError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeploymentConfigError::DeploymentConfigInUse(ref cause) => cause,
-            DeleteDeploymentConfigError::DeploymentConfigNameRequired(ref cause) => cause,
-            DeleteDeploymentConfigError::InvalidDeploymentConfigName(ref cause) => cause,
-            DeleteDeploymentConfigError::InvalidOperation(ref cause) => cause,
+            DeleteDeploymentConfigError::DeploymentConfigInUse(ref cause) => write!(f, "{}", cause),
+            DeleteDeploymentConfigError::DeploymentConfigNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDeploymentConfigError::InvalidDeploymentConfigName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDeploymentConfigError::InvalidOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeploymentConfigError {}
 /// Errors returned by DeleteDeploymentGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeploymentGroupError {
@@ -3744,20 +3818,22 @@ impl DeleteDeploymentGroupError {
 }
 impl fmt::Display for DeleteDeploymentGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeploymentGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeploymentGroupError::ApplicationNameRequired(ref cause) => cause,
-            DeleteDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => cause,
-            DeleteDeploymentGroupError::InvalidApplicationName(ref cause) => cause,
-            DeleteDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => cause,
-            DeleteDeploymentGroupError::InvalidRole(ref cause) => cause,
+            DeleteDeploymentGroupError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDeploymentGroupError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            DeleteDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDeploymentGroupError::InvalidRole(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeploymentGroupError {}
 /// Errors returned by DeleteGitHubAccountToken
 #[derive(Debug, PartialEq)]
 pub enum DeleteGitHubAccountTokenError {
@@ -3811,20 +3887,24 @@ impl DeleteGitHubAccountTokenError {
 }
 impl fmt::Display for DeleteGitHubAccountTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGitHubAccountTokenError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGitHubAccountTokenError::GitHubAccountTokenDoesNotExist(ref cause) => cause,
-            DeleteGitHubAccountTokenError::GitHubAccountTokenNameRequired(ref cause) => cause,
-            DeleteGitHubAccountTokenError::InvalidGitHubAccountTokenName(ref cause) => cause,
-            DeleteGitHubAccountTokenError::OperationNotSupported(ref cause) => cause,
-            DeleteGitHubAccountTokenError::ResourceValidation(ref cause) => cause,
+            DeleteGitHubAccountTokenError::GitHubAccountTokenDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteGitHubAccountTokenError::GitHubAccountTokenNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteGitHubAccountTokenError::InvalidGitHubAccountTokenName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteGitHubAccountTokenError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteGitHubAccountTokenError::ResourceValidation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGitHubAccountTokenError {}
 /// Errors returned by DeregisterOnPremisesInstance
 #[derive(Debug, PartialEq)]
 pub enum DeregisterOnPremisesInstanceError {
@@ -3859,17 +3939,17 @@ impl DeregisterOnPremisesInstanceError {
 }
 impl fmt::Display for DeregisterOnPremisesInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterOnPremisesInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterOnPremisesInstanceError::InstanceNameRequired(ref cause) => cause,
-            DeregisterOnPremisesInstanceError::InvalidInstanceName(ref cause) => cause,
+            DeregisterOnPremisesInstanceError::InstanceNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterOnPremisesInstanceError::InvalidInstanceName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterOnPremisesInstanceError {}
 /// Errors returned by GetApplication
 #[derive(Debug, PartialEq)]
 pub enum GetApplicationError {
@@ -3909,18 +3989,14 @@ impl GetApplicationError {
 }
 impl fmt::Display for GetApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            GetApplicationError::ApplicationDoesNotExist(ref cause) => cause,
-            GetApplicationError::ApplicationNameRequired(ref cause) => cause,
-            GetApplicationError::InvalidApplicationName(ref cause) => cause,
+            GetApplicationError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetApplicationError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            GetApplicationError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApplicationError {}
 /// Errors returned by GetApplicationRevision
 #[derive(Debug, PartialEq)]
 pub enum GetApplicationRevisionError {
@@ -3981,21 +4057,23 @@ impl GetApplicationRevisionError {
 }
 impl fmt::Display for GetApplicationRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApplicationRevisionError {
-    fn description(&self) -> &str {
         match *self {
-            GetApplicationRevisionError::ApplicationDoesNotExist(ref cause) => cause,
-            GetApplicationRevisionError::ApplicationNameRequired(ref cause) => cause,
-            GetApplicationRevisionError::InvalidApplicationName(ref cause) => cause,
-            GetApplicationRevisionError::InvalidRevision(ref cause) => cause,
-            GetApplicationRevisionError::RevisionDoesNotExist(ref cause) => cause,
-            GetApplicationRevisionError::RevisionRequired(ref cause) => cause,
+            GetApplicationRevisionError::ApplicationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetApplicationRevisionError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetApplicationRevisionError::InvalidApplicationName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetApplicationRevisionError::InvalidRevision(ref cause) => write!(f, "{}", cause),
+            GetApplicationRevisionError::RevisionDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetApplicationRevisionError::RevisionRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApplicationRevisionError {}
 /// Errors returned by GetDeployment
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentError {
@@ -4031,18 +4109,14 @@ impl GetDeploymentError {
 }
 impl fmt::Display for GetDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentError::DeploymentDoesNotExist(ref cause) => cause,
-            GetDeploymentError::DeploymentIdRequired(ref cause) => cause,
-            GetDeploymentError::InvalidDeploymentId(ref cause) => cause,
+            GetDeploymentError::DeploymentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDeploymentError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            GetDeploymentError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentError {}
 /// Errors returned by GetDeploymentConfig
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentConfigError {
@@ -4089,19 +4163,21 @@ impl GetDeploymentConfigError {
 }
 impl fmt::Display for GetDeploymentConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentConfigError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            GetDeploymentConfigError::DeploymentConfigNameRequired(ref cause) => cause,
-            GetDeploymentConfigError::InvalidComputePlatform(ref cause) => cause,
-            GetDeploymentConfigError::InvalidDeploymentConfigName(ref cause) => cause,
+            GetDeploymentConfigError::DeploymentConfigDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentConfigError::DeploymentConfigNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentConfigError::InvalidComputePlatform(ref cause) => write!(f, "{}", cause),
+            GetDeploymentConfigError::InvalidDeploymentConfigName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetDeploymentConfigError {}
 /// Errors returned by GetDeploymentGroup
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentGroupError {
@@ -4169,22 +4245,26 @@ impl GetDeploymentGroupError {
 }
 impl fmt::Display for GetDeploymentGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentGroupError::ApplicationDoesNotExist(ref cause) => cause,
-            GetDeploymentGroupError::ApplicationNameRequired(ref cause) => cause,
-            GetDeploymentGroupError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            GetDeploymentGroupError::DeploymentGroupDoesNotExist(ref cause) => cause,
-            GetDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => cause,
-            GetDeploymentGroupError::InvalidApplicationName(ref cause) => cause,
-            GetDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => cause,
+            GetDeploymentGroupError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDeploymentGroupError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            GetDeploymentGroupError::DeploymentConfigDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentGroupError::DeploymentGroupDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentGroupError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            GetDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetDeploymentGroupError {}
 /// Errors returned by GetDeploymentInstance
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentInstanceError {
@@ -4252,22 +4332,18 @@ impl GetDeploymentInstanceError {
 }
 impl fmt::Display for GetDeploymentInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentInstanceError::DeploymentDoesNotExist(ref cause) => cause,
-            GetDeploymentInstanceError::DeploymentIdRequired(ref cause) => cause,
-            GetDeploymentInstanceError::InstanceDoesNotExist(ref cause) => cause,
-            GetDeploymentInstanceError::InstanceIdRequired(ref cause) => cause,
-            GetDeploymentInstanceError::InvalidComputePlatform(ref cause) => cause,
-            GetDeploymentInstanceError::InvalidDeploymentId(ref cause) => cause,
-            GetDeploymentInstanceError::InvalidInstanceName(ref cause) => cause,
+            GetDeploymentInstanceError::DeploymentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDeploymentInstanceError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            GetDeploymentInstanceError::InstanceDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDeploymentInstanceError::InstanceIdRequired(ref cause) => write!(f, "{}", cause),
+            GetDeploymentInstanceError::InvalidComputePlatform(ref cause) => write!(f, "{}", cause),
+            GetDeploymentInstanceError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
+            GetDeploymentInstanceError::InvalidInstanceName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentInstanceError {}
 /// Errors returned by GetDeploymentTarget
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentTargetError {
@@ -4342,23 +4418,25 @@ impl GetDeploymentTargetError {
 }
 impl fmt::Display for GetDeploymentTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentTargetError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentTargetError::DeploymentDoesNotExist(ref cause) => cause,
-            GetDeploymentTargetError::DeploymentIdRequired(ref cause) => cause,
-            GetDeploymentTargetError::DeploymentNotStarted(ref cause) => cause,
-            GetDeploymentTargetError::DeploymentTargetDoesNotExist(ref cause) => cause,
-            GetDeploymentTargetError::DeploymentTargetIdRequired(ref cause) => cause,
-            GetDeploymentTargetError::InvalidDeploymentId(ref cause) => cause,
-            GetDeploymentTargetError::InvalidDeploymentTargetId(ref cause) => cause,
-            GetDeploymentTargetError::InvalidInstanceName(ref cause) => cause,
+            GetDeploymentTargetError::DeploymentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDeploymentTargetError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            GetDeploymentTargetError::DeploymentNotStarted(ref cause) => write!(f, "{}", cause),
+            GetDeploymentTargetError::DeploymentTargetDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentTargetError::DeploymentTargetIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentTargetError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
+            GetDeploymentTargetError::InvalidDeploymentTargetId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDeploymentTargetError::InvalidInstanceName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentTargetError {}
 /// Errors returned by GetOnPremisesInstance
 #[derive(Debug, PartialEq)]
 pub enum GetOnPremisesInstanceError {
@@ -4398,18 +4476,14 @@ impl GetOnPremisesInstanceError {
 }
 impl fmt::Display for GetOnPremisesInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOnPremisesInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetOnPremisesInstanceError::InstanceNameRequired(ref cause) => cause,
-            GetOnPremisesInstanceError::InstanceNotRegistered(ref cause) => cause,
-            GetOnPremisesInstanceError::InvalidInstanceName(ref cause) => cause,
+            GetOnPremisesInstanceError::InstanceNameRequired(ref cause) => write!(f, "{}", cause),
+            GetOnPremisesInstanceError::InstanceNotRegistered(ref cause) => write!(f, "{}", cause),
+            GetOnPremisesInstanceError::InvalidInstanceName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOnPremisesInstanceError {}
 /// Errors returned by ListApplicationRevisions
 #[derive(Debug, PartialEq)]
 pub enum ListApplicationRevisionsError {
@@ -4498,25 +4572,35 @@ impl ListApplicationRevisionsError {
 }
 impl fmt::Display for ListApplicationRevisionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApplicationRevisionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListApplicationRevisionsError::ApplicationDoesNotExist(ref cause) => cause,
-            ListApplicationRevisionsError::ApplicationNameRequired(ref cause) => cause,
-            ListApplicationRevisionsError::BucketNameFilterRequired(ref cause) => cause,
-            ListApplicationRevisionsError::InvalidApplicationName(ref cause) => cause,
-            ListApplicationRevisionsError::InvalidBucketNameFilter(ref cause) => cause,
-            ListApplicationRevisionsError::InvalidDeployedStateFilter(ref cause) => cause,
-            ListApplicationRevisionsError::InvalidKeyPrefixFilter(ref cause) => cause,
-            ListApplicationRevisionsError::InvalidNextToken(ref cause) => cause,
-            ListApplicationRevisionsError::InvalidSortBy(ref cause) => cause,
-            ListApplicationRevisionsError::InvalidSortOrder(ref cause) => cause,
+            ListApplicationRevisionsError::ApplicationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationRevisionsError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationRevisionsError::BucketNameFilterRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationRevisionsError::InvalidApplicationName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationRevisionsError::InvalidBucketNameFilter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationRevisionsError::InvalidDeployedStateFilter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationRevisionsError::InvalidKeyPrefixFilter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationRevisionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListApplicationRevisionsError::InvalidSortBy(ref cause) => write!(f, "{}", cause),
+            ListApplicationRevisionsError::InvalidSortOrder(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListApplicationRevisionsError {}
 /// Errors returned by ListApplications
 #[derive(Debug, PartialEq)]
 pub enum ListApplicationsError {
@@ -4540,16 +4624,12 @@ impl ListApplicationsError {
 }
 impl fmt::Display for ListApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApplicationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListApplicationsError::InvalidNextToken(ref cause) => cause,
+            ListApplicationsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListApplicationsError {}
 /// Errors returned by ListDeploymentConfigs
 #[derive(Debug, PartialEq)]
 pub enum ListDeploymentConfigsError {
@@ -4575,16 +4655,12 @@ impl ListDeploymentConfigsError {
 }
 impl fmt::Display for ListDeploymentConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeploymentConfigsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeploymentConfigsError::InvalidNextToken(ref cause) => cause,
+            ListDeploymentConfigsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeploymentConfigsError {}
 /// Errors returned by ListDeploymentGroups
 #[derive(Debug, PartialEq)]
 pub enum ListDeploymentGroupsError {
@@ -4631,19 +4707,15 @@ impl ListDeploymentGroupsError {
 }
 impl fmt::Display for ListDeploymentGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeploymentGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeploymentGroupsError::ApplicationDoesNotExist(ref cause) => cause,
-            ListDeploymentGroupsError::ApplicationNameRequired(ref cause) => cause,
-            ListDeploymentGroupsError::InvalidApplicationName(ref cause) => cause,
-            ListDeploymentGroupsError::InvalidNextToken(ref cause) => cause,
+            ListDeploymentGroupsError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListDeploymentGroupsError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            ListDeploymentGroupsError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            ListDeploymentGroupsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeploymentGroupsError {}
 /// Errors returned by ListDeploymentInstances
 #[derive(Debug, PartialEq)]
 pub enum ListDeploymentInstancesError {
@@ -4732,25 +4804,31 @@ impl ListDeploymentInstancesError {
 }
 impl fmt::Display for ListDeploymentInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeploymentInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeploymentInstancesError::DeploymentDoesNotExist(ref cause) => cause,
-            ListDeploymentInstancesError::DeploymentIdRequired(ref cause) => cause,
-            ListDeploymentInstancesError::DeploymentNotStarted(ref cause) => cause,
-            ListDeploymentInstancesError::InvalidComputePlatform(ref cause) => cause,
-            ListDeploymentInstancesError::InvalidDeploymentId(ref cause) => cause,
-            ListDeploymentInstancesError::InvalidDeploymentInstanceType(ref cause) => cause,
-            ListDeploymentInstancesError::InvalidInstanceStatus(ref cause) => cause,
-            ListDeploymentInstancesError::InvalidInstanceType(ref cause) => cause,
-            ListDeploymentInstancesError::InvalidNextToken(ref cause) => cause,
-            ListDeploymentInstancesError::InvalidTargetFilterName(ref cause) => cause,
+            ListDeploymentInstancesError::DeploymentDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDeploymentInstancesError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            ListDeploymentInstancesError::DeploymentNotStarted(ref cause) => write!(f, "{}", cause),
+            ListDeploymentInstancesError::InvalidComputePlatform(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDeploymentInstancesError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
+            ListDeploymentInstancesError::InvalidDeploymentInstanceType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDeploymentInstancesError::InvalidInstanceStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDeploymentInstancesError::InvalidInstanceType(ref cause) => write!(f, "{}", cause),
+            ListDeploymentInstancesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListDeploymentInstancesError::InvalidTargetFilterName(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListDeploymentInstancesError {}
 /// Errors returned by ListDeploymentTargets
 #[derive(Debug, PartialEq)]
 pub enum ListDeploymentTargetsError {
@@ -4825,23 +4903,21 @@ impl ListDeploymentTargetsError {
 }
 impl fmt::Display for ListDeploymentTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeploymentTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeploymentTargetsError::DeploymentDoesNotExist(ref cause) => cause,
-            ListDeploymentTargetsError::DeploymentIdRequired(ref cause) => cause,
-            ListDeploymentTargetsError::DeploymentNotStarted(ref cause) => cause,
-            ListDeploymentTargetsError::InvalidDeploymentId(ref cause) => cause,
-            ListDeploymentTargetsError::InvalidDeploymentInstanceType(ref cause) => cause,
-            ListDeploymentTargetsError::InvalidInstanceStatus(ref cause) => cause,
-            ListDeploymentTargetsError::InvalidInstanceType(ref cause) => cause,
-            ListDeploymentTargetsError::InvalidNextToken(ref cause) => cause,
+            ListDeploymentTargetsError::DeploymentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListDeploymentTargetsError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            ListDeploymentTargetsError::DeploymentNotStarted(ref cause) => write!(f, "{}", cause),
+            ListDeploymentTargetsError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
+            ListDeploymentTargetsError::InvalidDeploymentInstanceType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDeploymentTargetsError::InvalidInstanceStatus(ref cause) => write!(f, "{}", cause),
+            ListDeploymentTargetsError::InvalidInstanceType(ref cause) => write!(f, "{}", cause),
+            ListDeploymentTargetsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeploymentTargetsError {}
 /// Errors returned by ListDeployments
 #[derive(Debug, PartialEq)]
 pub enum ListDeploymentsError {
@@ -4919,24 +4995,20 @@ impl ListDeploymentsError {
 }
 impl fmt::Display for ListDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeploymentsError::ApplicationDoesNotExist(ref cause) => cause,
-            ListDeploymentsError::ApplicationNameRequired(ref cause) => cause,
-            ListDeploymentsError::DeploymentGroupDoesNotExist(ref cause) => cause,
-            ListDeploymentsError::DeploymentGroupNameRequired(ref cause) => cause,
-            ListDeploymentsError::InvalidApplicationName(ref cause) => cause,
-            ListDeploymentsError::InvalidDeploymentGroupName(ref cause) => cause,
-            ListDeploymentsError::InvalidDeploymentStatus(ref cause) => cause,
-            ListDeploymentsError::InvalidNextToken(ref cause) => cause,
-            ListDeploymentsError::InvalidTimeRange(ref cause) => cause,
+            ListDeploymentsError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::DeploymentGroupDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::DeploymentGroupNameRequired(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::InvalidDeploymentGroupName(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::InvalidDeploymentStatus(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListDeploymentsError::InvalidTimeRange(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeploymentsError {}
 /// Errors returned by ListGitHubAccountTokenNames
 #[derive(Debug, PartialEq)]
 pub enum ListGitHubAccountTokenNamesError {
@@ -4978,18 +5050,18 @@ impl ListGitHubAccountTokenNamesError {
 }
 impl fmt::Display for ListGitHubAccountTokenNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGitHubAccountTokenNamesError {
-    fn description(&self) -> &str {
         match *self {
-            ListGitHubAccountTokenNamesError::InvalidNextToken(ref cause) => cause,
-            ListGitHubAccountTokenNamesError::OperationNotSupported(ref cause) => cause,
-            ListGitHubAccountTokenNamesError::ResourceValidation(ref cause) => cause,
+            ListGitHubAccountTokenNamesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListGitHubAccountTokenNamesError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListGitHubAccountTokenNamesError::ResourceValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListGitHubAccountTokenNamesError {}
 /// Errors returned by ListOnPremisesInstances
 #[derive(Debug, PartialEq)]
 pub enum ListOnPremisesInstancesError {
@@ -5029,18 +5101,16 @@ impl ListOnPremisesInstancesError {
 }
 impl fmt::Display for ListOnPremisesInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOnPremisesInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListOnPremisesInstancesError::InvalidNextToken(ref cause) => cause,
-            ListOnPremisesInstancesError::InvalidRegistrationStatus(ref cause) => cause,
-            ListOnPremisesInstancesError::InvalidTagFilter(ref cause) => cause,
+            ListOnPremisesInstancesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListOnPremisesInstancesError::InvalidRegistrationStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOnPremisesInstancesError::InvalidTagFilter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOnPremisesInstancesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -5076,18 +5146,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::ArnNotSupported(ref cause) => cause,
-            ListTagsForResourceError::InvalidArn(ref cause) => cause,
-            ListTagsForResourceError::ResourceArnRequired(ref cause) => cause,
+            ListTagsForResourceError::ArnNotSupported(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceArnRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PutLifecycleEventHookExecutionStatus
 #[derive(Debug, PartialEq)]
 pub enum PutLifecycleEventHookExecutionStatusError {
@@ -5129,30 +5195,32 @@ _ => {}
 }
 impl fmt::Display for PutLifecycleEventHookExecutionStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLifecycleEventHookExecutionStatusError {
-    fn description(&self) -> &str {
         match *self {
-            PutLifecycleEventHookExecutionStatusError::DeploymentDoesNotExist(ref cause) => cause,
-            PutLifecycleEventHookExecutionStatusError::DeploymentIdRequired(ref cause) => cause,
-            PutLifecycleEventHookExecutionStatusError::InvalidDeploymentId(ref cause) => cause,
+            PutLifecycleEventHookExecutionStatusError::DeploymentDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutLifecycleEventHookExecutionStatusError::DeploymentIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutLifecycleEventHookExecutionStatusError::InvalidDeploymentId(ref cause) => {
+                write!(f, "{}", cause)
+            }
             PutLifecycleEventHookExecutionStatusError::InvalidLifecycleEventHookExecutionId(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             PutLifecycleEventHookExecutionStatusError::InvalidLifecycleEventHookExecutionStatus(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             PutLifecycleEventHookExecutionStatusError::LifecycleEventAlreadyCompleted(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             PutLifecycleEventHookExecutionStatusError::UnsupportedActionForDeploymentType(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLifecycleEventHookExecutionStatusError {}
 /// Errors returned by RegisterApplicationRevision
 #[derive(Debug, PartialEq)]
 pub enum RegisterApplicationRevisionError {
@@ -5215,21 +5283,25 @@ impl RegisterApplicationRevisionError {
 }
 impl fmt::Display for RegisterApplicationRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterApplicationRevisionError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterApplicationRevisionError::ApplicationDoesNotExist(ref cause) => cause,
-            RegisterApplicationRevisionError::ApplicationNameRequired(ref cause) => cause,
-            RegisterApplicationRevisionError::DescriptionTooLong(ref cause) => cause,
-            RegisterApplicationRevisionError::InvalidApplicationName(ref cause) => cause,
-            RegisterApplicationRevisionError::InvalidRevision(ref cause) => cause,
-            RegisterApplicationRevisionError::RevisionRequired(ref cause) => cause,
+            RegisterApplicationRevisionError::ApplicationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterApplicationRevisionError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterApplicationRevisionError::DescriptionTooLong(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterApplicationRevisionError::InvalidApplicationName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterApplicationRevisionError::InvalidRevision(ref cause) => write!(f, "{}", cause),
+            RegisterApplicationRevisionError::RevisionRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterApplicationRevisionError {}
 /// Errors returned by RegisterOnPremisesInstance
 #[derive(Debug, PartialEq)]
 pub enum RegisterOnPremisesInstanceError {
@@ -5320,25 +5392,37 @@ impl RegisterOnPremisesInstanceError {
 }
 impl fmt::Display for RegisterOnPremisesInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterOnPremisesInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterOnPremisesInstanceError::IamArnRequired(ref cause) => cause,
-            RegisterOnPremisesInstanceError::IamSessionArnAlreadyRegistered(ref cause) => cause,
-            RegisterOnPremisesInstanceError::IamUserArnAlreadyRegistered(ref cause) => cause,
-            RegisterOnPremisesInstanceError::IamUserArnRequired(ref cause) => cause,
-            RegisterOnPremisesInstanceError::InstanceNameAlreadyRegistered(ref cause) => cause,
-            RegisterOnPremisesInstanceError::InstanceNameRequired(ref cause) => cause,
-            RegisterOnPremisesInstanceError::InvalidIamSessionArn(ref cause) => cause,
-            RegisterOnPremisesInstanceError::InvalidIamUserArn(ref cause) => cause,
-            RegisterOnPremisesInstanceError::InvalidInstanceName(ref cause) => cause,
-            RegisterOnPremisesInstanceError::MultipleIamArnsProvided(ref cause) => cause,
+            RegisterOnPremisesInstanceError::IamArnRequired(ref cause) => write!(f, "{}", cause),
+            RegisterOnPremisesInstanceError::IamSessionArnAlreadyRegistered(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterOnPremisesInstanceError::IamUserArnAlreadyRegistered(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterOnPremisesInstanceError::IamUserArnRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterOnPremisesInstanceError::InstanceNameAlreadyRegistered(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterOnPremisesInstanceError::InstanceNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterOnPremisesInstanceError::InvalidIamSessionArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterOnPremisesInstanceError::InvalidIamUserArn(ref cause) => write!(f, "{}", cause),
+            RegisterOnPremisesInstanceError::InvalidInstanceName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterOnPremisesInstanceError::MultipleIamArnsProvided(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterOnPremisesInstanceError {}
 /// Errors returned by RemoveTagsFromOnPremisesInstances
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromOnPremisesInstancesError {
@@ -5408,22 +5492,30 @@ impl RemoveTagsFromOnPremisesInstancesError {
 }
 impl fmt::Display for RemoveTagsFromOnPremisesInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromOnPremisesInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromOnPremisesInstancesError::InstanceLimitExceeded(ref cause) => cause,
-            RemoveTagsFromOnPremisesInstancesError::InstanceNameRequired(ref cause) => cause,
-            RemoveTagsFromOnPremisesInstancesError::InstanceNotRegistered(ref cause) => cause,
-            RemoveTagsFromOnPremisesInstancesError::InvalidInstanceName(ref cause) => cause,
-            RemoveTagsFromOnPremisesInstancesError::InvalidTag(ref cause) => cause,
-            RemoveTagsFromOnPremisesInstancesError::TagLimitExceeded(ref cause) => cause,
-            RemoveTagsFromOnPremisesInstancesError::TagRequired(ref cause) => cause,
+            RemoveTagsFromOnPremisesInstancesError::InstanceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromOnPremisesInstancesError::InstanceNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromOnPremisesInstancesError::InstanceNotRegistered(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromOnPremisesInstancesError::InvalidInstanceName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromOnPremisesInstancesError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromOnPremisesInstancesError::TagLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromOnPremisesInstancesError::TagRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveTagsFromOnPremisesInstancesError {}
 /// Errors returned by SkipWaitTimeForInstanceTermination
 #[derive(Debug, PartialEq)]
 pub enum SkipWaitTimeForInstanceTerminationError {
@@ -5490,23 +5582,29 @@ impl SkipWaitTimeForInstanceTerminationError {
 }
 impl fmt::Display for SkipWaitTimeForInstanceTerminationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SkipWaitTimeForInstanceTerminationError {
-    fn description(&self) -> &str {
         match *self {
-            SkipWaitTimeForInstanceTerminationError::DeploymentAlreadyCompleted(ref cause) => cause,
-            SkipWaitTimeForInstanceTerminationError::DeploymentDoesNotExist(ref cause) => cause,
-            SkipWaitTimeForInstanceTerminationError::DeploymentIdRequired(ref cause) => cause,
-            SkipWaitTimeForInstanceTerminationError::DeploymentNotStarted(ref cause) => cause,
-            SkipWaitTimeForInstanceTerminationError::InvalidDeploymentId(ref cause) => cause,
+            SkipWaitTimeForInstanceTerminationError::DeploymentAlreadyCompleted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SkipWaitTimeForInstanceTerminationError::DeploymentDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SkipWaitTimeForInstanceTerminationError::DeploymentIdRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SkipWaitTimeForInstanceTerminationError::DeploymentNotStarted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SkipWaitTimeForInstanceTerminationError::InvalidDeploymentId(ref cause) => {
+                write!(f, "{}", cause)
+            }
             SkipWaitTimeForInstanceTerminationError::UnsupportedActionForDeploymentType(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SkipWaitTimeForInstanceTerminationError {}
 /// Errors returned by StopDeployment
 #[derive(Debug, PartialEq)]
 pub enum StopDeploymentError {
@@ -5556,20 +5654,16 @@ impl StopDeploymentError {
 }
 impl fmt::Display for StopDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            StopDeploymentError::DeploymentAlreadyCompleted(ref cause) => cause,
-            StopDeploymentError::DeploymentDoesNotExist(ref cause) => cause,
-            StopDeploymentError::DeploymentGroupDoesNotExist(ref cause) => cause,
-            StopDeploymentError::DeploymentIdRequired(ref cause) => cause,
-            StopDeploymentError::InvalidDeploymentId(ref cause) => cause,
+            StopDeploymentError::DeploymentAlreadyCompleted(ref cause) => write!(f, "{}", cause),
+            StopDeploymentError::DeploymentDoesNotExist(ref cause) => write!(f, "{}", cause),
+            StopDeploymentError::DeploymentGroupDoesNotExist(ref cause) => write!(f, "{}", cause),
+            StopDeploymentError::DeploymentIdRequired(ref cause) => write!(f, "{}", cause),
+            StopDeploymentError::InvalidDeploymentId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopDeploymentError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5632,23 +5726,19 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ApplicationDoesNotExist(ref cause) => cause,
-            TagResourceError::ArnNotSupported(ref cause) => cause,
-            TagResourceError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            TagResourceError::DeploymentGroupDoesNotExist(ref cause) => cause,
-            TagResourceError::InvalidArn(ref cause) => cause,
-            TagResourceError::InvalidTagsToAdd(ref cause) => cause,
-            TagResourceError::ResourceArnRequired(ref cause) => cause,
-            TagResourceError::TagRequired(ref cause) => cause,
+            TagResourceError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ArnNotSupported(ref cause) => write!(f, "{}", cause),
+            TagResourceError::DeploymentConfigDoesNotExist(ref cause) => write!(f, "{}", cause),
+            TagResourceError::DeploymentGroupDoesNotExist(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidTagsToAdd(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceArnRequired(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -5713,23 +5803,19 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ApplicationDoesNotExist(ref cause) => cause,
-            UntagResourceError::ArnNotSupported(ref cause) => cause,
-            UntagResourceError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            UntagResourceError::DeploymentGroupDoesNotExist(ref cause) => cause,
-            UntagResourceError::InvalidArn(ref cause) => cause,
-            UntagResourceError::InvalidTagsToAdd(ref cause) => cause,
-            UntagResourceError::ResourceArnRequired(ref cause) => cause,
-            UntagResourceError::TagRequired(ref cause) => cause,
+            UntagResourceError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ArnNotSupported(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::DeploymentConfigDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::DeploymentGroupDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidTagsToAdd(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceArnRequired(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TagRequired(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateApplication
 #[derive(Debug, PartialEq)]
 pub enum UpdateApplicationError {
@@ -5776,19 +5862,15 @@ impl UpdateApplicationError {
 }
 impl fmt::Display for UpdateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApplicationError::ApplicationAlreadyExists(ref cause) => cause,
-            UpdateApplicationError::ApplicationDoesNotExist(ref cause) => cause,
-            UpdateApplicationError::ApplicationNameRequired(ref cause) => cause,
-            UpdateApplicationError::InvalidApplicationName(ref cause) => cause,
+            UpdateApplicationError::ApplicationAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::ApplicationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::ApplicationNameRequired(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApplicationError {}
 /// Errors returned by UpdateDeploymentGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeploymentGroupError {
@@ -6009,45 +6091,77 @@ impl UpdateDeploymentGroupError {
 }
 impl fmt::Display for UpdateDeploymentGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeploymentGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeploymentGroupError::AlarmsLimitExceeded(ref cause) => cause,
-            UpdateDeploymentGroupError::ApplicationDoesNotExist(ref cause) => cause,
-            UpdateDeploymentGroupError::ApplicationNameRequired(ref cause) => cause,
-            UpdateDeploymentGroupError::DeploymentConfigDoesNotExist(ref cause) => cause,
-            UpdateDeploymentGroupError::DeploymentGroupAlreadyExists(ref cause) => cause,
-            UpdateDeploymentGroupError::DeploymentGroupDoesNotExist(ref cause) => cause,
-            UpdateDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => cause,
-            UpdateDeploymentGroupError::ECSServiceMappingLimitExceeded(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidAlarmConfig(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidApplicationName(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidAutoRollbackConfig(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidAutoScalingGroup(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidBlueGreenDeploymentConfiguration(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidDeploymentConfigName(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidDeploymentStyle(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidEC2TagCombination(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidEC2Tag(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidECSService(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidInput(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidLoadBalancerInfo(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidOnPremisesTagCombination(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidRole(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidTag(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidTargetGroupPair(ref cause) => cause,
-            UpdateDeploymentGroupError::InvalidTriggerConfig(ref cause) => cause,
-            UpdateDeploymentGroupError::LifecycleHookLimitExceeded(ref cause) => cause,
-            UpdateDeploymentGroupError::TagSetListLimitExceeded(ref cause) => cause,
-            UpdateDeploymentGroupError::Throttling(ref cause) => cause,
-            UpdateDeploymentGroupError::TriggerTargetsLimitExceeded(ref cause) => cause,
+            UpdateDeploymentGroupError::AlarmsLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::ApplicationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::ApplicationNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::DeploymentConfigDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::DeploymentGroupAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::DeploymentGroupDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::DeploymentGroupNameRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::ECSServiceMappingLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidAlarmConfig(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidApplicationName(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidAutoRollbackConfig(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidAutoScalingGroup(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidBlueGreenDeploymentConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidDeploymentConfigName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidDeploymentGroupName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidDeploymentStyle(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidEC2TagCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidEC2Tag(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidECSService(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidLoadBalancerInfo(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidOnPremisesTagCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidTargetGroupPair(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::InvalidTriggerConfig(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::LifecycleHookLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::TagSetListLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeploymentGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateDeploymentGroupError::TriggerTargetsLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateDeploymentGroupError {}
 /// Trait representing the capabilities of the CodeDeploy API. CodeDeploy clients implement this trait.
 pub trait CodeDeploy {
     /// <p>Adds tags to on-premises instances.</p>

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -1954,17 +1954,13 @@ impl AcknowledgeJobError {
 }
 impl fmt::Display for AcknowledgeJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcknowledgeJobError {
-    fn description(&self) -> &str {
         match *self {
-            AcknowledgeJobError::InvalidNonce(ref cause) => cause,
-            AcknowledgeJobError::JobNotFound(ref cause) => cause,
+            AcknowledgeJobError::InvalidNonce(ref cause) => write!(f, "{}", cause),
+            AcknowledgeJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcknowledgeJobError {}
 /// Errors returned by AcknowledgeThirdPartyJob
 #[derive(Debug, PartialEq)]
 pub enum AcknowledgeThirdPartyJobError {
@@ -2004,18 +2000,14 @@ impl AcknowledgeThirdPartyJobError {
 }
 impl fmt::Display for AcknowledgeThirdPartyJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcknowledgeThirdPartyJobError {
-    fn description(&self) -> &str {
         match *self {
-            AcknowledgeThirdPartyJobError::InvalidClientToken(ref cause) => cause,
-            AcknowledgeThirdPartyJobError::InvalidNonce(ref cause) => cause,
-            AcknowledgeThirdPartyJobError::JobNotFound(ref cause) => cause,
+            AcknowledgeThirdPartyJobError::InvalidClientToken(ref cause) => write!(f, "{}", cause),
+            AcknowledgeThirdPartyJobError::InvalidNonce(ref cause) => write!(f, "{}", cause),
+            AcknowledgeThirdPartyJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcknowledgeThirdPartyJobError {}
 /// Errors returned by CreateCustomActionType
 #[derive(Debug, PartialEq)]
 pub enum CreateCustomActionTypeError {
@@ -2058,19 +2050,17 @@ impl CreateCustomActionTypeError {
 }
 impl fmt::Display for CreateCustomActionTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCustomActionTypeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCustomActionTypeError::ConcurrentModification(ref cause) => cause,
-            CreateCustomActionTypeError::InvalidTags(ref cause) => cause,
-            CreateCustomActionTypeError::LimitExceeded(ref cause) => cause,
-            CreateCustomActionTypeError::TooManyTags(ref cause) => cause,
+            CreateCustomActionTypeError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCustomActionTypeError::InvalidTags(ref cause) => write!(f, "{}", cause),
+            CreateCustomActionTypeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCustomActionTypeError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCustomActionTypeError {}
 /// Errors returned by CreatePipeline
 #[derive(Debug, PartialEq)]
 pub enum CreatePipelineError {
@@ -2142,24 +2132,20 @@ impl CreatePipelineError {
 }
 impl fmt::Display for CreatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePipelineError::ConcurrentModification(ref cause) => cause,
-            CreatePipelineError::InvalidActionDeclaration(ref cause) => cause,
-            CreatePipelineError::InvalidBlockerDeclaration(ref cause) => cause,
-            CreatePipelineError::InvalidStageDeclaration(ref cause) => cause,
-            CreatePipelineError::InvalidStructure(ref cause) => cause,
-            CreatePipelineError::InvalidTags(ref cause) => cause,
-            CreatePipelineError::LimitExceeded(ref cause) => cause,
-            CreatePipelineError::PipelineNameInUse(ref cause) => cause,
-            CreatePipelineError::TooManyTags(ref cause) => cause,
+            CreatePipelineError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InvalidActionDeclaration(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InvalidBlockerDeclaration(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InvalidStageDeclaration(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InvalidStructure(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InvalidTags(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::PipelineNameInUse(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePipelineError {}
 /// Errors returned by DeleteCustomActionType
 #[derive(Debug, PartialEq)]
 pub enum DeleteCustomActionTypeError {
@@ -2185,16 +2171,14 @@ impl DeleteCustomActionTypeError {
 }
 impl fmt::Display for DeleteCustomActionTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCustomActionTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCustomActionTypeError::ConcurrentModification(ref cause) => cause,
+            DeleteCustomActionTypeError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCustomActionTypeError {}
 /// Errors returned by DeletePipeline
 #[derive(Debug, PartialEq)]
 pub enum DeletePipelineError {
@@ -2220,16 +2204,12 @@ impl DeletePipelineError {
 }
 impl fmt::Display for DeletePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePipelineError::ConcurrentModification(ref cause) => cause,
+            DeletePipelineError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePipelineError {}
 /// Errors returned by DeleteWebhook
 #[derive(Debug, PartialEq)]
 pub enum DeleteWebhookError {
@@ -2255,16 +2235,12 @@ impl DeleteWebhookError {
 }
 impl fmt::Display for DeleteWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWebhookError::ConcurrentModification(ref cause) => cause,
+            DeleteWebhookError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWebhookError {}
 /// Errors returned by DeregisterWebhookWithThirdParty
 #[derive(Debug, PartialEq)]
 pub enum DeregisterWebhookWithThirdPartyError {
@@ -2292,16 +2268,14 @@ impl DeregisterWebhookWithThirdPartyError {
 }
 impl fmt::Display for DeregisterWebhookWithThirdPartyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterWebhookWithThirdPartyError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterWebhookWithThirdPartyError::WebhookNotFound(ref cause) => cause,
+            DeregisterWebhookWithThirdPartyError::WebhookNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterWebhookWithThirdPartyError {}
 /// Errors returned by DisableStageTransition
 #[derive(Debug, PartialEq)]
 pub enum DisableStageTransitionError {
@@ -2334,17 +2308,13 @@ impl DisableStageTransitionError {
 }
 impl fmt::Display for DisableStageTransitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableStageTransitionError {
-    fn description(&self) -> &str {
         match *self {
-            DisableStageTransitionError::PipelineNotFound(ref cause) => cause,
-            DisableStageTransitionError::StageNotFound(ref cause) => cause,
+            DisableStageTransitionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            DisableStageTransitionError::StageNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableStageTransitionError {}
 /// Errors returned by EnableStageTransition
 #[derive(Debug, PartialEq)]
 pub enum EnableStageTransitionError {
@@ -2375,17 +2345,13 @@ impl EnableStageTransitionError {
 }
 impl fmt::Display for EnableStageTransitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableStageTransitionError {
-    fn description(&self) -> &str {
         match *self {
-            EnableStageTransitionError::PipelineNotFound(ref cause) => cause,
-            EnableStageTransitionError::StageNotFound(ref cause) => cause,
+            EnableStageTransitionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            EnableStageTransitionError::StageNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableStageTransitionError {}
 /// Errors returned by GetJobDetails
 #[derive(Debug, PartialEq)]
 pub enum GetJobDetailsError {
@@ -2409,16 +2375,12 @@ impl GetJobDetailsError {
 }
 impl fmt::Display for GetJobDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobDetailsError::JobNotFound(ref cause) => cause,
+            GetJobDetailsError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobDetailsError {}
 /// Errors returned by GetPipeline
 #[derive(Debug, PartialEq)]
 pub enum GetPipelineError {
@@ -2447,17 +2409,13 @@ impl GetPipelineError {
 }
 impl fmt::Display for GetPipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPipelineError {
-    fn description(&self) -> &str {
         match *self {
-            GetPipelineError::PipelineNotFound(ref cause) => cause,
-            GetPipelineError::PipelineVersionNotFound(ref cause) => cause,
+            GetPipelineError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            GetPipelineError::PipelineVersionNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPipelineError {}
 /// Errors returned by GetPipelineExecution
 #[derive(Debug, PartialEq)]
 pub enum GetPipelineExecutionError {
@@ -2490,17 +2448,15 @@ impl GetPipelineExecutionError {
 }
 impl fmt::Display for GetPipelineExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPipelineExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            GetPipelineExecutionError::PipelineExecutionNotFound(ref cause) => cause,
-            GetPipelineExecutionError::PipelineNotFound(ref cause) => cause,
+            GetPipelineExecutionError::PipelineExecutionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPipelineExecutionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPipelineExecutionError {}
 /// Errors returned by GetPipelineState
 #[derive(Debug, PartialEq)]
 pub enum GetPipelineStateError {
@@ -2524,16 +2480,12 @@ impl GetPipelineStateError {
 }
 impl fmt::Display for GetPipelineStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPipelineStateError {
-    fn description(&self) -> &str {
         match *self {
-            GetPipelineStateError::PipelineNotFound(ref cause) => cause,
+            GetPipelineStateError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPipelineStateError {}
 /// Errors returned by GetThirdPartyJobDetails
 #[derive(Debug, PartialEq)]
 pub enum GetThirdPartyJobDetailsError {
@@ -2569,18 +2521,14 @@ impl GetThirdPartyJobDetailsError {
 }
 impl fmt::Display for GetThirdPartyJobDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetThirdPartyJobDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetThirdPartyJobDetailsError::InvalidClientToken(ref cause) => cause,
-            GetThirdPartyJobDetailsError::InvalidJob(ref cause) => cause,
-            GetThirdPartyJobDetailsError::JobNotFound(ref cause) => cause,
+            GetThirdPartyJobDetailsError::InvalidClientToken(ref cause) => write!(f, "{}", cause),
+            GetThirdPartyJobDetailsError::InvalidJob(ref cause) => write!(f, "{}", cause),
+            GetThirdPartyJobDetailsError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetThirdPartyJobDetailsError {}
 /// Errors returned by ListActionExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListActionExecutionsError {
@@ -2620,18 +2568,16 @@ impl ListActionExecutionsError {
 }
 impl fmt::Display for ListActionExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListActionExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListActionExecutionsError::InvalidNextToken(ref cause) => cause,
-            ListActionExecutionsError::PipelineExecutionNotFound(ref cause) => cause,
-            ListActionExecutionsError::PipelineNotFound(ref cause) => cause,
+            ListActionExecutionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListActionExecutionsError::PipelineExecutionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListActionExecutionsError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListActionExecutionsError {}
 /// Errors returned by ListActionTypes
 #[derive(Debug, PartialEq)]
 pub enum ListActionTypesError {
@@ -2655,16 +2601,12 @@ impl ListActionTypesError {
 }
 impl fmt::Display for ListActionTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListActionTypesError {
-    fn description(&self) -> &str {
         match *self {
-            ListActionTypesError::InvalidNextToken(ref cause) => cause,
+            ListActionTypesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListActionTypesError {}
 /// Errors returned by ListPipelineExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListPipelineExecutionsError {
@@ -2697,17 +2639,13 @@ impl ListPipelineExecutionsError {
 }
 impl fmt::Display for ListPipelineExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPipelineExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPipelineExecutionsError::InvalidNextToken(ref cause) => cause,
-            ListPipelineExecutionsError::PipelineNotFound(ref cause) => cause,
+            ListPipelineExecutionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListPipelineExecutionsError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPipelineExecutionsError {}
 /// Errors returned by ListPipelines
 #[derive(Debug, PartialEq)]
 pub enum ListPipelinesError {
@@ -2731,16 +2669,12 @@ impl ListPipelinesError {
 }
 impl fmt::Display for ListPipelinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPipelinesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPipelinesError::InvalidNextToken(ref cause) => cause,
+            ListPipelinesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPipelinesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2778,18 +2712,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InvalidArn(ref cause) => cause,
-            ListTagsForResourceError::InvalidNextToken(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListWebhooks
 #[derive(Debug, PartialEq)]
 pub enum ListWebhooksError {
@@ -2813,16 +2743,12 @@ impl ListWebhooksError {
 }
 impl fmt::Display for ListWebhooksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWebhooksError {
-    fn description(&self) -> &str {
         match *self {
-            ListWebhooksError::InvalidNextToken(ref cause) => cause,
+            ListWebhooksError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWebhooksError {}
 /// Errors returned by PollForJobs
 #[derive(Debug, PartialEq)]
 pub enum PollForJobsError {
@@ -2846,16 +2772,12 @@ impl PollForJobsError {
 }
 impl fmt::Display for PollForJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PollForJobsError {
-    fn description(&self) -> &str {
         match *self {
-            PollForJobsError::ActionTypeNotFound(ref cause) => cause,
+            PollForJobsError::ActionTypeNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PollForJobsError {}
 /// Errors returned by PollForThirdPartyJobs
 #[derive(Debug, PartialEq)]
 pub enum PollForThirdPartyJobsError {
@@ -2881,16 +2803,12 @@ impl PollForThirdPartyJobsError {
 }
 impl fmt::Display for PollForThirdPartyJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PollForThirdPartyJobsError {
-    fn description(&self) -> &str {
         match *self {
-            PollForThirdPartyJobsError::ActionTypeNotFound(ref cause) => cause,
+            PollForThirdPartyJobsError::ActionTypeNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PollForThirdPartyJobsError {}
 /// Errors returned by PutActionRevision
 #[derive(Debug, PartialEq)]
 pub enum PutActionRevisionError {
@@ -2924,18 +2842,14 @@ impl PutActionRevisionError {
 }
 impl fmt::Display for PutActionRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutActionRevisionError {
-    fn description(&self) -> &str {
         match *self {
-            PutActionRevisionError::ActionNotFound(ref cause) => cause,
-            PutActionRevisionError::PipelineNotFound(ref cause) => cause,
-            PutActionRevisionError::StageNotFound(ref cause) => cause,
+            PutActionRevisionError::ActionNotFound(ref cause) => write!(f, "{}", cause),
+            PutActionRevisionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            PutActionRevisionError::StageNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutActionRevisionError {}
 /// Errors returned by PutApprovalResult
 #[derive(Debug, PartialEq)]
 pub enum PutApprovalResultError {
@@ -2983,20 +2897,16 @@ impl PutApprovalResultError {
 }
 impl fmt::Display for PutApprovalResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutApprovalResultError {
-    fn description(&self) -> &str {
         match *self {
-            PutApprovalResultError::ActionNotFound(ref cause) => cause,
-            PutApprovalResultError::ApprovalAlreadyCompleted(ref cause) => cause,
-            PutApprovalResultError::InvalidApprovalToken(ref cause) => cause,
-            PutApprovalResultError::PipelineNotFound(ref cause) => cause,
-            PutApprovalResultError::StageNotFound(ref cause) => cause,
+            PutApprovalResultError::ActionNotFound(ref cause) => write!(f, "{}", cause),
+            PutApprovalResultError::ApprovalAlreadyCompleted(ref cause) => write!(f, "{}", cause),
+            PutApprovalResultError::InvalidApprovalToken(ref cause) => write!(f, "{}", cause),
+            PutApprovalResultError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            PutApprovalResultError::StageNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutApprovalResultError {}
 /// Errors returned by PutJobFailureResult
 #[derive(Debug, PartialEq)]
 pub enum PutJobFailureResultError {
@@ -3025,17 +2935,13 @@ impl PutJobFailureResultError {
 }
 impl fmt::Display for PutJobFailureResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutJobFailureResultError {
-    fn description(&self) -> &str {
         match *self {
-            PutJobFailureResultError::InvalidJobState(ref cause) => cause,
-            PutJobFailureResultError::JobNotFound(ref cause) => cause,
+            PutJobFailureResultError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            PutJobFailureResultError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutJobFailureResultError {}
 /// Errors returned by PutJobSuccessResult
 #[derive(Debug, PartialEq)]
 pub enum PutJobSuccessResultError {
@@ -3071,18 +2977,16 @@ impl PutJobSuccessResultError {
 }
 impl fmt::Display for PutJobSuccessResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutJobSuccessResultError {
-    fn description(&self) -> &str {
         match *self {
-            PutJobSuccessResultError::InvalidJobState(ref cause) => cause,
-            PutJobSuccessResultError::JobNotFound(ref cause) => cause,
-            PutJobSuccessResultError::OutputVariablesSizeExceeded(ref cause) => cause,
+            PutJobSuccessResultError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            PutJobSuccessResultError::JobNotFound(ref cause) => write!(f, "{}", cause),
+            PutJobSuccessResultError::OutputVariablesSizeExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutJobSuccessResultError {}
 /// Errors returned by PutThirdPartyJobFailureResult
 #[derive(Debug, PartialEq)]
 pub enum PutThirdPartyJobFailureResultError {
@@ -3124,18 +3028,18 @@ impl PutThirdPartyJobFailureResultError {
 }
 impl fmt::Display for PutThirdPartyJobFailureResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutThirdPartyJobFailureResultError {
-    fn description(&self) -> &str {
         match *self {
-            PutThirdPartyJobFailureResultError::InvalidClientToken(ref cause) => cause,
-            PutThirdPartyJobFailureResultError::InvalidJobState(ref cause) => cause,
-            PutThirdPartyJobFailureResultError::JobNotFound(ref cause) => cause,
+            PutThirdPartyJobFailureResultError::InvalidClientToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutThirdPartyJobFailureResultError::InvalidJobState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutThirdPartyJobFailureResultError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutThirdPartyJobFailureResultError {}
 /// Errors returned by PutThirdPartyJobSuccessResult
 #[derive(Debug, PartialEq)]
 pub enum PutThirdPartyJobSuccessResultError {
@@ -3177,18 +3081,18 @@ impl PutThirdPartyJobSuccessResultError {
 }
 impl fmt::Display for PutThirdPartyJobSuccessResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutThirdPartyJobSuccessResultError {
-    fn description(&self) -> &str {
         match *self {
-            PutThirdPartyJobSuccessResultError::InvalidClientToken(ref cause) => cause,
-            PutThirdPartyJobSuccessResultError::InvalidJobState(ref cause) => cause,
-            PutThirdPartyJobSuccessResultError::JobNotFound(ref cause) => cause,
+            PutThirdPartyJobSuccessResultError::InvalidClientToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutThirdPartyJobSuccessResultError::InvalidJobState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutThirdPartyJobSuccessResultError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutThirdPartyJobSuccessResultError {}
 /// Errors returned by PutWebhook
 #[derive(Debug, PartialEq)]
 pub enum PutWebhookError {
@@ -3246,22 +3150,20 @@ impl PutWebhookError {
 }
 impl fmt::Display for PutWebhookError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutWebhookError {
-    fn description(&self) -> &str {
         match *self {
-            PutWebhookError::ConcurrentModification(ref cause) => cause,
-            PutWebhookError::InvalidTags(ref cause) => cause,
-            PutWebhookError::InvalidWebhookAuthenticationParameters(ref cause) => cause,
-            PutWebhookError::InvalidWebhookFilterPattern(ref cause) => cause,
-            PutWebhookError::LimitExceeded(ref cause) => cause,
-            PutWebhookError::PipelineNotFound(ref cause) => cause,
-            PutWebhookError::TooManyTags(ref cause) => cause,
+            PutWebhookError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            PutWebhookError::InvalidTags(ref cause) => write!(f, "{}", cause),
+            PutWebhookError::InvalidWebhookAuthenticationParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutWebhookError::InvalidWebhookFilterPattern(ref cause) => write!(f, "{}", cause),
+            PutWebhookError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutWebhookError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            PutWebhookError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutWebhookError {}
 /// Errors returned by RegisterWebhookWithThirdParty
 #[derive(Debug, PartialEq)]
 pub enum RegisterWebhookWithThirdPartyError {
@@ -3289,16 +3191,14 @@ impl RegisterWebhookWithThirdPartyError {
 }
 impl fmt::Display for RegisterWebhookWithThirdPartyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterWebhookWithThirdPartyError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterWebhookWithThirdPartyError::WebhookNotFound(ref cause) => cause,
+            RegisterWebhookWithThirdPartyError::WebhookNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterWebhookWithThirdPartyError {}
 /// Errors returned by RetryStageExecution
 #[derive(Debug, PartialEq)]
 pub enum RetryStageExecutionError {
@@ -3343,19 +3243,17 @@ impl RetryStageExecutionError {
 }
 impl fmt::Display for RetryStageExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RetryStageExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            RetryStageExecutionError::NotLatestPipelineExecution(ref cause) => cause,
-            RetryStageExecutionError::PipelineNotFound(ref cause) => cause,
-            RetryStageExecutionError::StageNotFound(ref cause) => cause,
-            RetryStageExecutionError::StageNotRetryable(ref cause) => cause,
+            RetryStageExecutionError::NotLatestPipelineExecution(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RetryStageExecutionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            RetryStageExecutionError::StageNotFound(ref cause) => write!(f, "{}", cause),
+            RetryStageExecutionError::StageNotRetryable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RetryStageExecutionError {}
 /// Errors returned by StartPipelineExecution
 #[derive(Debug, PartialEq)]
 pub enum StartPipelineExecutionError {
@@ -3381,16 +3279,12 @@ impl StartPipelineExecutionError {
 }
 impl fmt::Display for StartPipelineExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartPipelineExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StartPipelineExecutionError::PipelineNotFound(ref cause) => cause,
+            StartPipelineExecutionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartPipelineExecutionError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3434,20 +3328,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ConcurrentModification(ref cause) => cause,
-            TagResourceError::InvalidArn(ref cause) => cause,
-            TagResourceError::InvalidTags(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidTags(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3488,19 +3378,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ConcurrentModification(ref cause) => cause,
-            UntagResourceError::InvalidArn(ref cause) => cause,
-            UntagResourceError::InvalidTags(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidTags(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdatePipeline
 #[derive(Debug, PartialEq)]
 pub enum UpdatePipelineError {
@@ -3550,20 +3436,16 @@ impl UpdatePipelineError {
 }
 impl fmt::Display for UpdatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePipelineError::InvalidActionDeclaration(ref cause) => cause,
-            UpdatePipelineError::InvalidBlockerDeclaration(ref cause) => cause,
-            UpdatePipelineError::InvalidStageDeclaration(ref cause) => cause,
-            UpdatePipelineError::InvalidStructure(ref cause) => cause,
-            UpdatePipelineError::LimitExceeded(ref cause) => cause,
+            UpdatePipelineError::InvalidActionDeclaration(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::InvalidBlockerDeclaration(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::InvalidStageDeclaration(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::InvalidStructure(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePipelineError {}
 /// Trait representing the capabilities of the CodePipeline API. CodePipeline clients implement this trait.
 pub trait CodePipeline {
     /// <p>Returns information about a specified job and whether that job has been received by the job worker. Used for custom actions only.</p>

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -784,21 +784,19 @@ impl AssociateTeamMemberError {
 }
 impl fmt::Display for AssociateTeamMemberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateTeamMemberError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateTeamMemberError::ConcurrentModification(ref cause) => cause,
-            AssociateTeamMemberError::InvalidServiceRole(ref cause) => cause,
-            AssociateTeamMemberError::LimitExceeded(ref cause) => cause,
-            AssociateTeamMemberError::ProjectConfiguration(ref cause) => cause,
-            AssociateTeamMemberError::ProjectNotFound(ref cause) => cause,
-            AssociateTeamMemberError::TeamMemberAlreadyAssociated(ref cause) => cause,
+            AssociateTeamMemberError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            AssociateTeamMemberError::InvalidServiceRole(ref cause) => write!(f, "{}", cause),
+            AssociateTeamMemberError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateTeamMemberError::ProjectConfiguration(ref cause) => write!(f, "{}", cause),
+            AssociateTeamMemberError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateTeamMemberError::TeamMemberAlreadyAssociated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateTeamMemberError {}
 /// Errors returned by CreateProject
 #[derive(Debug, PartialEq)]
 pub enum CreateProjectError {
@@ -849,21 +847,17 @@ impl CreateProjectError {
 }
 impl fmt::Display for CreateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProjectError::ConcurrentModification(ref cause) => cause,
-            CreateProjectError::InvalidServiceRole(ref cause) => cause,
-            CreateProjectError::LimitExceeded(ref cause) => cause,
-            CreateProjectError::ProjectAlreadyExists(ref cause) => cause,
-            CreateProjectError::ProjectConfiguration(ref cause) => cause,
-            CreateProjectError::ProjectCreationFailed(ref cause) => cause,
+            CreateProjectError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::InvalidServiceRole(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ProjectAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ProjectConfiguration(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ProjectCreationFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProjectError {}
 /// Errors returned by CreateUserProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateUserProfileError {
@@ -889,16 +883,12 @@ impl CreateUserProfileError {
 }
 impl fmt::Display for CreateUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserProfileError::UserProfileAlreadyExists(ref cause) => cause,
+            CreateUserProfileError::UserProfileAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserProfileError {}
 /// Errors returned by DeleteProject
 #[derive(Debug, PartialEq)]
 pub enum DeleteProjectError {
@@ -929,17 +919,13 @@ impl DeleteProjectError {
 }
 impl fmt::Display for DeleteProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProjectError::ConcurrentModification(ref cause) => cause,
-            DeleteProjectError::InvalidServiceRole(ref cause) => cause,
+            DeleteProjectError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::InvalidServiceRole(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProjectError {}
 /// Errors returned by DeleteUserProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserProfileError {}
@@ -957,14 +943,10 @@ impl DeleteUserProfileError {
 }
 impl fmt::Display for DeleteUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserProfileError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteUserProfileError {}
 /// Errors returned by DescribeProject
 #[derive(Debug, PartialEq)]
 pub enum DescribeProjectError {
@@ -1007,19 +989,15 @@ impl DescribeProjectError {
 }
 impl fmt::Display for DescribeProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProjectError::ConcurrentModification(ref cause) => cause,
-            DescribeProjectError::InvalidServiceRole(ref cause) => cause,
-            DescribeProjectError::ProjectConfiguration(ref cause) => cause,
-            DescribeProjectError::ProjectNotFound(ref cause) => cause,
+            DescribeProjectError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::InvalidServiceRole(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::ProjectConfiguration(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProjectError {}
 /// Errors returned by DescribeUserProfile
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserProfileError {
@@ -1045,16 +1023,12 @@ impl DescribeUserProfileError {
 }
 impl fmt::Display for DescribeUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserProfileError::UserProfileNotFound(ref cause) => cause,
+            DescribeUserProfileError::UserProfileNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserProfileError {}
 /// Errors returned by DisassociateTeamMember
 #[derive(Debug, PartialEq)]
 pub enum DisassociateTeamMemberError {
@@ -1094,18 +1068,16 @@ impl DisassociateTeamMemberError {
 }
 impl fmt::Display for DisassociateTeamMemberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateTeamMemberError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateTeamMemberError::ConcurrentModification(ref cause) => cause,
-            DisassociateTeamMemberError::InvalidServiceRole(ref cause) => cause,
-            DisassociateTeamMemberError::ProjectNotFound(ref cause) => cause,
+            DisassociateTeamMemberError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateTeamMemberError::InvalidServiceRole(ref cause) => write!(f, "{}", cause),
+            DisassociateTeamMemberError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateTeamMemberError {}
 /// Errors returned by ListProjects
 #[derive(Debug, PartialEq)]
 pub enum ListProjectsError {
@@ -1129,16 +1101,12 @@ impl ListProjectsError {
 }
 impl fmt::Display for ListProjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProjectsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProjectsError::InvalidNextToken(ref cause) => cause,
+            ListProjectsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProjectsError {}
 /// Errors returned by ListResources
 #[derive(Debug, PartialEq)]
 pub enum ListResourcesError {
@@ -1167,17 +1135,13 @@ impl ListResourcesError {
 }
 impl fmt::Display for ListResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourcesError::InvalidNextToken(ref cause) => cause,
-            ListResourcesError::ProjectNotFound(ref cause) => cause,
+            ListResourcesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourcesError {}
 /// Errors returned by ListTagsForProject
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForProjectError {
@@ -1206,17 +1170,13 @@ impl ListTagsForProjectError {
 }
 impl fmt::Display for ListTagsForProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForProjectError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForProjectError::InvalidNextToken(ref cause) => cause,
-            ListTagsForProjectError::ProjectNotFound(ref cause) => cause,
+            ListTagsForProjectError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListTagsForProjectError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForProjectError {}
 /// Errors returned by ListTeamMembers
 #[derive(Debug, PartialEq)]
 pub enum ListTeamMembersError {
@@ -1245,17 +1205,13 @@ impl ListTeamMembersError {
 }
 impl fmt::Display for ListTeamMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTeamMembersError {
-    fn description(&self) -> &str {
         match *self {
-            ListTeamMembersError::InvalidNextToken(ref cause) => cause,
-            ListTeamMembersError::ProjectNotFound(ref cause) => cause,
+            ListTeamMembersError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListTeamMembersError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTeamMembersError {}
 /// Errors returned by ListUserProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListUserProfilesError {
@@ -1279,16 +1235,12 @@ impl ListUserProfilesError {
 }
 impl fmt::Display for ListUserProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListUserProfilesError::InvalidNextToken(ref cause) => cause,
+            ListUserProfilesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUserProfilesError {}
 /// Errors returned by TagProject
 #[derive(Debug, PartialEq)]
 pub enum TagProjectError {
@@ -1322,18 +1274,14 @@ impl TagProjectError {
 }
 impl fmt::Display for TagProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagProjectError {
-    fn description(&self) -> &str {
         match *self {
-            TagProjectError::ConcurrentModification(ref cause) => cause,
-            TagProjectError::LimitExceeded(ref cause) => cause,
-            TagProjectError::ProjectNotFound(ref cause) => cause,
+            TagProjectError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagProjectError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagProjectError {}
 /// Errors returned by UntagProject
 #[derive(Debug, PartialEq)]
 pub enum UntagProjectError {
@@ -1367,18 +1315,14 @@ impl UntagProjectError {
 }
 impl fmt::Display for UntagProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagProjectError {
-    fn description(&self) -> &str {
         match *self {
-            UntagProjectError::ConcurrentModification(ref cause) => cause,
-            UntagProjectError::LimitExceeded(ref cause) => cause,
-            UntagProjectError::ProjectNotFound(ref cause) => cause,
+            UntagProjectError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagProjectError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagProjectError {}
 /// Errors returned by UpdateProject
 #[derive(Debug, PartialEq)]
 pub enum UpdateProjectError {
@@ -1402,16 +1346,12 @@ impl UpdateProjectError {
 }
 impl fmt::Display for UpdateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProjectError::ProjectNotFound(ref cause) => cause,
+            UpdateProjectError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProjectError {}
 /// Errors returned by UpdateTeamMember
 #[derive(Debug, PartialEq)]
 pub enum UpdateTeamMemberError {
@@ -1464,21 +1404,17 @@ impl UpdateTeamMemberError {
 }
 impl fmt::Display for UpdateTeamMemberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTeamMemberError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTeamMemberError::ConcurrentModification(ref cause) => cause,
-            UpdateTeamMemberError::InvalidServiceRole(ref cause) => cause,
-            UpdateTeamMemberError::LimitExceeded(ref cause) => cause,
-            UpdateTeamMemberError::ProjectConfiguration(ref cause) => cause,
-            UpdateTeamMemberError::ProjectNotFound(ref cause) => cause,
-            UpdateTeamMemberError::TeamMemberNotFound(ref cause) => cause,
+            UpdateTeamMemberError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateTeamMemberError::InvalidServiceRole(ref cause) => write!(f, "{}", cause),
+            UpdateTeamMemberError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateTeamMemberError::ProjectConfiguration(ref cause) => write!(f, "{}", cause),
+            UpdateTeamMemberError::ProjectNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTeamMemberError::TeamMemberNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTeamMemberError {}
 /// Errors returned by UpdateUserProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserProfileError {
@@ -1504,16 +1440,12 @@ impl UpdateUserProfileError {
 }
 impl fmt::Display for UpdateUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserProfileError::UserProfileNotFound(ref cause) => cause,
+            UpdateUserProfileError::UserProfileNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserProfileError {}
 /// Trait representing the capabilities of the CodeStar API. CodeStar clients implement this trait.
 pub trait CodeStar {
     /// <p>Adds an IAM user to the team for an AWS CodeStar project.</p>

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -687,21 +687,17 @@ impl CreateIdentityPoolError {
 }
 impl fmt::Display for CreateIdentityPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIdentityPoolError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIdentityPoolError::InternalError(ref cause) => cause,
-            CreateIdentityPoolError::InvalidParameter(ref cause) => cause,
-            CreateIdentityPoolError::LimitExceeded(ref cause) => cause,
-            CreateIdentityPoolError::NotAuthorized(ref cause) => cause,
-            CreateIdentityPoolError::ResourceConflict(ref cause) => cause,
-            CreateIdentityPoolError::TooManyRequests(ref cause) => cause,
+            CreateIdentityPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateIdentityPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateIdentityPoolError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateIdentityPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateIdentityPoolError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            CreateIdentityPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIdentityPoolError {}
 /// Errors returned by DeleteIdentities
 #[derive(Debug, PartialEq)]
 pub enum DeleteIdentitiesError {
@@ -735,18 +731,14 @@ impl DeleteIdentitiesError {
 }
 impl fmt::Display for DeleteIdentitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIdentitiesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIdentitiesError::InternalError(ref cause) => cause,
-            DeleteIdentitiesError::InvalidParameter(ref cause) => cause,
-            DeleteIdentitiesError::TooManyRequests(ref cause) => cause,
+            DeleteIdentitiesError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteIdentitiesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteIdentitiesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIdentitiesError {}
 /// Errors returned by DeleteIdentityPool
 #[derive(Debug, PartialEq)]
 pub enum DeleteIdentityPoolError {
@@ -790,20 +782,16 @@ impl DeleteIdentityPoolError {
 }
 impl fmt::Display for DeleteIdentityPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIdentityPoolError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIdentityPoolError::InternalError(ref cause) => cause,
-            DeleteIdentityPoolError::InvalidParameter(ref cause) => cause,
-            DeleteIdentityPoolError::NotAuthorized(ref cause) => cause,
-            DeleteIdentityPoolError::ResourceNotFound(ref cause) => cause,
-            DeleteIdentityPoolError::TooManyRequests(ref cause) => cause,
+            DeleteIdentityPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityPoolError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIdentityPoolError {}
 /// Errors returned by DescribeIdentity
 #[derive(Debug, PartialEq)]
 pub enum DescribeIdentityError {
@@ -847,20 +835,16 @@ impl DescribeIdentityError {
 }
 impl fmt::Display for DescribeIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIdentityError::InternalError(ref cause) => cause,
-            DescribeIdentityError::InvalidParameter(ref cause) => cause,
-            DescribeIdentityError::NotAuthorized(ref cause) => cause,
-            DescribeIdentityError::ResourceNotFound(ref cause) => cause,
-            DescribeIdentityError::TooManyRequests(ref cause) => cause,
+            DescribeIdentityError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIdentityError {}
 /// Errors returned by DescribeIdentityPool
 #[derive(Debug, PartialEq)]
 pub enum DescribeIdentityPoolError {
@@ -910,20 +894,16 @@ impl DescribeIdentityPoolError {
 }
 impl fmt::Display for DescribeIdentityPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIdentityPoolError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIdentityPoolError::InternalError(ref cause) => cause,
-            DescribeIdentityPoolError::InvalidParameter(ref cause) => cause,
-            DescribeIdentityPoolError::NotAuthorized(ref cause) => cause,
-            DescribeIdentityPoolError::ResourceNotFound(ref cause) => cause,
-            DescribeIdentityPoolError::TooManyRequests(ref cause) => cause,
+            DescribeIdentityPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIdentityPoolError {}
 /// Errors returned by GetCredentialsForIdentity
 #[derive(Debug, PartialEq)]
 pub enum GetCredentialsForIdentityError {
@@ -998,23 +978,21 @@ impl GetCredentialsForIdentityError {
 }
 impl fmt::Display for GetCredentialsForIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCredentialsForIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            GetCredentialsForIdentityError::ExternalService(ref cause) => cause,
-            GetCredentialsForIdentityError::InternalError(ref cause) => cause,
-            GetCredentialsForIdentityError::InvalidIdentityPoolConfiguration(ref cause) => cause,
-            GetCredentialsForIdentityError::InvalidParameter(ref cause) => cause,
-            GetCredentialsForIdentityError::NotAuthorized(ref cause) => cause,
-            GetCredentialsForIdentityError::ResourceConflict(ref cause) => cause,
-            GetCredentialsForIdentityError::ResourceNotFound(ref cause) => cause,
-            GetCredentialsForIdentityError::TooManyRequests(ref cause) => cause,
+            GetCredentialsForIdentityError::ExternalService(ref cause) => write!(f, "{}", cause),
+            GetCredentialsForIdentityError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetCredentialsForIdentityError::InvalidIdentityPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCredentialsForIdentityError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetCredentialsForIdentityError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetCredentialsForIdentityError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            GetCredentialsForIdentityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetCredentialsForIdentityError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCredentialsForIdentityError {}
 /// Errors returned by GetId
 #[derive(Debug, PartialEq)]
 pub enum GetIdError {
@@ -1073,23 +1051,19 @@ impl GetIdError {
 }
 impl fmt::Display for GetIdError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdError {
-    fn description(&self) -> &str {
         match *self {
-            GetIdError::ExternalService(ref cause) => cause,
-            GetIdError::InternalError(ref cause) => cause,
-            GetIdError::InvalidParameter(ref cause) => cause,
-            GetIdError::LimitExceeded(ref cause) => cause,
-            GetIdError::NotAuthorized(ref cause) => cause,
-            GetIdError::ResourceConflict(ref cause) => cause,
-            GetIdError::ResourceNotFound(ref cause) => cause,
-            GetIdError::TooManyRequests(ref cause) => cause,
+            GetIdError::ExternalService(ref cause) => write!(f, "{}", cause),
+            GetIdError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetIdError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetIdError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetIdError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetIdError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            GetIdError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetIdError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIdError {}
 /// Errors returned by GetIdentityPoolRoles
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityPoolRolesError {
@@ -1146,21 +1120,17 @@ impl GetIdentityPoolRolesError {
 }
 impl fmt::Display for GetIdentityPoolRolesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityPoolRolesError {
-    fn description(&self) -> &str {
         match *self {
-            GetIdentityPoolRolesError::InternalError(ref cause) => cause,
-            GetIdentityPoolRolesError::InvalidParameter(ref cause) => cause,
-            GetIdentityPoolRolesError::NotAuthorized(ref cause) => cause,
-            GetIdentityPoolRolesError::ResourceConflict(ref cause) => cause,
-            GetIdentityPoolRolesError::ResourceNotFound(ref cause) => cause,
-            GetIdentityPoolRolesError::TooManyRequests(ref cause) => cause,
+            GetIdentityPoolRolesError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetIdentityPoolRolesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetIdentityPoolRolesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetIdentityPoolRolesError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            GetIdentityPoolRolesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetIdentityPoolRolesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIdentityPoolRolesError {}
 /// Errors returned by GetOpenIdToken
 #[derive(Debug, PartialEq)]
 pub enum GetOpenIdTokenError {
@@ -1214,22 +1184,18 @@ impl GetOpenIdTokenError {
 }
 impl fmt::Display for GetOpenIdTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOpenIdTokenError {
-    fn description(&self) -> &str {
         match *self {
-            GetOpenIdTokenError::ExternalService(ref cause) => cause,
-            GetOpenIdTokenError::InternalError(ref cause) => cause,
-            GetOpenIdTokenError::InvalidParameter(ref cause) => cause,
-            GetOpenIdTokenError::NotAuthorized(ref cause) => cause,
-            GetOpenIdTokenError::ResourceConflict(ref cause) => cause,
-            GetOpenIdTokenError::ResourceNotFound(ref cause) => cause,
-            GetOpenIdTokenError::TooManyRequests(ref cause) => cause,
+            GetOpenIdTokenError::ExternalService(ref cause) => write!(f, "{}", cause),
+            GetOpenIdTokenError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetOpenIdTokenError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetOpenIdTokenError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetOpenIdTokenError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            GetOpenIdTokenError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetOpenIdTokenError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOpenIdTokenError {}
 /// Errors returned by GetOpenIdTokenForDeveloperIdentity
 #[derive(Debug, PartialEq)]
 pub enum GetOpenIdTokenForDeveloperIdentityError {
@@ -1301,24 +1267,32 @@ impl GetOpenIdTokenForDeveloperIdentityError {
 }
 impl fmt::Display for GetOpenIdTokenForDeveloperIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOpenIdTokenForDeveloperIdentityError {
-    fn description(&self) -> &str {
         match *self {
             GetOpenIdTokenForDeveloperIdentityError::DeveloperUserAlreadyRegistered(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            GetOpenIdTokenForDeveloperIdentityError::InternalError(ref cause) => cause,
-            GetOpenIdTokenForDeveloperIdentityError::InvalidParameter(ref cause) => cause,
-            GetOpenIdTokenForDeveloperIdentityError::NotAuthorized(ref cause) => cause,
-            GetOpenIdTokenForDeveloperIdentityError::ResourceConflict(ref cause) => cause,
-            GetOpenIdTokenForDeveloperIdentityError::ResourceNotFound(ref cause) => cause,
-            GetOpenIdTokenForDeveloperIdentityError::TooManyRequests(ref cause) => cause,
+            GetOpenIdTokenForDeveloperIdentityError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetOpenIdTokenForDeveloperIdentityError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetOpenIdTokenForDeveloperIdentityError::NotAuthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetOpenIdTokenForDeveloperIdentityError::ResourceConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetOpenIdTokenForDeveloperIdentityError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetOpenIdTokenForDeveloperIdentityError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetOpenIdTokenForDeveloperIdentityError {}
 /// Errors returned by ListIdentities
 #[derive(Debug, PartialEq)]
 pub enum ListIdentitiesError {
@@ -1362,20 +1336,16 @@ impl ListIdentitiesError {
 }
 impl fmt::Display for ListIdentitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIdentitiesError {
-    fn description(&self) -> &str {
         match *self {
-            ListIdentitiesError::InternalError(ref cause) => cause,
-            ListIdentitiesError::InvalidParameter(ref cause) => cause,
-            ListIdentitiesError::NotAuthorized(ref cause) => cause,
-            ListIdentitiesError::ResourceNotFound(ref cause) => cause,
-            ListIdentitiesError::TooManyRequests(ref cause) => cause,
+            ListIdentitiesError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListIdentitiesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListIdentitiesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListIdentitiesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListIdentitiesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIdentitiesError {}
 /// Errors returned by ListIdentityPools
 #[derive(Debug, PartialEq)]
 pub enum ListIdentityPoolsError {
@@ -1419,20 +1389,16 @@ impl ListIdentityPoolsError {
 }
 impl fmt::Display for ListIdentityPoolsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIdentityPoolsError {
-    fn description(&self) -> &str {
         match *self {
-            ListIdentityPoolsError::InternalError(ref cause) => cause,
-            ListIdentityPoolsError::InvalidParameter(ref cause) => cause,
-            ListIdentityPoolsError::NotAuthorized(ref cause) => cause,
-            ListIdentityPoolsError::ResourceNotFound(ref cause) => cause,
-            ListIdentityPoolsError::TooManyRequests(ref cause) => cause,
+            ListIdentityPoolsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListIdentityPoolsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListIdentityPoolsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListIdentityPoolsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListIdentityPoolsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIdentityPoolsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1480,20 +1446,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalError(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::NotAuthorized(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::TooManyRequests(ref cause) => cause,
+            ListTagsForResourceError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by LookupDeveloperIdentity
 #[derive(Debug, PartialEq)]
 pub enum LookupDeveloperIdentityError {
@@ -1554,21 +1516,17 @@ impl LookupDeveloperIdentityError {
 }
 impl fmt::Display for LookupDeveloperIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for LookupDeveloperIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            LookupDeveloperIdentityError::InternalError(ref cause) => cause,
-            LookupDeveloperIdentityError::InvalidParameter(ref cause) => cause,
-            LookupDeveloperIdentityError::NotAuthorized(ref cause) => cause,
-            LookupDeveloperIdentityError::ResourceConflict(ref cause) => cause,
-            LookupDeveloperIdentityError::ResourceNotFound(ref cause) => cause,
-            LookupDeveloperIdentityError::TooManyRequests(ref cause) => cause,
+            LookupDeveloperIdentityError::InternalError(ref cause) => write!(f, "{}", cause),
+            LookupDeveloperIdentityError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            LookupDeveloperIdentityError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            LookupDeveloperIdentityError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            LookupDeveloperIdentityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            LookupDeveloperIdentityError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for LookupDeveloperIdentityError {}
 /// Errors returned by MergeDeveloperIdentities
 #[derive(Debug, PartialEq)]
 pub enum MergeDeveloperIdentitiesError {
@@ -1629,21 +1587,17 @@ impl MergeDeveloperIdentitiesError {
 }
 impl fmt::Display for MergeDeveloperIdentitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergeDeveloperIdentitiesError {
-    fn description(&self) -> &str {
         match *self {
-            MergeDeveloperIdentitiesError::InternalError(ref cause) => cause,
-            MergeDeveloperIdentitiesError::InvalidParameter(ref cause) => cause,
-            MergeDeveloperIdentitiesError::NotAuthorized(ref cause) => cause,
-            MergeDeveloperIdentitiesError::ResourceConflict(ref cause) => cause,
-            MergeDeveloperIdentitiesError::ResourceNotFound(ref cause) => cause,
-            MergeDeveloperIdentitiesError::TooManyRequests(ref cause) => cause,
+            MergeDeveloperIdentitiesError::InternalError(ref cause) => write!(f, "{}", cause),
+            MergeDeveloperIdentitiesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            MergeDeveloperIdentitiesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            MergeDeveloperIdentitiesError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            MergeDeveloperIdentitiesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            MergeDeveloperIdentitiesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for MergeDeveloperIdentitiesError {}
 /// Errors returned by SetIdentityPoolRoles
 #[derive(Debug, PartialEq)]
 pub enum SetIdentityPoolRolesError {
@@ -1707,22 +1661,18 @@ impl SetIdentityPoolRolesError {
 }
 impl fmt::Display for SetIdentityPoolRolesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIdentityPoolRolesError {
-    fn description(&self) -> &str {
         match *self {
-            SetIdentityPoolRolesError::ConcurrentModification(ref cause) => cause,
-            SetIdentityPoolRolesError::InternalError(ref cause) => cause,
-            SetIdentityPoolRolesError::InvalidParameter(ref cause) => cause,
-            SetIdentityPoolRolesError::NotAuthorized(ref cause) => cause,
-            SetIdentityPoolRolesError::ResourceConflict(ref cause) => cause,
-            SetIdentityPoolRolesError::ResourceNotFound(ref cause) => cause,
-            SetIdentityPoolRolesError::TooManyRequests(ref cause) => cause,
+            SetIdentityPoolRolesError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolRolesError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolRolesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolRolesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolRolesError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolRolesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolRolesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetIdentityPoolRolesError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1766,20 +1716,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalError(ref cause) => cause,
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::NotAuthorized(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
+            TagResourceError::InternalError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UnlinkDeveloperIdentity
 #[derive(Debug, PartialEq)]
 pub enum UnlinkDeveloperIdentityError {
@@ -1840,21 +1786,17 @@ impl UnlinkDeveloperIdentityError {
 }
 impl fmt::Display for UnlinkDeveloperIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnlinkDeveloperIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            UnlinkDeveloperIdentityError::InternalError(ref cause) => cause,
-            UnlinkDeveloperIdentityError::InvalidParameter(ref cause) => cause,
-            UnlinkDeveloperIdentityError::NotAuthorized(ref cause) => cause,
-            UnlinkDeveloperIdentityError::ResourceConflict(ref cause) => cause,
-            UnlinkDeveloperIdentityError::ResourceNotFound(ref cause) => cause,
-            UnlinkDeveloperIdentityError::TooManyRequests(ref cause) => cause,
+            UnlinkDeveloperIdentityError::InternalError(ref cause) => write!(f, "{}", cause),
+            UnlinkDeveloperIdentityError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UnlinkDeveloperIdentityError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UnlinkDeveloperIdentityError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UnlinkDeveloperIdentityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UnlinkDeveloperIdentityError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnlinkDeveloperIdentityError {}
 /// Errors returned by UnlinkIdentity
 #[derive(Debug, PartialEq)]
 pub enum UnlinkIdentityError {
@@ -1908,22 +1850,18 @@ impl UnlinkIdentityError {
 }
 impl fmt::Display for UnlinkIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnlinkIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            UnlinkIdentityError::ExternalService(ref cause) => cause,
-            UnlinkIdentityError::InternalError(ref cause) => cause,
-            UnlinkIdentityError::InvalidParameter(ref cause) => cause,
-            UnlinkIdentityError::NotAuthorized(ref cause) => cause,
-            UnlinkIdentityError::ResourceConflict(ref cause) => cause,
-            UnlinkIdentityError::ResourceNotFound(ref cause) => cause,
-            UnlinkIdentityError::TooManyRequests(ref cause) => cause,
+            UnlinkIdentityError::ExternalService(ref cause) => write!(f, "{}", cause),
+            UnlinkIdentityError::InternalError(ref cause) => write!(f, "{}", cause),
+            UnlinkIdentityError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UnlinkIdentityError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UnlinkIdentityError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UnlinkIdentityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UnlinkIdentityError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnlinkIdentityError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1967,20 +1905,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalError(ref cause) => cause,
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::NotAuthorized(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
+            UntagResourceError::InternalError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateIdentityPool
 #[derive(Debug, PartialEq)]
 pub enum UpdateIdentityPoolError {
@@ -2041,23 +1975,19 @@ impl UpdateIdentityPoolError {
 }
 impl fmt::Display for UpdateIdentityPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIdentityPoolError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIdentityPoolError::ConcurrentModification(ref cause) => cause,
-            UpdateIdentityPoolError::InternalError(ref cause) => cause,
-            UpdateIdentityPoolError::InvalidParameter(ref cause) => cause,
-            UpdateIdentityPoolError::LimitExceeded(ref cause) => cause,
-            UpdateIdentityPoolError::NotAuthorized(ref cause) => cause,
-            UpdateIdentityPoolError::ResourceConflict(ref cause) => cause,
-            UpdateIdentityPoolError::ResourceNotFound(ref cause) => cause,
-            UpdateIdentityPoolError::TooManyRequests(ref cause) => cause,
+            UpdateIdentityPoolError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityPoolError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityPoolError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityPoolError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIdentityPoolError {}
 /// Trait representing the capabilities of the Amazon Cognito Identity API. Amazon Cognito Identity clients implement this trait.
 pub trait CognitoIdentity {
     /// <p>Creates a new identity pool. The identity pool is a store of user identity information that is specific to your AWS account. The keys for <code>SupportedLoginProviders</code> are as follows:</p> <ul> <li> <p>Facebook: <code>graph.facebook.com</code> </p> </li> <li> <p>Google: <code>accounts.google.com</code> </p> </li> <li> <p>Amazon: <code>www.amazon.com</code> </p> </li> <li> <p>Twitter: <code>api.twitter.com</code> </p> </li> <li> <p>Digits: <code>www.digits.com</code> </p> </li> </ul> <p>You must use AWS Developer credentials to call this API.</p>

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -4089,21 +4089,17 @@ impl AddCustomAttributesError {
 }
 impl fmt::Display for AddCustomAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddCustomAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            AddCustomAttributesError::InternalError(ref cause) => cause,
-            AddCustomAttributesError::InvalidParameter(ref cause) => cause,
-            AddCustomAttributesError::NotAuthorized(ref cause) => cause,
-            AddCustomAttributesError::ResourceNotFound(ref cause) => cause,
-            AddCustomAttributesError::TooManyRequests(ref cause) => cause,
-            AddCustomAttributesError::UserImportInProgress(ref cause) => cause,
+            AddCustomAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            AddCustomAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AddCustomAttributesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AddCustomAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddCustomAttributesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AddCustomAttributesError::UserImportInProgress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddCustomAttributesError {}
 /// Errors returned by AdminAddUserToGroup
 #[derive(Debug, PartialEq)]
 pub enum AdminAddUserToGroupError {
@@ -4156,21 +4152,17 @@ impl AdminAddUserToGroupError {
 }
 impl fmt::Display for AdminAddUserToGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminAddUserToGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AdminAddUserToGroupError::InternalError(ref cause) => cause,
-            AdminAddUserToGroupError::InvalidParameter(ref cause) => cause,
-            AdminAddUserToGroupError::NotAuthorized(ref cause) => cause,
-            AdminAddUserToGroupError::ResourceNotFound(ref cause) => cause,
-            AdminAddUserToGroupError::TooManyRequests(ref cause) => cause,
-            AdminAddUserToGroupError::UserNotFound(ref cause) => cause,
+            AdminAddUserToGroupError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminAddUserToGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminAddUserToGroupError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminAddUserToGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminAddUserToGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminAddUserToGroupError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminAddUserToGroupError {}
 /// Errors returned by AdminConfirmSignUp
 #[derive(Debug, PartialEq)]
 pub enum AdminConfirmSignUpError {
@@ -4250,26 +4242,22 @@ impl AdminConfirmSignUpError {
 }
 impl fmt::Display for AdminConfirmSignUpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminConfirmSignUpError {
-    fn description(&self) -> &str {
         match *self {
-            AdminConfirmSignUpError::InternalError(ref cause) => cause,
-            AdminConfirmSignUpError::InvalidLambdaResponse(ref cause) => cause,
-            AdminConfirmSignUpError::InvalidParameter(ref cause) => cause,
-            AdminConfirmSignUpError::LimitExceeded(ref cause) => cause,
-            AdminConfirmSignUpError::NotAuthorized(ref cause) => cause,
-            AdminConfirmSignUpError::ResourceNotFound(ref cause) => cause,
-            AdminConfirmSignUpError::TooManyFailedAttempts(ref cause) => cause,
-            AdminConfirmSignUpError::TooManyRequests(ref cause) => cause,
-            AdminConfirmSignUpError::UnexpectedLambda(ref cause) => cause,
-            AdminConfirmSignUpError::UserLambdaValidation(ref cause) => cause,
-            AdminConfirmSignUpError::UserNotFound(ref cause) => cause,
+            AdminConfirmSignUpError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::TooManyFailedAttempts(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            AdminConfirmSignUpError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminConfirmSignUpError {}
 /// Errors returned by AdminCreateUser
 #[derive(Debug, PartialEq)]
 pub enum AdminCreateUserError {
@@ -4378,31 +4366,29 @@ impl AdminCreateUserError {
 }
 impl fmt::Display for AdminCreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminCreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminCreateUserError::CodeDeliveryFailure(ref cause) => cause,
-            AdminCreateUserError::InternalError(ref cause) => cause,
-            AdminCreateUserError::InvalidLambdaResponse(ref cause) => cause,
-            AdminCreateUserError::InvalidParameter(ref cause) => cause,
-            AdminCreateUserError::InvalidPassword(ref cause) => cause,
-            AdminCreateUserError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            AdminCreateUserError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            AdminCreateUserError::NotAuthorized(ref cause) => cause,
-            AdminCreateUserError::PreconditionNotMet(ref cause) => cause,
-            AdminCreateUserError::ResourceNotFound(ref cause) => cause,
-            AdminCreateUserError::TooManyRequests(ref cause) => cause,
-            AdminCreateUserError::UnexpectedLambda(ref cause) => cause,
-            AdminCreateUserError::UnsupportedUserState(ref cause) => cause,
-            AdminCreateUserError::UserLambdaValidation(ref cause) => cause,
-            AdminCreateUserError::UserNotFound(ref cause) => cause,
-            AdminCreateUserError::UsernameExists(ref cause) => cause,
+            AdminCreateUserError::CodeDeliveryFailure(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::InvalidSmsRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminCreateUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::PreconditionNotMet(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::UnsupportedUserState(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
+            AdminCreateUserError::UsernameExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminCreateUserError {}
 /// Errors returned by AdminDeleteUser
 #[derive(Debug, PartialEq)]
 pub enum AdminDeleteUserError {
@@ -4451,21 +4437,17 @@ impl AdminDeleteUserError {
 }
 impl fmt::Display for AdminDeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminDeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminDeleteUserError::InternalError(ref cause) => cause,
-            AdminDeleteUserError::InvalidParameter(ref cause) => cause,
-            AdminDeleteUserError::NotAuthorized(ref cause) => cause,
-            AdminDeleteUserError::ResourceNotFound(ref cause) => cause,
-            AdminDeleteUserError::TooManyRequests(ref cause) => cause,
-            AdminDeleteUserError::UserNotFound(ref cause) => cause,
+            AdminDeleteUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminDeleteUserError {}
 /// Errors returned by AdminDeleteUserAttributes
 #[derive(Debug, PartialEq)]
 pub enum AdminDeleteUserAttributesError {
@@ -4526,21 +4508,17 @@ impl AdminDeleteUserAttributesError {
 }
 impl fmt::Display for AdminDeleteUserAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminDeleteUserAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            AdminDeleteUserAttributesError::InternalError(ref cause) => cause,
-            AdminDeleteUserAttributesError::InvalidParameter(ref cause) => cause,
-            AdminDeleteUserAttributesError::NotAuthorized(ref cause) => cause,
-            AdminDeleteUserAttributesError::ResourceNotFound(ref cause) => cause,
-            AdminDeleteUserAttributesError::TooManyRequests(ref cause) => cause,
-            AdminDeleteUserAttributesError::UserNotFound(ref cause) => cause,
+            AdminDeleteUserAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserAttributesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserAttributesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminDeleteUserAttributesError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminDeleteUserAttributesError {}
 /// Errors returned by AdminDisableProviderForUser
 #[derive(Debug, PartialEq)]
 pub enum AdminDisableProviderForUserError {
@@ -4610,22 +4588,18 @@ impl AdminDisableProviderForUserError {
 }
 impl fmt::Display for AdminDisableProviderForUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminDisableProviderForUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminDisableProviderForUserError::AliasExists(ref cause) => cause,
-            AdminDisableProviderForUserError::InternalError(ref cause) => cause,
-            AdminDisableProviderForUserError::InvalidParameter(ref cause) => cause,
-            AdminDisableProviderForUserError::NotAuthorized(ref cause) => cause,
-            AdminDisableProviderForUserError::ResourceNotFound(ref cause) => cause,
-            AdminDisableProviderForUserError::TooManyRequests(ref cause) => cause,
-            AdminDisableProviderForUserError::UserNotFound(ref cause) => cause,
+            AdminDisableProviderForUserError::AliasExists(ref cause) => write!(f, "{}", cause),
+            AdminDisableProviderForUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminDisableProviderForUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminDisableProviderForUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminDisableProviderForUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminDisableProviderForUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminDisableProviderForUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminDisableProviderForUserError {}
 /// Errors returned by AdminDisableUser
 #[derive(Debug, PartialEq)]
 pub enum AdminDisableUserError {
@@ -4674,21 +4648,17 @@ impl AdminDisableUserError {
 }
 impl fmt::Display for AdminDisableUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminDisableUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminDisableUserError::InternalError(ref cause) => cause,
-            AdminDisableUserError::InvalidParameter(ref cause) => cause,
-            AdminDisableUserError::NotAuthorized(ref cause) => cause,
-            AdminDisableUserError::ResourceNotFound(ref cause) => cause,
-            AdminDisableUserError::TooManyRequests(ref cause) => cause,
-            AdminDisableUserError::UserNotFound(ref cause) => cause,
+            AdminDisableUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminDisableUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminDisableUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminDisableUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminDisableUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminDisableUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminDisableUserError {}
 /// Errors returned by AdminEnableUser
 #[derive(Debug, PartialEq)]
 pub enum AdminEnableUserError {
@@ -4737,21 +4707,17 @@ impl AdminEnableUserError {
 }
 impl fmt::Display for AdminEnableUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminEnableUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminEnableUserError::InternalError(ref cause) => cause,
-            AdminEnableUserError::InvalidParameter(ref cause) => cause,
-            AdminEnableUserError::NotAuthorized(ref cause) => cause,
-            AdminEnableUserError::ResourceNotFound(ref cause) => cause,
-            AdminEnableUserError::TooManyRequests(ref cause) => cause,
-            AdminEnableUserError::UserNotFound(ref cause) => cause,
+            AdminEnableUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminEnableUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminEnableUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminEnableUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminEnableUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminEnableUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminEnableUserError {}
 /// Errors returned by AdminForgetDevice
 #[derive(Debug, PartialEq)]
 pub enum AdminForgetDeviceError {
@@ -4807,22 +4773,20 @@ impl AdminForgetDeviceError {
 }
 impl fmt::Display for AdminForgetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminForgetDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            AdminForgetDeviceError::InternalError(ref cause) => cause,
-            AdminForgetDeviceError::InvalidParameter(ref cause) => cause,
-            AdminForgetDeviceError::InvalidUserPoolConfiguration(ref cause) => cause,
-            AdminForgetDeviceError::NotAuthorized(ref cause) => cause,
-            AdminForgetDeviceError::ResourceNotFound(ref cause) => cause,
-            AdminForgetDeviceError::TooManyRequests(ref cause) => cause,
-            AdminForgetDeviceError::UserNotFound(ref cause) => cause,
+            AdminForgetDeviceError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminForgetDeviceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminForgetDeviceError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminForgetDeviceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminForgetDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminForgetDeviceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminForgetDeviceError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminForgetDeviceError {}
 /// Errors returned by AdminGetDevice
 #[derive(Debug, PartialEq)]
 pub enum AdminGetDeviceError {
@@ -4873,21 +4837,17 @@ impl AdminGetDeviceError {
 }
 impl fmt::Display for AdminGetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminGetDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            AdminGetDeviceError::InternalError(ref cause) => cause,
-            AdminGetDeviceError::InvalidParameter(ref cause) => cause,
-            AdminGetDeviceError::InvalidUserPoolConfiguration(ref cause) => cause,
-            AdminGetDeviceError::NotAuthorized(ref cause) => cause,
-            AdminGetDeviceError::ResourceNotFound(ref cause) => cause,
-            AdminGetDeviceError::TooManyRequests(ref cause) => cause,
+            AdminGetDeviceError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminGetDeviceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminGetDeviceError::InvalidUserPoolConfiguration(ref cause) => write!(f, "{}", cause),
+            AdminGetDeviceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminGetDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminGetDeviceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminGetDeviceError {}
 /// Errors returned by AdminGetUser
 #[derive(Debug, PartialEq)]
 pub enum AdminGetUserError {
@@ -4936,21 +4896,17 @@ impl AdminGetUserError {
 }
 impl fmt::Display for AdminGetUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminGetUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminGetUserError::InternalError(ref cause) => cause,
-            AdminGetUserError::InvalidParameter(ref cause) => cause,
-            AdminGetUserError::NotAuthorized(ref cause) => cause,
-            AdminGetUserError::ResourceNotFound(ref cause) => cause,
-            AdminGetUserError::TooManyRequests(ref cause) => cause,
-            AdminGetUserError::UserNotFound(ref cause) => cause,
+            AdminGetUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminGetUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminGetUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminGetUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminGetUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminGetUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminGetUserError {}
 /// Errors returned by AdminInitiateAuth
 #[derive(Debug, PartialEq)]
 pub enum AdminInitiateAuthError {
@@ -5056,30 +5012,30 @@ impl AdminInitiateAuthError {
 }
 impl fmt::Display for AdminInitiateAuthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminInitiateAuthError {
-    fn description(&self) -> &str {
         match *self {
-            AdminInitiateAuthError::InternalError(ref cause) => cause,
-            AdminInitiateAuthError::InvalidLambdaResponse(ref cause) => cause,
-            AdminInitiateAuthError::InvalidParameter(ref cause) => cause,
-            AdminInitiateAuthError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            AdminInitiateAuthError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            AdminInitiateAuthError::InvalidUserPoolConfiguration(ref cause) => cause,
-            AdminInitiateAuthError::MFAMethodNotFound(ref cause) => cause,
-            AdminInitiateAuthError::NotAuthorized(ref cause) => cause,
-            AdminInitiateAuthError::PasswordResetRequired(ref cause) => cause,
-            AdminInitiateAuthError::ResourceNotFound(ref cause) => cause,
-            AdminInitiateAuthError::TooManyRequests(ref cause) => cause,
-            AdminInitiateAuthError::UnexpectedLambda(ref cause) => cause,
-            AdminInitiateAuthError::UserLambdaValidation(ref cause) => cause,
-            AdminInitiateAuthError::UserNotConfirmed(ref cause) => cause,
-            AdminInitiateAuthError::UserNotFound(ref cause) => cause,
+            AdminInitiateAuthError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::InvalidSmsRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminInitiateAuthError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminInitiateAuthError::MFAMethodNotFound(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            AdminInitiateAuthError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminInitiateAuthError {}
 /// Errors returned by AdminLinkProviderForUser
 #[derive(Debug, PartialEq)]
 pub enum AdminLinkProviderForUserError {
@@ -5147,22 +5103,18 @@ impl AdminLinkProviderForUserError {
 }
 impl fmt::Display for AdminLinkProviderForUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminLinkProviderForUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminLinkProviderForUserError::AliasExists(ref cause) => cause,
-            AdminLinkProviderForUserError::InternalError(ref cause) => cause,
-            AdminLinkProviderForUserError::InvalidParameter(ref cause) => cause,
-            AdminLinkProviderForUserError::NotAuthorized(ref cause) => cause,
-            AdminLinkProviderForUserError::ResourceNotFound(ref cause) => cause,
-            AdminLinkProviderForUserError::TooManyRequests(ref cause) => cause,
-            AdminLinkProviderForUserError::UserNotFound(ref cause) => cause,
+            AdminLinkProviderForUserError::AliasExists(ref cause) => write!(f, "{}", cause),
+            AdminLinkProviderForUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminLinkProviderForUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminLinkProviderForUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminLinkProviderForUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminLinkProviderForUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminLinkProviderForUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminLinkProviderForUserError {}
 /// Errors returned by AdminListDevices
 #[derive(Debug, PartialEq)]
 pub enum AdminListDevicesError {
@@ -5213,21 +5165,19 @@ impl AdminListDevicesError {
 }
 impl fmt::Display for AdminListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminListDevicesError {
-    fn description(&self) -> &str {
         match *self {
-            AdminListDevicesError::InternalError(ref cause) => cause,
-            AdminListDevicesError::InvalidParameter(ref cause) => cause,
-            AdminListDevicesError::InvalidUserPoolConfiguration(ref cause) => cause,
-            AdminListDevicesError::NotAuthorized(ref cause) => cause,
-            AdminListDevicesError::ResourceNotFound(ref cause) => cause,
-            AdminListDevicesError::TooManyRequests(ref cause) => cause,
+            AdminListDevicesError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminListDevicesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminListDevicesError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminListDevicesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminListDevicesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminListDevicesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminListDevicesError {}
 /// Errors returned by AdminListGroupsForUser
 #[derive(Debug, PartialEq)]
 pub enum AdminListGroupsForUserError {
@@ -5286,21 +5236,17 @@ impl AdminListGroupsForUserError {
 }
 impl fmt::Display for AdminListGroupsForUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminListGroupsForUserError {
-    fn description(&self) -> &str {
         match *self {
-            AdminListGroupsForUserError::InternalError(ref cause) => cause,
-            AdminListGroupsForUserError::InvalidParameter(ref cause) => cause,
-            AdminListGroupsForUserError::NotAuthorized(ref cause) => cause,
-            AdminListGroupsForUserError::ResourceNotFound(ref cause) => cause,
-            AdminListGroupsForUserError::TooManyRequests(ref cause) => cause,
-            AdminListGroupsForUserError::UserNotFound(ref cause) => cause,
+            AdminListGroupsForUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminListGroupsForUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminListGroupsForUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminListGroupsForUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminListGroupsForUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminListGroupsForUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminListGroupsForUserError {}
 /// Errors returned by AdminListUserAuthEvents
 #[derive(Debug, PartialEq)]
 pub enum AdminListUserAuthEventsError {
@@ -5368,22 +5314,20 @@ impl AdminListUserAuthEventsError {
 }
 impl fmt::Display for AdminListUserAuthEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminListUserAuthEventsError {
-    fn description(&self) -> &str {
         match *self {
-            AdminListUserAuthEventsError::InternalError(ref cause) => cause,
-            AdminListUserAuthEventsError::InvalidParameter(ref cause) => cause,
-            AdminListUserAuthEventsError::NotAuthorized(ref cause) => cause,
-            AdminListUserAuthEventsError::ResourceNotFound(ref cause) => cause,
-            AdminListUserAuthEventsError::TooManyRequests(ref cause) => cause,
-            AdminListUserAuthEventsError::UserNotFound(ref cause) => cause,
-            AdminListUserAuthEventsError::UserPoolAddOnNotEnabled(ref cause) => cause,
+            AdminListUserAuthEventsError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminListUserAuthEventsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminListUserAuthEventsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminListUserAuthEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminListUserAuthEventsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminListUserAuthEventsError::UserNotFound(ref cause) => write!(f, "{}", cause),
+            AdminListUserAuthEventsError::UserPoolAddOnNotEnabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AdminListUserAuthEventsError {}
 /// Errors returned by AdminRemoveUserFromGroup
 #[derive(Debug, PartialEq)]
 pub enum AdminRemoveUserFromGroupError {
@@ -5444,21 +5388,17 @@ impl AdminRemoveUserFromGroupError {
 }
 impl fmt::Display for AdminRemoveUserFromGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminRemoveUserFromGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AdminRemoveUserFromGroupError::InternalError(ref cause) => cause,
-            AdminRemoveUserFromGroupError::InvalidParameter(ref cause) => cause,
-            AdminRemoveUserFromGroupError::NotAuthorized(ref cause) => cause,
-            AdminRemoveUserFromGroupError::ResourceNotFound(ref cause) => cause,
-            AdminRemoveUserFromGroupError::TooManyRequests(ref cause) => cause,
-            AdminRemoveUserFromGroupError::UserNotFound(ref cause) => cause,
+            AdminRemoveUserFromGroupError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminRemoveUserFromGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminRemoveUserFromGroupError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminRemoveUserFromGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminRemoveUserFromGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminRemoveUserFromGroupError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminRemoveUserFromGroupError {}
 /// Errors returned by AdminResetUserPassword
 #[derive(Debug, PartialEq)]
 pub enum AdminResetUserPasswordError {
@@ -5566,28 +5506,30 @@ impl AdminResetUserPasswordError {
 }
 impl fmt::Display for AdminResetUserPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminResetUserPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            AdminResetUserPasswordError::InternalError(ref cause) => cause,
-            AdminResetUserPasswordError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            AdminResetUserPasswordError::InvalidLambdaResponse(ref cause) => cause,
-            AdminResetUserPasswordError::InvalidParameter(ref cause) => cause,
-            AdminResetUserPasswordError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            AdminResetUserPasswordError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            AdminResetUserPasswordError::LimitExceeded(ref cause) => cause,
-            AdminResetUserPasswordError::NotAuthorized(ref cause) => cause,
-            AdminResetUserPasswordError::ResourceNotFound(ref cause) => cause,
-            AdminResetUserPasswordError::TooManyRequests(ref cause) => cause,
-            AdminResetUserPasswordError::UnexpectedLambda(ref cause) => cause,
-            AdminResetUserPasswordError::UserLambdaValidation(ref cause) => cause,
-            AdminResetUserPasswordError::UserNotFound(ref cause) => cause,
+            AdminResetUserPasswordError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::InvalidEmailRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminResetUserPasswordError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminResetUserPasswordError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminResetUserPasswordError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            AdminResetUserPasswordError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminResetUserPasswordError {}
 /// Errors returned by AdminRespondToAuthChallenge
 #[derive(Debug, PartialEq)]
 pub enum AdminRespondToAuthChallengeError {
@@ -5748,35 +5690,47 @@ impl AdminRespondToAuthChallengeError {
 }
 impl fmt::Display for AdminRespondToAuthChallengeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminRespondToAuthChallengeError {
-    fn description(&self) -> &str {
         match *self {
-            AdminRespondToAuthChallengeError::AliasExists(ref cause) => cause,
-            AdminRespondToAuthChallengeError::CodeMismatch(ref cause) => cause,
-            AdminRespondToAuthChallengeError::ExpiredCode(ref cause) => cause,
-            AdminRespondToAuthChallengeError::InternalError(ref cause) => cause,
-            AdminRespondToAuthChallengeError::InvalidLambdaResponse(ref cause) => cause,
-            AdminRespondToAuthChallengeError::InvalidParameter(ref cause) => cause,
-            AdminRespondToAuthChallengeError::InvalidPassword(ref cause) => cause,
-            AdminRespondToAuthChallengeError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            AdminRespondToAuthChallengeError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            AdminRespondToAuthChallengeError::InvalidUserPoolConfiguration(ref cause) => cause,
-            AdminRespondToAuthChallengeError::MFAMethodNotFound(ref cause) => cause,
-            AdminRespondToAuthChallengeError::NotAuthorized(ref cause) => cause,
-            AdminRespondToAuthChallengeError::PasswordResetRequired(ref cause) => cause,
-            AdminRespondToAuthChallengeError::ResourceNotFound(ref cause) => cause,
-            AdminRespondToAuthChallengeError::SoftwareTokenMFANotFound(ref cause) => cause,
-            AdminRespondToAuthChallengeError::TooManyRequests(ref cause) => cause,
-            AdminRespondToAuthChallengeError::UnexpectedLambda(ref cause) => cause,
-            AdminRespondToAuthChallengeError::UserLambdaValidation(ref cause) => cause,
-            AdminRespondToAuthChallengeError::UserNotConfirmed(ref cause) => cause,
-            AdminRespondToAuthChallengeError::UserNotFound(ref cause) => cause,
+            AdminRespondToAuthChallengeError::AliasExists(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::CodeMismatch(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::ExpiredCode(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::InvalidLambdaResponse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::MFAMethodNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::PasswordResetRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::SoftwareTokenMFANotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::UserLambdaValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminRespondToAuthChallengeError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            AdminRespondToAuthChallengeError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminRespondToAuthChallengeError {}
 /// Errors returned by AdminSetUserMFAPreference
 #[derive(Debug, PartialEq)]
 pub enum AdminSetUserMFAPreferenceError {
@@ -5844,22 +5798,20 @@ impl AdminSetUserMFAPreferenceError {
 }
 impl fmt::Display for AdminSetUserMFAPreferenceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminSetUserMFAPreferenceError {
-    fn description(&self) -> &str {
         match *self {
-            AdminSetUserMFAPreferenceError::InternalError(ref cause) => cause,
-            AdminSetUserMFAPreferenceError::InvalidParameter(ref cause) => cause,
-            AdminSetUserMFAPreferenceError::NotAuthorized(ref cause) => cause,
-            AdminSetUserMFAPreferenceError::PasswordResetRequired(ref cause) => cause,
-            AdminSetUserMFAPreferenceError::ResourceNotFound(ref cause) => cause,
-            AdminSetUserMFAPreferenceError::UserNotConfirmed(ref cause) => cause,
-            AdminSetUserMFAPreferenceError::UserNotFound(ref cause) => cause,
+            AdminSetUserMFAPreferenceError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminSetUserMFAPreferenceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminSetUserMFAPreferenceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminSetUserMFAPreferenceError::PasswordResetRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminSetUserMFAPreferenceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminSetUserMFAPreferenceError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            AdminSetUserMFAPreferenceError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminSetUserMFAPreferenceError {}
 /// Errors returned by AdminSetUserPassword
 #[derive(Debug, PartialEq)]
 pub enum AdminSetUserPasswordError {
@@ -5921,22 +5873,18 @@ impl AdminSetUserPasswordError {
 }
 impl fmt::Display for AdminSetUserPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminSetUserPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            AdminSetUserPasswordError::InternalError(ref cause) => cause,
-            AdminSetUserPasswordError::InvalidParameter(ref cause) => cause,
-            AdminSetUserPasswordError::InvalidPassword(ref cause) => cause,
-            AdminSetUserPasswordError::NotAuthorized(ref cause) => cause,
-            AdminSetUserPasswordError::ResourceNotFound(ref cause) => cause,
-            AdminSetUserPasswordError::TooManyRequests(ref cause) => cause,
-            AdminSetUserPasswordError::UserNotFound(ref cause) => cause,
+            AdminSetUserPasswordError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminSetUserPasswordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminSetUserPasswordError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            AdminSetUserPasswordError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminSetUserPasswordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminSetUserPasswordError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminSetUserPasswordError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminSetUserPasswordError {}
 /// Errors returned by AdminSetUserSettings
 #[derive(Debug, PartialEq)]
 pub enum AdminSetUserSettingsError {
@@ -5984,20 +5932,16 @@ impl AdminSetUserSettingsError {
 }
 impl fmt::Display for AdminSetUserSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminSetUserSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            AdminSetUserSettingsError::InternalError(ref cause) => cause,
-            AdminSetUserSettingsError::InvalidParameter(ref cause) => cause,
-            AdminSetUserSettingsError::NotAuthorized(ref cause) => cause,
-            AdminSetUserSettingsError::ResourceNotFound(ref cause) => cause,
-            AdminSetUserSettingsError::UserNotFound(ref cause) => cause,
+            AdminSetUserSettingsError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminSetUserSettingsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminSetUserSettingsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminSetUserSettingsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminSetUserSettingsError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminSetUserSettingsError {}
 /// Errors returned by AdminUpdateAuthEventFeedback
 #[derive(Debug, PartialEq)]
 pub enum AdminUpdateAuthEventFeedbackError {
@@ -6067,22 +6011,24 @@ impl AdminUpdateAuthEventFeedbackError {
 }
 impl fmt::Display for AdminUpdateAuthEventFeedbackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminUpdateAuthEventFeedbackError {
-    fn description(&self) -> &str {
         match *self {
-            AdminUpdateAuthEventFeedbackError::InternalError(ref cause) => cause,
-            AdminUpdateAuthEventFeedbackError::InvalidParameter(ref cause) => cause,
-            AdminUpdateAuthEventFeedbackError::NotAuthorized(ref cause) => cause,
-            AdminUpdateAuthEventFeedbackError::ResourceNotFound(ref cause) => cause,
-            AdminUpdateAuthEventFeedbackError::TooManyRequests(ref cause) => cause,
-            AdminUpdateAuthEventFeedbackError::UserNotFound(ref cause) => cause,
-            AdminUpdateAuthEventFeedbackError::UserPoolAddOnNotEnabled(ref cause) => cause,
+            AdminUpdateAuthEventFeedbackError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminUpdateAuthEventFeedbackError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateAuthEventFeedbackError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminUpdateAuthEventFeedbackError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateAuthEventFeedbackError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminUpdateAuthEventFeedbackError::UserNotFound(ref cause) => write!(f, "{}", cause),
+            AdminUpdateAuthEventFeedbackError::UserPoolAddOnNotEnabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AdminUpdateAuthEventFeedbackError {}
 /// Errors returned by AdminUpdateDeviceStatus
 #[derive(Debug, PartialEq)]
 pub enum AdminUpdateDeviceStatusError {
@@ -6150,22 +6096,20 @@ impl AdminUpdateDeviceStatusError {
 }
 impl fmt::Display for AdminUpdateDeviceStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminUpdateDeviceStatusError {
-    fn description(&self) -> &str {
         match *self {
-            AdminUpdateDeviceStatusError::InternalError(ref cause) => cause,
-            AdminUpdateDeviceStatusError::InvalidParameter(ref cause) => cause,
-            AdminUpdateDeviceStatusError::InvalidUserPoolConfiguration(ref cause) => cause,
-            AdminUpdateDeviceStatusError::NotAuthorized(ref cause) => cause,
-            AdminUpdateDeviceStatusError::ResourceNotFound(ref cause) => cause,
-            AdminUpdateDeviceStatusError::TooManyRequests(ref cause) => cause,
-            AdminUpdateDeviceStatusError::UserNotFound(ref cause) => cause,
+            AdminUpdateDeviceStatusError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminUpdateDeviceStatusError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminUpdateDeviceStatusError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateDeviceStatusError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminUpdateDeviceStatusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminUpdateDeviceStatusError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminUpdateDeviceStatusError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminUpdateDeviceStatusError {}
 /// Errors returned by AdminUpdateUserAttributes
 #[derive(Debug, PartialEq)]
 pub enum AdminUpdateUserAttributesError {
@@ -6275,28 +6219,34 @@ impl AdminUpdateUserAttributesError {
 }
 impl fmt::Display for AdminUpdateUserAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminUpdateUserAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            AdminUpdateUserAttributesError::AliasExists(ref cause) => cause,
-            AdminUpdateUserAttributesError::InternalError(ref cause) => cause,
-            AdminUpdateUserAttributesError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            AdminUpdateUserAttributesError::InvalidLambdaResponse(ref cause) => cause,
-            AdminUpdateUserAttributesError::InvalidParameter(ref cause) => cause,
-            AdminUpdateUserAttributesError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            AdminUpdateUserAttributesError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            AdminUpdateUserAttributesError::NotAuthorized(ref cause) => cause,
-            AdminUpdateUserAttributesError::ResourceNotFound(ref cause) => cause,
-            AdminUpdateUserAttributesError::TooManyRequests(ref cause) => cause,
-            AdminUpdateUserAttributesError::UnexpectedLambda(ref cause) => cause,
-            AdminUpdateUserAttributesError::UserLambdaValidation(ref cause) => cause,
-            AdminUpdateUserAttributesError::UserNotFound(ref cause) => cause,
+            AdminUpdateUserAttributesError::AliasExists(ref cause) => write!(f, "{}", cause),
+            AdminUpdateUserAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminUpdateUserAttributesError::InvalidEmailRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateUserAttributesError::InvalidLambdaResponse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateUserAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminUpdateUserAttributesError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateUserAttributesError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateUserAttributesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminUpdateUserAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminUpdateUserAttributesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminUpdateUserAttributesError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            AdminUpdateUserAttributesError::UserLambdaValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AdminUpdateUserAttributesError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminUpdateUserAttributesError {}
 /// Errors returned by AdminUserGlobalSignOut
 #[derive(Debug, PartialEq)]
 pub enum AdminUserGlobalSignOutError {
@@ -6355,21 +6305,17 @@ impl AdminUserGlobalSignOutError {
 }
 impl fmt::Display for AdminUserGlobalSignOutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AdminUserGlobalSignOutError {
-    fn description(&self) -> &str {
         match *self {
-            AdminUserGlobalSignOutError::InternalError(ref cause) => cause,
-            AdminUserGlobalSignOutError::InvalidParameter(ref cause) => cause,
-            AdminUserGlobalSignOutError::NotAuthorized(ref cause) => cause,
-            AdminUserGlobalSignOutError::ResourceNotFound(ref cause) => cause,
-            AdminUserGlobalSignOutError::TooManyRequests(ref cause) => cause,
-            AdminUserGlobalSignOutError::UserNotFound(ref cause) => cause,
+            AdminUserGlobalSignOutError::InternalError(ref cause) => write!(f, "{}", cause),
+            AdminUserGlobalSignOutError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AdminUserGlobalSignOutError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AdminUserGlobalSignOutError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AdminUserGlobalSignOutError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AdminUserGlobalSignOutError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AdminUserGlobalSignOutError {}
 /// Errors returned by AssociateSoftwareToken
 #[derive(Debug, PartialEq)]
 pub enum AssociateSoftwareTokenError {
@@ -6423,20 +6369,18 @@ impl AssociateSoftwareTokenError {
 }
 impl fmt::Display for AssociateSoftwareTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateSoftwareTokenError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateSoftwareTokenError::InternalError(ref cause) => cause,
-            AssociateSoftwareTokenError::InvalidParameter(ref cause) => cause,
-            AssociateSoftwareTokenError::NotAuthorized(ref cause) => cause,
-            AssociateSoftwareTokenError::ResourceNotFound(ref cause) => cause,
-            AssociateSoftwareTokenError::SoftwareTokenMFANotFound(ref cause) => cause,
+            AssociateSoftwareTokenError::InternalError(ref cause) => write!(f, "{}", cause),
+            AssociateSoftwareTokenError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateSoftwareTokenError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AssociateSoftwareTokenError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateSoftwareTokenError::SoftwareTokenMFANotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateSoftwareTokenError {}
 /// Errors returned by ChangePassword
 #[derive(Debug, PartialEq)]
 pub enum ChangePasswordError {
@@ -6507,25 +6451,21 @@ impl ChangePasswordError {
 }
 impl fmt::Display for ChangePasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ChangePasswordError {
-    fn description(&self) -> &str {
         match *self {
-            ChangePasswordError::InternalError(ref cause) => cause,
-            ChangePasswordError::InvalidParameter(ref cause) => cause,
-            ChangePasswordError::InvalidPassword(ref cause) => cause,
-            ChangePasswordError::LimitExceeded(ref cause) => cause,
-            ChangePasswordError::NotAuthorized(ref cause) => cause,
-            ChangePasswordError::PasswordResetRequired(ref cause) => cause,
-            ChangePasswordError::ResourceNotFound(ref cause) => cause,
-            ChangePasswordError::TooManyRequests(ref cause) => cause,
-            ChangePasswordError::UserNotConfirmed(ref cause) => cause,
-            ChangePasswordError::UserNotFound(ref cause) => cause,
+            ChangePasswordError::InternalError(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ChangePasswordError {}
 /// Errors returned by ConfirmDevice
 #[derive(Debug, PartialEq)]
 pub enum ConfirmDeviceError {
@@ -6606,27 +6546,23 @@ impl ConfirmDeviceError {
 }
 impl fmt::Display for ConfirmDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmDeviceError::InternalError(ref cause) => cause,
-            ConfirmDeviceError::InvalidLambdaResponse(ref cause) => cause,
-            ConfirmDeviceError::InvalidParameter(ref cause) => cause,
-            ConfirmDeviceError::InvalidPassword(ref cause) => cause,
-            ConfirmDeviceError::InvalidUserPoolConfiguration(ref cause) => cause,
-            ConfirmDeviceError::NotAuthorized(ref cause) => cause,
-            ConfirmDeviceError::PasswordResetRequired(ref cause) => cause,
-            ConfirmDeviceError::ResourceNotFound(ref cause) => cause,
-            ConfirmDeviceError::TooManyRequests(ref cause) => cause,
-            ConfirmDeviceError::UserNotConfirmed(ref cause) => cause,
-            ConfirmDeviceError::UserNotFound(ref cause) => cause,
-            ConfirmDeviceError::UsernameExists(ref cause) => cause,
+            ConfirmDeviceError::InternalError(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::InvalidUserPoolConfiguration(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::UserNotFound(ref cause) => write!(f, "{}", cause),
+            ConfirmDeviceError::UsernameExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConfirmDeviceError {}
 /// Errors returned by ConfirmForgotPassword
 #[derive(Debug, PartialEq)]
 pub enum ConfirmForgotPasswordError {
@@ -6738,30 +6674,26 @@ impl ConfirmForgotPasswordError {
 }
 impl fmt::Display for ConfirmForgotPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmForgotPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmForgotPasswordError::CodeMismatch(ref cause) => cause,
-            ConfirmForgotPasswordError::ExpiredCode(ref cause) => cause,
-            ConfirmForgotPasswordError::InternalError(ref cause) => cause,
-            ConfirmForgotPasswordError::InvalidLambdaResponse(ref cause) => cause,
-            ConfirmForgotPasswordError::InvalidParameter(ref cause) => cause,
-            ConfirmForgotPasswordError::InvalidPassword(ref cause) => cause,
-            ConfirmForgotPasswordError::LimitExceeded(ref cause) => cause,
-            ConfirmForgotPasswordError::NotAuthorized(ref cause) => cause,
-            ConfirmForgotPasswordError::ResourceNotFound(ref cause) => cause,
-            ConfirmForgotPasswordError::TooManyFailedAttempts(ref cause) => cause,
-            ConfirmForgotPasswordError::TooManyRequests(ref cause) => cause,
-            ConfirmForgotPasswordError::UnexpectedLambda(ref cause) => cause,
-            ConfirmForgotPasswordError::UserLambdaValidation(ref cause) => cause,
-            ConfirmForgotPasswordError::UserNotConfirmed(ref cause) => cause,
-            ConfirmForgotPasswordError::UserNotFound(ref cause) => cause,
+            ConfirmForgotPasswordError::CodeMismatch(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::ExpiredCode(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::InternalError(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::TooManyFailedAttempts(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            ConfirmForgotPasswordError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConfirmForgotPasswordError {}
 /// Errors returned by ConfirmSignUp
 #[derive(Debug, PartialEq)]
 pub enum ConfirmSignUpError {
@@ -6850,29 +6782,25 @@ impl ConfirmSignUpError {
 }
 impl fmt::Display for ConfirmSignUpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmSignUpError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmSignUpError::AliasExists(ref cause) => cause,
-            ConfirmSignUpError::CodeMismatch(ref cause) => cause,
-            ConfirmSignUpError::ExpiredCode(ref cause) => cause,
-            ConfirmSignUpError::InternalError(ref cause) => cause,
-            ConfirmSignUpError::InvalidLambdaResponse(ref cause) => cause,
-            ConfirmSignUpError::InvalidParameter(ref cause) => cause,
-            ConfirmSignUpError::LimitExceeded(ref cause) => cause,
-            ConfirmSignUpError::NotAuthorized(ref cause) => cause,
-            ConfirmSignUpError::ResourceNotFound(ref cause) => cause,
-            ConfirmSignUpError::TooManyFailedAttempts(ref cause) => cause,
-            ConfirmSignUpError::TooManyRequests(ref cause) => cause,
-            ConfirmSignUpError::UnexpectedLambda(ref cause) => cause,
-            ConfirmSignUpError::UserLambdaValidation(ref cause) => cause,
-            ConfirmSignUpError::UserNotFound(ref cause) => cause,
+            ConfirmSignUpError::AliasExists(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::CodeMismatch(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::ExpiredCode(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::InternalError(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::TooManyFailedAttempts(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            ConfirmSignUpError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConfirmSignUpError {}
 /// Errors returned by CreateGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupError {
@@ -6926,22 +6854,18 @@ impl CreateGroupError {
 }
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupError::GroupExists(ref cause) => cause,
-            CreateGroupError::InternalError(ref cause) => cause,
-            CreateGroupError::InvalidParameter(ref cause) => cause,
-            CreateGroupError::LimitExceeded(ref cause) => cause,
-            CreateGroupError::NotAuthorized(ref cause) => cause,
-            CreateGroupError::ResourceNotFound(ref cause) => cause,
-            CreateGroupError::TooManyRequests(ref cause) => cause,
+            CreateGroupError::GroupExists(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGroupError {}
 /// Errors returned by CreateIdentityProvider
 #[derive(Debug, PartialEq)]
 pub enum CreateIdentityProviderError {
@@ -7009,22 +6933,18 @@ impl CreateIdentityProviderError {
 }
 impl fmt::Display for CreateIdentityProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIdentityProviderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIdentityProviderError::DuplicateProvider(ref cause) => cause,
-            CreateIdentityProviderError::InternalError(ref cause) => cause,
-            CreateIdentityProviderError::InvalidParameter(ref cause) => cause,
-            CreateIdentityProviderError::LimitExceeded(ref cause) => cause,
-            CreateIdentityProviderError::NotAuthorized(ref cause) => cause,
-            CreateIdentityProviderError::ResourceNotFound(ref cause) => cause,
-            CreateIdentityProviderError::TooManyRequests(ref cause) => cause,
+            CreateIdentityProviderError::DuplicateProvider(ref cause) => write!(f, "{}", cause),
+            CreateIdentityProviderError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateIdentityProviderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateIdentityProviderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateIdentityProviderError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateIdentityProviderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateIdentityProviderError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIdentityProviderError {}
 /// Errors returned by CreateResourceServer
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceServerError {
@@ -7079,21 +6999,17 @@ impl CreateResourceServerError {
 }
 impl fmt::Display for CreateResourceServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceServerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceServerError::InternalError(ref cause) => cause,
-            CreateResourceServerError::InvalidParameter(ref cause) => cause,
-            CreateResourceServerError::LimitExceeded(ref cause) => cause,
-            CreateResourceServerError::NotAuthorized(ref cause) => cause,
-            CreateResourceServerError::ResourceNotFound(ref cause) => cause,
-            CreateResourceServerError::TooManyRequests(ref cause) => cause,
+            CreateResourceServerError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateResourceServerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateResourceServerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateResourceServerError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateResourceServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateResourceServerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateResourceServerError {}
 /// Errors returned by CreateUserImportJob
 #[derive(Debug, PartialEq)]
 pub enum CreateUserImportJobError {
@@ -7153,22 +7069,18 @@ impl CreateUserImportJobError {
 }
 impl fmt::Display for CreateUserImportJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserImportJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserImportJobError::InternalError(ref cause) => cause,
-            CreateUserImportJobError::InvalidParameter(ref cause) => cause,
-            CreateUserImportJobError::LimitExceeded(ref cause) => cause,
-            CreateUserImportJobError::NotAuthorized(ref cause) => cause,
-            CreateUserImportJobError::PreconditionNotMet(ref cause) => cause,
-            CreateUserImportJobError::ResourceNotFound(ref cause) => cause,
-            CreateUserImportJobError::TooManyRequests(ref cause) => cause,
+            CreateUserImportJobError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateUserImportJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateUserImportJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserImportJobError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateUserImportJobError::PreconditionNotMet(ref cause) => write!(f, "{}", cause),
+            CreateUserImportJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateUserImportJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserImportJobError {}
 /// Errors returned by CreateUserPool
 #[derive(Debug, PartialEq)]
 pub enum CreateUserPoolError {
@@ -7238,24 +7150,22 @@ impl CreateUserPoolError {
 }
 impl fmt::Display for CreateUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserPoolError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserPoolError::InternalError(ref cause) => cause,
-            CreateUserPoolError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            CreateUserPoolError::InvalidParameter(ref cause) => cause,
-            CreateUserPoolError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            CreateUserPoolError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            CreateUserPoolError::LimitExceeded(ref cause) => cause,
-            CreateUserPoolError::NotAuthorized(ref cause) => cause,
-            CreateUserPoolError::TooManyRequests(ref cause) => cause,
-            CreateUserPoolError::UserPoolTagging(ref cause) => cause,
+            CreateUserPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolError::InvalidEmailRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolError::InvalidSmsRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUserPoolError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolError::UserPoolTagging(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserPoolError {}
 /// Errors returned by CreateUserPoolClient
 #[derive(Debug, PartialEq)]
 pub enum CreateUserPoolClientError {
@@ -7324,23 +7234,19 @@ impl CreateUserPoolClientError {
 }
 impl fmt::Display for CreateUserPoolClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserPoolClientError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserPoolClientError::InternalError(ref cause) => cause,
-            CreateUserPoolClientError::InvalidOAuthFlow(ref cause) => cause,
-            CreateUserPoolClientError::InvalidParameter(ref cause) => cause,
-            CreateUserPoolClientError::LimitExceeded(ref cause) => cause,
-            CreateUserPoolClientError::NotAuthorized(ref cause) => cause,
-            CreateUserPoolClientError::ResourceNotFound(ref cause) => cause,
-            CreateUserPoolClientError::ScopeDoesNotExist(ref cause) => cause,
-            CreateUserPoolClientError::TooManyRequests(ref cause) => cause,
+            CreateUserPoolClientError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolClientError::InvalidOAuthFlow(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolClientError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolClientError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolClientError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolClientError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolClientError::ScopeDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolClientError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserPoolClientError {}
 /// Errors returned by CreateUserPoolDomain
 #[derive(Debug, PartialEq)]
 pub enum CreateUserPoolDomainError {
@@ -7388,20 +7294,16 @@ impl CreateUserPoolDomainError {
 }
 impl fmt::Display for CreateUserPoolDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserPoolDomainError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserPoolDomainError::InternalError(ref cause) => cause,
-            CreateUserPoolDomainError::InvalidParameter(ref cause) => cause,
-            CreateUserPoolDomainError::LimitExceeded(ref cause) => cause,
-            CreateUserPoolDomainError::NotAuthorized(ref cause) => cause,
-            CreateUserPoolDomainError::ResourceNotFound(ref cause) => cause,
+            CreateUserPoolDomainError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolDomainError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolDomainError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolDomainError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            CreateUserPoolDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserPoolDomainError {}
 /// Errors returned by DeleteGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteGroupError {
@@ -7445,20 +7347,16 @@ impl DeleteGroupError {
 }
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGroupError::InternalError(ref cause) => cause,
-            DeleteGroupError::InvalidParameter(ref cause) => cause,
-            DeleteGroupError::NotAuthorized(ref cause) => cause,
-            DeleteGroupError::ResourceNotFound(ref cause) => cause,
-            DeleteGroupError::TooManyRequests(ref cause) => cause,
+            DeleteGroupError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGroupError {}
 /// Errors returned by DeleteIdentityProvider
 #[derive(Debug, PartialEq)]
 pub enum DeleteIdentityProviderError {
@@ -7519,21 +7417,19 @@ impl DeleteIdentityProviderError {
 }
 impl fmt::Display for DeleteIdentityProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIdentityProviderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIdentityProviderError::InternalError(ref cause) => cause,
-            DeleteIdentityProviderError::InvalidParameter(ref cause) => cause,
-            DeleteIdentityProviderError::NotAuthorized(ref cause) => cause,
-            DeleteIdentityProviderError::ResourceNotFound(ref cause) => cause,
-            DeleteIdentityProviderError::TooManyRequests(ref cause) => cause,
-            DeleteIdentityProviderError::UnsupportedIdentityProvider(ref cause) => cause,
+            DeleteIdentityProviderError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityProviderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityProviderError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityProviderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityProviderError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteIdentityProviderError::UnsupportedIdentityProvider(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteIdentityProviderError {}
 /// Errors returned by DeleteResourceServer
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourceServerError {
@@ -7583,20 +7479,16 @@ impl DeleteResourceServerError {
 }
 impl fmt::Display for DeleteResourceServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourceServerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourceServerError::InternalError(ref cause) => cause,
-            DeleteResourceServerError::InvalidParameter(ref cause) => cause,
-            DeleteResourceServerError::NotAuthorized(ref cause) => cause,
-            DeleteResourceServerError::ResourceNotFound(ref cause) => cause,
-            DeleteResourceServerError::TooManyRequests(ref cause) => cause,
+            DeleteResourceServerError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteResourceServerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteResourceServerError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteResourceServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteResourceServerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourceServerError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -7655,23 +7547,19 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::InternalError(ref cause) => cause,
-            DeleteUserError::InvalidParameter(ref cause) => cause,
-            DeleteUserError::NotAuthorized(ref cause) => cause,
-            DeleteUserError::PasswordResetRequired(ref cause) => cause,
-            DeleteUserError::ResourceNotFound(ref cause) => cause,
-            DeleteUserError::TooManyRequests(ref cause) => cause,
-            DeleteUserError::UserNotConfirmed(ref cause) => cause,
-            DeleteUserError::UserNotFound(ref cause) => cause,
+            DeleteUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DeleteUserAttributes
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserAttributesError {
@@ -7740,23 +7628,19 @@ impl DeleteUserAttributesError {
 }
 impl fmt::Display for DeleteUserAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserAttributesError::InternalError(ref cause) => cause,
-            DeleteUserAttributesError::InvalidParameter(ref cause) => cause,
-            DeleteUserAttributesError::NotAuthorized(ref cause) => cause,
-            DeleteUserAttributesError::PasswordResetRequired(ref cause) => cause,
-            DeleteUserAttributesError::ResourceNotFound(ref cause) => cause,
-            DeleteUserAttributesError::TooManyRequests(ref cause) => cause,
-            DeleteUserAttributesError::UserNotConfirmed(ref cause) => cause,
-            DeleteUserAttributesError::UserNotFound(ref cause) => cause,
+            DeleteUserAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteUserAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteUserAttributesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteUserAttributesError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            DeleteUserAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserAttributesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteUserAttributesError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            DeleteUserAttributesError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserAttributesError {}
 /// Errors returned by DeleteUserPool
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserPoolError {
@@ -7805,21 +7689,17 @@ impl DeleteUserPoolError {
 }
 impl fmt::Display for DeleteUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserPoolError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserPoolError::InternalError(ref cause) => cause,
-            DeleteUserPoolError::InvalidParameter(ref cause) => cause,
-            DeleteUserPoolError::NotAuthorized(ref cause) => cause,
-            DeleteUserPoolError::ResourceNotFound(ref cause) => cause,
-            DeleteUserPoolError::TooManyRequests(ref cause) => cause,
-            DeleteUserPoolError::UserImportInProgress(ref cause) => cause,
+            DeleteUserPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolError::UserImportInProgress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserPoolError {}
 /// Errors returned by DeleteUserPoolClient
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserPoolClientError {
@@ -7869,20 +7749,16 @@ impl DeleteUserPoolClientError {
 }
 impl fmt::Display for DeleteUserPoolClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserPoolClientError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserPoolClientError::InternalError(ref cause) => cause,
-            DeleteUserPoolClientError::InvalidParameter(ref cause) => cause,
-            DeleteUserPoolClientError::NotAuthorized(ref cause) => cause,
-            DeleteUserPoolClientError::ResourceNotFound(ref cause) => cause,
-            DeleteUserPoolClientError::TooManyRequests(ref cause) => cause,
+            DeleteUserPoolClientError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolClientError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolClientError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolClientError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolClientError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserPoolClientError {}
 /// Errors returned by DeleteUserPoolDomain
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserPoolDomainError {
@@ -7925,19 +7801,15 @@ impl DeleteUserPoolDomainError {
 }
 impl fmt::Display for DeleteUserPoolDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserPoolDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserPoolDomainError::InternalError(ref cause) => cause,
-            DeleteUserPoolDomainError::InvalidParameter(ref cause) => cause,
-            DeleteUserPoolDomainError::NotAuthorized(ref cause) => cause,
-            DeleteUserPoolDomainError::ResourceNotFound(ref cause) => cause,
+            DeleteUserPoolDomainError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolDomainError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolDomainError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteUserPoolDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserPoolDomainError {}
 /// Errors returned by DescribeIdentityProvider
 #[derive(Debug, PartialEq)]
 pub enum DescribeIdentityProviderError {
@@ -7991,20 +7863,16 @@ impl DescribeIdentityProviderError {
 }
 impl fmt::Display for DescribeIdentityProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIdentityProviderError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIdentityProviderError::InternalError(ref cause) => cause,
-            DescribeIdentityProviderError::InvalidParameter(ref cause) => cause,
-            DescribeIdentityProviderError::NotAuthorized(ref cause) => cause,
-            DescribeIdentityProviderError::ResourceNotFound(ref cause) => cause,
-            DescribeIdentityProviderError::TooManyRequests(ref cause) => cause,
+            DescribeIdentityProviderError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityProviderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityProviderError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityProviderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityProviderError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIdentityProviderError {}
 /// Errors returned by DescribeResourceServer
 #[derive(Debug, PartialEq)]
 pub enum DescribeResourceServerError {
@@ -8058,20 +7926,16 @@ impl DescribeResourceServerError {
 }
 impl fmt::Display for DescribeResourceServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeResourceServerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeResourceServerError::InternalError(ref cause) => cause,
-            DescribeResourceServerError::InvalidParameter(ref cause) => cause,
-            DescribeResourceServerError::NotAuthorized(ref cause) => cause,
-            DescribeResourceServerError::ResourceNotFound(ref cause) => cause,
-            DescribeResourceServerError::TooManyRequests(ref cause) => cause,
+            DescribeResourceServerError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeResourceServerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeResourceServerError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeResourceServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeResourceServerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeResourceServerError {}
 /// Errors returned by DescribeRiskConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeRiskConfigurationError {
@@ -8132,21 +7996,19 @@ impl DescribeRiskConfigurationError {
 }
 impl fmt::Display for DescribeRiskConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRiskConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRiskConfigurationError::InternalError(ref cause) => cause,
-            DescribeRiskConfigurationError::InvalidParameter(ref cause) => cause,
-            DescribeRiskConfigurationError::NotAuthorized(ref cause) => cause,
-            DescribeRiskConfigurationError::ResourceNotFound(ref cause) => cause,
-            DescribeRiskConfigurationError::TooManyRequests(ref cause) => cause,
-            DescribeRiskConfigurationError::UserPoolAddOnNotEnabled(ref cause) => cause,
+            DescribeRiskConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeRiskConfigurationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeRiskConfigurationError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeRiskConfigurationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeRiskConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeRiskConfigurationError::UserPoolAddOnNotEnabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeRiskConfigurationError {}
 /// Errors returned by DescribeUserImportJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserImportJobError {
@@ -8196,20 +8058,16 @@ impl DescribeUserImportJobError {
 }
 impl fmt::Display for DescribeUserImportJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserImportJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserImportJobError::InternalError(ref cause) => cause,
-            DescribeUserImportJobError::InvalidParameter(ref cause) => cause,
-            DescribeUserImportJobError::NotAuthorized(ref cause) => cause,
-            DescribeUserImportJobError::ResourceNotFound(ref cause) => cause,
-            DescribeUserImportJobError::TooManyRequests(ref cause) => cause,
+            DescribeUserImportJobError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeUserImportJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUserImportJobError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeUserImportJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserImportJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserImportJobError {}
 /// Errors returned by DescribeUserPool
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserPoolError {
@@ -8258,21 +8116,17 @@ impl DescribeUserPoolError {
 }
 impl fmt::Display for DescribeUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserPoolError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserPoolError::InternalError(ref cause) => cause,
-            DescribeUserPoolError::InvalidParameter(ref cause) => cause,
-            DescribeUserPoolError::NotAuthorized(ref cause) => cause,
-            DescribeUserPoolError::ResourceNotFound(ref cause) => cause,
-            DescribeUserPoolError::TooManyRequests(ref cause) => cause,
-            DescribeUserPoolError::UserPoolTagging(ref cause) => cause,
+            DescribeUserPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolError::UserPoolTagging(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserPoolError {}
 /// Errors returned by DescribeUserPoolClient
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserPoolClientError {
@@ -8326,20 +8180,16 @@ impl DescribeUserPoolClientError {
 }
 impl fmt::Display for DescribeUserPoolClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserPoolClientError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserPoolClientError::InternalError(ref cause) => cause,
-            DescribeUserPoolClientError::InvalidParameter(ref cause) => cause,
-            DescribeUserPoolClientError::NotAuthorized(ref cause) => cause,
-            DescribeUserPoolClientError::ResourceNotFound(ref cause) => cause,
-            DescribeUserPoolClientError::TooManyRequests(ref cause) => cause,
+            DescribeUserPoolClientError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolClientError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolClientError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolClientError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolClientError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserPoolClientError {}
 /// Errors returned by DescribeUserPoolDomain
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserPoolDomainError {
@@ -8386,19 +8236,15 @@ impl DescribeUserPoolDomainError {
 }
 impl fmt::Display for DescribeUserPoolDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserPoolDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserPoolDomainError::InternalError(ref cause) => cause,
-            DescribeUserPoolDomainError::InvalidParameter(ref cause) => cause,
-            DescribeUserPoolDomainError::NotAuthorized(ref cause) => cause,
-            DescribeUserPoolDomainError::ResourceNotFound(ref cause) => cause,
+            DescribeUserPoolDomainError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolDomainError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolDomainError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeUserPoolDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserPoolDomainError {}
 /// Errors returned by ForgetDevice
 #[derive(Debug, PartialEq)]
 pub enum ForgetDeviceError {
@@ -8464,24 +8310,20 @@ impl ForgetDeviceError {
 }
 impl fmt::Display for ForgetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ForgetDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            ForgetDeviceError::InternalError(ref cause) => cause,
-            ForgetDeviceError::InvalidParameter(ref cause) => cause,
-            ForgetDeviceError::InvalidUserPoolConfiguration(ref cause) => cause,
-            ForgetDeviceError::NotAuthorized(ref cause) => cause,
-            ForgetDeviceError::PasswordResetRequired(ref cause) => cause,
-            ForgetDeviceError::ResourceNotFound(ref cause) => cause,
-            ForgetDeviceError::TooManyRequests(ref cause) => cause,
-            ForgetDeviceError::UserNotConfirmed(ref cause) => cause,
-            ForgetDeviceError::UserNotFound(ref cause) => cause,
+            ForgetDeviceError::InternalError(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::InvalidUserPoolConfiguration(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            ForgetDeviceError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ForgetDeviceError {}
 /// Errors returned by ForgotPassword
 #[derive(Debug, PartialEq)]
 pub enum ForgotPasswordError {
@@ -8583,30 +8425,28 @@ impl ForgotPasswordError {
 }
 impl fmt::Display for ForgotPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ForgotPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            ForgotPasswordError::CodeDeliveryFailure(ref cause) => cause,
-            ForgotPasswordError::InternalError(ref cause) => cause,
-            ForgotPasswordError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            ForgotPasswordError::InvalidLambdaResponse(ref cause) => cause,
-            ForgotPasswordError::InvalidParameter(ref cause) => cause,
-            ForgotPasswordError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            ForgotPasswordError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            ForgotPasswordError::LimitExceeded(ref cause) => cause,
-            ForgotPasswordError::NotAuthorized(ref cause) => cause,
-            ForgotPasswordError::ResourceNotFound(ref cause) => cause,
-            ForgotPasswordError::TooManyRequests(ref cause) => cause,
-            ForgotPasswordError::UnexpectedLambda(ref cause) => cause,
-            ForgotPasswordError::UserLambdaValidation(ref cause) => cause,
-            ForgotPasswordError::UserNotConfirmed(ref cause) => cause,
-            ForgotPasswordError::UserNotFound(ref cause) => cause,
+            ForgotPasswordError::CodeDeliveryFailure(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::InternalError(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::InvalidEmailRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::InvalidSmsRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ForgotPasswordError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            ForgotPasswordError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ForgotPasswordError {}
 /// Errors returned by GetCSVHeader
 #[derive(Debug, PartialEq)]
 pub enum GetCSVHeaderError {
@@ -8650,20 +8490,16 @@ impl GetCSVHeaderError {
 }
 impl fmt::Display for GetCSVHeaderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCSVHeaderError {
-    fn description(&self) -> &str {
         match *self {
-            GetCSVHeaderError::InternalError(ref cause) => cause,
-            GetCSVHeaderError::InvalidParameter(ref cause) => cause,
-            GetCSVHeaderError::NotAuthorized(ref cause) => cause,
-            GetCSVHeaderError::ResourceNotFound(ref cause) => cause,
-            GetCSVHeaderError::TooManyRequests(ref cause) => cause,
+            GetCSVHeaderError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetCSVHeaderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetCSVHeaderError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetCSVHeaderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetCSVHeaderError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCSVHeaderError {}
 /// Errors returned by GetDevice
 #[derive(Debug, PartialEq)]
 pub enum GetDeviceError {
@@ -8729,24 +8565,20 @@ impl GetDeviceError {
 }
 impl fmt::Display for GetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeviceError::InternalError(ref cause) => cause,
-            GetDeviceError::InvalidParameter(ref cause) => cause,
-            GetDeviceError::InvalidUserPoolConfiguration(ref cause) => cause,
-            GetDeviceError::NotAuthorized(ref cause) => cause,
-            GetDeviceError::PasswordResetRequired(ref cause) => cause,
-            GetDeviceError::ResourceNotFound(ref cause) => cause,
-            GetDeviceError::TooManyRequests(ref cause) => cause,
-            GetDeviceError::UserNotConfirmed(ref cause) => cause,
-            GetDeviceError::UserNotFound(ref cause) => cause,
+            GetDeviceError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::InvalidUserPoolConfiguration(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeviceError {}
 /// Errors returned by GetGroup
 #[derive(Debug, PartialEq)]
 pub enum GetGroupError {
@@ -8790,20 +8622,16 @@ impl GetGroupError {
 }
 impl fmt::Display for GetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupError::InternalError(ref cause) => cause,
-            GetGroupError::InvalidParameter(ref cause) => cause,
-            GetGroupError::NotAuthorized(ref cause) => cause,
-            GetGroupError::ResourceNotFound(ref cause) => cause,
-            GetGroupError::TooManyRequests(ref cause) => cause,
+            GetGroupError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetGroupError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupError {}
 /// Errors returned by GetIdentityProviderByIdentifier
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityProviderByIdentifierError {
@@ -8859,20 +8687,26 @@ impl GetIdentityProviderByIdentifierError {
 }
 impl fmt::Display for GetIdentityProviderByIdentifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityProviderByIdentifierError {
-    fn description(&self) -> &str {
         match *self {
-            GetIdentityProviderByIdentifierError::InternalError(ref cause) => cause,
-            GetIdentityProviderByIdentifierError::InvalidParameter(ref cause) => cause,
-            GetIdentityProviderByIdentifierError::NotAuthorized(ref cause) => cause,
-            GetIdentityProviderByIdentifierError::ResourceNotFound(ref cause) => cause,
-            GetIdentityProviderByIdentifierError::TooManyRequests(ref cause) => cause,
+            GetIdentityProviderByIdentifierError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetIdentityProviderByIdentifierError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetIdentityProviderByIdentifierError::NotAuthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetIdentityProviderByIdentifierError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetIdentityProviderByIdentifierError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetIdentityProviderByIdentifierError {}
 /// Errors returned by GetSigningCertificate
 #[derive(Debug, PartialEq)]
 pub enum GetSigningCertificateError {
@@ -8910,18 +8744,14 @@ impl GetSigningCertificateError {
 }
 impl fmt::Display for GetSigningCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSigningCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            GetSigningCertificateError::InternalError(ref cause) => cause,
-            GetSigningCertificateError::InvalidParameter(ref cause) => cause,
-            GetSigningCertificateError::ResourceNotFound(ref cause) => cause,
+            GetSigningCertificateError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetSigningCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetSigningCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSigningCertificateError {}
 /// Errors returned by GetUICustomization
 #[derive(Debug, PartialEq)]
 pub enum GetUICustomizationError {
@@ -8965,20 +8795,16 @@ impl GetUICustomizationError {
 }
 impl fmt::Display for GetUICustomizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUICustomizationError {
-    fn description(&self) -> &str {
         match *self {
-            GetUICustomizationError::InternalError(ref cause) => cause,
-            GetUICustomizationError::InvalidParameter(ref cause) => cause,
-            GetUICustomizationError::NotAuthorized(ref cause) => cause,
-            GetUICustomizationError::ResourceNotFound(ref cause) => cause,
-            GetUICustomizationError::TooManyRequests(ref cause) => cause,
+            GetUICustomizationError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetUICustomizationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetUICustomizationError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetUICustomizationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetUICustomizationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUICustomizationError {}
 /// Errors returned by GetUser
 #[derive(Debug, PartialEq)]
 pub enum GetUserError {
@@ -9037,23 +8863,19 @@ impl GetUserError {
 }
 impl fmt::Display for GetUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserError::InternalError(ref cause) => cause,
-            GetUserError::InvalidParameter(ref cause) => cause,
-            GetUserError::NotAuthorized(ref cause) => cause,
-            GetUserError::PasswordResetRequired(ref cause) => cause,
-            GetUserError::ResourceNotFound(ref cause) => cause,
-            GetUserError::TooManyRequests(ref cause) => cause,
-            GetUserError::UserNotConfirmed(ref cause) => cause,
-            GetUserError::UserNotFound(ref cause) => cause,
+            GetUserError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetUserError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetUserError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            GetUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GetUserError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            GetUserError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserError {}
 /// Errors returned by GetUserAttributeVerificationCode
 #[derive(Debug, PartialEq)]
 pub enum GetUserAttributeVerificationCodeError {
@@ -9190,33 +9012,59 @@ impl GetUserAttributeVerificationCodeError {
 }
 impl fmt::Display for GetUserAttributeVerificationCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserAttributeVerificationCodeError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserAttributeVerificationCodeError::CodeDeliveryFailure(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::InternalError(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::InvalidLambdaResponse(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::InvalidParameter(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::InvalidSmsRoleTrustRelationship(ref cause) => {
-                cause
+            GetUserAttributeVerificationCodeError::CodeDeliveryFailure(ref cause) => {
+                write!(f, "{}", cause)
             }
-            GetUserAttributeVerificationCodeError::LimitExceeded(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::NotAuthorized(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::PasswordResetRequired(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::ResourceNotFound(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::TooManyRequests(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::UnexpectedLambda(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::UserLambdaValidation(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::UserNotConfirmed(ref cause) => cause,
-            GetUserAttributeVerificationCodeError::UserNotFound(ref cause) => cause,
+            GetUserAttributeVerificationCodeError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::InvalidEmailRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::InvalidLambdaResponse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::NotAuthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::PasswordResetRequired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::UnexpectedLambda(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::UserLambdaValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::UserNotConfirmed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetUserAttributeVerificationCodeError::UserNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetUserAttributeVerificationCodeError {}
 /// Errors returned by GetUserPoolMfaConfig
 #[derive(Debug, PartialEq)]
 pub enum GetUserPoolMfaConfigError {
@@ -9266,20 +9114,16 @@ impl GetUserPoolMfaConfigError {
 }
 impl fmt::Display for GetUserPoolMfaConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserPoolMfaConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserPoolMfaConfigError::InternalError(ref cause) => cause,
-            GetUserPoolMfaConfigError::InvalidParameter(ref cause) => cause,
-            GetUserPoolMfaConfigError::NotAuthorized(ref cause) => cause,
-            GetUserPoolMfaConfigError::ResourceNotFound(ref cause) => cause,
-            GetUserPoolMfaConfigError::TooManyRequests(ref cause) => cause,
+            GetUserPoolMfaConfigError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetUserPoolMfaConfigError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetUserPoolMfaConfigError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetUserPoolMfaConfigError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetUserPoolMfaConfigError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserPoolMfaConfigError {}
 /// Errors returned by GlobalSignOut
 #[derive(Debug, PartialEq)]
 pub enum GlobalSignOutError {
@@ -9333,22 +9177,18 @@ impl GlobalSignOutError {
 }
 impl fmt::Display for GlobalSignOutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GlobalSignOutError {
-    fn description(&self) -> &str {
         match *self {
-            GlobalSignOutError::InternalError(ref cause) => cause,
-            GlobalSignOutError::InvalidParameter(ref cause) => cause,
-            GlobalSignOutError::NotAuthorized(ref cause) => cause,
-            GlobalSignOutError::PasswordResetRequired(ref cause) => cause,
-            GlobalSignOutError::ResourceNotFound(ref cause) => cause,
-            GlobalSignOutError::TooManyRequests(ref cause) => cause,
-            GlobalSignOutError::UserNotConfirmed(ref cause) => cause,
+            GlobalSignOutError::InternalError(ref cause) => write!(f, "{}", cause),
+            GlobalSignOutError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GlobalSignOutError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GlobalSignOutError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            GlobalSignOutError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GlobalSignOutError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            GlobalSignOutError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GlobalSignOutError {}
 /// Errors returned by InitiateAuth
 #[derive(Debug, PartialEq)]
 pub enum InitiateAuthError {
@@ -9443,29 +9283,25 @@ impl InitiateAuthError {
 }
 impl fmt::Display for InitiateAuthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitiateAuthError {
-    fn description(&self) -> &str {
         match *self {
-            InitiateAuthError::InternalError(ref cause) => cause,
-            InitiateAuthError::InvalidLambdaResponse(ref cause) => cause,
-            InitiateAuthError::InvalidParameter(ref cause) => cause,
-            InitiateAuthError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            InitiateAuthError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            InitiateAuthError::InvalidUserPoolConfiguration(ref cause) => cause,
-            InitiateAuthError::NotAuthorized(ref cause) => cause,
-            InitiateAuthError::PasswordResetRequired(ref cause) => cause,
-            InitiateAuthError::ResourceNotFound(ref cause) => cause,
-            InitiateAuthError::TooManyRequests(ref cause) => cause,
-            InitiateAuthError::UnexpectedLambda(ref cause) => cause,
-            InitiateAuthError::UserLambdaValidation(ref cause) => cause,
-            InitiateAuthError::UserNotConfirmed(ref cause) => cause,
-            InitiateAuthError::UserNotFound(ref cause) => cause,
+            InitiateAuthError::InternalError(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::InvalidSmsRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::InvalidSmsRoleTrustRelationship(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::InvalidUserPoolConfiguration(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            InitiateAuthError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InitiateAuthError {}
 /// Errors returned by ListDevices
 #[derive(Debug, PartialEq)]
 pub enum ListDevicesError {
@@ -9531,24 +9367,20 @@ impl ListDevicesError {
 }
 impl fmt::Display for ListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDevicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDevicesError::InternalError(ref cause) => cause,
-            ListDevicesError::InvalidParameter(ref cause) => cause,
-            ListDevicesError::InvalidUserPoolConfiguration(ref cause) => cause,
-            ListDevicesError::NotAuthorized(ref cause) => cause,
-            ListDevicesError::PasswordResetRequired(ref cause) => cause,
-            ListDevicesError::ResourceNotFound(ref cause) => cause,
-            ListDevicesError::TooManyRequests(ref cause) => cause,
-            ListDevicesError::UserNotConfirmed(ref cause) => cause,
-            ListDevicesError::UserNotFound(ref cause) => cause,
+            ListDevicesError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::InvalidUserPoolConfiguration(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDevicesError {}
 /// Errors returned by ListGroups
 #[derive(Debug, PartialEq)]
 pub enum ListGroupsError {
@@ -9592,20 +9424,16 @@ impl ListGroupsError {
 }
 impl fmt::Display for ListGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupsError::InternalError(ref cause) => cause,
-            ListGroupsError::InvalidParameter(ref cause) => cause,
-            ListGroupsError::NotAuthorized(ref cause) => cause,
-            ListGroupsError::ResourceNotFound(ref cause) => cause,
-            ListGroupsError::TooManyRequests(ref cause) => cause,
+            ListGroupsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupsError {}
 /// Errors returned by ListIdentityProviders
 #[derive(Debug, PartialEq)]
 pub enum ListIdentityProvidersError {
@@ -9655,20 +9483,16 @@ impl ListIdentityProvidersError {
 }
 impl fmt::Display for ListIdentityProvidersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIdentityProvidersError {
-    fn description(&self) -> &str {
         match *self {
-            ListIdentityProvidersError::InternalError(ref cause) => cause,
-            ListIdentityProvidersError::InvalidParameter(ref cause) => cause,
-            ListIdentityProvidersError::NotAuthorized(ref cause) => cause,
-            ListIdentityProvidersError::ResourceNotFound(ref cause) => cause,
-            ListIdentityProvidersError::TooManyRequests(ref cause) => cause,
+            ListIdentityProvidersError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListIdentityProvidersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListIdentityProvidersError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListIdentityProvidersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListIdentityProvidersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIdentityProvidersError {}
 /// Errors returned by ListResourceServers
 #[derive(Debug, PartialEq)]
 pub enum ListResourceServersError {
@@ -9716,20 +9540,16 @@ impl ListResourceServersError {
 }
 impl fmt::Display for ListResourceServersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceServersError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceServersError::InternalError(ref cause) => cause,
-            ListResourceServersError::InvalidParameter(ref cause) => cause,
-            ListResourceServersError::NotAuthorized(ref cause) => cause,
-            ListResourceServersError::ResourceNotFound(ref cause) => cause,
-            ListResourceServersError::TooManyRequests(ref cause) => cause,
+            ListResourceServersError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListResourceServersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListResourceServersError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListResourceServersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListResourceServersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourceServersError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -9777,20 +9597,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalError(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::NotAuthorized(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::TooManyRequests(ref cause) => cause,
+            ListTagsForResourceError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListUserImportJobs
 #[derive(Debug, PartialEq)]
 pub enum ListUserImportJobsError {
@@ -9834,20 +9650,16 @@ impl ListUserImportJobsError {
 }
 impl fmt::Display for ListUserImportJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserImportJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListUserImportJobsError::InternalError(ref cause) => cause,
-            ListUserImportJobsError::InvalidParameter(ref cause) => cause,
-            ListUserImportJobsError::NotAuthorized(ref cause) => cause,
-            ListUserImportJobsError::ResourceNotFound(ref cause) => cause,
-            ListUserImportJobsError::TooManyRequests(ref cause) => cause,
+            ListUserImportJobsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListUserImportJobsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUserImportJobsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListUserImportJobsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUserImportJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUserImportJobsError {}
 /// Errors returned by ListUserPoolClients
 #[derive(Debug, PartialEq)]
 pub enum ListUserPoolClientsError {
@@ -9895,20 +9707,16 @@ impl ListUserPoolClientsError {
 }
 impl fmt::Display for ListUserPoolClientsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserPoolClientsError {
-    fn description(&self) -> &str {
         match *self {
-            ListUserPoolClientsError::InternalError(ref cause) => cause,
-            ListUserPoolClientsError::InvalidParameter(ref cause) => cause,
-            ListUserPoolClientsError::NotAuthorized(ref cause) => cause,
-            ListUserPoolClientsError::ResourceNotFound(ref cause) => cause,
-            ListUserPoolClientsError::TooManyRequests(ref cause) => cause,
+            ListUserPoolClientsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListUserPoolClientsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUserPoolClientsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListUserPoolClientsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUserPoolClientsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUserPoolClientsError {}
 /// Errors returned by ListUserPools
 #[derive(Debug, PartialEq)]
 pub enum ListUserPoolsError {
@@ -9947,19 +9755,15 @@ impl ListUserPoolsError {
 }
 impl fmt::Display for ListUserPoolsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserPoolsError {
-    fn description(&self) -> &str {
         match *self {
-            ListUserPoolsError::InternalError(ref cause) => cause,
-            ListUserPoolsError::InvalidParameter(ref cause) => cause,
-            ListUserPoolsError::NotAuthorized(ref cause) => cause,
-            ListUserPoolsError::TooManyRequests(ref cause) => cause,
+            ListUserPoolsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListUserPoolsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUserPoolsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListUserPoolsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUserPoolsError {}
 /// Errors returned by ListUsers
 #[derive(Debug, PartialEq)]
 pub enum ListUsersError {
@@ -10003,20 +9807,16 @@ impl ListUsersError {
 }
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersError::InternalError(ref cause) => cause,
-            ListUsersError::InvalidParameter(ref cause) => cause,
-            ListUsersError::NotAuthorized(ref cause) => cause,
-            ListUsersError::ResourceNotFound(ref cause) => cause,
-            ListUsersError::TooManyRequests(ref cause) => cause,
+            ListUsersError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListUsersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUsersError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListUsersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUsersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersError {}
 /// Errors returned by ListUsersInGroup
 #[derive(Debug, PartialEq)]
 pub enum ListUsersInGroupError {
@@ -10060,20 +9860,16 @@ impl ListUsersInGroupError {
 }
 impl fmt::Display for ListUsersInGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersInGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersInGroupError::InternalError(ref cause) => cause,
-            ListUsersInGroupError::InvalidParameter(ref cause) => cause,
-            ListUsersInGroupError::NotAuthorized(ref cause) => cause,
-            ListUsersInGroupError::ResourceNotFound(ref cause) => cause,
-            ListUsersInGroupError::TooManyRequests(ref cause) => cause,
+            ListUsersInGroupError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListUsersInGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUsersInGroupError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListUsersInGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUsersInGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersInGroupError {}
 /// Errors returned by ResendConfirmationCode
 #[derive(Debug, PartialEq)]
 pub enum ResendConfirmationCodeError {
@@ -10188,29 +9984,31 @@ impl ResendConfirmationCodeError {
 }
 impl fmt::Display for ResendConfirmationCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResendConfirmationCodeError {
-    fn description(&self) -> &str {
         match *self {
-            ResendConfirmationCodeError::CodeDeliveryFailure(ref cause) => cause,
-            ResendConfirmationCodeError::InternalError(ref cause) => cause,
-            ResendConfirmationCodeError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            ResendConfirmationCodeError::InvalidLambdaResponse(ref cause) => cause,
-            ResendConfirmationCodeError::InvalidParameter(ref cause) => cause,
-            ResendConfirmationCodeError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            ResendConfirmationCodeError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            ResendConfirmationCodeError::LimitExceeded(ref cause) => cause,
-            ResendConfirmationCodeError::NotAuthorized(ref cause) => cause,
-            ResendConfirmationCodeError::ResourceNotFound(ref cause) => cause,
-            ResendConfirmationCodeError::TooManyRequests(ref cause) => cause,
-            ResendConfirmationCodeError::UnexpectedLambda(ref cause) => cause,
-            ResendConfirmationCodeError::UserLambdaValidation(ref cause) => cause,
-            ResendConfirmationCodeError::UserNotFound(ref cause) => cause,
+            ResendConfirmationCodeError::CodeDeliveryFailure(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::InternalError(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::InvalidEmailRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResendConfirmationCodeError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResendConfirmationCodeError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResendConfirmationCodeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            ResendConfirmationCodeError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResendConfirmationCodeError {}
 /// Errors returned by RespondToAuthChallenge
 #[derive(Debug, PartialEq)]
 pub enum RespondToAuthChallengeError {
@@ -10361,35 +10159,39 @@ impl RespondToAuthChallengeError {
 }
 impl fmt::Display for RespondToAuthChallengeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RespondToAuthChallengeError {
-    fn description(&self) -> &str {
         match *self {
-            RespondToAuthChallengeError::AliasExists(ref cause) => cause,
-            RespondToAuthChallengeError::CodeMismatch(ref cause) => cause,
-            RespondToAuthChallengeError::ExpiredCode(ref cause) => cause,
-            RespondToAuthChallengeError::InternalError(ref cause) => cause,
-            RespondToAuthChallengeError::InvalidLambdaResponse(ref cause) => cause,
-            RespondToAuthChallengeError::InvalidParameter(ref cause) => cause,
-            RespondToAuthChallengeError::InvalidPassword(ref cause) => cause,
-            RespondToAuthChallengeError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            RespondToAuthChallengeError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            RespondToAuthChallengeError::InvalidUserPoolConfiguration(ref cause) => cause,
-            RespondToAuthChallengeError::MFAMethodNotFound(ref cause) => cause,
-            RespondToAuthChallengeError::NotAuthorized(ref cause) => cause,
-            RespondToAuthChallengeError::PasswordResetRequired(ref cause) => cause,
-            RespondToAuthChallengeError::ResourceNotFound(ref cause) => cause,
-            RespondToAuthChallengeError::SoftwareTokenMFANotFound(ref cause) => cause,
-            RespondToAuthChallengeError::TooManyRequests(ref cause) => cause,
-            RespondToAuthChallengeError::UnexpectedLambda(ref cause) => cause,
-            RespondToAuthChallengeError::UserLambdaValidation(ref cause) => cause,
-            RespondToAuthChallengeError::UserNotConfirmed(ref cause) => cause,
-            RespondToAuthChallengeError::UserNotFound(ref cause) => cause,
+            RespondToAuthChallengeError::AliasExists(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::CodeMismatch(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::ExpiredCode(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::InternalError(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondToAuthChallengeError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondToAuthChallengeError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondToAuthChallengeError::MFAMethodNotFound(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::SoftwareTokenMFANotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondToAuthChallengeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            RespondToAuthChallengeError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RespondToAuthChallengeError {}
 /// Errors returned by SetRiskConfiguration
 #[derive(Debug, PartialEq)]
 pub enum SetRiskConfigurationError {
@@ -10460,23 +10262,21 @@ impl SetRiskConfigurationError {
 }
 impl fmt::Display for SetRiskConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetRiskConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            SetRiskConfigurationError::CodeDeliveryFailure(ref cause) => cause,
-            SetRiskConfigurationError::InternalError(ref cause) => cause,
-            SetRiskConfigurationError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            SetRiskConfigurationError::InvalidParameter(ref cause) => cause,
-            SetRiskConfigurationError::NotAuthorized(ref cause) => cause,
-            SetRiskConfigurationError::ResourceNotFound(ref cause) => cause,
-            SetRiskConfigurationError::TooManyRequests(ref cause) => cause,
-            SetRiskConfigurationError::UserPoolAddOnNotEnabled(ref cause) => cause,
+            SetRiskConfigurationError::CodeDeliveryFailure(ref cause) => write!(f, "{}", cause),
+            SetRiskConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetRiskConfigurationError::InvalidEmailRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetRiskConfigurationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetRiskConfigurationError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetRiskConfigurationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetRiskConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            SetRiskConfigurationError::UserPoolAddOnNotEnabled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetRiskConfigurationError {}
 /// Errors returned by SetUICustomization
 #[derive(Debug, PartialEq)]
 pub enum SetUICustomizationError {
@@ -10520,20 +10320,16 @@ impl SetUICustomizationError {
 }
 impl fmt::Display for SetUICustomizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetUICustomizationError {
-    fn description(&self) -> &str {
         match *self {
-            SetUICustomizationError::InternalError(ref cause) => cause,
-            SetUICustomizationError::InvalidParameter(ref cause) => cause,
-            SetUICustomizationError::NotAuthorized(ref cause) => cause,
-            SetUICustomizationError::ResourceNotFound(ref cause) => cause,
-            SetUICustomizationError::TooManyRequests(ref cause) => cause,
+            SetUICustomizationError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetUICustomizationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetUICustomizationError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetUICustomizationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetUICustomizationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetUICustomizationError {}
 /// Errors returned by SetUserMFAPreference
 #[derive(Debug, PartialEq)]
 pub enum SetUserMFAPreferenceError {
@@ -10595,22 +10391,18 @@ impl SetUserMFAPreferenceError {
 }
 impl fmt::Display for SetUserMFAPreferenceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetUserMFAPreferenceError {
-    fn description(&self) -> &str {
         match *self {
-            SetUserMFAPreferenceError::InternalError(ref cause) => cause,
-            SetUserMFAPreferenceError::InvalidParameter(ref cause) => cause,
-            SetUserMFAPreferenceError::NotAuthorized(ref cause) => cause,
-            SetUserMFAPreferenceError::PasswordResetRequired(ref cause) => cause,
-            SetUserMFAPreferenceError::ResourceNotFound(ref cause) => cause,
-            SetUserMFAPreferenceError::UserNotConfirmed(ref cause) => cause,
-            SetUserMFAPreferenceError::UserNotFound(ref cause) => cause,
+            SetUserMFAPreferenceError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetUserMFAPreferenceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetUserMFAPreferenceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetUserMFAPreferenceError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            SetUserMFAPreferenceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetUserMFAPreferenceError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            SetUserMFAPreferenceError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetUserMFAPreferenceError {}
 /// Errors returned by SetUserPoolMfaConfig
 #[derive(Debug, PartialEq)]
 pub enum SetUserPoolMfaConfigError {
@@ -10674,22 +10466,22 @@ impl SetUserPoolMfaConfigError {
 }
 impl fmt::Display for SetUserPoolMfaConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetUserPoolMfaConfigError {
-    fn description(&self) -> &str {
         match *self {
-            SetUserPoolMfaConfigError::InternalError(ref cause) => cause,
-            SetUserPoolMfaConfigError::InvalidParameter(ref cause) => cause,
-            SetUserPoolMfaConfigError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            SetUserPoolMfaConfigError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            SetUserPoolMfaConfigError::NotAuthorized(ref cause) => cause,
-            SetUserPoolMfaConfigError::ResourceNotFound(ref cause) => cause,
-            SetUserPoolMfaConfigError::TooManyRequests(ref cause) => cause,
+            SetUserPoolMfaConfigError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetUserPoolMfaConfigError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetUserPoolMfaConfigError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetUserPoolMfaConfigError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetUserPoolMfaConfigError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetUserPoolMfaConfigError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetUserPoolMfaConfigError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetUserPoolMfaConfigError {}
 /// Errors returned by SetUserSettings
 #[derive(Debug, PartialEq)]
 pub enum SetUserSettingsError {
@@ -10745,22 +10537,18 @@ impl SetUserSettingsError {
 }
 impl fmt::Display for SetUserSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetUserSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            SetUserSettingsError::InternalError(ref cause) => cause,
-            SetUserSettingsError::InvalidParameter(ref cause) => cause,
-            SetUserSettingsError::NotAuthorized(ref cause) => cause,
-            SetUserSettingsError::PasswordResetRequired(ref cause) => cause,
-            SetUserSettingsError::ResourceNotFound(ref cause) => cause,
-            SetUserSettingsError::UserNotConfirmed(ref cause) => cause,
-            SetUserSettingsError::UserNotFound(ref cause) => cause,
+            SetUserSettingsError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetUserSettingsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetUserSettingsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetUserSettingsError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            SetUserSettingsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetUserSettingsError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            SetUserSettingsError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetUserSettingsError {}
 /// Errors returned by SignUp
 #[derive(Debug, PartialEq)]
 pub enum SignUpError {
@@ -10851,29 +10639,25 @@ impl SignUpError {
 }
 impl fmt::Display for SignUpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SignUpError {
-    fn description(&self) -> &str {
         match *self {
-            SignUpError::CodeDeliveryFailure(ref cause) => cause,
-            SignUpError::InternalError(ref cause) => cause,
-            SignUpError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            SignUpError::InvalidLambdaResponse(ref cause) => cause,
-            SignUpError::InvalidParameter(ref cause) => cause,
-            SignUpError::InvalidPassword(ref cause) => cause,
-            SignUpError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            SignUpError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            SignUpError::NotAuthorized(ref cause) => cause,
-            SignUpError::ResourceNotFound(ref cause) => cause,
-            SignUpError::TooManyRequests(ref cause) => cause,
-            SignUpError::UnexpectedLambda(ref cause) => cause,
-            SignUpError::UserLambdaValidation(ref cause) => cause,
-            SignUpError::UsernameExists(ref cause) => cause,
+            SignUpError::CodeDeliveryFailure(ref cause) => write!(f, "{}", cause),
+            SignUpError::InternalError(ref cause) => write!(f, "{}", cause),
+            SignUpError::InvalidEmailRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            SignUpError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            SignUpError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SignUpError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            SignUpError::InvalidSmsRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            SignUpError::InvalidSmsRoleTrustRelationship(ref cause) => write!(f, "{}", cause),
+            SignUpError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SignUpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SignUpError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            SignUpError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            SignUpError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            SignUpError::UsernameExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SignUpError {}
 /// Errors returned by StartUserImportJob
 #[derive(Debug, PartialEq)]
 pub enum StartUserImportJobError {
@@ -10924,21 +10708,17 @@ impl StartUserImportJobError {
 }
 impl fmt::Display for StartUserImportJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartUserImportJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartUserImportJobError::InternalError(ref cause) => cause,
-            StartUserImportJobError::InvalidParameter(ref cause) => cause,
-            StartUserImportJobError::NotAuthorized(ref cause) => cause,
-            StartUserImportJobError::PreconditionNotMet(ref cause) => cause,
-            StartUserImportJobError::ResourceNotFound(ref cause) => cause,
-            StartUserImportJobError::TooManyRequests(ref cause) => cause,
+            StartUserImportJobError::InternalError(ref cause) => write!(f, "{}", cause),
+            StartUserImportJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartUserImportJobError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            StartUserImportJobError::PreconditionNotMet(ref cause) => write!(f, "{}", cause),
+            StartUserImportJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartUserImportJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartUserImportJobError {}
 /// Errors returned by StopUserImportJob
 #[derive(Debug, PartialEq)]
 pub enum StopUserImportJobError {
@@ -10989,21 +10769,17 @@ impl StopUserImportJobError {
 }
 impl fmt::Display for StopUserImportJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopUserImportJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopUserImportJobError::InternalError(ref cause) => cause,
-            StopUserImportJobError::InvalidParameter(ref cause) => cause,
-            StopUserImportJobError::NotAuthorized(ref cause) => cause,
-            StopUserImportJobError::PreconditionNotMet(ref cause) => cause,
-            StopUserImportJobError::ResourceNotFound(ref cause) => cause,
-            StopUserImportJobError::TooManyRequests(ref cause) => cause,
+            StopUserImportJobError::InternalError(ref cause) => write!(f, "{}", cause),
+            StopUserImportJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopUserImportJobError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            StopUserImportJobError::PreconditionNotMet(ref cause) => write!(f, "{}", cause),
+            StopUserImportJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopUserImportJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopUserImportJobError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -11047,20 +10823,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalError(ref cause) => cause,
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::NotAuthorized(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
+            TagResourceError::InternalError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -11104,20 +10876,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalError(ref cause) => cause,
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::NotAuthorized(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
+            UntagResourceError::InternalError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateAuthEventFeedback
 #[derive(Debug, PartialEq)]
 pub enum UpdateAuthEventFeedbackError {
@@ -11185,22 +10953,20 @@ impl UpdateAuthEventFeedbackError {
 }
 impl fmt::Display for UpdateAuthEventFeedbackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAuthEventFeedbackError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAuthEventFeedbackError::InternalError(ref cause) => cause,
-            UpdateAuthEventFeedbackError::InvalidParameter(ref cause) => cause,
-            UpdateAuthEventFeedbackError::NotAuthorized(ref cause) => cause,
-            UpdateAuthEventFeedbackError::ResourceNotFound(ref cause) => cause,
-            UpdateAuthEventFeedbackError::TooManyRequests(ref cause) => cause,
-            UpdateAuthEventFeedbackError::UserNotFound(ref cause) => cause,
-            UpdateAuthEventFeedbackError::UserPoolAddOnNotEnabled(ref cause) => cause,
+            UpdateAuthEventFeedbackError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateAuthEventFeedbackError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateAuthEventFeedbackError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateAuthEventFeedbackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAuthEventFeedbackError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateAuthEventFeedbackError::UserNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAuthEventFeedbackError::UserPoolAddOnNotEnabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateAuthEventFeedbackError {}
 /// Errors returned by UpdateDeviceStatus
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeviceStatusError {
@@ -11268,24 +11034,22 @@ impl UpdateDeviceStatusError {
 }
 impl fmt::Display for UpdateDeviceStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeviceStatusError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeviceStatusError::InternalError(ref cause) => cause,
-            UpdateDeviceStatusError::InvalidParameter(ref cause) => cause,
-            UpdateDeviceStatusError::InvalidUserPoolConfiguration(ref cause) => cause,
-            UpdateDeviceStatusError::NotAuthorized(ref cause) => cause,
-            UpdateDeviceStatusError::PasswordResetRequired(ref cause) => cause,
-            UpdateDeviceStatusError::ResourceNotFound(ref cause) => cause,
-            UpdateDeviceStatusError::TooManyRequests(ref cause) => cause,
-            UpdateDeviceStatusError::UserNotConfirmed(ref cause) => cause,
-            UpdateDeviceStatusError::UserNotFound(ref cause) => cause,
+            UpdateDeviceStatusError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStatusError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStatusError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDeviceStatusError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStatusError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStatusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStatusError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStatusError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStatusError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDeviceStatusError {}
 /// Errors returned by UpdateGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateGroupError {
@@ -11329,20 +11093,16 @@ impl UpdateGroupError {
 }
 impl fmt::Display for UpdateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGroupError::InternalError(ref cause) => cause,
-            UpdateGroupError::InvalidParameter(ref cause) => cause,
-            UpdateGroupError::NotAuthorized(ref cause) => cause,
-            UpdateGroupError::ResourceNotFound(ref cause) => cause,
-            UpdateGroupError::TooManyRequests(ref cause) => cause,
+            UpdateGroupError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGroupError {}
 /// Errors returned by UpdateIdentityProvider
 #[derive(Debug, PartialEq)]
 pub enum UpdateIdentityProviderError {
@@ -11403,21 +11163,19 @@ impl UpdateIdentityProviderError {
 }
 impl fmt::Display for UpdateIdentityProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIdentityProviderError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIdentityProviderError::InternalError(ref cause) => cause,
-            UpdateIdentityProviderError::InvalidParameter(ref cause) => cause,
-            UpdateIdentityProviderError::NotAuthorized(ref cause) => cause,
-            UpdateIdentityProviderError::ResourceNotFound(ref cause) => cause,
-            UpdateIdentityProviderError::TooManyRequests(ref cause) => cause,
-            UpdateIdentityProviderError::UnsupportedIdentityProvider(ref cause) => cause,
+            UpdateIdentityProviderError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityProviderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityProviderError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityProviderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityProviderError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateIdentityProviderError::UnsupportedIdentityProvider(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateIdentityProviderError {}
 /// Errors returned by UpdateResourceServer
 #[derive(Debug, PartialEq)]
 pub enum UpdateResourceServerError {
@@ -11467,20 +11225,16 @@ impl UpdateResourceServerError {
 }
 impl fmt::Display for UpdateResourceServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateResourceServerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateResourceServerError::InternalError(ref cause) => cause,
-            UpdateResourceServerError::InvalidParameter(ref cause) => cause,
-            UpdateResourceServerError::NotAuthorized(ref cause) => cause,
-            UpdateResourceServerError::ResourceNotFound(ref cause) => cause,
-            UpdateResourceServerError::TooManyRequests(ref cause) => cause,
+            UpdateResourceServerError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateResourceServerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateResourceServerError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateResourceServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateResourceServerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateResourceServerError {}
 /// Errors returned by UpdateUserAttributes
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserAttributesError {
@@ -11613,33 +11367,35 @@ impl UpdateUserAttributesError {
 }
 impl fmt::Display for UpdateUserAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserAttributesError::AliasExists(ref cause) => cause,
-            UpdateUserAttributesError::CodeDeliveryFailure(ref cause) => cause,
-            UpdateUserAttributesError::CodeMismatch(ref cause) => cause,
-            UpdateUserAttributesError::ExpiredCode(ref cause) => cause,
-            UpdateUserAttributesError::InternalError(ref cause) => cause,
-            UpdateUserAttributesError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            UpdateUserAttributesError::InvalidLambdaResponse(ref cause) => cause,
-            UpdateUserAttributesError::InvalidParameter(ref cause) => cause,
-            UpdateUserAttributesError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            UpdateUserAttributesError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            UpdateUserAttributesError::NotAuthorized(ref cause) => cause,
-            UpdateUserAttributesError::PasswordResetRequired(ref cause) => cause,
-            UpdateUserAttributesError::ResourceNotFound(ref cause) => cause,
-            UpdateUserAttributesError::TooManyRequests(ref cause) => cause,
-            UpdateUserAttributesError::UnexpectedLambda(ref cause) => cause,
-            UpdateUserAttributesError::UserLambdaValidation(ref cause) => cause,
-            UpdateUserAttributesError::UserNotConfirmed(ref cause) => cause,
-            UpdateUserAttributesError::UserNotFound(ref cause) => cause,
+            UpdateUserAttributesError::AliasExists(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::CodeDeliveryFailure(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::CodeMismatch(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::ExpiredCode(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::InvalidEmailRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateUserAttributesError::InvalidLambdaResponse(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::InvalidSmsRoleAccessPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateUserAttributesError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateUserAttributesError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::UnexpectedLambda(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::UserLambdaValidation(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            UpdateUserAttributesError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserAttributesError {}
 /// Errors returned by UpdateUserPool
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserPoolError {
@@ -11721,26 +11477,24 @@ impl UpdateUserPoolError {
 }
 impl fmt::Display for UpdateUserPoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserPoolError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserPoolError::ConcurrentModification(ref cause) => cause,
-            UpdateUserPoolError::InternalError(ref cause) => cause,
-            UpdateUserPoolError::InvalidEmailRoleAccessPolicy(ref cause) => cause,
-            UpdateUserPoolError::InvalidParameter(ref cause) => cause,
-            UpdateUserPoolError::InvalidSmsRoleAccessPolicy(ref cause) => cause,
-            UpdateUserPoolError::InvalidSmsRoleTrustRelationship(ref cause) => cause,
-            UpdateUserPoolError::NotAuthorized(ref cause) => cause,
-            UpdateUserPoolError::ResourceNotFound(ref cause) => cause,
-            UpdateUserPoolError::TooManyRequests(ref cause) => cause,
-            UpdateUserPoolError::UserImportInProgress(ref cause) => cause,
-            UpdateUserPoolError::UserPoolTagging(ref cause) => cause,
+            UpdateUserPoolError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::InvalidEmailRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::InvalidSmsRoleAccessPolicy(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::InvalidSmsRoleTrustRelationship(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateUserPoolError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::UserImportInProgress(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolError::UserPoolTagging(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserPoolError {}
 /// Errors returned by UpdateUserPoolClient
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserPoolClientError {
@@ -11811,23 +11565,19 @@ impl UpdateUserPoolClientError {
 }
 impl fmt::Display for UpdateUserPoolClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserPoolClientError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserPoolClientError::ConcurrentModification(ref cause) => cause,
-            UpdateUserPoolClientError::InternalError(ref cause) => cause,
-            UpdateUserPoolClientError::InvalidOAuthFlow(ref cause) => cause,
-            UpdateUserPoolClientError::InvalidParameter(ref cause) => cause,
-            UpdateUserPoolClientError::NotAuthorized(ref cause) => cause,
-            UpdateUserPoolClientError::ResourceNotFound(ref cause) => cause,
-            UpdateUserPoolClientError::ScopeDoesNotExist(ref cause) => cause,
-            UpdateUserPoolClientError::TooManyRequests(ref cause) => cause,
+            UpdateUserPoolClientError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolClientError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolClientError::InvalidOAuthFlow(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolClientError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolClientError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolClientError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolClientError::ScopeDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolClientError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserPoolClientError {}
 /// Errors returned by UpdateUserPoolDomain
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserPoolDomainError {
@@ -11877,20 +11627,16 @@ impl UpdateUserPoolDomainError {
 }
 impl fmt::Display for UpdateUserPoolDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserPoolDomainError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserPoolDomainError::InternalError(ref cause) => cause,
-            UpdateUserPoolDomainError::InvalidParameter(ref cause) => cause,
-            UpdateUserPoolDomainError::NotAuthorized(ref cause) => cause,
-            UpdateUserPoolDomainError::ResourceNotFound(ref cause) => cause,
-            UpdateUserPoolDomainError::TooManyRequests(ref cause) => cause,
+            UpdateUserPoolDomainError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolDomainError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolDomainError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserPoolDomainError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserPoolDomainError {}
 /// Errors returned by VerifySoftwareToken
 #[derive(Debug, PartialEq)]
 pub enum VerifySoftwareTokenError {
@@ -11983,27 +11729,25 @@ impl VerifySoftwareTokenError {
 }
 impl fmt::Display for VerifySoftwareTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifySoftwareTokenError {
-    fn description(&self) -> &str {
         match *self {
-            VerifySoftwareTokenError::CodeMismatch(ref cause) => cause,
-            VerifySoftwareTokenError::EnableSoftwareTokenMFA(ref cause) => cause,
-            VerifySoftwareTokenError::InternalError(ref cause) => cause,
-            VerifySoftwareTokenError::InvalidParameter(ref cause) => cause,
-            VerifySoftwareTokenError::InvalidUserPoolConfiguration(ref cause) => cause,
-            VerifySoftwareTokenError::NotAuthorized(ref cause) => cause,
-            VerifySoftwareTokenError::PasswordResetRequired(ref cause) => cause,
-            VerifySoftwareTokenError::ResourceNotFound(ref cause) => cause,
-            VerifySoftwareTokenError::SoftwareTokenMFANotFound(ref cause) => cause,
-            VerifySoftwareTokenError::TooManyRequests(ref cause) => cause,
-            VerifySoftwareTokenError::UserNotConfirmed(ref cause) => cause,
-            VerifySoftwareTokenError::UserNotFound(ref cause) => cause,
+            VerifySoftwareTokenError::CodeMismatch(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::EnableSoftwareTokenMFA(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::InternalError(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::InvalidUserPoolConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            VerifySoftwareTokenError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::SoftwareTokenMFANotFound(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            VerifySoftwareTokenError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for VerifySoftwareTokenError {}
 /// Errors returned by VerifyUserAttribute
 #[derive(Debug, PartialEq)]
 pub enum VerifyUserAttributeError {
@@ -12085,26 +11829,22 @@ impl VerifyUserAttributeError {
 }
 impl fmt::Display for VerifyUserAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifyUserAttributeError {
-    fn description(&self) -> &str {
         match *self {
-            VerifyUserAttributeError::CodeMismatch(ref cause) => cause,
-            VerifyUserAttributeError::ExpiredCode(ref cause) => cause,
-            VerifyUserAttributeError::InternalError(ref cause) => cause,
-            VerifyUserAttributeError::InvalidParameter(ref cause) => cause,
-            VerifyUserAttributeError::LimitExceeded(ref cause) => cause,
-            VerifyUserAttributeError::NotAuthorized(ref cause) => cause,
-            VerifyUserAttributeError::PasswordResetRequired(ref cause) => cause,
-            VerifyUserAttributeError::ResourceNotFound(ref cause) => cause,
-            VerifyUserAttributeError::TooManyRequests(ref cause) => cause,
-            VerifyUserAttributeError::UserNotConfirmed(ref cause) => cause,
-            VerifyUserAttributeError::UserNotFound(ref cause) => cause,
+            VerifyUserAttributeError::CodeMismatch(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::ExpiredCode(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::InternalError(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::PasswordResetRequired(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::UserNotConfirmed(ref cause) => write!(f, "{}", cause),
+            VerifyUserAttributeError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for VerifyUserAttributeError {}
 /// Trait representing the capabilities of the Amazon Cognito Identity Provider API. Amazon Cognito Identity Provider clients implement this trait.
 pub trait CognitoIdentityProvider {
     /// <p>Adds additional user attributes to the user pool schema.</p>

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -718,21 +718,17 @@ impl BulkPublishError {
 }
 impl fmt::Display for BulkPublishError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BulkPublishError {
-    fn description(&self) -> &str {
         match *self {
-            BulkPublishError::AlreadyStreamed(ref cause) => cause,
-            BulkPublishError::DuplicateRequest(ref cause) => cause,
-            BulkPublishError::InternalError(ref cause) => cause,
-            BulkPublishError::InvalidParameter(ref cause) => cause,
-            BulkPublishError::NotAuthorized(ref cause) => cause,
-            BulkPublishError::ResourceNotFound(ref cause) => cause,
+            BulkPublishError::AlreadyStreamed(ref cause) => write!(f, "{}", cause),
+            BulkPublishError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            BulkPublishError::InternalError(ref cause) => write!(f, "{}", cause),
+            BulkPublishError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            BulkPublishError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            BulkPublishError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BulkPublishError {}
 /// Errors returned by DeleteDataset
 #[derive(Debug, PartialEq)]
 pub enum DeleteDatasetError {
@@ -781,21 +777,17 @@ impl DeleteDatasetError {
 }
 impl fmt::Display for DeleteDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDatasetError::InternalError(ref cause) => cause,
-            DeleteDatasetError::InvalidParameter(ref cause) => cause,
-            DeleteDatasetError::NotAuthorized(ref cause) => cause,
-            DeleteDatasetError::ResourceConflict(ref cause) => cause,
-            DeleteDatasetError::ResourceNotFound(ref cause) => cause,
-            DeleteDatasetError::TooManyRequests(ref cause) => cause,
+            DeleteDatasetError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDatasetError {}
 /// Errors returned by DescribeDataset
 #[derive(Debug, PartialEq)]
 pub enum DescribeDatasetError {
@@ -839,20 +831,16 @@ impl DescribeDatasetError {
 }
 impl fmt::Display for DescribeDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDatasetError::InternalError(ref cause) => cause,
-            DescribeDatasetError::InvalidParameter(ref cause) => cause,
-            DescribeDatasetError::NotAuthorized(ref cause) => cause,
-            DescribeDatasetError::ResourceNotFound(ref cause) => cause,
-            DescribeDatasetError::TooManyRequests(ref cause) => cause,
+            DescribeDatasetError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDatasetError {}
 /// Errors returned by DescribeIdentityPoolUsage
 #[derive(Debug, PartialEq)]
 pub enum DescribeIdentityPoolUsageError {
@@ -906,20 +894,16 @@ impl DescribeIdentityPoolUsageError {
 }
 impl fmt::Display for DescribeIdentityPoolUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIdentityPoolUsageError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIdentityPoolUsageError::InternalError(ref cause) => cause,
-            DescribeIdentityPoolUsageError::InvalidParameter(ref cause) => cause,
-            DescribeIdentityPoolUsageError::NotAuthorized(ref cause) => cause,
-            DescribeIdentityPoolUsageError::ResourceNotFound(ref cause) => cause,
-            DescribeIdentityPoolUsageError::TooManyRequests(ref cause) => cause,
+            DescribeIdentityPoolUsageError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolUsageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolUsageError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolUsageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityPoolUsageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIdentityPoolUsageError {}
 /// Errors returned by DescribeIdentityUsage
 #[derive(Debug, PartialEq)]
 pub enum DescribeIdentityUsageError {
@@ -969,20 +953,16 @@ impl DescribeIdentityUsageError {
 }
 impl fmt::Display for DescribeIdentityUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIdentityUsageError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIdentityUsageError::InternalError(ref cause) => cause,
-            DescribeIdentityUsageError::InvalidParameter(ref cause) => cause,
-            DescribeIdentityUsageError::NotAuthorized(ref cause) => cause,
-            DescribeIdentityUsageError::ResourceNotFound(ref cause) => cause,
-            DescribeIdentityUsageError::TooManyRequests(ref cause) => cause,
+            DescribeIdentityUsageError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityUsageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityUsageError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityUsageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeIdentityUsageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIdentityUsageError {}
 /// Errors returned by GetBulkPublishDetails
 #[derive(Debug, PartialEq)]
 pub enum GetBulkPublishDetailsError {
@@ -1025,19 +1005,15 @@ impl GetBulkPublishDetailsError {
 }
 impl fmt::Display for GetBulkPublishDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBulkPublishDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetBulkPublishDetailsError::InternalError(ref cause) => cause,
-            GetBulkPublishDetailsError::InvalidParameter(ref cause) => cause,
-            GetBulkPublishDetailsError::NotAuthorized(ref cause) => cause,
-            GetBulkPublishDetailsError::ResourceNotFound(ref cause) => cause,
+            GetBulkPublishDetailsError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetBulkPublishDetailsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetBulkPublishDetailsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetBulkPublishDetailsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBulkPublishDetailsError {}
 /// Errors returned by GetCognitoEvents
 #[derive(Debug, PartialEq)]
 pub enum GetCognitoEventsError {
@@ -1081,20 +1057,16 @@ impl GetCognitoEventsError {
 }
 impl fmt::Display for GetCognitoEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCognitoEventsError {
-    fn description(&self) -> &str {
         match *self {
-            GetCognitoEventsError::InternalError(ref cause) => cause,
-            GetCognitoEventsError::InvalidParameter(ref cause) => cause,
-            GetCognitoEventsError::NotAuthorized(ref cause) => cause,
-            GetCognitoEventsError::ResourceNotFound(ref cause) => cause,
-            GetCognitoEventsError::TooManyRequests(ref cause) => cause,
+            GetCognitoEventsError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetCognitoEventsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetCognitoEventsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetCognitoEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetCognitoEventsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCognitoEventsError {}
 /// Errors returned by GetIdentityPoolConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityPoolConfigurationError {
@@ -1150,20 +1122,20 @@ impl GetIdentityPoolConfigurationError {
 }
 impl fmt::Display for GetIdentityPoolConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityPoolConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetIdentityPoolConfigurationError::InternalError(ref cause) => cause,
-            GetIdentityPoolConfigurationError::InvalidParameter(ref cause) => cause,
-            GetIdentityPoolConfigurationError::NotAuthorized(ref cause) => cause,
-            GetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => cause,
-            GetIdentityPoolConfigurationError::TooManyRequests(ref cause) => cause,
+            GetIdentityPoolConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetIdentityPoolConfigurationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetIdentityPoolConfigurationError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetIdentityPoolConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIdentityPoolConfigurationError {}
 /// Errors returned by ListDatasets
 #[derive(Debug, PartialEq)]
 pub enum ListDatasetsError {
@@ -1202,19 +1174,15 @@ impl ListDatasetsError {
 }
 impl fmt::Display for ListDatasetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDatasetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDatasetsError::InternalError(ref cause) => cause,
-            ListDatasetsError::InvalidParameter(ref cause) => cause,
-            ListDatasetsError::NotAuthorized(ref cause) => cause,
-            ListDatasetsError::TooManyRequests(ref cause) => cause,
+            ListDatasetsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListDatasetsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListDatasetsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListDatasetsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDatasetsError {}
 /// Errors returned by ListIdentityPoolUsage
 #[derive(Debug, PartialEq)]
 pub enum ListIdentityPoolUsageError {
@@ -1257,19 +1225,15 @@ impl ListIdentityPoolUsageError {
 }
 impl fmt::Display for ListIdentityPoolUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIdentityPoolUsageError {
-    fn description(&self) -> &str {
         match *self {
-            ListIdentityPoolUsageError::InternalError(ref cause) => cause,
-            ListIdentityPoolUsageError::InvalidParameter(ref cause) => cause,
-            ListIdentityPoolUsageError::NotAuthorized(ref cause) => cause,
-            ListIdentityPoolUsageError::TooManyRequests(ref cause) => cause,
+            ListIdentityPoolUsageError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListIdentityPoolUsageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListIdentityPoolUsageError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListIdentityPoolUsageError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIdentityPoolUsageError {}
 /// Errors returned by ListRecords
 #[derive(Debug, PartialEq)]
 pub enum ListRecordsError {
@@ -1308,19 +1272,15 @@ impl ListRecordsError {
 }
 impl fmt::Display for ListRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRecordsError::InternalError(ref cause) => cause,
-            ListRecordsError::InvalidParameter(ref cause) => cause,
-            ListRecordsError::NotAuthorized(ref cause) => cause,
-            ListRecordsError::TooManyRequests(ref cause) => cause,
+            ListRecordsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListRecordsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListRecordsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListRecordsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRecordsError {}
 /// Errors returned by RegisterDevice
 #[derive(Debug, PartialEq)]
 pub enum RegisterDeviceError {
@@ -1369,21 +1329,17 @@ impl RegisterDeviceError {
 }
 impl fmt::Display for RegisterDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterDeviceError::InternalError(ref cause) => cause,
-            RegisterDeviceError::InvalidConfiguration(ref cause) => cause,
-            RegisterDeviceError::InvalidParameter(ref cause) => cause,
-            RegisterDeviceError::NotAuthorized(ref cause) => cause,
-            RegisterDeviceError::ResourceNotFound(ref cause) => cause,
-            RegisterDeviceError::TooManyRequests(ref cause) => cause,
+            RegisterDeviceError::InternalError(ref cause) => write!(f, "{}", cause),
+            RegisterDeviceError::InvalidConfiguration(ref cause) => write!(f, "{}", cause),
+            RegisterDeviceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RegisterDeviceError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            RegisterDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RegisterDeviceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterDeviceError {}
 /// Errors returned by SetCognitoEvents
 #[derive(Debug, PartialEq)]
 pub enum SetCognitoEventsError {
@@ -1427,20 +1383,16 @@ impl SetCognitoEventsError {
 }
 impl fmt::Display for SetCognitoEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetCognitoEventsError {
-    fn description(&self) -> &str {
         match *self {
-            SetCognitoEventsError::InternalError(ref cause) => cause,
-            SetCognitoEventsError::InvalidParameter(ref cause) => cause,
-            SetCognitoEventsError::NotAuthorized(ref cause) => cause,
-            SetCognitoEventsError::ResourceNotFound(ref cause) => cause,
-            SetCognitoEventsError::TooManyRequests(ref cause) => cause,
+            SetCognitoEventsError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetCognitoEventsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetCognitoEventsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetCognitoEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetCognitoEventsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetCognitoEventsError {}
 /// Errors returned by SetIdentityPoolConfiguration
 #[derive(Debug, PartialEq)]
 pub enum SetIdentityPoolConfigurationError {
@@ -1503,21 +1455,23 @@ impl SetIdentityPoolConfigurationError {
 }
 impl fmt::Display for SetIdentityPoolConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIdentityPoolConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            SetIdentityPoolConfigurationError::ConcurrentModification(ref cause) => cause,
-            SetIdentityPoolConfigurationError::InternalError(ref cause) => cause,
-            SetIdentityPoolConfigurationError::InvalidParameter(ref cause) => cause,
-            SetIdentityPoolConfigurationError::NotAuthorized(ref cause) => cause,
-            SetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => cause,
-            SetIdentityPoolConfigurationError::TooManyRequests(ref cause) => cause,
+            SetIdentityPoolConfigurationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetIdentityPoolConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolConfigurationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetIdentityPoolConfigurationError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetIdentityPoolConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetIdentityPoolConfigurationError {}
 /// Errors returned by SubscribeToDataset
 #[derive(Debug, PartialEq)]
 pub enum SubscribeToDatasetError {
@@ -1568,21 +1522,17 @@ impl SubscribeToDatasetError {
 }
 impl fmt::Display for SubscribeToDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubscribeToDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            SubscribeToDatasetError::InternalError(ref cause) => cause,
-            SubscribeToDatasetError::InvalidConfiguration(ref cause) => cause,
-            SubscribeToDatasetError::InvalidParameter(ref cause) => cause,
-            SubscribeToDatasetError::NotAuthorized(ref cause) => cause,
-            SubscribeToDatasetError::ResourceNotFound(ref cause) => cause,
-            SubscribeToDatasetError::TooManyRequests(ref cause) => cause,
+            SubscribeToDatasetError::InternalError(ref cause) => write!(f, "{}", cause),
+            SubscribeToDatasetError::InvalidConfiguration(ref cause) => write!(f, "{}", cause),
+            SubscribeToDatasetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SubscribeToDatasetError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            SubscribeToDatasetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SubscribeToDatasetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SubscribeToDatasetError {}
 /// Errors returned by UnsubscribeFromDataset
 #[derive(Debug, PartialEq)]
 pub enum UnsubscribeFromDatasetError {
@@ -1643,21 +1593,17 @@ impl UnsubscribeFromDatasetError {
 }
 impl fmt::Display for UnsubscribeFromDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnsubscribeFromDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            UnsubscribeFromDatasetError::InternalError(ref cause) => cause,
-            UnsubscribeFromDatasetError::InvalidConfiguration(ref cause) => cause,
-            UnsubscribeFromDatasetError::InvalidParameter(ref cause) => cause,
-            UnsubscribeFromDatasetError::NotAuthorized(ref cause) => cause,
-            UnsubscribeFromDatasetError::ResourceNotFound(ref cause) => cause,
-            UnsubscribeFromDatasetError::TooManyRequests(ref cause) => cause,
+            UnsubscribeFromDatasetError::InternalError(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromDatasetError::InvalidConfiguration(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromDatasetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromDatasetError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromDatasetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromDatasetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnsubscribeFromDatasetError {}
 /// Errors returned by UpdateRecords
 #[derive(Debug, PartialEq)]
 pub enum UpdateRecordsError {
@@ -1723,24 +1669,20 @@ impl UpdateRecordsError {
 }
 impl fmt::Display for UpdateRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRecordsError::InternalError(ref cause) => cause,
-            UpdateRecordsError::InvalidLambdaFunctionOutput(ref cause) => cause,
-            UpdateRecordsError::InvalidParameter(ref cause) => cause,
-            UpdateRecordsError::LambdaThrottled(ref cause) => cause,
-            UpdateRecordsError::LimitExceeded(ref cause) => cause,
-            UpdateRecordsError::NotAuthorized(ref cause) => cause,
-            UpdateRecordsError::ResourceConflict(ref cause) => cause,
-            UpdateRecordsError::ResourceNotFound(ref cause) => cause,
-            UpdateRecordsError::TooManyRequests(ref cause) => cause,
+            UpdateRecordsError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::InvalidLambdaFunctionOutput(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::LambdaThrottled(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRecordsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRecordsError {}
 /// Trait representing the capabilities of the Amazon Cognito Sync API. Amazon Cognito Sync clients implement this trait.
 pub trait CognitoSync {
     /// <p>Initiates a bulk publish of all existing datasets for an Identity Pool to the configured stream. Customers are limited to one successful bulk publish per 24 hours. Bulk publish is an asynchronous request, customers can see the status of the request via the GetBulkPublishDetails operation.</p> <p>This API can only be called with developer credentials. You cannot call this API with the temporary user credentials provided by Cognito Identity.</p>

--- a/rusoto/services/comprehend/src/generated.rs
+++ b/rusoto/services/comprehend/src/generated.rs
@@ -2412,19 +2412,19 @@ impl BatchDetectDominantLanguageError {
 }
 impl fmt::Display for BatchDetectDominantLanguageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDetectDominantLanguageError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDetectDominantLanguageError::BatchSizeLimitExceeded(ref cause) => cause,
-            BatchDetectDominantLanguageError::InternalServer(ref cause) => cause,
-            BatchDetectDominantLanguageError::InvalidRequest(ref cause) => cause,
-            BatchDetectDominantLanguageError::TextSizeLimitExceeded(ref cause) => cause,
+            BatchDetectDominantLanguageError::BatchSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchDetectDominantLanguageError::InternalServer(ref cause) => write!(f, "{}", cause),
+            BatchDetectDominantLanguageError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            BatchDetectDominantLanguageError::TextSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchDetectDominantLanguageError {}
 /// Errors returned by BatchDetectEntities
 #[derive(Debug, PartialEq)]
 pub enum BatchDetectEntitiesError {
@@ -2474,20 +2474,16 @@ impl BatchDetectEntitiesError {
 }
 impl fmt::Display for BatchDetectEntitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDetectEntitiesError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDetectEntitiesError::BatchSizeLimitExceeded(ref cause) => cause,
-            BatchDetectEntitiesError::InternalServer(ref cause) => cause,
-            BatchDetectEntitiesError::InvalidRequest(ref cause) => cause,
-            BatchDetectEntitiesError::TextSizeLimitExceeded(ref cause) => cause,
-            BatchDetectEntitiesError::UnsupportedLanguage(ref cause) => cause,
+            BatchDetectEntitiesError::BatchSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectEntitiesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            BatchDetectEntitiesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            BatchDetectEntitiesError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectEntitiesError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDetectEntitiesError {}
 /// Errors returned by BatchDetectKeyPhrases
 #[derive(Debug, PartialEq)]
 pub enum BatchDetectKeyPhrasesError {
@@ -2541,20 +2537,16 @@ impl BatchDetectKeyPhrasesError {
 }
 impl fmt::Display for BatchDetectKeyPhrasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDetectKeyPhrasesError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDetectKeyPhrasesError::BatchSizeLimitExceeded(ref cause) => cause,
-            BatchDetectKeyPhrasesError::InternalServer(ref cause) => cause,
-            BatchDetectKeyPhrasesError::InvalidRequest(ref cause) => cause,
-            BatchDetectKeyPhrasesError::TextSizeLimitExceeded(ref cause) => cause,
-            BatchDetectKeyPhrasesError::UnsupportedLanguage(ref cause) => cause,
+            BatchDetectKeyPhrasesError::BatchSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectKeyPhrasesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            BatchDetectKeyPhrasesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            BatchDetectKeyPhrasesError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectKeyPhrasesError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDetectKeyPhrasesError {}
 /// Errors returned by BatchDetectSentiment
 #[derive(Debug, PartialEq)]
 pub enum BatchDetectSentimentError {
@@ -2604,20 +2596,16 @@ impl BatchDetectSentimentError {
 }
 impl fmt::Display for BatchDetectSentimentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDetectSentimentError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDetectSentimentError::BatchSizeLimitExceeded(ref cause) => cause,
-            BatchDetectSentimentError::InternalServer(ref cause) => cause,
-            BatchDetectSentimentError::InvalidRequest(ref cause) => cause,
-            BatchDetectSentimentError::TextSizeLimitExceeded(ref cause) => cause,
-            BatchDetectSentimentError::UnsupportedLanguage(ref cause) => cause,
+            BatchDetectSentimentError::BatchSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectSentimentError::InternalServer(ref cause) => write!(f, "{}", cause),
+            BatchDetectSentimentError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            BatchDetectSentimentError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectSentimentError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDetectSentimentError {}
 /// Errors returned by BatchDetectSyntax
 #[derive(Debug, PartialEq)]
 pub enum BatchDetectSyntaxError {
@@ -2667,20 +2655,16 @@ impl BatchDetectSyntaxError {
 }
 impl fmt::Display for BatchDetectSyntaxError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDetectSyntaxError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDetectSyntaxError::BatchSizeLimitExceeded(ref cause) => cause,
-            BatchDetectSyntaxError::InternalServer(ref cause) => cause,
-            BatchDetectSyntaxError::InvalidRequest(ref cause) => cause,
-            BatchDetectSyntaxError::TextSizeLimitExceeded(ref cause) => cause,
-            BatchDetectSyntaxError::UnsupportedLanguage(ref cause) => cause,
+            BatchDetectSyntaxError::BatchSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectSyntaxError::InternalServer(ref cause) => write!(f, "{}", cause),
+            BatchDetectSyntaxError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            BatchDetectSyntaxError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchDetectSyntaxError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDetectSyntaxError {}
 /// Errors returned by ClassifyDocument
 #[derive(Debug, PartialEq)]
 pub enum ClassifyDocumentError {
@@ -2723,19 +2707,15 @@ impl ClassifyDocumentError {
 }
 impl fmt::Display for ClassifyDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ClassifyDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            ClassifyDocumentError::InternalServer(ref cause) => cause,
-            ClassifyDocumentError::InvalidRequest(ref cause) => cause,
-            ClassifyDocumentError::ResourceUnavailable(ref cause) => cause,
-            ClassifyDocumentError::TextSizeLimitExceeded(ref cause) => cause,
+            ClassifyDocumentError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ClassifyDocumentError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ClassifyDocumentError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
+            ClassifyDocumentError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ClassifyDocumentError {}
 /// Errors returned by CreateDocumentClassifier
 #[derive(Debug, PartialEq)]
 pub enum CreateDocumentClassifierError {
@@ -2810,23 +2790,21 @@ impl CreateDocumentClassifierError {
 }
 impl fmt::Display for CreateDocumentClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDocumentClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDocumentClassifierError::InternalServer(ref cause) => cause,
-            CreateDocumentClassifierError::InvalidRequest(ref cause) => cause,
-            CreateDocumentClassifierError::KmsKeyValidation(ref cause) => cause,
-            CreateDocumentClassifierError::ResourceInUse(ref cause) => cause,
-            CreateDocumentClassifierError::ResourceLimitExceeded(ref cause) => cause,
-            CreateDocumentClassifierError::TooManyRequests(ref cause) => cause,
-            CreateDocumentClassifierError::TooManyTags(ref cause) => cause,
-            CreateDocumentClassifierError::UnsupportedLanguage(ref cause) => cause,
+            CreateDocumentClassifierError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateDocumentClassifierError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateDocumentClassifierError::KmsKeyValidation(ref cause) => write!(f, "{}", cause),
+            CreateDocumentClassifierError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateDocumentClassifierError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDocumentClassifierError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateDocumentClassifierError::TooManyTags(ref cause) => write!(f, "{}", cause),
+            CreateDocumentClassifierError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDocumentClassifierError {}
 /// Errors returned by CreateEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateEndpointError {
@@ -2887,23 +2865,19 @@ impl CreateEndpointError {
 }
 impl fmt::Display for CreateEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEndpointError::InternalServer(ref cause) => cause,
-            CreateEndpointError::InvalidRequest(ref cause) => cause,
-            CreateEndpointError::ResourceInUse(ref cause) => cause,
-            CreateEndpointError::ResourceLimitExceeded(ref cause) => cause,
-            CreateEndpointError::ResourceNotFound(ref cause) => cause,
-            CreateEndpointError::ResourceUnavailable(ref cause) => cause,
-            CreateEndpointError::TooManyRequests(ref cause) => cause,
-            CreateEndpointError::TooManyTags(ref cause) => cause,
+            CreateEndpointError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEndpointError {}
 /// Errors returned by CreateEntityRecognizer
 #[derive(Debug, PartialEq)]
 pub enum CreateEntityRecognizerError {
@@ -2976,23 +2950,19 @@ impl CreateEntityRecognizerError {
 }
 impl fmt::Display for CreateEntityRecognizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEntityRecognizerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEntityRecognizerError::InternalServer(ref cause) => cause,
-            CreateEntityRecognizerError::InvalidRequest(ref cause) => cause,
-            CreateEntityRecognizerError::KmsKeyValidation(ref cause) => cause,
-            CreateEntityRecognizerError::ResourceInUse(ref cause) => cause,
-            CreateEntityRecognizerError::ResourceLimitExceeded(ref cause) => cause,
-            CreateEntityRecognizerError::TooManyRequests(ref cause) => cause,
-            CreateEntityRecognizerError::TooManyTags(ref cause) => cause,
-            CreateEntityRecognizerError::UnsupportedLanguage(ref cause) => cause,
+            CreateEntityRecognizerError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateEntityRecognizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateEntityRecognizerError::KmsKeyValidation(ref cause) => write!(f, "{}", cause),
+            CreateEntityRecognizerError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateEntityRecognizerError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateEntityRecognizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateEntityRecognizerError::TooManyTags(ref cause) => write!(f, "{}", cause),
+            CreateEntityRecognizerError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEntityRecognizerError {}
 /// Errors returned by DeleteDocumentClassifier
 #[derive(Debug, PartialEq)]
 pub enum DeleteDocumentClassifierError {
@@ -3053,21 +3023,17 @@ impl DeleteDocumentClassifierError {
 }
 impl fmt::Display for DeleteDocumentClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDocumentClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDocumentClassifierError::InternalServer(ref cause) => cause,
-            DeleteDocumentClassifierError::InvalidRequest(ref cause) => cause,
-            DeleteDocumentClassifierError::ResourceInUse(ref cause) => cause,
-            DeleteDocumentClassifierError::ResourceNotFound(ref cause) => cause,
-            DeleteDocumentClassifierError::ResourceUnavailable(ref cause) => cause,
-            DeleteDocumentClassifierError::TooManyRequests(ref cause) => cause,
+            DeleteDocumentClassifierError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentClassifierError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentClassifierError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentClassifierError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentClassifierError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentClassifierError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDocumentClassifierError {}
 /// Errors returned by DeleteEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteEndpointError {
@@ -3111,20 +3077,16 @@ impl DeleteEndpointError {
 }
 impl fmt::Display for DeleteEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEndpointError::InternalServer(ref cause) => cause,
-            DeleteEndpointError::InvalidRequest(ref cause) => cause,
-            DeleteEndpointError::ResourceInUse(ref cause) => cause,
-            DeleteEndpointError::ResourceNotFound(ref cause) => cause,
-            DeleteEndpointError::TooManyRequests(ref cause) => cause,
+            DeleteEndpointError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteEndpointError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteEndpointError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEndpointError {}
 /// Errors returned by DeleteEntityRecognizer
 #[derive(Debug, PartialEq)]
 pub enum DeleteEntityRecognizerError {
@@ -3185,21 +3147,17 @@ impl DeleteEntityRecognizerError {
 }
 impl fmt::Display for DeleteEntityRecognizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEntityRecognizerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEntityRecognizerError::InternalServer(ref cause) => cause,
-            DeleteEntityRecognizerError::InvalidRequest(ref cause) => cause,
-            DeleteEntityRecognizerError::ResourceInUse(ref cause) => cause,
-            DeleteEntityRecognizerError::ResourceNotFound(ref cause) => cause,
-            DeleteEntityRecognizerError::ResourceUnavailable(ref cause) => cause,
-            DeleteEntityRecognizerError::TooManyRequests(ref cause) => cause,
+            DeleteEntityRecognizerError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteEntityRecognizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteEntityRecognizerError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteEntityRecognizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteEntityRecognizerError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteEntityRecognizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEntityRecognizerError {}
 /// Errors returned by DescribeDocumentClassificationJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeDocumentClassificationJobError {
@@ -3248,19 +3206,23 @@ impl DescribeDocumentClassificationJobError {
 }
 impl fmt::Display for DescribeDocumentClassificationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDocumentClassificationJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDocumentClassificationJobError::InternalServer(ref cause) => cause,
-            DescribeDocumentClassificationJobError::InvalidRequest(ref cause) => cause,
-            DescribeDocumentClassificationJobError::JobNotFound(ref cause) => cause,
-            DescribeDocumentClassificationJobError::TooManyRequests(ref cause) => cause,
+            DescribeDocumentClassificationJobError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDocumentClassificationJobError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDocumentClassificationJobError::JobNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDocumentClassificationJobError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDocumentClassificationJobError {}
 /// Errors returned by DescribeDocumentClassifier
 #[derive(Debug, PartialEq)]
 pub enum DescribeDocumentClassifierError {
@@ -3309,19 +3271,15 @@ impl DescribeDocumentClassifierError {
 }
 impl fmt::Display for DescribeDocumentClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDocumentClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDocumentClassifierError::InternalServer(ref cause) => cause,
-            DescribeDocumentClassifierError::InvalidRequest(ref cause) => cause,
-            DescribeDocumentClassifierError::ResourceNotFound(ref cause) => cause,
-            DescribeDocumentClassifierError::TooManyRequests(ref cause) => cause,
+            DescribeDocumentClassifierError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentClassifierError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentClassifierError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentClassifierError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDocumentClassifierError {}
 /// Errors returned by DescribeDominantLanguageDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeDominantLanguageDetectionJobError {
@@ -3370,19 +3328,23 @@ impl DescribeDominantLanguageDetectionJobError {
 }
 impl fmt::Display for DescribeDominantLanguageDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDominantLanguageDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDominantLanguageDetectionJobError::InternalServer(ref cause) => cause,
-            DescribeDominantLanguageDetectionJobError::InvalidRequest(ref cause) => cause,
-            DescribeDominantLanguageDetectionJobError::JobNotFound(ref cause) => cause,
-            DescribeDominantLanguageDetectionJobError::TooManyRequests(ref cause) => cause,
+            DescribeDominantLanguageDetectionJobError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDominantLanguageDetectionJobError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDominantLanguageDetectionJobError::JobNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDominantLanguageDetectionJobError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDominantLanguageDetectionJobError {}
 /// Errors returned by DescribeEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointError {
@@ -3421,19 +3383,15 @@ impl DescribeEndpointError {
 }
 impl fmt::Display for DescribeEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEndpointError::InternalServer(ref cause) => cause,
-            DescribeEndpointError::InvalidRequest(ref cause) => cause,
-            DescribeEndpointError::ResourceNotFound(ref cause) => cause,
-            DescribeEndpointError::TooManyRequests(ref cause) => cause,
+            DescribeEndpointError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEndpointError {}
 /// Errors returned by DescribeEntitiesDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeEntitiesDetectionJobError {
@@ -3482,19 +3440,15 @@ impl DescribeEntitiesDetectionJobError {
 }
 impl fmt::Display for DescribeEntitiesDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEntitiesDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEntitiesDetectionJobError::InternalServer(ref cause) => cause,
-            DescribeEntitiesDetectionJobError::InvalidRequest(ref cause) => cause,
-            DescribeEntitiesDetectionJobError::JobNotFound(ref cause) => cause,
-            DescribeEntitiesDetectionJobError::TooManyRequests(ref cause) => cause,
+            DescribeEntitiesDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeEntitiesDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEntitiesDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEntitiesDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEntitiesDetectionJobError {}
 /// Errors returned by DescribeEntityRecognizer
 #[derive(Debug, PartialEq)]
 pub enum DescribeEntityRecognizerError {
@@ -3541,19 +3495,15 @@ impl DescribeEntityRecognizerError {
 }
 impl fmt::Display for DescribeEntityRecognizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEntityRecognizerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEntityRecognizerError::InternalServer(ref cause) => cause,
-            DescribeEntityRecognizerError::InvalidRequest(ref cause) => cause,
-            DescribeEntityRecognizerError::ResourceNotFound(ref cause) => cause,
-            DescribeEntityRecognizerError::TooManyRequests(ref cause) => cause,
+            DescribeEntityRecognizerError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeEntityRecognizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEntityRecognizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEntityRecognizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEntityRecognizerError {}
 /// Errors returned by DescribeKeyPhrasesDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeKeyPhrasesDetectionJobError {
@@ -3602,19 +3552,21 @@ impl DescribeKeyPhrasesDetectionJobError {
 }
 impl fmt::Display for DescribeKeyPhrasesDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeKeyPhrasesDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeKeyPhrasesDetectionJobError::InternalServer(ref cause) => cause,
-            DescribeKeyPhrasesDetectionJobError::InvalidRequest(ref cause) => cause,
-            DescribeKeyPhrasesDetectionJobError::JobNotFound(ref cause) => cause,
-            DescribeKeyPhrasesDetectionJobError::TooManyRequests(ref cause) => cause,
+            DescribeKeyPhrasesDetectionJobError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeKeyPhrasesDetectionJobError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeKeyPhrasesDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeKeyPhrasesDetectionJobError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeKeyPhrasesDetectionJobError {}
 /// Errors returned by DescribeSentimentDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeSentimentDetectionJobError {
@@ -3663,19 +3615,17 @@ impl DescribeSentimentDetectionJobError {
 }
 impl fmt::Display for DescribeSentimentDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSentimentDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSentimentDetectionJobError::InternalServer(ref cause) => cause,
-            DescribeSentimentDetectionJobError::InvalidRequest(ref cause) => cause,
-            DescribeSentimentDetectionJobError::JobNotFound(ref cause) => cause,
-            DescribeSentimentDetectionJobError::TooManyRequests(ref cause) => cause,
+            DescribeSentimentDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeSentimentDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeSentimentDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeSentimentDetectionJobError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeSentimentDetectionJobError {}
 /// Errors returned by DescribeTopicsDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeTopicsDetectionJobError {
@@ -3724,19 +3674,15 @@ impl DescribeTopicsDetectionJobError {
 }
 impl fmt::Display for DescribeTopicsDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTopicsDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTopicsDetectionJobError::InternalServer(ref cause) => cause,
-            DescribeTopicsDetectionJobError::InvalidRequest(ref cause) => cause,
-            DescribeTopicsDetectionJobError::JobNotFound(ref cause) => cause,
-            DescribeTopicsDetectionJobError::TooManyRequests(ref cause) => cause,
+            DescribeTopicsDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeTopicsDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeTopicsDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTopicsDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTopicsDetectionJobError {}
 /// Errors returned by DetectDominantLanguage
 #[derive(Debug, PartialEq)]
 pub enum DetectDominantLanguageError {
@@ -3776,18 +3722,14 @@ impl DetectDominantLanguageError {
 }
 impl fmt::Display for DetectDominantLanguageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectDominantLanguageError {
-    fn description(&self) -> &str {
         match *self {
-            DetectDominantLanguageError::InternalServer(ref cause) => cause,
-            DetectDominantLanguageError::InvalidRequest(ref cause) => cause,
-            DetectDominantLanguageError::TextSizeLimitExceeded(ref cause) => cause,
+            DetectDominantLanguageError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectDominantLanguageError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectDominantLanguageError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectDominantLanguageError {}
 /// Errors returned by DetectEntities
 #[derive(Debug, PartialEq)]
 pub enum DetectEntitiesError {
@@ -3828,19 +3770,15 @@ impl DetectEntitiesError {
 }
 impl fmt::Display for DetectEntitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectEntitiesError {
-    fn description(&self) -> &str {
         match *self {
-            DetectEntitiesError::InternalServer(ref cause) => cause,
-            DetectEntitiesError::InvalidRequest(ref cause) => cause,
-            DetectEntitiesError::TextSizeLimitExceeded(ref cause) => cause,
-            DetectEntitiesError::UnsupportedLanguage(ref cause) => cause,
+            DetectEntitiesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectEntitiesError {}
 /// Errors returned by DetectKeyPhrases
 #[derive(Debug, PartialEq)]
 pub enum DetectKeyPhrasesError {
@@ -3883,19 +3821,15 @@ impl DetectKeyPhrasesError {
 }
 impl fmt::Display for DetectKeyPhrasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectKeyPhrasesError {
-    fn description(&self) -> &str {
         match *self {
-            DetectKeyPhrasesError::InternalServer(ref cause) => cause,
-            DetectKeyPhrasesError::InvalidRequest(ref cause) => cause,
-            DetectKeyPhrasesError::TextSizeLimitExceeded(ref cause) => cause,
-            DetectKeyPhrasesError::UnsupportedLanguage(ref cause) => cause,
+            DetectKeyPhrasesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectKeyPhrasesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectKeyPhrasesError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectKeyPhrasesError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectKeyPhrasesError {}
 /// Errors returned by DetectSentiment
 #[derive(Debug, PartialEq)]
 pub enum DetectSentimentError {
@@ -3936,19 +3870,15 @@ impl DetectSentimentError {
 }
 impl fmt::Display for DetectSentimentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectSentimentError {
-    fn description(&self) -> &str {
         match *self {
-            DetectSentimentError::InternalServer(ref cause) => cause,
-            DetectSentimentError::InvalidRequest(ref cause) => cause,
-            DetectSentimentError::TextSizeLimitExceeded(ref cause) => cause,
-            DetectSentimentError::UnsupportedLanguage(ref cause) => cause,
+            DetectSentimentError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectSentimentError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectSentimentError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectSentimentError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectSentimentError {}
 /// Errors returned by DetectSyntax
 #[derive(Debug, PartialEq)]
 pub enum DetectSyntaxError {
@@ -3987,19 +3917,15 @@ impl DetectSyntaxError {
 }
 impl fmt::Display for DetectSyntaxError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectSyntaxError {
-    fn description(&self) -> &str {
         match *self {
-            DetectSyntaxError::InternalServer(ref cause) => cause,
-            DetectSyntaxError::InvalidRequest(ref cause) => cause,
-            DetectSyntaxError::TextSizeLimitExceeded(ref cause) => cause,
-            DetectSyntaxError::UnsupportedLanguage(ref cause) => cause,
+            DetectSyntaxError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectSyntaxError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectSyntaxError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectSyntaxError::UnsupportedLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectSyntaxError {}
 /// Errors returned by ListDocumentClassificationJobs
 #[derive(Debug, PartialEq)]
 pub enum ListDocumentClassificationJobsError {
@@ -4048,19 +3974,21 @@ impl ListDocumentClassificationJobsError {
 }
 impl fmt::Display for ListDocumentClassificationJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDocumentClassificationJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDocumentClassificationJobsError::InternalServer(ref cause) => cause,
-            ListDocumentClassificationJobsError::InvalidFilter(ref cause) => cause,
-            ListDocumentClassificationJobsError::InvalidRequest(ref cause) => cause,
-            ListDocumentClassificationJobsError::TooManyRequests(ref cause) => cause,
+            ListDocumentClassificationJobsError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDocumentClassificationJobsError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListDocumentClassificationJobsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDocumentClassificationJobsError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListDocumentClassificationJobsError {}
 /// Errors returned by ListDocumentClassifiers
 #[derive(Debug, PartialEq)]
 pub enum ListDocumentClassifiersError {
@@ -4107,19 +4035,15 @@ impl ListDocumentClassifiersError {
 }
 impl fmt::Display for ListDocumentClassifiersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDocumentClassifiersError {
-    fn description(&self) -> &str {
         match *self {
-            ListDocumentClassifiersError::InternalServer(ref cause) => cause,
-            ListDocumentClassifiersError::InvalidFilter(ref cause) => cause,
-            ListDocumentClassifiersError::InvalidRequest(ref cause) => cause,
-            ListDocumentClassifiersError::TooManyRequests(ref cause) => cause,
+            ListDocumentClassifiersError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListDocumentClassifiersError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListDocumentClassifiersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDocumentClassifiersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDocumentClassifiersError {}
 /// Errors returned by ListDominantLanguageDetectionJobs
 #[derive(Debug, PartialEq)]
 pub enum ListDominantLanguageDetectionJobsError {
@@ -4168,19 +4092,23 @@ impl ListDominantLanguageDetectionJobsError {
 }
 impl fmt::Display for ListDominantLanguageDetectionJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDominantLanguageDetectionJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDominantLanguageDetectionJobsError::InternalServer(ref cause) => cause,
-            ListDominantLanguageDetectionJobsError::InvalidFilter(ref cause) => cause,
-            ListDominantLanguageDetectionJobsError::InvalidRequest(ref cause) => cause,
-            ListDominantLanguageDetectionJobsError::TooManyRequests(ref cause) => cause,
+            ListDominantLanguageDetectionJobsError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDominantLanguageDetectionJobsError::InvalidFilter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDominantLanguageDetectionJobsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListDominantLanguageDetectionJobsError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListDominantLanguageDetectionJobsError {}
 /// Errors returned by ListEndpoints
 #[derive(Debug, PartialEq)]
 pub enum ListEndpointsError {
@@ -4214,18 +4142,14 @@ impl ListEndpointsError {
 }
 impl fmt::Display for ListEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            ListEndpointsError::InternalServer(ref cause) => cause,
-            ListEndpointsError::InvalidRequest(ref cause) => cause,
-            ListEndpointsError::TooManyRequests(ref cause) => cause,
+            ListEndpointsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListEndpointsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListEndpointsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEndpointsError {}
 /// Errors returned by ListEntitiesDetectionJobs
 #[derive(Debug, PartialEq)]
 pub enum ListEntitiesDetectionJobsError {
@@ -4272,19 +4196,15 @@ impl ListEntitiesDetectionJobsError {
 }
 impl fmt::Display for ListEntitiesDetectionJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEntitiesDetectionJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListEntitiesDetectionJobsError::InternalServer(ref cause) => cause,
-            ListEntitiesDetectionJobsError::InvalidFilter(ref cause) => cause,
-            ListEntitiesDetectionJobsError::InvalidRequest(ref cause) => cause,
-            ListEntitiesDetectionJobsError::TooManyRequests(ref cause) => cause,
+            ListEntitiesDetectionJobsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListEntitiesDetectionJobsError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListEntitiesDetectionJobsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListEntitiesDetectionJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEntitiesDetectionJobsError {}
 /// Errors returned by ListEntityRecognizers
 #[derive(Debug, PartialEq)]
 pub enum ListEntityRecognizersError {
@@ -4329,19 +4249,15 @@ impl ListEntityRecognizersError {
 }
 impl fmt::Display for ListEntityRecognizersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEntityRecognizersError {
-    fn description(&self) -> &str {
         match *self {
-            ListEntityRecognizersError::InternalServer(ref cause) => cause,
-            ListEntityRecognizersError::InvalidFilter(ref cause) => cause,
-            ListEntityRecognizersError::InvalidRequest(ref cause) => cause,
-            ListEntityRecognizersError::TooManyRequests(ref cause) => cause,
+            ListEntityRecognizersError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListEntityRecognizersError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListEntityRecognizersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListEntityRecognizersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEntityRecognizersError {}
 /// Errors returned by ListKeyPhrasesDetectionJobs
 #[derive(Debug, PartialEq)]
 pub enum ListKeyPhrasesDetectionJobsError {
@@ -4390,19 +4306,15 @@ impl ListKeyPhrasesDetectionJobsError {
 }
 impl fmt::Display for ListKeyPhrasesDetectionJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListKeyPhrasesDetectionJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListKeyPhrasesDetectionJobsError::InternalServer(ref cause) => cause,
-            ListKeyPhrasesDetectionJobsError::InvalidFilter(ref cause) => cause,
-            ListKeyPhrasesDetectionJobsError::InvalidRequest(ref cause) => cause,
-            ListKeyPhrasesDetectionJobsError::TooManyRequests(ref cause) => cause,
+            ListKeyPhrasesDetectionJobsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListKeyPhrasesDetectionJobsError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListKeyPhrasesDetectionJobsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListKeyPhrasesDetectionJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListKeyPhrasesDetectionJobsError {}
 /// Errors returned by ListSentimentDetectionJobs
 #[derive(Debug, PartialEq)]
 pub enum ListSentimentDetectionJobsError {
@@ -4451,19 +4363,15 @@ impl ListSentimentDetectionJobsError {
 }
 impl fmt::Display for ListSentimentDetectionJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSentimentDetectionJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSentimentDetectionJobsError::InternalServer(ref cause) => cause,
-            ListSentimentDetectionJobsError::InvalidFilter(ref cause) => cause,
-            ListSentimentDetectionJobsError::InvalidRequest(ref cause) => cause,
-            ListSentimentDetectionJobsError::TooManyRequests(ref cause) => cause,
+            ListSentimentDetectionJobsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListSentimentDetectionJobsError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListSentimentDetectionJobsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListSentimentDetectionJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSentimentDetectionJobsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -4499,18 +4407,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalServer(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTopicsDetectionJobs
 #[derive(Debug, PartialEq)]
 pub enum ListTopicsDetectionJobsError {
@@ -4557,19 +4461,15 @@ impl ListTopicsDetectionJobsError {
 }
 impl fmt::Display for ListTopicsDetectionJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTopicsDetectionJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTopicsDetectionJobsError::InternalServer(ref cause) => cause,
-            ListTopicsDetectionJobsError::InvalidFilter(ref cause) => cause,
-            ListTopicsDetectionJobsError::InvalidRequest(ref cause) => cause,
-            ListTopicsDetectionJobsError::TooManyRequests(ref cause) => cause,
+            ListTopicsDetectionJobsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListTopicsDetectionJobsError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListTopicsDetectionJobsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTopicsDetectionJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTopicsDetectionJobsError {}
 /// Errors returned by StartDocumentClassificationJob
 #[derive(Debug, PartialEq)]
 pub enum StartDocumentClassificationJobError {
@@ -4632,21 +4532,29 @@ impl StartDocumentClassificationJobError {
 }
 impl fmt::Display for StartDocumentClassificationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDocumentClassificationJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartDocumentClassificationJobError::InternalServer(ref cause) => cause,
-            StartDocumentClassificationJobError::InvalidRequest(ref cause) => cause,
-            StartDocumentClassificationJobError::KmsKeyValidation(ref cause) => cause,
-            StartDocumentClassificationJobError::ResourceNotFound(ref cause) => cause,
-            StartDocumentClassificationJobError::ResourceUnavailable(ref cause) => cause,
-            StartDocumentClassificationJobError::TooManyRequests(ref cause) => cause,
+            StartDocumentClassificationJobError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentClassificationJobError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentClassificationJobError::KmsKeyValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentClassificationJobError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentClassificationJobError::ResourceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentClassificationJobError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartDocumentClassificationJobError {}
 /// Errors returned by StartDominantLanguageDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StartDominantLanguageDetectionJobError {
@@ -4695,19 +4603,23 @@ impl StartDominantLanguageDetectionJobError {
 }
 impl fmt::Display for StartDominantLanguageDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDominantLanguageDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartDominantLanguageDetectionJobError::InternalServer(ref cause) => cause,
-            StartDominantLanguageDetectionJobError::InvalidRequest(ref cause) => cause,
-            StartDominantLanguageDetectionJobError::KmsKeyValidation(ref cause) => cause,
-            StartDominantLanguageDetectionJobError::TooManyRequests(ref cause) => cause,
+            StartDominantLanguageDetectionJobError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDominantLanguageDetectionJobError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDominantLanguageDetectionJobError::KmsKeyValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDominantLanguageDetectionJobError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartDominantLanguageDetectionJobError {}
 /// Errors returned by StartEntitiesDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StartEntitiesDetectionJobError {
@@ -4768,21 +4680,19 @@ impl StartEntitiesDetectionJobError {
 }
 impl fmt::Display for StartEntitiesDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartEntitiesDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartEntitiesDetectionJobError::InternalServer(ref cause) => cause,
-            StartEntitiesDetectionJobError::InvalidRequest(ref cause) => cause,
-            StartEntitiesDetectionJobError::KmsKeyValidation(ref cause) => cause,
-            StartEntitiesDetectionJobError::ResourceNotFound(ref cause) => cause,
-            StartEntitiesDetectionJobError::ResourceUnavailable(ref cause) => cause,
-            StartEntitiesDetectionJobError::TooManyRequests(ref cause) => cause,
+            StartEntitiesDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StartEntitiesDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartEntitiesDetectionJobError::KmsKeyValidation(ref cause) => write!(f, "{}", cause),
+            StartEntitiesDetectionJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartEntitiesDetectionJobError::ResourceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartEntitiesDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartEntitiesDetectionJobError {}
 /// Errors returned by StartKeyPhrasesDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StartKeyPhrasesDetectionJobError {
@@ -4831,19 +4741,15 @@ impl StartKeyPhrasesDetectionJobError {
 }
 impl fmt::Display for StartKeyPhrasesDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartKeyPhrasesDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartKeyPhrasesDetectionJobError::InternalServer(ref cause) => cause,
-            StartKeyPhrasesDetectionJobError::InvalidRequest(ref cause) => cause,
-            StartKeyPhrasesDetectionJobError::KmsKeyValidation(ref cause) => cause,
-            StartKeyPhrasesDetectionJobError::TooManyRequests(ref cause) => cause,
+            StartKeyPhrasesDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StartKeyPhrasesDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartKeyPhrasesDetectionJobError::KmsKeyValidation(ref cause) => write!(f, "{}", cause),
+            StartKeyPhrasesDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartKeyPhrasesDetectionJobError {}
 /// Errors returned by StartSentimentDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StartSentimentDetectionJobError {
@@ -4892,19 +4798,15 @@ impl StartSentimentDetectionJobError {
 }
 impl fmt::Display for StartSentimentDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartSentimentDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartSentimentDetectionJobError::InternalServer(ref cause) => cause,
-            StartSentimentDetectionJobError::InvalidRequest(ref cause) => cause,
-            StartSentimentDetectionJobError::KmsKeyValidation(ref cause) => cause,
-            StartSentimentDetectionJobError::TooManyRequests(ref cause) => cause,
+            StartSentimentDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StartSentimentDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartSentimentDetectionJobError::KmsKeyValidation(ref cause) => write!(f, "{}", cause),
+            StartSentimentDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartSentimentDetectionJobError {}
 /// Errors returned by StartTopicsDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StartTopicsDetectionJobError {
@@ -4951,19 +4853,15 @@ impl StartTopicsDetectionJobError {
 }
 impl fmt::Display for StartTopicsDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartTopicsDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartTopicsDetectionJobError::InternalServer(ref cause) => cause,
-            StartTopicsDetectionJobError::InvalidRequest(ref cause) => cause,
-            StartTopicsDetectionJobError::KmsKeyValidation(ref cause) => cause,
-            StartTopicsDetectionJobError::TooManyRequests(ref cause) => cause,
+            StartTopicsDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StartTopicsDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartTopicsDetectionJobError::KmsKeyValidation(ref cause) => write!(f, "{}", cause),
+            StartTopicsDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartTopicsDetectionJobError {}
 /// Errors returned by StopDominantLanguageDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StopDominantLanguageDetectionJobError {
@@ -5005,18 +4903,18 @@ impl StopDominantLanguageDetectionJobError {
 }
 impl fmt::Display for StopDominantLanguageDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopDominantLanguageDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopDominantLanguageDetectionJobError::InternalServer(ref cause) => cause,
-            StopDominantLanguageDetectionJobError::InvalidRequest(ref cause) => cause,
-            StopDominantLanguageDetectionJobError::JobNotFound(ref cause) => cause,
+            StopDominantLanguageDetectionJobError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopDominantLanguageDetectionJobError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopDominantLanguageDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopDominantLanguageDetectionJobError {}
 /// Errors returned by StopEntitiesDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StopEntitiesDetectionJobError {
@@ -5056,18 +4954,14 @@ impl StopEntitiesDetectionJobError {
 }
 impl fmt::Display for StopEntitiesDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopEntitiesDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopEntitiesDetectionJobError::InternalServer(ref cause) => cause,
-            StopEntitiesDetectionJobError::InvalidRequest(ref cause) => cause,
-            StopEntitiesDetectionJobError::JobNotFound(ref cause) => cause,
+            StopEntitiesDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StopEntitiesDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopEntitiesDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopEntitiesDetectionJobError {}
 /// Errors returned by StopKeyPhrasesDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StopKeyPhrasesDetectionJobError {
@@ -5109,18 +5003,14 @@ impl StopKeyPhrasesDetectionJobError {
 }
 impl fmt::Display for StopKeyPhrasesDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopKeyPhrasesDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopKeyPhrasesDetectionJobError::InternalServer(ref cause) => cause,
-            StopKeyPhrasesDetectionJobError::InvalidRequest(ref cause) => cause,
-            StopKeyPhrasesDetectionJobError::JobNotFound(ref cause) => cause,
+            StopKeyPhrasesDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StopKeyPhrasesDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopKeyPhrasesDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopKeyPhrasesDetectionJobError {}
 /// Errors returned by StopSentimentDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StopSentimentDetectionJobError {
@@ -5160,18 +5050,14 @@ impl StopSentimentDetectionJobError {
 }
 impl fmt::Display for StopSentimentDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopSentimentDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopSentimentDetectionJobError::InternalServer(ref cause) => cause,
-            StopSentimentDetectionJobError::InvalidRequest(ref cause) => cause,
-            StopSentimentDetectionJobError::JobNotFound(ref cause) => cause,
+            StopSentimentDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StopSentimentDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopSentimentDetectionJobError::JobNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopSentimentDetectionJobError {}
 /// Errors returned by StopTrainingDocumentClassifier
 #[derive(Debug, PartialEq)]
 pub enum StopTrainingDocumentClassifierError {
@@ -5220,19 +5106,23 @@ impl StopTrainingDocumentClassifierError {
 }
 impl fmt::Display for StopTrainingDocumentClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopTrainingDocumentClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            StopTrainingDocumentClassifierError::InternalServer(ref cause) => cause,
-            StopTrainingDocumentClassifierError::InvalidRequest(ref cause) => cause,
-            StopTrainingDocumentClassifierError::ResourceNotFound(ref cause) => cause,
-            StopTrainingDocumentClassifierError::TooManyRequests(ref cause) => cause,
+            StopTrainingDocumentClassifierError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopTrainingDocumentClassifierError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopTrainingDocumentClassifierError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopTrainingDocumentClassifierError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StopTrainingDocumentClassifierError {}
 /// Errors returned by StopTrainingEntityRecognizer
 #[derive(Debug, PartialEq)]
 pub enum StopTrainingEntityRecognizerError {
@@ -5281,19 +5171,17 @@ impl StopTrainingEntityRecognizerError {
 }
 impl fmt::Display for StopTrainingEntityRecognizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopTrainingEntityRecognizerError {
-    fn description(&self) -> &str {
         match *self {
-            StopTrainingEntityRecognizerError::InternalServer(ref cause) => cause,
-            StopTrainingEntityRecognizerError::InvalidRequest(ref cause) => cause,
-            StopTrainingEntityRecognizerError::ResourceNotFound(ref cause) => cause,
-            StopTrainingEntityRecognizerError::TooManyRequests(ref cause) => cause,
+            StopTrainingEntityRecognizerError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StopTrainingEntityRecognizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopTrainingEntityRecognizerError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopTrainingEntityRecognizerError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopTrainingEntityRecognizerError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5337,20 +5225,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ConcurrentModification(ref cause) => cause,
-            TagResourceError::InternalServer(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -5396,20 +5280,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ConcurrentModification(ref cause) => cause,
-            UntagResourceError::InternalServer(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::TooManyTagKeys(ref cause) => cause,
+            UntagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyTagKeys(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateEndpoint
 #[derive(Debug, PartialEq)]
 pub enum UpdateEndpointError {
@@ -5465,22 +5345,18 @@ impl UpdateEndpointError {
 }
 impl fmt::Display for UpdateEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEndpointError::InternalServer(ref cause) => cause,
-            UpdateEndpointError::InvalidRequest(ref cause) => cause,
-            UpdateEndpointError::ResourceInUse(ref cause) => cause,
-            UpdateEndpointError::ResourceLimitExceeded(ref cause) => cause,
-            UpdateEndpointError::ResourceNotFound(ref cause) => cause,
-            UpdateEndpointError::ResourceUnavailable(ref cause) => cause,
-            UpdateEndpointError::TooManyRequests(ref cause) => cause,
+            UpdateEndpointError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UpdateEndpointError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateEndpointError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateEndpointError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateEndpointError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEndpointError {}
 /// Trait representing the capabilities of the Amazon Comprehend API. Amazon Comprehend clients implement this trait.
 pub trait Comprehend {
     /// <p>Determines the dominant language of the input text for a batch of documents. For a list of languages that Amazon Comprehend can detect, see <a href="https://docs.aws.amazon.com/comprehend/latest/dg/how-languages.html">Amazon Comprehend Supported Languages</a>. </p>

--- a/rusoto/services/comprehendmedical/src/generated.rs
+++ b/rusoto/services/comprehendmedical/src/generated.rs
@@ -558,19 +558,23 @@ impl DescribeEntitiesDetectionV2JobError {
 }
 impl fmt::Display for DescribeEntitiesDetectionV2JobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEntitiesDetectionV2JobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEntitiesDetectionV2JobError::InternalServer(ref cause) => cause,
-            DescribeEntitiesDetectionV2JobError::InvalidRequest(ref cause) => cause,
-            DescribeEntitiesDetectionV2JobError::ResourceNotFound(ref cause) => cause,
-            DescribeEntitiesDetectionV2JobError::TooManyRequests(ref cause) => cause,
+            DescribeEntitiesDetectionV2JobError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEntitiesDetectionV2JobError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEntitiesDetectionV2JobError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEntitiesDetectionV2JobError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEntitiesDetectionV2JobError {}
 /// Errors returned by DescribePHIDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum DescribePHIDetectionJobError {
@@ -617,19 +621,15 @@ impl DescribePHIDetectionJobError {
 }
 impl fmt::Display for DescribePHIDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePHIDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePHIDetectionJobError::InternalServer(ref cause) => cause,
-            DescribePHIDetectionJobError::InvalidRequest(ref cause) => cause,
-            DescribePHIDetectionJobError::ResourceNotFound(ref cause) => cause,
-            DescribePHIDetectionJobError::TooManyRequests(ref cause) => cause,
+            DescribePHIDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribePHIDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribePHIDetectionJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribePHIDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePHIDetectionJobError {}
 /// Errors returned by DetectEntities
 #[derive(Debug, PartialEq)]
 pub enum DetectEntitiesError {
@@ -680,21 +680,17 @@ impl DetectEntitiesError {
 }
 impl fmt::Display for DetectEntitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectEntitiesError {
-    fn description(&self) -> &str {
         match *self {
-            DetectEntitiesError::InternalServer(ref cause) => cause,
-            DetectEntitiesError::InvalidEncoding(ref cause) => cause,
-            DetectEntitiesError::InvalidRequest(ref cause) => cause,
-            DetectEntitiesError::ServiceUnavailable(ref cause) => cause,
-            DetectEntitiesError::TextSizeLimitExceeded(ref cause) => cause,
-            DetectEntitiesError::TooManyRequests(ref cause) => cause,
+            DetectEntitiesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::InvalidEncoding(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectEntitiesError {}
 /// Errors returned by DetectEntitiesV2
 #[derive(Debug, PartialEq)]
 pub enum DetectEntitiesV2Error {
@@ -745,21 +741,17 @@ impl DetectEntitiesV2Error {
 }
 impl fmt::Display for DetectEntitiesV2Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectEntitiesV2Error {
-    fn description(&self) -> &str {
         match *self {
-            DetectEntitiesV2Error::InternalServer(ref cause) => cause,
-            DetectEntitiesV2Error::InvalidEncoding(ref cause) => cause,
-            DetectEntitiesV2Error::InvalidRequest(ref cause) => cause,
-            DetectEntitiesV2Error::ServiceUnavailable(ref cause) => cause,
-            DetectEntitiesV2Error::TextSizeLimitExceeded(ref cause) => cause,
-            DetectEntitiesV2Error::TooManyRequests(ref cause) => cause,
+            DetectEntitiesV2Error::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesV2Error::InvalidEncoding(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesV2Error::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesV2Error::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesV2Error::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectEntitiesV2Error::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectEntitiesV2Error {}
 /// Errors returned by DetectPHI
 #[derive(Debug, PartialEq)]
 pub enum DetectPHIError {
@@ -808,21 +800,17 @@ impl DetectPHIError {
 }
 impl fmt::Display for DetectPHIError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectPHIError {
-    fn description(&self) -> &str {
         match *self {
-            DetectPHIError::InternalServer(ref cause) => cause,
-            DetectPHIError::InvalidEncoding(ref cause) => cause,
-            DetectPHIError::InvalidRequest(ref cause) => cause,
-            DetectPHIError::ServiceUnavailable(ref cause) => cause,
-            DetectPHIError::TextSizeLimitExceeded(ref cause) => cause,
-            DetectPHIError::TooManyRequests(ref cause) => cause,
+            DetectPHIError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DetectPHIError::InvalidEncoding(ref cause) => write!(f, "{}", cause),
+            DetectPHIError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetectPHIError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DetectPHIError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectPHIError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectPHIError {}
 /// Errors returned by ListEntitiesDetectionV2Jobs
 #[derive(Debug, PartialEq)]
 pub enum ListEntitiesDetectionV2JobsError {
@@ -864,18 +852,14 @@ impl ListEntitiesDetectionV2JobsError {
 }
 impl fmt::Display for ListEntitiesDetectionV2JobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEntitiesDetectionV2JobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListEntitiesDetectionV2JobsError::InternalServer(ref cause) => cause,
-            ListEntitiesDetectionV2JobsError::InvalidRequest(ref cause) => cause,
-            ListEntitiesDetectionV2JobsError::TooManyRequests(ref cause) => cause,
+            ListEntitiesDetectionV2JobsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListEntitiesDetectionV2JobsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListEntitiesDetectionV2JobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEntitiesDetectionV2JobsError {}
 /// Errors returned by ListPHIDetectionJobs
 #[derive(Debug, PartialEq)]
 pub enum ListPHIDetectionJobsError {
@@ -911,18 +895,14 @@ impl ListPHIDetectionJobsError {
 }
 impl fmt::Display for ListPHIDetectionJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPHIDetectionJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPHIDetectionJobsError::InternalServer(ref cause) => cause,
-            ListPHIDetectionJobsError::InvalidRequest(ref cause) => cause,
-            ListPHIDetectionJobsError::TooManyRequests(ref cause) => cause,
+            ListPHIDetectionJobsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListPHIDetectionJobsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPHIDetectionJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPHIDetectionJobsError {}
 /// Errors returned by StartEntitiesDetectionV2Job
 #[derive(Debug, PartialEq)]
 pub enum StartEntitiesDetectionV2JobError {
@@ -971,19 +951,15 @@ impl StartEntitiesDetectionV2JobError {
 }
 impl fmt::Display for StartEntitiesDetectionV2JobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartEntitiesDetectionV2JobError {
-    fn description(&self) -> &str {
         match *self {
-            StartEntitiesDetectionV2JobError::InternalServer(ref cause) => cause,
-            StartEntitiesDetectionV2JobError::InvalidRequest(ref cause) => cause,
-            StartEntitiesDetectionV2JobError::ResourceNotFound(ref cause) => cause,
-            StartEntitiesDetectionV2JobError::TooManyRequests(ref cause) => cause,
+            StartEntitiesDetectionV2JobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StartEntitiesDetectionV2JobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartEntitiesDetectionV2JobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartEntitiesDetectionV2JobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartEntitiesDetectionV2JobError {}
 /// Errors returned by StartPHIDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StartPHIDetectionJobError {
@@ -1026,19 +1002,15 @@ impl StartPHIDetectionJobError {
 }
 impl fmt::Display for StartPHIDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartPHIDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartPHIDetectionJobError::InternalServer(ref cause) => cause,
-            StartPHIDetectionJobError::InvalidRequest(ref cause) => cause,
-            StartPHIDetectionJobError::ResourceNotFound(ref cause) => cause,
-            StartPHIDetectionJobError::TooManyRequests(ref cause) => cause,
+            StartPHIDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StartPHIDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartPHIDetectionJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartPHIDetectionJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartPHIDetectionJobError {}
 /// Errors returned by StopEntitiesDetectionV2Job
 #[derive(Debug, PartialEq)]
 pub enum StopEntitiesDetectionV2JobError {
@@ -1080,18 +1052,14 @@ impl StopEntitiesDetectionV2JobError {
 }
 impl fmt::Display for StopEntitiesDetectionV2JobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopEntitiesDetectionV2JobError {
-    fn description(&self) -> &str {
         match *self {
-            StopEntitiesDetectionV2JobError::InternalServer(ref cause) => cause,
-            StopEntitiesDetectionV2JobError::InvalidRequest(ref cause) => cause,
-            StopEntitiesDetectionV2JobError::ResourceNotFound(ref cause) => cause,
+            StopEntitiesDetectionV2JobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StopEntitiesDetectionV2JobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopEntitiesDetectionV2JobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopEntitiesDetectionV2JobError {}
 /// Errors returned by StopPHIDetectionJob
 #[derive(Debug, PartialEq)]
 pub enum StopPHIDetectionJobError {
@@ -1127,18 +1095,14 @@ impl StopPHIDetectionJobError {
 }
 impl fmt::Display for StopPHIDetectionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopPHIDetectionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopPHIDetectionJobError::InternalServer(ref cause) => cause,
-            StopPHIDetectionJobError::InvalidRequest(ref cause) => cause,
-            StopPHIDetectionJobError::ResourceNotFound(ref cause) => cause,
+            StopPHIDetectionJobError::InternalServer(ref cause) => write!(f, "{}", cause),
+            StopPHIDetectionJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopPHIDetectionJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopPHIDetectionJobError {}
 /// Trait representing the capabilities of the ComprehendMedical API. ComprehendMedical clients implement this trait.
 pub trait ComprehendMedical {
     /// <p>Gets the properties associated with a medical entities detection job. Use this operation to get the status of a detection job.</p>

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -3565,16 +3565,14 @@ impl BatchGetAggregateResourceConfigError {
 }
 impl fmt::Display for BatchGetAggregateResourceConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetAggregateResourceConfigError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetAggregateResourceConfigError::NoSuchConfigurationAggregator(ref cause) => cause,
+            BatchGetAggregateResourceConfigError::NoSuchConfigurationAggregator(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchGetAggregateResourceConfigError {}
 /// Errors returned by BatchGetResourceConfig
 #[derive(Debug, PartialEq)]
 pub enum BatchGetResourceConfigError {
@@ -3600,16 +3598,14 @@ impl BatchGetResourceConfigError {
 }
 impl fmt::Display for BatchGetResourceConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetResourceConfigError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetResourceConfigError::NoAvailableConfigurationRecorder(ref cause) => cause,
+            BatchGetResourceConfigError::NoAvailableConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchGetResourceConfigError {}
 /// Errors returned by DeleteAggregationAuthorization
 #[derive(Debug, PartialEq)]
 pub enum DeleteAggregationAuthorizationError {
@@ -3637,16 +3633,14 @@ impl DeleteAggregationAuthorizationError {
 }
 impl fmt::Display for DeleteAggregationAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAggregationAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAggregationAuthorizationError::InvalidParameterValue(ref cause) => cause,
+            DeleteAggregationAuthorizationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteAggregationAuthorizationError {}
 /// Errors returned by DeleteConfigRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteConfigRuleError {
@@ -3675,17 +3669,13 @@ impl DeleteConfigRuleError {
 }
 impl fmt::Display for DeleteConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConfigRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConfigRuleError::NoSuchConfigRule(ref cause) => cause,
-            DeleteConfigRuleError::ResourceInUse(ref cause) => cause,
+            DeleteConfigRuleError::NoSuchConfigRule(ref cause) => write!(f, "{}", cause),
+            DeleteConfigRuleError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConfigRuleError {}
 /// Errors returned by DeleteConfigurationAggregator
 #[derive(Debug, PartialEq)]
 pub enum DeleteConfigurationAggregatorError {
@@ -3713,16 +3703,14 @@ impl DeleteConfigurationAggregatorError {
 }
 impl fmt::Display for DeleteConfigurationAggregatorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConfigurationAggregatorError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConfigurationAggregatorError::NoSuchConfigurationAggregator(ref cause) => cause,
+            DeleteConfigurationAggregatorError::NoSuchConfigurationAggregator(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteConfigurationAggregatorError {}
 /// Errors returned by DeleteConfigurationRecorder
 #[derive(Debug, PartialEq)]
 pub enum DeleteConfigurationRecorderError {
@@ -3750,16 +3738,14 @@ impl DeleteConfigurationRecorderError {
 }
 impl fmt::Display for DeleteConfigurationRecorderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConfigurationRecorderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConfigurationRecorderError::NoSuchConfigurationRecorder(ref cause) => cause,
+            DeleteConfigurationRecorderError::NoSuchConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteConfigurationRecorderError {}
 /// Errors returned by DeleteConformancePack
 #[derive(Debug, PartialEq)]
 pub enum DeleteConformancePackError {
@@ -3790,17 +3776,13 @@ impl DeleteConformancePackError {
 }
 impl fmt::Display for DeleteConformancePackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConformancePackError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConformancePackError::NoSuchConformancePack(ref cause) => cause,
-            DeleteConformancePackError::ResourceInUse(ref cause) => cause,
+            DeleteConformancePackError::NoSuchConformancePack(ref cause) => write!(f, "{}", cause),
+            DeleteConformancePackError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConformancePackError {}
 /// Errors returned by DeleteDeliveryChannel
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeliveryChannelError {
@@ -3833,17 +3815,15 @@ impl DeleteDeliveryChannelError {
 }
 impl fmt::Display for DeleteDeliveryChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeliveryChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeliveryChannelError::LastDeliveryChannelDeleteFailed(ref cause) => cause,
-            DeleteDeliveryChannelError::NoSuchDeliveryChannel(ref cause) => cause,
+            DeleteDeliveryChannelError::LastDeliveryChannelDeleteFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDeliveryChannelError::NoSuchDeliveryChannel(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeliveryChannelError {}
 /// Errors returned by DeleteEvaluationResults
 #[derive(Debug, PartialEq)]
 pub enum DeleteEvaluationResultsError {
@@ -3876,17 +3856,13 @@ impl DeleteEvaluationResultsError {
 }
 impl fmt::Display for DeleteEvaluationResultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEvaluationResultsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEvaluationResultsError::NoSuchConfigRule(ref cause) => cause,
-            DeleteEvaluationResultsError::ResourceInUse(ref cause) => cause,
+            DeleteEvaluationResultsError::NoSuchConfigRule(ref cause) => write!(f, "{}", cause),
+            DeleteEvaluationResultsError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEvaluationResultsError {}
 /// Errors returned by DeleteOrganizationConfigRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteOrganizationConfigRuleError {
@@ -3928,18 +3904,18 @@ impl DeleteOrganizationConfigRuleError {
 }
 impl fmt::Display for DeleteOrganizationConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOrganizationConfigRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteOrganizationConfigRuleError::NoSuchOrganizationConfigRule(ref cause) => cause,
-            DeleteOrganizationConfigRuleError::OrganizationAccessDenied(ref cause) => cause,
-            DeleteOrganizationConfigRuleError::ResourceInUse(ref cause) => cause,
+            DeleteOrganizationConfigRuleError::NoSuchOrganizationConfigRule(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOrganizationConfigRuleError::OrganizationAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOrganizationConfigRuleError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteOrganizationConfigRuleError {}
 /// Errors returned by DeleteOrganizationConformancePack
 #[derive(Debug, PartialEq)]
 pub enum DeleteOrganizationConformancePackError {
@@ -3983,20 +3959,20 @@ impl DeleteOrganizationConformancePackError {
 }
 impl fmt::Display for DeleteOrganizationConformancePackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOrganizationConformancePackError {
-    fn description(&self) -> &str {
         match *self {
             DeleteOrganizationConformancePackError::NoSuchOrganizationConformancePack(
                 ref cause,
-            ) => cause,
-            DeleteOrganizationConformancePackError::OrganizationAccessDenied(ref cause) => cause,
-            DeleteOrganizationConformancePackError::ResourceInUse(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DeleteOrganizationConformancePackError::OrganizationAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOrganizationConformancePackError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteOrganizationConformancePackError {}
 /// Errors returned by DeletePendingAggregationRequest
 #[derive(Debug, PartialEq)]
 pub enum DeletePendingAggregationRequestError {
@@ -4024,16 +4000,14 @@ impl DeletePendingAggregationRequestError {
 }
 impl fmt::Display for DeletePendingAggregationRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePendingAggregationRequestError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePendingAggregationRequestError::InvalidParameterValue(ref cause) => cause,
+            DeletePendingAggregationRequestError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeletePendingAggregationRequestError {}
 /// Errors returned by DeleteRemediationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteRemediationConfigurationError {
@@ -4070,17 +4044,17 @@ impl DeleteRemediationConfigurationError {
 }
 impl fmt::Display for DeleteRemediationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRemediationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRemediationConfigurationError::NoSuchRemediationConfiguration(ref cause) => cause,
-            DeleteRemediationConfigurationError::RemediationInProgress(ref cause) => cause,
+            DeleteRemediationConfigurationError::NoSuchRemediationConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRemediationConfigurationError::RemediationInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRemediationConfigurationError {}
 /// Errors returned by DeleteRemediationExceptions
 #[derive(Debug, PartialEq)]
 pub enum DeleteRemediationExceptionsError {
@@ -4108,16 +4082,14 @@ impl DeleteRemediationExceptionsError {
 }
 impl fmt::Display for DeleteRemediationExceptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRemediationExceptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRemediationExceptionsError::NoSuchRemediation(ref cause) => cause,
+            DeleteRemediationExceptionsError::NoSuchRemediation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRemediationExceptionsError {}
 /// Errors returned by DeleteResourceConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourceConfigError {
@@ -4143,16 +4115,14 @@ impl DeleteResourceConfigError {
 }
 impl fmt::Display for DeleteResourceConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourceConfigError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourceConfigError::NoRunningConfigurationRecorder(ref cause) => cause,
+            DeleteResourceConfigError::NoRunningConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteResourceConfigError {}
 /// Errors returned by DeleteRetentionConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteRetentionConfigurationError {
@@ -4187,17 +4157,17 @@ impl DeleteRetentionConfigurationError {
 }
 impl fmt::Display for DeleteRetentionConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRetentionConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRetentionConfigurationError::InvalidParameterValue(ref cause) => cause,
-            DeleteRetentionConfigurationError::NoSuchRetentionConfiguration(ref cause) => cause,
+            DeleteRetentionConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRetentionConfigurationError::NoSuchRetentionConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRetentionConfigurationError {}
 /// Errors returned by DeliverConfigSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeliverConfigSnapshotError {
@@ -4237,18 +4207,18 @@ impl DeliverConfigSnapshotError {
 }
 impl fmt::Display for DeliverConfigSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeliverConfigSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeliverConfigSnapshotError::NoAvailableConfigurationRecorder(ref cause) => cause,
-            DeliverConfigSnapshotError::NoRunningConfigurationRecorder(ref cause) => cause,
-            DeliverConfigSnapshotError::NoSuchDeliveryChannel(ref cause) => cause,
+            DeliverConfigSnapshotError::NoAvailableConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeliverConfigSnapshotError::NoRunningConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeliverConfigSnapshotError::NoSuchDeliveryChannel(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeliverConfigSnapshotError {}
 /// Errors returned by DescribeAggregateComplianceByConfigRules
 #[derive(Debug, PartialEq)]
 pub enum DescribeAggregateComplianceByConfigRulesError {
@@ -4290,20 +4260,20 @@ impl DescribeAggregateComplianceByConfigRulesError {
 }
 impl fmt::Display for DescribeAggregateComplianceByConfigRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAggregateComplianceByConfigRulesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAggregateComplianceByConfigRulesError::InvalidLimit(ref cause) => cause,
-            DescribeAggregateComplianceByConfigRulesError::InvalidNextToken(ref cause) => cause,
+            DescribeAggregateComplianceByConfigRulesError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAggregateComplianceByConfigRulesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeAggregateComplianceByConfigRulesError::NoSuchConfigurationAggregator(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAggregateComplianceByConfigRulesError {}
 /// Errors returned by DescribeAggregationAuthorizations
 #[derive(Debug, PartialEq)]
 pub enum DescribeAggregationAuthorizationsError {
@@ -4345,18 +4315,20 @@ impl DescribeAggregationAuthorizationsError {
 }
 impl fmt::Display for DescribeAggregationAuthorizationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAggregationAuthorizationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAggregationAuthorizationsError::InvalidLimit(ref cause) => cause,
-            DescribeAggregationAuthorizationsError::InvalidNextToken(ref cause) => cause,
-            DescribeAggregationAuthorizationsError::InvalidParameterValue(ref cause) => cause,
+            DescribeAggregationAuthorizationsError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAggregationAuthorizationsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAggregationAuthorizationsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAggregationAuthorizationsError {}
 /// Errors returned by DescribeComplianceByConfigRule
 #[derive(Debug, PartialEq)]
 pub enum DescribeComplianceByConfigRuleError {
@@ -4398,18 +4370,20 @@ impl DescribeComplianceByConfigRuleError {
 }
 impl fmt::Display for DescribeComplianceByConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeComplianceByConfigRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeComplianceByConfigRuleError::InvalidNextToken(ref cause) => cause,
-            DescribeComplianceByConfigRuleError::InvalidParameterValue(ref cause) => cause,
-            DescribeComplianceByConfigRuleError::NoSuchConfigRule(ref cause) => cause,
+            DescribeComplianceByConfigRuleError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeComplianceByConfigRuleError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeComplianceByConfigRuleError::NoSuchConfigRule(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeComplianceByConfigRuleError {}
 /// Errors returned by DescribeComplianceByResource
 #[derive(Debug, PartialEq)]
 pub enum DescribeComplianceByResourceError {
@@ -4444,17 +4418,17 @@ impl DescribeComplianceByResourceError {
 }
 impl fmt::Display for DescribeComplianceByResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeComplianceByResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeComplianceByResourceError::InvalidNextToken(ref cause) => cause,
-            DescribeComplianceByResourceError::InvalidParameterValue(ref cause) => cause,
+            DescribeComplianceByResourceError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeComplianceByResourceError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeComplianceByResourceError {}
 /// Errors returned by DescribeConfigRuleEvaluationStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigRuleEvaluationStatusError {
@@ -4496,18 +4470,20 @@ impl DescribeConfigRuleEvaluationStatusError {
 }
 impl fmt::Display for DescribeConfigRuleEvaluationStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigRuleEvaluationStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigRuleEvaluationStatusError::InvalidNextToken(ref cause) => cause,
-            DescribeConfigRuleEvaluationStatusError::InvalidParameterValue(ref cause) => cause,
-            DescribeConfigRuleEvaluationStatusError::NoSuchConfigRule(ref cause) => cause,
+            DescribeConfigRuleEvaluationStatusError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigRuleEvaluationStatusError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigRuleEvaluationStatusError::NoSuchConfigRule(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConfigRuleEvaluationStatusError {}
 /// Errors returned by DescribeConfigRules
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigRulesError {
@@ -4540,17 +4516,13 @@ impl DescribeConfigRulesError {
 }
 impl fmt::Display for DescribeConfigRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigRulesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigRulesError::InvalidNextToken(ref cause) => cause,
-            DescribeConfigRulesError::NoSuchConfigRule(ref cause) => cause,
+            DescribeConfigRulesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeConfigRulesError::NoSuchConfigRule(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigRulesError {}
 /// Errors returned by DescribeConfigurationAggregatorSourcesStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationAggregatorSourcesStatusError {
@@ -4583,23 +4555,23 @@ _ => {}
 }
 impl fmt::Display for DescribeConfigurationAggregatorSourcesStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationAggregatorSourcesStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationAggregatorSourcesStatusError::InvalidLimit(ref cause) => cause,
-            DescribeConfigurationAggregatorSourcesStatusError::InvalidNextToken(ref cause) => cause,
+            DescribeConfigurationAggregatorSourcesStatusError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigurationAggregatorSourcesStatusError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeConfigurationAggregatorSourcesStatusError::InvalidParameterValue(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DescribeConfigurationAggregatorSourcesStatusError::NoSuchConfigurationAggregator(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationAggregatorSourcesStatusError {}
 /// Errors returned by DescribeConfigurationAggregators
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationAggregatorsError {
@@ -4650,21 +4622,23 @@ impl DescribeConfigurationAggregatorsError {
 }
 impl fmt::Display for DescribeConfigurationAggregatorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationAggregatorsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationAggregatorsError::InvalidLimit(ref cause) => cause,
-            DescribeConfigurationAggregatorsError::InvalidNextToken(ref cause) => cause,
-            DescribeConfigurationAggregatorsError::InvalidParameterValue(ref cause) => cause,
+            DescribeConfigurationAggregatorsError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigurationAggregatorsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigurationAggregatorsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeConfigurationAggregatorsError::NoSuchConfigurationAggregator(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeConfigurationAggregatorsError {}
 /// Errors returned by DescribeConfigurationRecorderStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationRecorderStatusError {
@@ -4694,18 +4668,14 @@ impl DescribeConfigurationRecorderStatusError {
 }
 impl fmt::Display for DescribeConfigurationRecorderStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationRecorderStatusError {
-    fn description(&self) -> &str {
         match *self {
             DescribeConfigurationRecorderStatusError::NoSuchConfigurationRecorder(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeConfigurationRecorderStatusError {}
 /// Errors returned by DescribeConfigurationRecorders
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationRecordersError {
@@ -4733,16 +4703,14 @@ impl DescribeConfigurationRecordersError {
 }
 impl fmt::Display for DescribeConfigurationRecordersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationRecordersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationRecordersError::NoSuchConfigurationRecorder(ref cause) => cause,
+            DescribeConfigurationRecordersError::NoSuchConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConfigurationRecordersError {}
 /// Errors returned by DescribeConformancePackCompliance
 #[derive(Debug, PartialEq)]
 pub enum DescribeConformancePackComplianceError {
@@ -4800,22 +4768,26 @@ impl DescribeConformancePackComplianceError {
 }
 impl fmt::Display for DescribeConformancePackComplianceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConformancePackComplianceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConformancePackComplianceError::InvalidLimit(ref cause) => cause,
-            DescribeConformancePackComplianceError::InvalidNextToken(ref cause) => cause,
-            DescribeConformancePackComplianceError::InvalidParameterValue(ref cause) => cause,
+            DescribeConformancePackComplianceError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConformancePackComplianceError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConformancePackComplianceError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeConformancePackComplianceError::NoSuchConfigRuleInConformancePack(
                 ref cause,
-            ) => cause,
-            DescribeConformancePackComplianceError::NoSuchConformancePack(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DescribeConformancePackComplianceError::NoSuchConformancePack(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConformancePackComplianceError {}
 /// Errors returned by DescribeConformancePackStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeConformancePackStatusError {
@@ -4850,17 +4822,15 @@ impl DescribeConformancePackStatusError {
 }
 impl fmt::Display for DescribeConformancePackStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConformancePackStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConformancePackStatusError::InvalidLimit(ref cause) => cause,
-            DescribeConformancePackStatusError::InvalidNextToken(ref cause) => cause,
+            DescribeConformancePackStatusError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            DescribeConformancePackStatusError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConformancePackStatusError {}
 /// Errors returned by DescribeConformancePacks
 #[derive(Debug, PartialEq)]
 pub enum DescribeConformancePacksError {
@@ -4900,18 +4870,16 @@ impl DescribeConformancePacksError {
 }
 impl fmt::Display for DescribeConformancePacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConformancePacksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConformancePacksError::InvalidLimit(ref cause) => cause,
-            DescribeConformancePacksError::InvalidNextToken(ref cause) => cause,
-            DescribeConformancePacksError::NoSuchConformancePack(ref cause) => cause,
+            DescribeConformancePacksError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            DescribeConformancePacksError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeConformancePacksError::NoSuchConformancePack(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConformancePacksError {}
 /// Errors returned by DescribeDeliveryChannelStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeDeliveryChannelStatusError {
@@ -4939,16 +4907,14 @@ impl DescribeDeliveryChannelStatusError {
 }
 impl fmt::Display for DescribeDeliveryChannelStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDeliveryChannelStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDeliveryChannelStatusError::NoSuchDeliveryChannel(ref cause) => cause,
+            DescribeDeliveryChannelStatusError::NoSuchDeliveryChannel(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDeliveryChannelStatusError {}
 /// Errors returned by DescribeDeliveryChannels
 #[derive(Debug, PartialEq)]
 pub enum DescribeDeliveryChannelsError {
@@ -4974,16 +4940,14 @@ impl DescribeDeliveryChannelsError {
 }
 impl fmt::Display for DescribeDeliveryChannelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDeliveryChannelsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDeliveryChannelsError::NoSuchDeliveryChannel(ref cause) => cause,
+            DescribeDeliveryChannelsError::NoSuchDeliveryChannel(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDeliveryChannelsError {}
 /// Errors returned by DescribeOrganizationConfigRuleStatuses
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrganizationConfigRuleStatusesError {
@@ -5036,23 +5000,23 @@ impl DescribeOrganizationConfigRuleStatusesError {
 }
 impl fmt::Display for DescribeOrganizationConfigRuleStatusesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrganizationConfigRuleStatusesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOrganizationConfigRuleStatusesError::InvalidLimit(ref cause) => cause,
-            DescribeOrganizationConfigRuleStatusesError::InvalidNextToken(ref cause) => cause,
+            DescribeOrganizationConfigRuleStatusesError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationConfigRuleStatusesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeOrganizationConfigRuleStatusesError::NoSuchOrganizationConfigRule(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             DescribeOrganizationConfigRuleStatusesError::OrganizationAccessDenied(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeOrganizationConfigRuleStatusesError {}
 /// Errors returned by DescribeOrganizationConfigRules
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrganizationConfigRulesError {
@@ -5101,19 +5065,21 @@ impl DescribeOrganizationConfigRulesError {
 }
 impl fmt::Display for DescribeOrganizationConfigRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrganizationConfigRulesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOrganizationConfigRulesError::InvalidLimit(ref cause) => cause,
-            DescribeOrganizationConfigRulesError::InvalidNextToken(ref cause) => cause,
-            DescribeOrganizationConfigRulesError::NoSuchOrganizationConfigRule(ref cause) => cause,
-            DescribeOrganizationConfigRulesError::OrganizationAccessDenied(ref cause) => cause,
+            DescribeOrganizationConfigRulesError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationConfigRulesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationConfigRulesError::NoSuchOrganizationConfigRule(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationConfigRulesError::OrganizationAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeOrganizationConfigRulesError {}
 /// Errors returned by DescribeOrganizationConformancePackStatuses
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrganizationConformancePackStatusesError {
@@ -5146,23 +5112,23 @@ _ => {}
 }
 impl fmt::Display for DescribeOrganizationConformancePackStatusesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrganizationConformancePackStatusesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOrganizationConformancePackStatusesError::InvalidLimit(ref cause) => cause,
-            DescribeOrganizationConformancePackStatusesError::InvalidNextToken(ref cause) => cause,
+            DescribeOrganizationConformancePackStatusesError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationConformancePackStatusesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeOrganizationConformancePackStatusesError::NoSuchOrganizationConformancePack(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             DescribeOrganizationConformancePackStatusesError::OrganizationAccessDenied(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeOrganizationConformancePackStatusesError {}
 /// Errors returned by DescribeOrganizationConformancePacks
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrganizationConformancePacksError {
@@ -5213,21 +5179,23 @@ impl DescribeOrganizationConformancePacksError {
 }
 impl fmt::Display for DescribeOrganizationConformancePacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrganizationConformancePacksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOrganizationConformancePacksError::InvalidLimit(ref cause) => cause,
-            DescribeOrganizationConformancePacksError::InvalidNextToken(ref cause) => cause,
+            DescribeOrganizationConformancePacksError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationConformancePacksError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeOrganizationConformancePacksError::NoSuchOrganizationConformancePack(
                 ref cause,
-            ) => cause,
-            DescribeOrganizationConformancePacksError::OrganizationAccessDenied(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DescribeOrganizationConformancePacksError::OrganizationAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeOrganizationConformancePacksError {}
 /// Errors returned by DescribePendingAggregationRequests
 #[derive(Debug, PartialEq)]
 pub enum DescribePendingAggregationRequestsError {
@@ -5269,18 +5237,20 @@ impl DescribePendingAggregationRequestsError {
 }
 impl fmt::Display for DescribePendingAggregationRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePendingAggregationRequestsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePendingAggregationRequestsError::InvalidLimit(ref cause) => cause,
-            DescribePendingAggregationRequestsError::InvalidNextToken(ref cause) => cause,
-            DescribePendingAggregationRequestsError::InvalidParameterValue(ref cause) => cause,
+            DescribePendingAggregationRequestsError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePendingAggregationRequestsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePendingAggregationRequestsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePendingAggregationRequestsError {}
 /// Errors returned by DescribeRemediationConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeRemediationConfigurationsError {}
@@ -5300,14 +5270,10 @@ impl DescribeRemediationConfigurationsError {
 }
 impl fmt::Display for DescribeRemediationConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRemediationConfigurationsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeRemediationConfigurationsError {}
 /// Errors returned by DescribeRemediationExceptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeRemediationExceptionsError {
@@ -5342,17 +5308,17 @@ impl DescribeRemediationExceptionsError {
 }
 impl fmt::Display for DescribeRemediationExceptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRemediationExceptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRemediationExceptionsError::InvalidNextToken(ref cause) => cause,
-            DescribeRemediationExceptionsError::InvalidParameterValue(ref cause) => cause,
+            DescribeRemediationExceptionsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeRemediationExceptionsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeRemediationExceptionsError {}
 /// Errors returned by DescribeRemediationExecutionStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeRemediationExecutionStatusError {
@@ -5389,19 +5355,17 @@ impl DescribeRemediationExecutionStatusError {
 }
 impl fmt::Display for DescribeRemediationExecutionStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRemediationExecutionStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRemediationExecutionStatusError::InvalidNextToken(ref cause) => cause,
+            DescribeRemediationExecutionStatusError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeRemediationExecutionStatusError::NoSuchRemediationConfiguration(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeRemediationExecutionStatusError {}
 /// Errors returned by DescribeRetentionConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeRetentionConfigurationsError {
@@ -5443,18 +5407,20 @@ impl DescribeRetentionConfigurationsError {
 }
 impl fmt::Display for DescribeRetentionConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRetentionConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRetentionConfigurationsError::InvalidNextToken(ref cause) => cause,
-            DescribeRetentionConfigurationsError::InvalidParameterValue(ref cause) => cause,
-            DescribeRetentionConfigurationsError::NoSuchRetentionConfiguration(ref cause) => cause,
+            DescribeRetentionConfigurationsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeRetentionConfigurationsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeRetentionConfigurationsError::NoSuchRetentionConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeRetentionConfigurationsError {}
 /// Errors returned by GetAggregateComplianceDetailsByConfigRule
 #[derive(Debug, PartialEq)]
 pub enum GetAggregateComplianceDetailsByConfigRuleError {
@@ -5496,20 +5462,20 @@ impl GetAggregateComplianceDetailsByConfigRuleError {
 }
 impl fmt::Display for GetAggregateComplianceDetailsByConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAggregateComplianceDetailsByConfigRuleError {
-    fn description(&self) -> &str {
         match *self {
-            GetAggregateComplianceDetailsByConfigRuleError::InvalidLimit(ref cause) => cause,
-            GetAggregateComplianceDetailsByConfigRuleError::InvalidNextToken(ref cause) => cause,
+            GetAggregateComplianceDetailsByConfigRuleError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAggregateComplianceDetailsByConfigRuleError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetAggregateComplianceDetailsByConfigRuleError::NoSuchConfigurationAggregator(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAggregateComplianceDetailsByConfigRuleError {}
 /// Errors returned by GetAggregateConfigRuleComplianceSummary
 #[derive(Debug, PartialEq)]
 pub enum GetAggregateConfigRuleComplianceSummaryError {
@@ -5553,20 +5519,20 @@ impl GetAggregateConfigRuleComplianceSummaryError {
 }
 impl fmt::Display for GetAggregateConfigRuleComplianceSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAggregateConfigRuleComplianceSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            GetAggregateConfigRuleComplianceSummaryError::InvalidLimit(ref cause) => cause,
-            GetAggregateConfigRuleComplianceSummaryError::InvalidNextToken(ref cause) => cause,
+            GetAggregateConfigRuleComplianceSummaryError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAggregateConfigRuleComplianceSummaryError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetAggregateConfigRuleComplianceSummaryError::NoSuchConfigurationAggregator(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAggregateConfigRuleComplianceSummaryError {}
 /// Errors returned by GetAggregateDiscoveredResourceCounts
 #[derive(Debug, PartialEq)]
 pub enum GetAggregateDiscoveredResourceCountsError {
@@ -5610,20 +5576,20 @@ impl GetAggregateDiscoveredResourceCountsError {
 }
 impl fmt::Display for GetAggregateDiscoveredResourceCountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAggregateDiscoveredResourceCountsError {
-    fn description(&self) -> &str {
         match *self {
-            GetAggregateDiscoveredResourceCountsError::InvalidLimit(ref cause) => cause,
-            GetAggregateDiscoveredResourceCountsError::InvalidNextToken(ref cause) => cause,
+            GetAggregateDiscoveredResourceCountsError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAggregateDiscoveredResourceCountsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetAggregateDiscoveredResourceCountsError::NoSuchConfigurationAggregator(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GetAggregateDiscoveredResourceCountsError {}
 /// Errors returned by GetAggregateResourceConfig
 #[derive(Debug, PartialEq)]
 pub enum GetAggregateResourceConfigError {
@@ -5665,18 +5631,20 @@ impl GetAggregateResourceConfigError {
 }
 impl fmt::Display for GetAggregateResourceConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAggregateResourceConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetAggregateResourceConfigError::NoSuchConfigurationAggregator(ref cause) => cause,
-            GetAggregateResourceConfigError::OversizedConfigurationItem(ref cause) => cause,
-            GetAggregateResourceConfigError::ResourceNotDiscovered(ref cause) => cause,
+            GetAggregateResourceConfigError::NoSuchConfigurationAggregator(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAggregateResourceConfigError::OversizedConfigurationItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAggregateResourceConfigError::ResourceNotDiscovered(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetAggregateResourceConfigError {}
 /// Errors returned by GetComplianceDetailsByConfigRule
 #[derive(Debug, PartialEq)]
 pub enum GetComplianceDetailsByConfigRuleError {
@@ -5718,18 +5686,20 @@ impl GetComplianceDetailsByConfigRuleError {
 }
 impl fmt::Display for GetComplianceDetailsByConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetComplianceDetailsByConfigRuleError {
-    fn description(&self) -> &str {
         match *self {
-            GetComplianceDetailsByConfigRuleError::InvalidNextToken(ref cause) => cause,
-            GetComplianceDetailsByConfigRuleError::InvalidParameterValue(ref cause) => cause,
-            GetComplianceDetailsByConfigRuleError::NoSuchConfigRule(ref cause) => cause,
+            GetComplianceDetailsByConfigRuleError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetComplianceDetailsByConfigRuleError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetComplianceDetailsByConfigRuleError::NoSuchConfigRule(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetComplianceDetailsByConfigRuleError {}
 /// Errors returned by GetComplianceDetailsByResource
 #[derive(Debug, PartialEq)]
 pub enum GetComplianceDetailsByResourceError {
@@ -5757,16 +5727,14 @@ impl GetComplianceDetailsByResourceError {
 }
 impl fmt::Display for GetComplianceDetailsByResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetComplianceDetailsByResourceError {
-    fn description(&self) -> &str {
         match *self {
-            GetComplianceDetailsByResourceError::InvalidParameterValue(ref cause) => cause,
+            GetComplianceDetailsByResourceError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetComplianceDetailsByResourceError {}
 /// Errors returned by GetComplianceSummaryByConfigRule
 #[derive(Debug, PartialEq)]
 pub enum GetComplianceSummaryByConfigRuleError {}
@@ -5786,14 +5754,10 @@ impl GetComplianceSummaryByConfigRuleError {
 }
 impl fmt::Display for GetComplianceSummaryByConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetComplianceSummaryByConfigRuleError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetComplianceSummaryByConfigRuleError {}
 /// Errors returned by GetComplianceSummaryByResourceType
 #[derive(Debug, PartialEq)]
 pub enum GetComplianceSummaryByResourceTypeError {
@@ -5821,16 +5785,14 @@ impl GetComplianceSummaryByResourceTypeError {
 }
 impl fmt::Display for GetComplianceSummaryByResourceTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetComplianceSummaryByResourceTypeError {
-    fn description(&self) -> &str {
         match *self {
-            GetComplianceSummaryByResourceTypeError::InvalidParameterValue(ref cause) => cause,
+            GetComplianceSummaryByResourceTypeError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetComplianceSummaryByResourceTypeError {}
 /// Errors returned by GetConformancePackComplianceDetails
 #[derive(Debug, PartialEq)]
 pub enum GetConformancePackComplianceDetailsError {
@@ -5888,22 +5850,26 @@ impl GetConformancePackComplianceDetailsError {
 }
 impl fmt::Display for GetConformancePackComplianceDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConformancePackComplianceDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetConformancePackComplianceDetailsError::InvalidLimit(ref cause) => cause,
-            GetConformancePackComplianceDetailsError::InvalidNextToken(ref cause) => cause,
-            GetConformancePackComplianceDetailsError::InvalidParameterValue(ref cause) => cause,
+            GetConformancePackComplianceDetailsError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetConformancePackComplianceDetailsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetConformancePackComplianceDetailsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetConformancePackComplianceDetailsError::NoSuchConfigRuleInConformancePack(
                 ref cause,
-            ) => cause,
-            GetConformancePackComplianceDetailsError::NoSuchConformancePack(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            GetConformancePackComplianceDetailsError::NoSuchConformancePack(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetConformancePackComplianceDetailsError {}
 /// Errors returned by GetConformancePackComplianceSummary
 #[derive(Debug, PartialEq)]
 pub enum GetConformancePackComplianceSummaryError {
@@ -5945,18 +5911,20 @@ impl GetConformancePackComplianceSummaryError {
 }
 impl fmt::Display for GetConformancePackComplianceSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConformancePackComplianceSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            GetConformancePackComplianceSummaryError::InvalidLimit(ref cause) => cause,
-            GetConformancePackComplianceSummaryError::InvalidNextToken(ref cause) => cause,
-            GetConformancePackComplianceSummaryError::NoSuchConformancePack(ref cause) => cause,
+            GetConformancePackComplianceSummaryError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetConformancePackComplianceSummaryError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetConformancePackComplianceSummaryError::NoSuchConformancePack(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetConformancePackComplianceSummaryError {}
 /// Errors returned by GetDiscoveredResourceCounts
 #[derive(Debug, PartialEq)]
 pub enum GetDiscoveredResourceCountsError {
@@ -5991,17 +5959,13 @@ impl GetDiscoveredResourceCountsError {
 }
 impl fmt::Display for GetDiscoveredResourceCountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDiscoveredResourceCountsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDiscoveredResourceCountsError::InvalidLimit(ref cause) => cause,
-            GetDiscoveredResourceCountsError::InvalidNextToken(ref cause) => cause,
+            GetDiscoveredResourceCountsError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            GetDiscoveredResourceCountsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDiscoveredResourceCountsError {}
 /// Errors returned by GetOrganizationConfigRuleDetailedStatus
 #[derive(Debug, PartialEq)]
 pub enum GetOrganizationConfigRuleDetailedStatusError {
@@ -6054,23 +6018,23 @@ impl GetOrganizationConfigRuleDetailedStatusError {
 }
 impl fmt::Display for GetOrganizationConfigRuleDetailedStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOrganizationConfigRuleDetailedStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetOrganizationConfigRuleDetailedStatusError::InvalidLimit(ref cause) => cause,
-            GetOrganizationConfigRuleDetailedStatusError::InvalidNextToken(ref cause) => cause,
+            GetOrganizationConfigRuleDetailedStatusError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetOrganizationConfigRuleDetailedStatusError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetOrganizationConfigRuleDetailedStatusError::NoSuchOrganizationConfigRule(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             GetOrganizationConfigRuleDetailedStatusError::OrganizationAccessDenied(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GetOrganizationConfigRuleDetailedStatusError {}
 /// Errors returned by GetOrganizationConformancePackDetailedStatus
 #[derive(Debug, PartialEq)]
 pub enum GetOrganizationConformancePackDetailedStatusError {
@@ -6103,19 +6067,15 @@ _ => {}
 }
 impl fmt::Display for GetOrganizationConformancePackDetailedStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOrganizationConformancePackDetailedStatusError {
-    fn description(&self) -> &str {
         match *self {
-                            GetOrganizationConformancePackDetailedStatusError::InvalidLimit(ref cause) => cause,
-GetOrganizationConformancePackDetailedStatusError::InvalidNextToken(ref cause) => cause,
-GetOrganizationConformancePackDetailedStatusError::NoSuchOrganizationConformancePack(ref cause) => cause,
-GetOrganizationConformancePackDetailedStatusError::OrganizationAccessDenied(ref cause) => cause
+                            GetOrganizationConformancePackDetailedStatusError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+GetOrganizationConformancePackDetailedStatusError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+GetOrganizationConformancePackDetailedStatusError::NoSuchOrganizationConformancePack(ref cause) => write!(f, "{}", cause),
+GetOrganizationConformancePackDetailedStatusError::OrganizationAccessDenied(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for GetOrganizationConformancePackDetailedStatusError {}
 /// Errors returned by GetResourceConfigHistory
 #[derive(Debug, PartialEq)]
 pub enum GetResourceConfigHistoryError {
@@ -6169,20 +6129,20 @@ impl GetResourceConfigHistoryError {
 }
 impl fmt::Display for GetResourceConfigHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceConfigHistoryError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceConfigHistoryError::InvalidLimit(ref cause) => cause,
-            GetResourceConfigHistoryError::InvalidNextToken(ref cause) => cause,
-            GetResourceConfigHistoryError::InvalidTimeRange(ref cause) => cause,
-            GetResourceConfigHistoryError::NoAvailableConfigurationRecorder(ref cause) => cause,
-            GetResourceConfigHistoryError::ResourceNotDiscovered(ref cause) => cause,
+            GetResourceConfigHistoryError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            GetResourceConfigHistoryError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetResourceConfigHistoryError::InvalidTimeRange(ref cause) => write!(f, "{}", cause),
+            GetResourceConfigHistoryError::NoAvailableConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetResourceConfigHistoryError::ResourceNotDiscovered(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetResourceConfigHistoryError {}
 /// Errors returned by ListAggregateDiscoveredResources
 #[derive(Debug, PartialEq)]
 pub enum ListAggregateDiscoveredResourcesError {
@@ -6226,20 +6186,20 @@ impl ListAggregateDiscoveredResourcesError {
 }
 impl fmt::Display for ListAggregateDiscoveredResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAggregateDiscoveredResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAggregateDiscoveredResourcesError::InvalidLimit(ref cause) => cause,
-            ListAggregateDiscoveredResourcesError::InvalidNextToken(ref cause) => cause,
+            ListAggregateDiscoveredResourcesError::InvalidLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAggregateDiscoveredResourcesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ListAggregateDiscoveredResourcesError::NoSuchConfigurationAggregator(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ListAggregateDiscoveredResourcesError {}
 /// Errors returned by ListDiscoveredResources
 #[derive(Debug, PartialEq)]
 pub enum ListDiscoveredResourcesError {
@@ -6279,18 +6239,16 @@ impl ListDiscoveredResourcesError {
 }
 impl fmt::Display for ListDiscoveredResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDiscoveredResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDiscoveredResourcesError::InvalidLimit(ref cause) => cause,
-            ListDiscoveredResourcesError::InvalidNextToken(ref cause) => cause,
-            ListDiscoveredResourcesError::NoAvailableConfigurationRecorder(ref cause) => cause,
+            ListDiscoveredResourcesError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            ListDiscoveredResourcesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListDiscoveredResourcesError::NoAvailableConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListDiscoveredResourcesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -6328,18 +6286,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InvalidLimit(ref cause) => cause,
-            ListTagsForResourceError::InvalidNextToken(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PutAggregationAuthorization
 #[derive(Debug, PartialEq)]
 pub enum PutAggregationAuthorizationError {
@@ -6367,16 +6321,14 @@ impl PutAggregationAuthorizationError {
 }
 impl fmt::Display for PutAggregationAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAggregationAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            PutAggregationAuthorizationError::InvalidParameterValue(ref cause) => cause,
+            PutAggregationAuthorizationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutAggregationAuthorizationError {}
 /// Errors returned by PutConfigRule
 #[derive(Debug, PartialEq)]
 pub enum PutConfigRuleError {
@@ -6426,20 +6378,18 @@ impl PutConfigRuleError {
 }
 impl fmt::Display for PutConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutConfigRuleError {
-    fn description(&self) -> &str {
         match *self {
-            PutConfigRuleError::InsufficientPermissions(ref cause) => cause,
-            PutConfigRuleError::InvalidParameterValue(ref cause) => cause,
-            PutConfigRuleError::MaxNumberOfConfigRulesExceeded(ref cause) => cause,
-            PutConfigRuleError::NoAvailableConfigurationRecorder(ref cause) => cause,
-            PutConfigRuleError::ResourceInUse(ref cause) => cause,
+            PutConfigRuleError::InsufficientPermissions(ref cause) => write!(f, "{}", cause),
+            PutConfigRuleError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutConfigRuleError::MaxNumberOfConfigRulesExceeded(ref cause) => write!(f, "{}", cause),
+            PutConfigRuleError::NoAvailableConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConfigRuleError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutConfigRuleError {}
 /// Errors returned by PutConfigurationAggregator
 #[derive(Debug, PartialEq)]
 pub enum PutConfigurationAggregatorError {
@@ -6502,21 +6452,25 @@ impl PutConfigurationAggregatorError {
 }
 impl fmt::Display for PutConfigurationAggregatorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutConfigurationAggregatorError {
-    fn description(&self) -> &str {
         match *self {
-            PutConfigurationAggregatorError::InvalidParameterValue(ref cause) => cause,
-            PutConfigurationAggregatorError::InvalidRole(ref cause) => cause,
-            PutConfigurationAggregatorError::LimitExceeded(ref cause) => cause,
-            PutConfigurationAggregatorError::NoAvailableOrganization(ref cause) => cause,
-            PutConfigurationAggregatorError::OrganizationAccessDenied(ref cause) => cause,
-            PutConfigurationAggregatorError::OrganizationAllFeaturesNotEnabled(ref cause) => cause,
+            PutConfigurationAggregatorError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConfigurationAggregatorError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            PutConfigurationAggregatorError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutConfigurationAggregatorError::NoAvailableOrganization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConfigurationAggregatorError::OrganizationAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConfigurationAggregatorError::OrganizationAllFeaturesNotEnabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutConfigurationAggregatorError {}
 /// Errors returned by PutConfigurationRecorder
 #[derive(Debug, PartialEq)]
 pub enum PutConfigurationRecorderError {
@@ -6565,21 +6519,21 @@ impl PutConfigurationRecorderError {
 }
 impl fmt::Display for PutConfigurationRecorderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutConfigurationRecorderError {
-    fn description(&self) -> &str {
         match *self {
-            PutConfigurationRecorderError::InvalidConfigurationRecorderName(ref cause) => cause,
-            PutConfigurationRecorderError::InvalidRecordingGroup(ref cause) => cause,
-            PutConfigurationRecorderError::InvalidRole(ref cause) => cause,
+            PutConfigurationRecorderError::InvalidConfigurationRecorderName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConfigurationRecorderError::InvalidRecordingGroup(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConfigurationRecorderError::InvalidRole(ref cause) => write!(f, "{}", cause),
             PutConfigurationRecorderError::MaxNumberOfConfigurationRecordersExceeded(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for PutConfigurationRecorderError {}
 /// Errors returned by PutConformancePack
 #[derive(Debug, PartialEq)]
 pub enum PutConformancePackError {
@@ -6631,20 +6585,20 @@ impl PutConformancePackError {
 }
 impl fmt::Display for PutConformancePackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutConformancePackError {
-    fn description(&self) -> &str {
         match *self {
-            PutConformancePackError::ConformancePackTemplateValidation(ref cause) => cause,
-            PutConformancePackError::InsufficientPermissions(ref cause) => cause,
-            PutConformancePackError::InvalidParameterValue(ref cause) => cause,
-            PutConformancePackError::MaxNumberOfConformancePacksExceeded(ref cause) => cause,
-            PutConformancePackError::ResourceInUse(ref cause) => cause,
+            PutConformancePackError::ConformancePackTemplateValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConformancePackError::InsufficientPermissions(ref cause) => write!(f, "{}", cause),
+            PutConformancePackError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutConformancePackError::MaxNumberOfConformancePacksExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutConformancePackError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutConformancePackError {}
 /// Errors returned by PutDeliveryChannel
 #[derive(Debug, PartialEq)]
 pub enum PutDeliveryChannelError {
@@ -6710,22 +6664,26 @@ impl PutDeliveryChannelError {
 }
 impl fmt::Display for PutDeliveryChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutDeliveryChannelError {
-    fn description(&self) -> &str {
         match *self {
-            PutDeliveryChannelError::InsufficientDeliveryPolicy(ref cause) => cause,
-            PutDeliveryChannelError::InvalidDeliveryChannelName(ref cause) => cause,
-            PutDeliveryChannelError::InvalidS3KeyPrefix(ref cause) => cause,
-            PutDeliveryChannelError::InvalidSNSTopicARN(ref cause) => cause,
-            PutDeliveryChannelError::MaxNumberOfDeliveryChannelsExceeded(ref cause) => cause,
-            PutDeliveryChannelError::NoAvailableConfigurationRecorder(ref cause) => cause,
-            PutDeliveryChannelError::NoSuchBucket(ref cause) => cause,
+            PutDeliveryChannelError::InsufficientDeliveryPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutDeliveryChannelError::InvalidDeliveryChannelName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutDeliveryChannelError::InvalidS3KeyPrefix(ref cause) => write!(f, "{}", cause),
+            PutDeliveryChannelError::InvalidSNSTopicARN(ref cause) => write!(f, "{}", cause),
+            PutDeliveryChannelError::MaxNumberOfDeliveryChannelsExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutDeliveryChannelError::NoAvailableConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutDeliveryChannelError::NoSuchBucket(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutDeliveryChannelError {}
 /// Errors returned by PutEvaluations
 #[derive(Debug, PartialEq)]
 pub enum PutEvaluationsError {
@@ -6761,18 +6719,14 @@ impl PutEvaluationsError {
 }
 impl fmt::Display for PutEvaluationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutEvaluationsError {
-    fn description(&self) -> &str {
         match *self {
-            PutEvaluationsError::InvalidParameterValue(ref cause) => cause,
-            PutEvaluationsError::InvalidResultToken(ref cause) => cause,
-            PutEvaluationsError::NoSuchConfigRule(ref cause) => cause,
+            PutEvaluationsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutEvaluationsError::InvalidResultToken(ref cause) => write!(f, "{}", cause),
+            PutEvaluationsError::NoSuchConfigRule(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutEvaluationsError {}
 /// Errors returned by PutOrganizationConfigRule
 #[derive(Debug, PartialEq)]
 pub enum PutOrganizationConfigRuleError {
@@ -6842,24 +6796,30 @@ impl PutOrganizationConfigRuleError {
 }
 impl fmt::Display for PutOrganizationConfigRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutOrganizationConfigRuleError {
-    fn description(&self) -> &str {
         match *self {
-            PutOrganizationConfigRuleError::InsufficientPermissions(ref cause) => cause,
-            PutOrganizationConfigRuleError::InvalidParameterValue(ref cause) => cause,
+            PutOrganizationConfigRuleError::InsufficientPermissions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutOrganizationConfigRuleError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             PutOrganizationConfigRuleError::MaxNumberOfOrganizationConfigRulesExceeded(
                 ref cause,
-            ) => cause,
-            PutOrganizationConfigRuleError::NoAvailableOrganization(ref cause) => cause,
-            PutOrganizationConfigRuleError::OrganizationAccessDenied(ref cause) => cause,
-            PutOrganizationConfigRuleError::OrganizationAllFeaturesNotEnabled(ref cause) => cause,
-            PutOrganizationConfigRuleError::ResourceInUse(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            PutOrganizationConfigRuleError::NoAvailableOrganization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutOrganizationConfigRuleError::OrganizationAccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutOrganizationConfigRuleError::OrganizationAllFeaturesNotEnabled(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutOrganizationConfigRuleError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutOrganizationConfigRuleError {}
 /// Errors returned by PutOrganizationConformancePack
 #[derive(Debug, PartialEq)]
 pub enum PutOrganizationConformancePackError {
@@ -6901,22 +6861,18 @@ _ => {}
 }
 impl fmt::Display for PutOrganizationConformancePackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutOrganizationConformancePackError {
-    fn description(&self) -> &str {
         match *self {
-                            PutOrganizationConformancePackError::InsufficientPermissions(ref cause) => cause,
-PutOrganizationConformancePackError::MaxNumberOfOrganizationConformancePacksExceeded(ref cause) => cause,
-PutOrganizationConformancePackError::NoAvailableOrganization(ref cause) => cause,
-PutOrganizationConformancePackError::OrganizationAccessDenied(ref cause) => cause,
-PutOrganizationConformancePackError::OrganizationAllFeaturesNotEnabled(ref cause) => cause,
-PutOrganizationConformancePackError::OrganizationConformancePackTemplateValidation(ref cause) => cause,
-PutOrganizationConformancePackError::ResourceInUse(ref cause) => cause
+                            PutOrganizationConformancePackError::InsufficientPermissions(ref cause) => write!(f, "{}", cause),
+PutOrganizationConformancePackError::MaxNumberOfOrganizationConformancePacksExceeded(ref cause) => write!(f, "{}", cause),
+PutOrganizationConformancePackError::NoAvailableOrganization(ref cause) => write!(f, "{}", cause),
+PutOrganizationConformancePackError::OrganizationAccessDenied(ref cause) => write!(f, "{}", cause),
+PutOrganizationConformancePackError::OrganizationAllFeaturesNotEnabled(ref cause) => write!(f, "{}", cause),
+PutOrganizationConformancePackError::OrganizationConformancePackTemplateValidation(ref cause) => write!(f, "{}", cause),
+PutOrganizationConformancePackError::ResourceInUse(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for PutOrganizationConformancePackError {}
 /// Errors returned by PutRemediationConfigurations
 #[derive(Debug, PartialEq)]
 pub enum PutRemediationConfigurationsError {
@@ -6951,17 +6907,17 @@ impl PutRemediationConfigurationsError {
 }
 impl fmt::Display for PutRemediationConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRemediationConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            PutRemediationConfigurationsError::InsufficientPermissions(ref cause) => cause,
-            PutRemediationConfigurationsError::InvalidParameterValue(ref cause) => cause,
+            PutRemediationConfigurationsError::InsufficientPermissions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRemediationConfigurationsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutRemediationConfigurationsError {}
 /// Errors returned by PutRemediationExceptions
 #[derive(Debug, PartialEq)]
 pub enum PutRemediationExceptionsError {
@@ -6987,16 +6943,14 @@ impl PutRemediationExceptionsError {
 }
 impl fmt::Display for PutRemediationExceptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRemediationExceptionsError {
-    fn description(&self) -> &str {
         match *self {
-            PutRemediationExceptionsError::InvalidParameterValue(ref cause) => cause,
+            PutRemediationExceptionsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutRemediationExceptionsError {}
 /// Errors returned by PutResourceConfig
 #[derive(Debug, PartialEq)]
 pub enum PutResourceConfigError {
@@ -7036,18 +6990,16 @@ impl PutResourceConfigError {
 }
 impl fmt::Display for PutResourceConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutResourceConfigError {
-    fn description(&self) -> &str {
         match *self {
-            PutResourceConfigError::InsufficientPermissions(ref cause) => cause,
-            PutResourceConfigError::MaxActiveResourcesExceeded(ref cause) => cause,
-            PutResourceConfigError::NoRunningConfigurationRecorder(ref cause) => cause,
+            PutResourceConfigError::InsufficientPermissions(ref cause) => write!(f, "{}", cause),
+            PutResourceConfigError::MaxActiveResourcesExceeded(ref cause) => write!(f, "{}", cause),
+            PutResourceConfigError::NoRunningConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutResourceConfigError {}
 /// Errors returned by PutRetentionConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutRetentionConfigurationError {
@@ -7082,19 +7034,17 @@ impl PutRetentionConfigurationError {
 }
 impl fmt::Display for PutRetentionConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRetentionConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutRetentionConfigurationError::InvalidParameterValue(ref cause) => cause,
+            PutRetentionConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             PutRetentionConfigurationError::MaxNumberOfRetentionConfigurationsExceeded(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRetentionConfigurationError {}
 /// Errors returned by SelectResourceConfig
 #[derive(Debug, PartialEq)]
 pub enum SelectResourceConfigError {
@@ -7132,18 +7082,14 @@ impl SelectResourceConfigError {
 }
 impl fmt::Display for SelectResourceConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SelectResourceConfigError {
-    fn description(&self) -> &str {
         match *self {
-            SelectResourceConfigError::InvalidExpression(ref cause) => cause,
-            SelectResourceConfigError::InvalidLimit(ref cause) => cause,
-            SelectResourceConfigError::InvalidNextToken(ref cause) => cause,
+            SelectResourceConfigError::InvalidExpression(ref cause) => write!(f, "{}", cause),
+            SelectResourceConfigError::InvalidLimit(ref cause) => write!(f, "{}", cause),
+            SelectResourceConfigError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SelectResourceConfigError {}
 /// Errors returned by StartConfigRulesEvaluation
 #[derive(Debug, PartialEq)]
 pub enum StartConfigRulesEvaluationError {
@@ -7192,19 +7138,17 @@ impl StartConfigRulesEvaluationError {
 }
 impl fmt::Display for StartConfigRulesEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartConfigRulesEvaluationError {
-    fn description(&self) -> &str {
         match *self {
-            StartConfigRulesEvaluationError::InvalidParameterValue(ref cause) => cause,
-            StartConfigRulesEvaluationError::LimitExceeded(ref cause) => cause,
-            StartConfigRulesEvaluationError::NoSuchConfigRule(ref cause) => cause,
-            StartConfigRulesEvaluationError::ResourceInUse(ref cause) => cause,
+            StartConfigRulesEvaluationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartConfigRulesEvaluationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartConfigRulesEvaluationError::NoSuchConfigRule(ref cause) => write!(f, "{}", cause),
+            StartConfigRulesEvaluationError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartConfigRulesEvaluationError {}
 /// Errors returned by StartConfigurationRecorder
 #[derive(Debug, PartialEq)]
 pub enum StartConfigurationRecorderError {
@@ -7239,17 +7183,17 @@ impl StartConfigurationRecorderError {
 }
 impl fmt::Display for StartConfigurationRecorderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartConfigurationRecorderError {
-    fn description(&self) -> &str {
         match *self {
-            StartConfigurationRecorderError::NoAvailableDeliveryChannel(ref cause) => cause,
-            StartConfigurationRecorderError::NoSuchConfigurationRecorder(ref cause) => cause,
+            StartConfigurationRecorderError::NoAvailableDeliveryChannel(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartConfigurationRecorderError::NoSuchConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartConfigurationRecorderError {}
 /// Errors returned by StartRemediationExecution
 #[derive(Debug, PartialEq)]
 pub enum StartRemediationExecutionError {
@@ -7289,18 +7233,20 @@ impl StartRemediationExecutionError {
 }
 impl fmt::Display for StartRemediationExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartRemediationExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StartRemediationExecutionError::InsufficientPermissions(ref cause) => cause,
-            StartRemediationExecutionError::InvalidParameterValue(ref cause) => cause,
-            StartRemediationExecutionError::NoSuchRemediationConfiguration(ref cause) => cause,
+            StartRemediationExecutionError::InsufficientPermissions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartRemediationExecutionError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartRemediationExecutionError::NoSuchRemediationConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartRemediationExecutionError {}
 /// Errors returned by StopConfigurationRecorder
 #[derive(Debug, PartialEq)]
 pub enum StopConfigurationRecorderError {
@@ -7326,16 +7272,14 @@ impl StopConfigurationRecorderError {
 }
 impl fmt::Display for StopConfigurationRecorderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopConfigurationRecorderError {
-    fn description(&self) -> &str {
         match *self {
-            StopConfigurationRecorderError::NoSuchConfigurationRecorder(ref cause) => cause,
+            StopConfigurationRecorderError::NoSuchConfigurationRecorder(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StopConfigurationRecorderError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -7364,17 +7308,13 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -7398,16 +7338,12 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the Config Service API. Config Service clients implement this trait.
 pub trait ConfigService {
     /// <p><p>Returns the current configuration items for resources that are present in your AWS Config aggregator. The operation also returns a list of resources that are not processed in the current request. If there are no unprocessed resources, the operation returns an empty <code>unprocessedResourceIdentifiers</code> list. </p> <note> <ul> <li> <p>The API does not return results for deleted resources.</p> </li> <li> <p> The API does not return tags and relationships.</p> </li> </ul> </note></p>

--- a/rusoto/services/connect/src/generated.rs
+++ b/rusoto/services/connect/src/generated.rs
@@ -1291,22 +1291,18 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::DuplicateResource(ref cause) => cause,
-            CreateUserError::InternalService(ref cause) => cause,
-            CreateUserError::InvalidParameter(ref cause) => cause,
-            CreateUserError::InvalidRequest(ref cause) => cause,
-            CreateUserError::LimitExceeded(ref cause) => cause,
-            CreateUserError::ResourceNotFound(ref cause) => cause,
-            CreateUserError::Throttling(ref cause) => cause,
+            CreateUserError::DuplicateResource(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateUserError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateUserError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -1350,20 +1346,16 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::InternalService(ref cause) => cause,
-            DeleteUserError::InvalidParameter(ref cause) => cause,
-            DeleteUserError::InvalidRequest(ref cause) => cause,
-            DeleteUserError::ResourceNotFound(ref cause) => cause,
-            DeleteUserError::Throttling(ref cause) => cause,
+            DeleteUserError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DescribeUser
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserError {
@@ -1407,20 +1399,16 @@ impl DescribeUserError {
 }
 impl fmt::Display for DescribeUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserError::InternalService(ref cause) => cause,
-            DescribeUserError::InvalidParameter(ref cause) => cause,
-            DescribeUserError::InvalidRequest(ref cause) => cause,
-            DescribeUserError::ResourceNotFound(ref cause) => cause,
-            DescribeUserError::Throttling(ref cause) => cause,
+            DescribeUserError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserError {}
 /// Errors returned by DescribeUserHierarchyGroup
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserHierarchyGroupError {
@@ -1476,20 +1464,16 @@ impl DescribeUserHierarchyGroupError {
 }
 impl fmt::Display for DescribeUserHierarchyGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserHierarchyGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserHierarchyGroupError::InternalService(ref cause) => cause,
-            DescribeUserHierarchyGroupError::InvalidParameter(ref cause) => cause,
-            DescribeUserHierarchyGroupError::InvalidRequest(ref cause) => cause,
-            DescribeUserHierarchyGroupError::ResourceNotFound(ref cause) => cause,
-            DescribeUserHierarchyGroupError::Throttling(ref cause) => cause,
+            DescribeUserHierarchyGroupError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeUserHierarchyGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUserHierarchyGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeUserHierarchyGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserHierarchyGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserHierarchyGroupError {}
 /// Errors returned by DescribeUserHierarchyStructure
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserHierarchyStructureError {
@@ -1545,20 +1529,24 @@ impl DescribeUserHierarchyStructureError {
 }
 impl fmt::Display for DescribeUserHierarchyStructureError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserHierarchyStructureError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserHierarchyStructureError::InternalService(ref cause) => cause,
-            DescribeUserHierarchyStructureError::InvalidParameter(ref cause) => cause,
-            DescribeUserHierarchyStructureError::InvalidRequest(ref cause) => cause,
-            DescribeUserHierarchyStructureError::ResourceNotFound(ref cause) => cause,
-            DescribeUserHierarchyStructureError::Throttling(ref cause) => cause,
+            DescribeUserHierarchyStructureError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeUserHierarchyStructureError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeUserHierarchyStructureError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeUserHierarchyStructureError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeUserHierarchyStructureError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserHierarchyStructureError {}
 /// Errors returned by GetContactAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetContactAttributesError {
@@ -1596,18 +1584,14 @@ impl GetContactAttributesError {
 }
 impl fmt::Display for GetContactAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetContactAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetContactAttributesError::InternalService(ref cause) => cause,
-            GetContactAttributesError::InvalidRequest(ref cause) => cause,
-            GetContactAttributesError::ResourceNotFound(ref cause) => cause,
+            GetContactAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetContactAttributesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetContactAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetContactAttributesError {}
 /// Errors returned by GetCurrentMetricData
 #[derive(Debug, PartialEq)]
 pub enum GetCurrentMetricDataError {
@@ -1657,20 +1641,16 @@ impl GetCurrentMetricDataError {
 }
 impl fmt::Display for GetCurrentMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCurrentMetricDataError {
-    fn description(&self) -> &str {
         match *self {
-            GetCurrentMetricDataError::InternalService(ref cause) => cause,
-            GetCurrentMetricDataError::InvalidParameter(ref cause) => cause,
-            GetCurrentMetricDataError::InvalidRequest(ref cause) => cause,
-            GetCurrentMetricDataError::ResourceNotFound(ref cause) => cause,
-            GetCurrentMetricDataError::Throttling(ref cause) => cause,
+            GetCurrentMetricDataError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetCurrentMetricDataError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetCurrentMetricDataError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetCurrentMetricDataError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetCurrentMetricDataError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCurrentMetricDataError {}
 /// Errors returned by GetFederationToken
 #[derive(Debug, PartialEq)]
 pub enum GetFederationTokenError {
@@ -1721,21 +1701,17 @@ impl GetFederationTokenError {
 }
 impl fmt::Display for GetFederationTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFederationTokenError {
-    fn description(&self) -> &str {
         match *self {
-            GetFederationTokenError::DuplicateResource(ref cause) => cause,
-            GetFederationTokenError::InternalService(ref cause) => cause,
-            GetFederationTokenError::InvalidParameter(ref cause) => cause,
-            GetFederationTokenError::InvalidRequest(ref cause) => cause,
-            GetFederationTokenError::ResourceNotFound(ref cause) => cause,
-            GetFederationTokenError::UserNotFound(ref cause) => cause,
+            GetFederationTokenError::DuplicateResource(ref cause) => write!(f, "{}", cause),
+            GetFederationTokenError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetFederationTokenError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetFederationTokenError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetFederationTokenError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetFederationTokenError::UserNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFederationTokenError {}
 /// Errors returned by GetMetricData
 #[derive(Debug, PartialEq)]
 pub enum GetMetricDataError {
@@ -1779,20 +1755,16 @@ impl GetMetricDataError {
 }
 impl fmt::Display for GetMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMetricDataError {
-    fn description(&self) -> &str {
         match *self {
-            GetMetricDataError::InternalService(ref cause) => cause,
-            GetMetricDataError::InvalidParameter(ref cause) => cause,
-            GetMetricDataError::InvalidRequest(ref cause) => cause,
-            GetMetricDataError::ResourceNotFound(ref cause) => cause,
-            GetMetricDataError::Throttling(ref cause) => cause,
+            GetMetricDataError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetMetricDataError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetMetricDataError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetMetricDataError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetMetricDataError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMetricDataError {}
 /// Errors returned by ListContactFlows
 #[derive(Debug, PartialEq)]
 pub enum ListContactFlowsError {
@@ -1836,20 +1808,16 @@ impl ListContactFlowsError {
 }
 impl fmt::Display for ListContactFlowsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListContactFlowsError {
-    fn description(&self) -> &str {
         match *self {
-            ListContactFlowsError::InternalService(ref cause) => cause,
-            ListContactFlowsError::InvalidParameter(ref cause) => cause,
-            ListContactFlowsError::InvalidRequest(ref cause) => cause,
-            ListContactFlowsError::ResourceNotFound(ref cause) => cause,
-            ListContactFlowsError::Throttling(ref cause) => cause,
+            ListContactFlowsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListContactFlowsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListContactFlowsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListContactFlowsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListContactFlowsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListContactFlowsError {}
 /// Errors returned by ListHoursOfOperations
 #[derive(Debug, PartialEq)]
 pub enum ListHoursOfOperationsError {
@@ -1901,20 +1869,16 @@ impl ListHoursOfOperationsError {
 }
 impl fmt::Display for ListHoursOfOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHoursOfOperationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListHoursOfOperationsError::InternalService(ref cause) => cause,
-            ListHoursOfOperationsError::InvalidParameter(ref cause) => cause,
-            ListHoursOfOperationsError::InvalidRequest(ref cause) => cause,
-            ListHoursOfOperationsError::ResourceNotFound(ref cause) => cause,
-            ListHoursOfOperationsError::Throttling(ref cause) => cause,
+            ListHoursOfOperationsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListHoursOfOperationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListHoursOfOperationsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListHoursOfOperationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListHoursOfOperationsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHoursOfOperationsError {}
 /// Errors returned by ListPhoneNumbers
 #[derive(Debug, PartialEq)]
 pub enum ListPhoneNumbersError {
@@ -1958,20 +1922,16 @@ impl ListPhoneNumbersError {
 }
 impl fmt::Display for ListPhoneNumbersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPhoneNumbersError {
-    fn description(&self) -> &str {
         match *self {
-            ListPhoneNumbersError::InternalService(ref cause) => cause,
-            ListPhoneNumbersError::InvalidParameter(ref cause) => cause,
-            ListPhoneNumbersError::InvalidRequest(ref cause) => cause,
-            ListPhoneNumbersError::ResourceNotFound(ref cause) => cause,
-            ListPhoneNumbersError::Throttling(ref cause) => cause,
+            ListPhoneNumbersError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPhoneNumbersError {}
 /// Errors returned by ListQueues
 #[derive(Debug, PartialEq)]
 pub enum ListQueuesError {
@@ -2015,20 +1975,16 @@ impl ListQueuesError {
 }
 impl fmt::Display for ListQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQueuesError {
-    fn description(&self) -> &str {
         match *self {
-            ListQueuesError::InternalService(ref cause) => cause,
-            ListQueuesError::InvalidParameter(ref cause) => cause,
-            ListQueuesError::InvalidRequest(ref cause) => cause,
-            ListQueuesError::ResourceNotFound(ref cause) => cause,
-            ListQueuesError::Throttling(ref cause) => cause,
+            ListQueuesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListQueuesError {}
 /// Errors returned by ListRoutingProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListRoutingProfilesError {
@@ -2076,20 +2032,16 @@ impl ListRoutingProfilesError {
 }
 impl fmt::Display for ListRoutingProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRoutingProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRoutingProfilesError::InternalService(ref cause) => cause,
-            ListRoutingProfilesError::InvalidParameter(ref cause) => cause,
-            ListRoutingProfilesError::InvalidRequest(ref cause) => cause,
-            ListRoutingProfilesError::ResourceNotFound(ref cause) => cause,
-            ListRoutingProfilesError::Throttling(ref cause) => cause,
+            ListRoutingProfilesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListRoutingProfilesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListRoutingProfilesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListRoutingProfilesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListRoutingProfilesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRoutingProfilesError {}
 /// Errors returned by ListSecurityProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListSecurityProfilesError {
@@ -2139,20 +2091,16 @@ impl ListSecurityProfilesError {
 }
 impl fmt::Display for ListSecurityProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSecurityProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListSecurityProfilesError::InternalService(ref cause) => cause,
-            ListSecurityProfilesError::InvalidParameter(ref cause) => cause,
-            ListSecurityProfilesError::InvalidRequest(ref cause) => cause,
-            ListSecurityProfilesError::ResourceNotFound(ref cause) => cause,
-            ListSecurityProfilesError::Throttling(ref cause) => cause,
+            ListSecurityProfilesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListSecurityProfilesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListSecurityProfilesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListSecurityProfilesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListSecurityProfilesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSecurityProfilesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2200,20 +2148,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalService(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::Throttling(ref cause) => cause,
+            ListTagsForResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListUserHierarchyGroups
 #[derive(Debug, PartialEq)]
 pub enum ListUserHierarchyGroupsError {
@@ -2265,20 +2209,16 @@ impl ListUserHierarchyGroupsError {
 }
 impl fmt::Display for ListUserHierarchyGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserHierarchyGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListUserHierarchyGroupsError::InternalService(ref cause) => cause,
-            ListUserHierarchyGroupsError::InvalidParameter(ref cause) => cause,
-            ListUserHierarchyGroupsError::InvalidRequest(ref cause) => cause,
-            ListUserHierarchyGroupsError::ResourceNotFound(ref cause) => cause,
-            ListUserHierarchyGroupsError::Throttling(ref cause) => cause,
+            ListUserHierarchyGroupsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListUserHierarchyGroupsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUserHierarchyGroupsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListUserHierarchyGroupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUserHierarchyGroupsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUserHierarchyGroupsError {}
 /// Errors returned by ListUsers
 #[derive(Debug, PartialEq)]
 pub enum ListUsersError {
@@ -2322,20 +2262,16 @@ impl ListUsersError {
 }
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersError::InternalService(ref cause) => cause,
-            ListUsersError::InvalidParameter(ref cause) => cause,
-            ListUsersError::InvalidRequest(ref cause) => cause,
-            ListUsersError::ResourceNotFound(ref cause) => cause,
-            ListUsersError::Throttling(ref cause) => cause,
+            ListUsersError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListUsersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUsersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListUsersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUsersError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersError {}
 /// Errors returned by StartChatContact
 #[derive(Debug, PartialEq)]
 pub enum StartChatContactError {
@@ -2379,20 +2315,16 @@ impl StartChatContactError {
 }
 impl fmt::Display for StartChatContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartChatContactError {
-    fn description(&self) -> &str {
         match *self {
-            StartChatContactError::InternalService(ref cause) => cause,
-            StartChatContactError::InvalidParameter(ref cause) => cause,
-            StartChatContactError::InvalidRequest(ref cause) => cause,
-            StartChatContactError::LimitExceeded(ref cause) => cause,
-            StartChatContactError::ResourceNotFound(ref cause) => cause,
+            StartChatContactError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartChatContactError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartChatContactError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartChatContactError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartChatContactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartChatContactError {}
 /// Errors returned by StartOutboundVoiceContact
 #[derive(Debug, PartialEq)]
 pub enum StartOutboundVoiceContactError {
@@ -2460,22 +2392,22 @@ impl StartOutboundVoiceContactError {
 }
 impl fmt::Display for StartOutboundVoiceContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartOutboundVoiceContactError {
-    fn description(&self) -> &str {
         match *self {
-            StartOutboundVoiceContactError::DestinationNotAllowed(ref cause) => cause,
-            StartOutboundVoiceContactError::InternalService(ref cause) => cause,
-            StartOutboundVoiceContactError::InvalidParameter(ref cause) => cause,
-            StartOutboundVoiceContactError::InvalidRequest(ref cause) => cause,
-            StartOutboundVoiceContactError::LimitExceeded(ref cause) => cause,
-            StartOutboundVoiceContactError::OutboundContactNotPermitted(ref cause) => cause,
-            StartOutboundVoiceContactError::ResourceNotFound(ref cause) => cause,
+            StartOutboundVoiceContactError::DestinationNotAllowed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartOutboundVoiceContactError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartOutboundVoiceContactError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartOutboundVoiceContactError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartOutboundVoiceContactError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartOutboundVoiceContactError::OutboundContactNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartOutboundVoiceContactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartOutboundVoiceContactError {}
 /// Errors returned by StopContact
 #[derive(Debug, PartialEq)]
 pub enum StopContactError {
@@ -2519,20 +2451,16 @@ impl StopContactError {
 }
 impl fmt::Display for StopContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopContactError {
-    fn description(&self) -> &str {
         match *self {
-            StopContactError::ContactNotFound(ref cause) => cause,
-            StopContactError::InternalService(ref cause) => cause,
-            StopContactError::InvalidParameter(ref cause) => cause,
-            StopContactError::InvalidRequest(ref cause) => cause,
-            StopContactError::ResourceNotFound(ref cause) => cause,
+            StopContactError::ContactNotFound(ref cause) => write!(f, "{}", cause),
+            StopContactError::InternalService(ref cause) => write!(f, "{}", cause),
+            StopContactError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopContactError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopContactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopContactError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2576,20 +2504,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalService(ref cause) => cause,
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::Throttling(ref cause) => cause,
+            TagResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2633,20 +2557,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalService(ref cause) => cause,
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::Throttling(ref cause) => cause,
+            UntagResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateContactAttributes
 #[derive(Debug, PartialEq)]
 pub enum UpdateContactAttributesError {
@@ -2693,19 +2613,15 @@ impl UpdateContactAttributesError {
 }
 impl fmt::Display for UpdateContactAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateContactAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateContactAttributesError::InternalService(ref cause) => cause,
-            UpdateContactAttributesError::InvalidParameter(ref cause) => cause,
-            UpdateContactAttributesError::InvalidRequest(ref cause) => cause,
-            UpdateContactAttributesError::ResourceNotFound(ref cause) => cause,
+            UpdateContactAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateContactAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateContactAttributesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateContactAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateContactAttributesError {}
 /// Errors returned by UpdateUserHierarchy
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserHierarchyError {
@@ -2753,20 +2669,16 @@ impl UpdateUserHierarchyError {
 }
 impl fmt::Display for UpdateUserHierarchyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserHierarchyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserHierarchyError::InternalService(ref cause) => cause,
-            UpdateUserHierarchyError::InvalidParameter(ref cause) => cause,
-            UpdateUserHierarchyError::InvalidRequest(ref cause) => cause,
-            UpdateUserHierarchyError::ResourceNotFound(ref cause) => cause,
-            UpdateUserHierarchyError::Throttling(ref cause) => cause,
+            UpdateUserHierarchyError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateUserHierarchyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserHierarchyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserHierarchyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserHierarchyError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserHierarchyError {}
 /// Errors returned by UpdateUserIdentityInfo
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserIdentityInfoError {
@@ -2818,20 +2730,16 @@ impl UpdateUserIdentityInfoError {
 }
 impl fmt::Display for UpdateUserIdentityInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserIdentityInfoError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserIdentityInfoError::InternalService(ref cause) => cause,
-            UpdateUserIdentityInfoError::InvalidParameter(ref cause) => cause,
-            UpdateUserIdentityInfoError::InvalidRequest(ref cause) => cause,
-            UpdateUserIdentityInfoError::ResourceNotFound(ref cause) => cause,
-            UpdateUserIdentityInfoError::Throttling(ref cause) => cause,
+            UpdateUserIdentityInfoError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateUserIdentityInfoError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserIdentityInfoError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserIdentityInfoError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserIdentityInfoError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserIdentityInfoError {}
 /// Errors returned by UpdateUserPhoneConfig
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserPhoneConfigError {
@@ -2883,20 +2791,16 @@ impl UpdateUserPhoneConfigError {
 }
 impl fmt::Display for UpdateUserPhoneConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserPhoneConfigError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserPhoneConfigError::InternalService(ref cause) => cause,
-            UpdateUserPhoneConfigError::InvalidParameter(ref cause) => cause,
-            UpdateUserPhoneConfigError::InvalidRequest(ref cause) => cause,
-            UpdateUserPhoneConfigError::ResourceNotFound(ref cause) => cause,
-            UpdateUserPhoneConfigError::Throttling(ref cause) => cause,
+            UpdateUserPhoneConfigError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateUserPhoneConfigError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserPhoneConfigError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserPhoneConfigError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserPhoneConfigError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserPhoneConfigError {}
 /// Errors returned by UpdateUserRoutingProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserRoutingProfileError {
@@ -2948,20 +2852,16 @@ impl UpdateUserRoutingProfileError {
 }
 impl fmt::Display for UpdateUserRoutingProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserRoutingProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserRoutingProfileError::InternalService(ref cause) => cause,
-            UpdateUserRoutingProfileError::InvalidParameter(ref cause) => cause,
-            UpdateUserRoutingProfileError::InvalidRequest(ref cause) => cause,
-            UpdateUserRoutingProfileError::ResourceNotFound(ref cause) => cause,
-            UpdateUserRoutingProfileError::Throttling(ref cause) => cause,
+            UpdateUserRoutingProfileError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateUserRoutingProfileError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserRoutingProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserRoutingProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserRoutingProfileError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserRoutingProfileError {}
 /// Errors returned by UpdateUserSecurityProfiles
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserSecurityProfilesError {
@@ -3017,20 +2917,16 @@ impl UpdateUserSecurityProfilesError {
 }
 impl fmt::Display for UpdateUserSecurityProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserSecurityProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserSecurityProfilesError::InternalService(ref cause) => cause,
-            UpdateUserSecurityProfilesError::InvalidParameter(ref cause) => cause,
-            UpdateUserSecurityProfilesError::InvalidRequest(ref cause) => cause,
-            UpdateUserSecurityProfilesError::ResourceNotFound(ref cause) => cause,
-            UpdateUserSecurityProfilesError::Throttling(ref cause) => cause,
+            UpdateUserSecurityProfilesError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateUserSecurityProfilesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateUserSecurityProfilesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserSecurityProfilesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserSecurityProfilesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserSecurityProfilesError {}
 /// Trait representing the capabilities of the Amazon Connect API. Amazon Connect clients implement this trait.
 pub trait Connect {
     /// <p>Creates a user account for the specified Amazon Connect instance.</p>

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -148,16 +148,12 @@ impl DeleteReportDefinitionError {
 }
 impl fmt::Display for DeleteReportDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReportDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReportDefinitionError::InternalError(ref cause) => cause,
+            DeleteReportDefinitionError::InternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReportDefinitionError {}
 /// Errors returned by DescribeReportDefinitions
 #[derive(Debug, PartialEq)]
 pub enum DescribeReportDefinitionsError {
@@ -183,16 +179,12 @@ impl DescribeReportDefinitionsError {
 }
 impl fmt::Display for DescribeReportDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReportDefinitionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReportDefinitionsError::InternalError(ref cause) => cause,
+            DescribeReportDefinitionsError::InternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeReportDefinitionsError {}
 /// Errors returned by ModifyReportDefinition
 #[derive(Debug, PartialEq)]
 pub enum ModifyReportDefinitionError {
@@ -218,16 +210,12 @@ impl ModifyReportDefinitionError {
 }
 impl fmt::Display for ModifyReportDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyReportDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyReportDefinitionError::InternalError(ref cause) => cause,
+            ModifyReportDefinitionError::InternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyReportDefinitionError {}
 /// Errors returned by PutReportDefinition
 #[derive(Debug, PartialEq)]
 pub enum PutReportDefinitionError {
@@ -265,18 +253,14 @@ impl PutReportDefinitionError {
 }
 impl fmt::Display for PutReportDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutReportDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            PutReportDefinitionError::DuplicateReportName(ref cause) => cause,
-            PutReportDefinitionError::InternalError(ref cause) => cause,
-            PutReportDefinitionError::ReportLimitReached(ref cause) => cause,
+            PutReportDefinitionError::DuplicateReportName(ref cause) => write!(f, "{}", cause),
+            PutReportDefinitionError::InternalError(ref cause) => write!(f, "{}", cause),
+            PutReportDefinitionError::ReportLimitReached(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutReportDefinitionError {}
 /// Trait representing the capabilities of the AWS Cost and Usage Report Service API. AWS Cost and Usage Report Service clients implement this trait.
 pub trait CostAndUsageReport {
     /// <p>Deletes the specified report.</p>

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -736,19 +736,15 @@ impl ActivatePipelineError {
 }
 impl fmt::Display for ActivatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ActivatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            ActivatePipelineError::InternalServiceError(ref cause) => cause,
-            ActivatePipelineError::InvalidRequest(ref cause) => cause,
-            ActivatePipelineError::PipelineDeleted(ref cause) => cause,
-            ActivatePipelineError::PipelineNotFound(ref cause) => cause,
+            ActivatePipelineError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ActivatePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ActivatePipelineError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            ActivatePipelineError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ActivatePipelineError {}
 /// Errors returned by AddTags
 #[derive(Debug, PartialEq)]
 pub enum AddTagsError {
@@ -787,19 +783,15 @@ impl AddTagsError {
 }
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsError::InternalServiceError(ref cause) => cause,
-            AddTagsError::InvalidRequest(ref cause) => cause,
-            AddTagsError::PipelineDeleted(ref cause) => cause,
-            AddTagsError::PipelineNotFound(ref cause) => cause,
+            AddTagsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            AddTagsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AddTagsError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            AddTagsError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsError {}
 /// Errors returned by CreatePipeline
 #[derive(Debug, PartialEq)]
 pub enum CreatePipelineError {
@@ -828,17 +820,13 @@ impl CreatePipelineError {
 }
 impl fmt::Display for CreatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePipelineError::InternalServiceError(ref cause) => cause,
-            CreatePipelineError::InvalidRequest(ref cause) => cause,
+            CreatePipelineError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePipelineError {}
 /// Errors returned by DeactivatePipeline
 #[derive(Debug, PartialEq)]
 pub enum DeactivatePipelineError {
@@ -879,19 +867,15 @@ impl DeactivatePipelineError {
 }
 impl fmt::Display for DeactivatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeactivatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            DeactivatePipelineError::InternalServiceError(ref cause) => cause,
-            DeactivatePipelineError::InvalidRequest(ref cause) => cause,
-            DeactivatePipelineError::PipelineDeleted(ref cause) => cause,
-            DeactivatePipelineError::PipelineNotFound(ref cause) => cause,
+            DeactivatePipelineError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DeactivatePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeactivatePipelineError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            DeactivatePipelineError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeactivatePipelineError {}
 /// Errors returned by DeletePipeline
 #[derive(Debug, PartialEq)]
 pub enum DeletePipelineError {
@@ -925,18 +909,14 @@ impl DeletePipelineError {
 }
 impl fmt::Display for DeletePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePipelineError::InternalServiceError(ref cause) => cause,
-            DeletePipelineError::InvalidRequest(ref cause) => cause,
-            DeletePipelineError::PipelineNotFound(ref cause) => cause,
+            DeletePipelineError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePipelineError {}
 /// Errors returned by DescribeObjects
 #[derive(Debug, PartialEq)]
 pub enum DescribeObjectsError {
@@ -977,19 +957,15 @@ impl DescribeObjectsError {
 }
 impl fmt::Display for DescribeObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeObjectsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeObjectsError::InternalServiceError(ref cause) => cause,
-            DescribeObjectsError::InvalidRequest(ref cause) => cause,
-            DescribeObjectsError::PipelineDeleted(ref cause) => cause,
-            DescribeObjectsError::PipelineNotFound(ref cause) => cause,
+            DescribeObjectsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DescribeObjectsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeObjectsError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            DescribeObjectsError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeObjectsError {}
 /// Errors returned by DescribePipelines
 #[derive(Debug, PartialEq)]
 pub enum DescribePipelinesError {
@@ -1030,19 +1006,15 @@ impl DescribePipelinesError {
 }
 impl fmt::Display for DescribePipelinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePipelinesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePipelinesError::InternalServiceError(ref cause) => cause,
-            DescribePipelinesError::InvalidRequest(ref cause) => cause,
-            DescribePipelinesError::PipelineDeleted(ref cause) => cause,
-            DescribePipelinesError::PipelineNotFound(ref cause) => cause,
+            DescribePipelinesError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DescribePipelinesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribePipelinesError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            DescribePipelinesError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePipelinesError {}
 /// Errors returned by EvaluateExpression
 #[derive(Debug, PartialEq)]
 pub enum EvaluateExpressionError {
@@ -1088,20 +1060,16 @@ impl EvaluateExpressionError {
 }
 impl fmt::Display for EvaluateExpressionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EvaluateExpressionError {
-    fn description(&self) -> &str {
         match *self {
-            EvaluateExpressionError::InternalServiceError(ref cause) => cause,
-            EvaluateExpressionError::InvalidRequest(ref cause) => cause,
-            EvaluateExpressionError::PipelineDeleted(ref cause) => cause,
-            EvaluateExpressionError::PipelineNotFound(ref cause) => cause,
-            EvaluateExpressionError::TaskNotFound(ref cause) => cause,
+            EvaluateExpressionError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            EvaluateExpressionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            EvaluateExpressionError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            EvaluateExpressionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            EvaluateExpressionError::TaskNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EvaluateExpressionError {}
 /// Errors returned by GetPipelineDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetPipelineDefinitionError {
@@ -1148,19 +1116,15 @@ impl GetPipelineDefinitionError {
 }
 impl fmt::Display for GetPipelineDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPipelineDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetPipelineDefinitionError::InternalServiceError(ref cause) => cause,
-            GetPipelineDefinitionError::InvalidRequest(ref cause) => cause,
-            GetPipelineDefinitionError::PipelineDeleted(ref cause) => cause,
-            GetPipelineDefinitionError::PipelineNotFound(ref cause) => cause,
+            GetPipelineDefinitionError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            GetPipelineDefinitionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetPipelineDefinitionError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            GetPipelineDefinitionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPipelineDefinitionError {}
 /// Errors returned by ListPipelines
 #[derive(Debug, PartialEq)]
 pub enum ListPipelinesError {
@@ -1189,17 +1153,13 @@ impl ListPipelinesError {
 }
 impl fmt::Display for ListPipelinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPipelinesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPipelinesError::InternalServiceError(ref cause) => cause,
-            ListPipelinesError::InvalidRequest(ref cause) => cause,
+            ListPipelinesError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ListPipelinesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPipelinesError {}
 /// Errors returned by PollForTask
 #[derive(Debug, PartialEq)]
 pub enum PollForTaskError {
@@ -1233,18 +1193,14 @@ impl PollForTaskError {
 }
 impl fmt::Display for PollForTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PollForTaskError {
-    fn description(&self) -> &str {
         match *self {
-            PollForTaskError::InternalServiceError(ref cause) => cause,
-            PollForTaskError::InvalidRequest(ref cause) => cause,
-            PollForTaskError::TaskNotFound(ref cause) => cause,
+            PollForTaskError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            PollForTaskError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PollForTaskError::TaskNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PollForTaskError {}
 /// Errors returned by PutPipelineDefinition
 #[derive(Debug, PartialEq)]
 pub enum PutPipelineDefinitionError {
@@ -1291,19 +1247,15 @@ impl PutPipelineDefinitionError {
 }
 impl fmt::Display for PutPipelineDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPipelineDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            PutPipelineDefinitionError::InternalServiceError(ref cause) => cause,
-            PutPipelineDefinitionError::InvalidRequest(ref cause) => cause,
-            PutPipelineDefinitionError::PipelineDeleted(ref cause) => cause,
-            PutPipelineDefinitionError::PipelineNotFound(ref cause) => cause,
+            PutPipelineDefinitionError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            PutPipelineDefinitionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutPipelineDefinitionError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            PutPipelineDefinitionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutPipelineDefinitionError {}
 /// Errors returned by QueryObjects
 #[derive(Debug, PartialEq)]
 pub enum QueryObjectsError {
@@ -1342,19 +1294,15 @@ impl QueryObjectsError {
 }
 impl fmt::Display for QueryObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for QueryObjectsError {
-    fn description(&self) -> &str {
         match *self {
-            QueryObjectsError::InternalServiceError(ref cause) => cause,
-            QueryObjectsError::InvalidRequest(ref cause) => cause,
-            QueryObjectsError::PipelineDeleted(ref cause) => cause,
-            QueryObjectsError::PipelineNotFound(ref cause) => cause,
+            QueryObjectsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            QueryObjectsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            QueryObjectsError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            QueryObjectsError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for QueryObjectsError {}
 /// Errors returned by RemoveTags
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsError {
@@ -1393,19 +1341,15 @@ impl RemoveTagsError {
 }
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsError::InternalServiceError(ref cause) => cause,
-            RemoveTagsError::InvalidRequest(ref cause) => cause,
-            RemoveTagsError::PipelineDeleted(ref cause) => cause,
-            RemoveTagsError::PipelineNotFound(ref cause) => cause,
+            RemoveTagsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsError {}
 /// Errors returned by ReportTaskProgress
 #[derive(Debug, PartialEq)]
 pub enum ReportTaskProgressError {
@@ -1451,20 +1395,16 @@ impl ReportTaskProgressError {
 }
 impl fmt::Display for ReportTaskProgressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReportTaskProgressError {
-    fn description(&self) -> &str {
         match *self {
-            ReportTaskProgressError::InternalServiceError(ref cause) => cause,
-            ReportTaskProgressError::InvalidRequest(ref cause) => cause,
-            ReportTaskProgressError::PipelineDeleted(ref cause) => cause,
-            ReportTaskProgressError::PipelineNotFound(ref cause) => cause,
-            ReportTaskProgressError::TaskNotFound(ref cause) => cause,
+            ReportTaskProgressError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ReportTaskProgressError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ReportTaskProgressError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            ReportTaskProgressError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            ReportTaskProgressError::TaskNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReportTaskProgressError {}
 /// Errors returned by ReportTaskRunnerHeartbeat
 #[derive(Debug, PartialEq)]
 pub enum ReportTaskRunnerHeartbeatError {
@@ -1497,17 +1437,15 @@ impl ReportTaskRunnerHeartbeatError {
 }
 impl fmt::Display for ReportTaskRunnerHeartbeatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReportTaskRunnerHeartbeatError {
-    fn description(&self) -> &str {
         match *self {
-            ReportTaskRunnerHeartbeatError::InternalServiceError(ref cause) => cause,
-            ReportTaskRunnerHeartbeatError::InvalidRequest(ref cause) => cause,
+            ReportTaskRunnerHeartbeatError::InternalServiceError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ReportTaskRunnerHeartbeatError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReportTaskRunnerHeartbeatError {}
 /// Errors returned by SetStatus
 #[derive(Debug, PartialEq)]
 pub enum SetStatusError {
@@ -1546,19 +1484,15 @@ impl SetStatusError {
 }
 impl fmt::Display for SetStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetStatusError {
-    fn description(&self) -> &str {
         match *self {
-            SetStatusError::InternalServiceError(ref cause) => cause,
-            SetStatusError::InvalidRequest(ref cause) => cause,
-            SetStatusError::PipelineDeleted(ref cause) => cause,
-            SetStatusError::PipelineNotFound(ref cause) => cause,
+            SetStatusError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            SetStatusError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SetStatusError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            SetStatusError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetStatusError {}
 /// Errors returned by SetTaskStatus
 #[derive(Debug, PartialEq)]
 pub enum SetTaskStatusError {
@@ -1602,20 +1536,16 @@ impl SetTaskStatusError {
 }
 impl fmt::Display for SetTaskStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetTaskStatusError {
-    fn description(&self) -> &str {
         match *self {
-            SetTaskStatusError::InternalServiceError(ref cause) => cause,
-            SetTaskStatusError::InvalidRequest(ref cause) => cause,
-            SetTaskStatusError::PipelineDeleted(ref cause) => cause,
-            SetTaskStatusError::PipelineNotFound(ref cause) => cause,
-            SetTaskStatusError::TaskNotFound(ref cause) => cause,
+            SetTaskStatusError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            SetTaskStatusError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SetTaskStatusError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            SetTaskStatusError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
+            SetTaskStatusError::TaskNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetTaskStatusError {}
 /// Errors returned by ValidatePipelineDefinition
 #[derive(Debug, PartialEq)]
 pub enum ValidatePipelineDefinitionError {
@@ -1664,19 +1594,17 @@ impl ValidatePipelineDefinitionError {
 }
 impl fmt::Display for ValidatePipelineDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ValidatePipelineDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            ValidatePipelineDefinitionError::InternalServiceError(ref cause) => cause,
-            ValidatePipelineDefinitionError::InvalidRequest(ref cause) => cause,
-            ValidatePipelineDefinitionError::PipelineDeleted(ref cause) => cause,
-            ValidatePipelineDefinitionError::PipelineNotFound(ref cause) => cause,
+            ValidatePipelineDefinitionError::InternalServiceError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ValidatePipelineDefinitionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ValidatePipelineDefinitionError::PipelineDeleted(ref cause) => write!(f, "{}", cause),
+            ValidatePipelineDefinitionError::PipelineNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ValidatePipelineDefinitionError {}
 /// Trait representing the capabilities of the AWS Data Pipeline API. AWS Data Pipeline clients implement this trait.
 pub trait DataPipeline {
     /// <p>Validates the specified pipeline and starts processing pipeline tasks. If the pipeline does not pass validation, activation fails.</p> <p>If you need to pause the pipeline to investigate an issue with a component, such as a data source or script, call <a>DeactivatePipeline</a>.</p> <p>To activate a finished pipeline, modify the end date for the pipeline and then activate it.</p>

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -1032,29 +1032,35 @@ impl CreateClusterError {
 }
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterError::ClusterAlreadyExistsFault(ref cause) => cause,
-            CreateClusterError::ClusterQuotaForCustomerExceededFault(ref cause) => cause,
-            CreateClusterError::InsufficientClusterCapacityFault(ref cause) => cause,
-            CreateClusterError::InvalidClusterStateFault(ref cause) => cause,
-            CreateClusterError::InvalidParameterCombination(ref cause) => cause,
-            CreateClusterError::InvalidParameterGroupStateFault(ref cause) => cause,
-            CreateClusterError::InvalidParameterValue(ref cause) => cause,
-            CreateClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateClusterError::NodeQuotaForClusterExceededFault(ref cause) => cause,
-            CreateClusterError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-            CreateClusterError::ParameterGroupNotFoundFault(ref cause) => cause,
-            CreateClusterError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
-            CreateClusterError::SubnetGroupNotFoundFault(ref cause) => cause,
-            CreateClusterError::TagQuotaPerResourceExceeded(ref cause) => cause,
+            CreateClusterError::ClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ClusterQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::InsufficientClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::NodeQuotaForClusterExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::ParameterGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ServiceLinkedRoleNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::SubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::TagQuotaPerResourceExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterError {}
 /// Errors returned by CreateParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateParameterGroupError {
@@ -1115,21 +1121,27 @@ impl CreateParameterGroupError {
 }
 impl fmt::Display for CreateParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateParameterGroupError::InvalidParameterCombination(ref cause) => cause,
-            CreateParameterGroupError::InvalidParameterGroupStateFault(ref cause) => cause,
-            CreateParameterGroupError::InvalidParameterValue(ref cause) => cause,
-            CreateParameterGroupError::ParameterGroupAlreadyExistsFault(ref cause) => cause,
-            CreateParameterGroupError::ParameterGroupQuotaExceededFault(ref cause) => cause,
-            CreateParameterGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            CreateParameterGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateParameterGroupError::InvalidParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateParameterGroupError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateParameterGroupError::ParameterGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateParameterGroupError::ParameterGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateParameterGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateParameterGroupError {}
 /// Errors returned by CreateSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateSubnetGroupError {
@@ -1181,20 +1193,22 @@ impl CreateSubnetGroupError {
 }
 impl fmt::Display for CreateSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            CreateSubnetGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
-            CreateSubnetGroupError::SubnetGroupAlreadyExistsFault(ref cause) => cause,
-            CreateSubnetGroupError::SubnetGroupQuotaExceededFault(ref cause) => cause,
-            CreateSubnetGroupError::SubnetQuotaExceededFault(ref cause) => cause,
+            CreateSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateSubnetGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSubnetGroupError::SubnetGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSubnetGroupError::SubnetGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSubnetGroupError::SubnetQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSubnetGroupError {}
 /// Errors returned by DecreaseReplicationFactor
 #[derive(Debug, PartialEq)]
 pub enum DecreaseReplicationFactorError {
@@ -1255,21 +1269,27 @@ impl DecreaseReplicationFactorError {
 }
 impl fmt::Display for DecreaseReplicationFactorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DecreaseReplicationFactorError {
-    fn description(&self) -> &str {
         match *self {
-            DecreaseReplicationFactorError::ClusterNotFoundFault(ref cause) => cause,
-            DecreaseReplicationFactorError::InvalidClusterStateFault(ref cause) => cause,
-            DecreaseReplicationFactorError::InvalidParameterCombination(ref cause) => cause,
-            DecreaseReplicationFactorError::InvalidParameterValue(ref cause) => cause,
-            DecreaseReplicationFactorError::NodeNotFoundFault(ref cause) => cause,
-            DecreaseReplicationFactorError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DecreaseReplicationFactorError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicationFactorError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicationFactorError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicationFactorError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicationFactorError::NodeNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DecreaseReplicationFactorError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DecreaseReplicationFactorError {}
 /// Errors returned by DeleteCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterError {
@@ -1319,20 +1339,16 @@ impl DeleteClusterError {
 }
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterError::ClusterNotFoundFault(ref cause) => cause,
-            DeleteClusterError::InvalidClusterStateFault(ref cause) => cause,
-            DeleteClusterError::InvalidParameterCombination(ref cause) => cause,
-            DeleteClusterError::InvalidParameterValue(ref cause) => cause,
-            DeleteClusterError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DeleteClusterError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ServiceLinkedRoleNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClusterError {}
 /// Errors returned by DeleteParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteParameterGroupError {
@@ -1386,20 +1402,24 @@ impl DeleteParameterGroupError {
 }
 impl fmt::Display for DeleteParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteParameterGroupError::InvalidParameterCombination(ref cause) => cause,
-            DeleteParameterGroupError::InvalidParameterGroupStateFault(ref cause) => cause,
-            DeleteParameterGroupError::InvalidParameterValue(ref cause) => cause,
-            DeleteParameterGroupError::ParameterGroupNotFoundFault(ref cause) => cause,
-            DeleteParameterGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DeleteParameterGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteParameterGroupError::InvalidParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteParameterGroupError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteParameterGroupError::ParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteParameterGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteParameterGroupError {}
 /// Errors returned by DeleteSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteSubnetGroupError {
@@ -1439,18 +1459,16 @@ impl DeleteSubnetGroupError {
 }
 impl fmt::Display for DeleteSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSubnetGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
-            DeleteSubnetGroupError::SubnetGroupInUseFault(ref cause) => cause,
-            DeleteSubnetGroupError::SubnetGroupNotFoundFault(ref cause) => cause,
+            DeleteSubnetGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteSubnetGroupError::SubnetGroupInUseFault(ref cause) => write!(f, "{}", cause),
+            DeleteSubnetGroupError::SubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSubnetGroupError {}
 /// Errors returned by DescribeClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeClustersError {
@@ -1497,19 +1515,17 @@ impl DescribeClustersError {
 }
 impl fmt::Display for DescribeClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClustersError::ClusterNotFoundFault(ref cause) => cause,
-            DescribeClustersError::InvalidParameterCombination(ref cause) => cause,
-            DescribeClustersError::InvalidParameterValue(ref cause) => cause,
-            DescribeClustersError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DescribeClustersError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeClustersError {}
 /// Errors returned by DescribeDefaultParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDefaultParametersError {
@@ -1549,18 +1565,20 @@ impl DescribeDefaultParametersError {
 }
 impl fmt::Display for DescribeDefaultParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDefaultParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDefaultParametersError::InvalidParameterCombination(ref cause) => cause,
-            DescribeDefaultParametersError::InvalidParameterValue(ref cause) => cause,
-            DescribeDefaultParametersError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DescribeDefaultParametersError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDefaultParametersError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDefaultParametersError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDefaultParametersError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {
@@ -1600,18 +1618,16 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeEventsError::InvalidParameterValue(ref cause) => cause,
-            DescribeEventsError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DescribeEventsError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            DescribeEventsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeEventsError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeParameterGroupsError {
@@ -1658,19 +1674,23 @@ impl DescribeParameterGroupsError {
 }
 impl fmt::Display for DescribeParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeParameterGroupsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeParameterGroupsError::InvalidParameterValue(ref cause) => cause,
-            DescribeParameterGroupsError::ParameterGroupNotFoundFault(ref cause) => cause,
-            DescribeParameterGroupsError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DescribeParameterGroupsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeParameterGroupsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeParameterGroupsError::ParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeParameterGroupsError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeParameterGroupsError {}
 /// Errors returned by DescribeParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeParametersError {
@@ -1717,19 +1737,21 @@ impl DescribeParametersError {
 }
 impl fmt::Display for DescribeParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeParametersError::InvalidParameterCombination(ref cause) => cause,
-            DescribeParametersError::InvalidParameterValue(ref cause) => cause,
-            DescribeParametersError::ParameterGroupNotFoundFault(ref cause) => cause,
-            DescribeParametersError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            DescribeParametersError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeParametersError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeParametersError::ParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeParametersError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeParametersError {}
 /// Errors returned by DescribeSubnetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeSubnetGroupsError {
@@ -1762,17 +1784,17 @@ impl DescribeSubnetGroupsError {
 }
 impl fmt::Display for DescribeSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSubnetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSubnetGroupsError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
-            DescribeSubnetGroupsError::SubnetGroupNotFoundFault(ref cause) => cause,
+            DescribeSubnetGroupsError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeSubnetGroupsError::SubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeSubnetGroupsError {}
 /// Errors returned by IncreaseReplicationFactor
 #[derive(Debug, PartialEq)]
 pub enum IncreaseReplicationFactorError {
@@ -1854,24 +1876,38 @@ impl IncreaseReplicationFactorError {
 }
 impl fmt::Display for IncreaseReplicationFactorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for IncreaseReplicationFactorError {
-    fn description(&self) -> &str {
         match *self {
-            IncreaseReplicationFactorError::ClusterNotFoundFault(ref cause) => cause,
-            IncreaseReplicationFactorError::InsufficientClusterCapacityFault(ref cause) => cause,
-            IncreaseReplicationFactorError::InvalidClusterStateFault(ref cause) => cause,
-            IncreaseReplicationFactorError::InvalidParameterCombination(ref cause) => cause,
-            IncreaseReplicationFactorError::InvalidParameterValue(ref cause) => cause,
-            IncreaseReplicationFactorError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            IncreaseReplicationFactorError::NodeQuotaForClusterExceededFault(ref cause) => cause,
-            IncreaseReplicationFactorError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-            IncreaseReplicationFactorError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            IncreaseReplicationFactorError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::InsufficientClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::NodeQuotaForClusterExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicationFactorError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for IncreaseReplicationFactorError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -1924,21 +1960,17 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::ClusterNotFoundFault(ref cause) => cause,
-            ListTagsError::InvalidARNFault(ref cause) => cause,
-            ListTagsError::InvalidClusterStateFault(ref cause) => cause,
-            ListTagsError::InvalidParameterCombination(ref cause) => cause,
-            ListTagsError::InvalidParameterValue(ref cause) => cause,
-            ListTagsError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            ListTagsError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InvalidARNFault(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListTagsError::ServiceLinkedRoleNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by RebootNode
 #[derive(Debug, PartialEq)]
 pub enum RebootNodeError {
@@ -1991,21 +2023,17 @@ impl RebootNodeError {
 }
 impl fmt::Display for RebootNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootNodeError {
-    fn description(&self) -> &str {
         match *self {
-            RebootNodeError::ClusterNotFoundFault(ref cause) => cause,
-            RebootNodeError::InvalidClusterStateFault(ref cause) => cause,
-            RebootNodeError::InvalidParameterCombination(ref cause) => cause,
-            RebootNodeError::InvalidParameterValue(ref cause) => cause,
-            RebootNodeError::NodeNotFoundFault(ref cause) => cause,
-            RebootNodeError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            RebootNodeError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RebootNodeError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            RebootNodeError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            RebootNodeError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            RebootNodeError::NodeNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RebootNodeError::ServiceLinkedRoleNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootNodeError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2067,22 +2095,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ClusterNotFoundFault(ref cause) => cause,
-            TagResourceError::InvalidARNFault(ref cause) => cause,
-            TagResourceError::InvalidClusterStateFault(ref cause) => cause,
-            TagResourceError::InvalidParameterCombination(ref cause) => cause,
-            TagResourceError::InvalidParameterValue(ref cause) => cause,
-            TagResourceError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
-            TagResourceError::TagQuotaPerResourceExceeded(ref cause) => cause,
+            TagResourceError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidARNFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ServiceLinkedRoleNotFoundFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagQuotaPerResourceExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2142,22 +2166,18 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ClusterNotFoundFault(ref cause) => cause,
-            UntagResourceError::InvalidARNFault(ref cause) => cause,
-            UntagResourceError::InvalidClusterStateFault(ref cause) => cause,
-            UntagResourceError::InvalidParameterCombination(ref cause) => cause,
-            UntagResourceError::InvalidParameterValue(ref cause) => cause,
-            UntagResourceError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
-            UntagResourceError::TagNotFoundFault(ref cause) => cause,
+            UntagResourceError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidARNFault(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ServiceLinkedRoleNotFoundFault(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TagNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateCluster
 #[derive(Debug, PartialEq)]
 pub enum UpdateClusterError {
@@ -2221,22 +2241,20 @@ impl UpdateClusterError {
 }
 impl fmt::Display for UpdateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClusterError::ClusterNotFoundFault(ref cause) => cause,
-            UpdateClusterError::InvalidClusterStateFault(ref cause) => cause,
-            UpdateClusterError::InvalidParameterCombination(ref cause) => cause,
-            UpdateClusterError::InvalidParameterGroupStateFault(ref cause) => cause,
-            UpdateClusterError::InvalidParameterValue(ref cause) => cause,
-            UpdateClusterError::ParameterGroupNotFoundFault(ref cause) => cause,
-            UpdateClusterError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            UpdateClusterError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::InvalidParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateClusterError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::ParameterGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::ServiceLinkedRoleNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClusterError {}
 /// Errors returned by UpdateParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateParameterGroupError {
@@ -2290,20 +2308,24 @@ impl UpdateParameterGroupError {
 }
 impl fmt::Display for UpdateParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateParameterGroupError::InvalidParameterCombination(ref cause) => cause,
-            UpdateParameterGroupError::InvalidParameterGroupStateFault(ref cause) => cause,
-            UpdateParameterGroupError::InvalidParameterValue(ref cause) => cause,
-            UpdateParameterGroupError::ParameterGroupNotFoundFault(ref cause) => cause,
-            UpdateParameterGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            UpdateParameterGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateParameterGroupError::InvalidParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateParameterGroupError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UpdateParameterGroupError::ParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateParameterGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateParameterGroupError {}
 /// Errors returned by UpdateSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateSubnetGroupError {
@@ -2353,20 +2375,18 @@ impl UpdateSubnetGroupError {
 }
 impl fmt::Display for UpdateSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            UpdateSubnetGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
-            UpdateSubnetGroupError::SubnetGroupNotFoundFault(ref cause) => cause,
-            UpdateSubnetGroupError::SubnetInUse(ref cause) => cause,
-            UpdateSubnetGroupError::SubnetQuotaExceededFault(ref cause) => cause,
+            UpdateSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            UpdateSubnetGroupError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSubnetGroupError::SubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            UpdateSubnetGroupError::SubnetInUse(ref cause) => write!(f, "{}", cause),
+            UpdateSubnetGroupError::SubnetQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSubnetGroupError {}
 /// Trait representing the capabilities of the Amazon DAX API. Amazon DAX clients implement this trait.
 pub trait DynamodbAccelerator {
     /// <p>Creates a DAX cluster. All nodes in the cluster run the same DAX caching software.</p>

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -3009,19 +3009,15 @@ impl CreateDevicePoolError {
 }
 impl fmt::Display for CreateDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDevicePoolError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDevicePoolError::Argument(ref cause) => cause,
-            CreateDevicePoolError::LimitExceeded(ref cause) => cause,
-            CreateDevicePoolError::NotFound(ref cause) => cause,
-            CreateDevicePoolError::ServiceAccount(ref cause) => cause,
+            CreateDevicePoolError::Argument(ref cause) => write!(f, "{}", cause),
+            CreateDevicePoolError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDevicePoolError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDevicePoolError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDevicePoolError {}
 /// Errors returned by CreateInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateInstanceProfileError {
@@ -3062,19 +3058,15 @@ impl CreateInstanceProfileError {
 }
 impl fmt::Display for CreateInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInstanceProfileError::Argument(ref cause) => cause,
-            CreateInstanceProfileError::LimitExceeded(ref cause) => cause,
-            CreateInstanceProfileError::NotFound(ref cause) => cause,
-            CreateInstanceProfileError::ServiceAccount(ref cause) => cause,
+            CreateInstanceProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            CreateInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateInstanceProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateInstanceProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInstanceProfileError {}
 /// Errors returned by CreateNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateNetworkProfileError {
@@ -3113,19 +3105,15 @@ impl CreateNetworkProfileError {
 }
 impl fmt::Display for CreateNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNetworkProfileError::Argument(ref cause) => cause,
-            CreateNetworkProfileError::LimitExceeded(ref cause) => cause,
-            CreateNetworkProfileError::NotFound(ref cause) => cause,
-            CreateNetworkProfileError::ServiceAccount(ref cause) => cause,
+            CreateNetworkProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            CreateNetworkProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateNetworkProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateNetworkProfileError {}
 /// Errors returned by CreateProject
 #[derive(Debug, PartialEq)]
 pub enum CreateProjectError {
@@ -3169,20 +3157,16 @@ impl CreateProjectError {
 }
 impl fmt::Display for CreateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProjectError::Argument(ref cause) => cause,
-            CreateProjectError::LimitExceeded(ref cause) => cause,
-            CreateProjectError::NotFound(ref cause) => cause,
-            CreateProjectError::ServiceAccount(ref cause) => cause,
-            CreateProjectError::TagOperation(ref cause) => cause,
+            CreateProjectError::Argument(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ServiceAccount(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::TagOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProjectError {}
 /// Errors returned by CreateRemoteAccessSession
 #[derive(Debug, PartialEq)]
 pub enum CreateRemoteAccessSessionError {
@@ -3225,19 +3209,15 @@ impl CreateRemoteAccessSessionError {
 }
 impl fmt::Display for CreateRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRemoteAccessSessionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRemoteAccessSessionError::Argument(ref cause) => cause,
-            CreateRemoteAccessSessionError::LimitExceeded(ref cause) => cause,
-            CreateRemoteAccessSessionError::NotFound(ref cause) => cause,
-            CreateRemoteAccessSessionError::ServiceAccount(ref cause) => cause,
+            CreateRemoteAccessSessionError::Argument(ref cause) => write!(f, "{}", cause),
+            CreateRemoteAccessSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRemoteAccessSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRemoteAccessSessionError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRemoteAccessSessionError {}
 /// Errors returned by CreateUpload
 #[derive(Debug, PartialEq)]
 pub enum CreateUploadError {
@@ -3276,19 +3256,15 @@ impl CreateUploadError {
 }
 impl fmt::Display for CreateUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUploadError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUploadError::Argument(ref cause) => cause,
-            CreateUploadError::LimitExceeded(ref cause) => cause,
-            CreateUploadError::NotFound(ref cause) => cause,
-            CreateUploadError::ServiceAccount(ref cause) => cause,
+            CreateUploadError::Argument(ref cause) => write!(f, "{}", cause),
+            CreateUploadError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUploadError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateUploadError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUploadError {}
 /// Errors returned by CreateVPCEConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateVPCEConfigurationError {
@@ -3326,18 +3302,14 @@ impl CreateVPCEConfigurationError {
 }
 impl fmt::Display for CreateVPCEConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVPCEConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVPCEConfigurationError::Argument(ref cause) => cause,
-            CreateVPCEConfigurationError::LimitExceeded(ref cause) => cause,
-            CreateVPCEConfigurationError::ServiceAccount(ref cause) => cause,
+            CreateVPCEConfigurationError::Argument(ref cause) => write!(f, "{}", cause),
+            CreateVPCEConfigurationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateVPCEConfigurationError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVPCEConfigurationError {}
 /// Errors returned by DeleteDevicePool
 #[derive(Debug, PartialEq)]
 pub enum DeleteDevicePoolError {
@@ -3376,19 +3348,15 @@ impl DeleteDevicePoolError {
 }
 impl fmt::Display for DeleteDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDevicePoolError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDevicePoolError::Argument(ref cause) => cause,
-            DeleteDevicePoolError::LimitExceeded(ref cause) => cause,
-            DeleteDevicePoolError::NotFound(ref cause) => cause,
-            DeleteDevicePoolError::ServiceAccount(ref cause) => cause,
+            DeleteDevicePoolError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteDevicePoolError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteDevicePoolError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDevicePoolError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDevicePoolError {}
 /// Errors returned by DeleteInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteInstanceProfileError {
@@ -3429,19 +3397,15 @@ impl DeleteInstanceProfileError {
 }
 impl fmt::Display for DeleteInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInstanceProfileError::Argument(ref cause) => cause,
-            DeleteInstanceProfileError::LimitExceeded(ref cause) => cause,
-            DeleteInstanceProfileError::NotFound(ref cause) => cause,
-            DeleteInstanceProfileError::ServiceAccount(ref cause) => cause,
+            DeleteInstanceProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInstanceProfileError {}
 /// Errors returned by DeleteNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteNetworkProfileError {
@@ -3480,19 +3444,15 @@ impl DeleteNetworkProfileError {
 }
 impl fmt::Display for DeleteNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNetworkProfileError::Argument(ref cause) => cause,
-            DeleteNetworkProfileError::LimitExceeded(ref cause) => cause,
-            DeleteNetworkProfileError::NotFound(ref cause) => cause,
-            DeleteNetworkProfileError::ServiceAccount(ref cause) => cause,
+            DeleteNetworkProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteNetworkProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteNetworkProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteNetworkProfileError {}
 /// Errors returned by DeleteProject
 #[derive(Debug, PartialEq)]
 pub enum DeleteProjectError {
@@ -3531,19 +3491,15 @@ impl DeleteProjectError {
 }
 impl fmt::Display for DeleteProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProjectError::Argument(ref cause) => cause,
-            DeleteProjectError::LimitExceeded(ref cause) => cause,
-            DeleteProjectError::NotFound(ref cause) => cause,
-            DeleteProjectError::ServiceAccount(ref cause) => cause,
+            DeleteProjectError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProjectError {}
 /// Errors returned by DeleteRemoteAccessSession
 #[derive(Debug, PartialEq)]
 pub enum DeleteRemoteAccessSessionError {
@@ -3586,19 +3542,15 @@ impl DeleteRemoteAccessSessionError {
 }
 impl fmt::Display for DeleteRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRemoteAccessSessionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRemoteAccessSessionError::Argument(ref cause) => cause,
-            DeleteRemoteAccessSessionError::LimitExceeded(ref cause) => cause,
-            DeleteRemoteAccessSessionError::NotFound(ref cause) => cause,
-            DeleteRemoteAccessSessionError::ServiceAccount(ref cause) => cause,
+            DeleteRemoteAccessSessionError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteRemoteAccessSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteRemoteAccessSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRemoteAccessSessionError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRemoteAccessSessionError {}
 /// Errors returned by DeleteRun
 #[derive(Debug, PartialEq)]
 pub enum DeleteRunError {
@@ -3637,19 +3589,15 @@ impl DeleteRunError {
 }
 impl fmt::Display for DeleteRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRunError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRunError::Argument(ref cause) => cause,
-            DeleteRunError::LimitExceeded(ref cause) => cause,
-            DeleteRunError::NotFound(ref cause) => cause,
-            DeleteRunError::ServiceAccount(ref cause) => cause,
+            DeleteRunError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteRunError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteRunError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRunError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRunError {}
 /// Errors returned by DeleteUpload
 #[derive(Debug, PartialEq)]
 pub enum DeleteUploadError {
@@ -3688,19 +3636,15 @@ impl DeleteUploadError {
 }
 impl fmt::Display for DeleteUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUploadError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUploadError::Argument(ref cause) => cause,
-            DeleteUploadError::LimitExceeded(ref cause) => cause,
-            DeleteUploadError::NotFound(ref cause) => cause,
-            DeleteUploadError::ServiceAccount(ref cause) => cause,
+            DeleteUploadError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteUploadError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteUploadError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUploadError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUploadError {}
 /// Errors returned by DeleteVPCEConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteVPCEConfigurationError {
@@ -3743,19 +3687,15 @@ impl DeleteVPCEConfigurationError {
 }
 impl fmt::Display for DeleteVPCEConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVPCEConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVPCEConfigurationError::Argument(ref cause) => cause,
-            DeleteVPCEConfigurationError::InvalidOperation(ref cause) => cause,
-            DeleteVPCEConfigurationError::NotFound(ref cause) => cause,
-            DeleteVPCEConfigurationError::ServiceAccount(ref cause) => cause,
+            DeleteVPCEConfigurationError::Argument(ref cause) => write!(f, "{}", cause),
+            DeleteVPCEConfigurationError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DeleteVPCEConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVPCEConfigurationError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVPCEConfigurationError {}
 /// Errors returned by GetAccountSettings
 #[derive(Debug, PartialEq)]
 pub enum GetAccountSettingsError {
@@ -3794,19 +3734,15 @@ impl GetAccountSettingsError {
 }
 impl fmt::Display for GetAccountSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountSettingsError::Argument(ref cause) => cause,
-            GetAccountSettingsError::LimitExceeded(ref cause) => cause,
-            GetAccountSettingsError::NotFound(ref cause) => cause,
-            GetAccountSettingsError::ServiceAccount(ref cause) => cause,
+            GetAccountSettingsError::Argument(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountSettingsError {}
 /// Errors returned by GetDevice
 #[derive(Debug, PartialEq)]
 pub enum GetDeviceError {
@@ -3845,19 +3781,15 @@ impl GetDeviceError {
 }
 impl fmt::Display for GetDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeviceError::Argument(ref cause) => cause,
-            GetDeviceError::LimitExceeded(ref cause) => cause,
-            GetDeviceError::NotFound(ref cause) => cause,
-            GetDeviceError::ServiceAccount(ref cause) => cause,
+            GetDeviceError::Argument(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDeviceError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeviceError {}
 /// Errors returned by GetDeviceInstance
 #[derive(Debug, PartialEq)]
 pub enum GetDeviceInstanceError {
@@ -3896,19 +3828,15 @@ impl GetDeviceInstanceError {
 }
 impl fmt::Display for GetDeviceInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeviceInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeviceInstanceError::Argument(ref cause) => cause,
-            GetDeviceInstanceError::LimitExceeded(ref cause) => cause,
-            GetDeviceInstanceError::NotFound(ref cause) => cause,
-            GetDeviceInstanceError::ServiceAccount(ref cause) => cause,
+            GetDeviceInstanceError::Argument(ref cause) => write!(f, "{}", cause),
+            GetDeviceInstanceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetDeviceInstanceError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDeviceInstanceError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeviceInstanceError {}
 /// Errors returned by GetDevicePool
 #[derive(Debug, PartialEq)]
 pub enum GetDevicePoolError {
@@ -3947,19 +3875,15 @@ impl GetDevicePoolError {
 }
 impl fmt::Display for GetDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDevicePoolError {
-    fn description(&self) -> &str {
         match *self {
-            GetDevicePoolError::Argument(ref cause) => cause,
-            GetDevicePoolError::LimitExceeded(ref cause) => cause,
-            GetDevicePoolError::NotFound(ref cause) => cause,
-            GetDevicePoolError::ServiceAccount(ref cause) => cause,
+            GetDevicePoolError::Argument(ref cause) => write!(f, "{}", cause),
+            GetDevicePoolError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetDevicePoolError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDevicePoolError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDevicePoolError {}
 /// Errors returned by GetDevicePoolCompatibility
 #[derive(Debug, PartialEq)]
 pub enum GetDevicePoolCompatibilityError {
@@ -4004,19 +3928,15 @@ impl GetDevicePoolCompatibilityError {
 }
 impl fmt::Display for GetDevicePoolCompatibilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDevicePoolCompatibilityError {
-    fn description(&self) -> &str {
         match *self {
-            GetDevicePoolCompatibilityError::Argument(ref cause) => cause,
-            GetDevicePoolCompatibilityError::LimitExceeded(ref cause) => cause,
-            GetDevicePoolCompatibilityError::NotFound(ref cause) => cause,
-            GetDevicePoolCompatibilityError::ServiceAccount(ref cause) => cause,
+            GetDevicePoolCompatibilityError::Argument(ref cause) => write!(f, "{}", cause),
+            GetDevicePoolCompatibilityError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetDevicePoolCompatibilityError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDevicePoolCompatibilityError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDevicePoolCompatibilityError {}
 /// Errors returned by GetInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceProfileError {
@@ -4055,19 +3975,15 @@ impl GetInstanceProfileError {
 }
 impl fmt::Display for GetInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceProfileError::Argument(ref cause) => cause,
-            GetInstanceProfileError::LimitExceeded(ref cause) => cause,
-            GetInstanceProfileError::NotFound(ref cause) => cause,
-            GetInstanceProfileError::ServiceAccount(ref cause) => cause,
+            GetInstanceProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            GetInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetInstanceProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceProfileError {}
 /// Errors returned by GetJob
 #[derive(Debug, PartialEq)]
 pub enum GetJobError {
@@ -4102,19 +4018,15 @@ impl GetJobError {
 }
 impl fmt::Display for GetJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobError::Argument(ref cause) => cause,
-            GetJobError::LimitExceeded(ref cause) => cause,
-            GetJobError::NotFound(ref cause) => cause,
-            GetJobError::ServiceAccount(ref cause) => cause,
+            GetJobError::Argument(ref cause) => write!(f, "{}", cause),
+            GetJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetJobError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobError {}
 /// Errors returned by GetNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum GetNetworkProfileError {
@@ -4153,19 +4065,15 @@ impl GetNetworkProfileError {
 }
 impl fmt::Display for GetNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            GetNetworkProfileError::Argument(ref cause) => cause,
-            GetNetworkProfileError::LimitExceeded(ref cause) => cause,
-            GetNetworkProfileError::NotFound(ref cause) => cause,
-            GetNetworkProfileError::ServiceAccount(ref cause) => cause,
+            GetNetworkProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            GetNetworkProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetNetworkProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetNetworkProfileError {}
 /// Errors returned by GetOfferingStatus
 #[derive(Debug, PartialEq)]
 pub enum GetOfferingStatusError {
@@ -4209,20 +4117,16 @@ impl GetOfferingStatusError {
 }
 impl fmt::Display for GetOfferingStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOfferingStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetOfferingStatusError::Argument(ref cause) => cause,
-            GetOfferingStatusError::LimitExceeded(ref cause) => cause,
-            GetOfferingStatusError::NotEligible(ref cause) => cause,
-            GetOfferingStatusError::NotFound(ref cause) => cause,
-            GetOfferingStatusError::ServiceAccount(ref cause) => cause,
+            GetOfferingStatusError::Argument(ref cause) => write!(f, "{}", cause),
+            GetOfferingStatusError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetOfferingStatusError::NotEligible(ref cause) => write!(f, "{}", cause),
+            GetOfferingStatusError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetOfferingStatusError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOfferingStatusError {}
 /// Errors returned by GetProject
 #[derive(Debug, PartialEq)]
 pub enum GetProjectError {
@@ -4261,19 +4165,15 @@ impl GetProjectError {
 }
 impl fmt::Display for GetProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetProjectError {
-    fn description(&self) -> &str {
         match *self {
-            GetProjectError::Argument(ref cause) => cause,
-            GetProjectError::LimitExceeded(ref cause) => cause,
-            GetProjectError::NotFound(ref cause) => cause,
-            GetProjectError::ServiceAccount(ref cause) => cause,
+            GetProjectError::Argument(ref cause) => write!(f, "{}", cause),
+            GetProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetProjectError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetProjectError {}
 /// Errors returned by GetRemoteAccessSession
 #[derive(Debug, PartialEq)]
 pub enum GetRemoteAccessSessionError {
@@ -4316,19 +4216,15 @@ impl GetRemoteAccessSessionError {
 }
 impl fmt::Display for GetRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRemoteAccessSessionError {
-    fn description(&self) -> &str {
         match *self {
-            GetRemoteAccessSessionError::Argument(ref cause) => cause,
-            GetRemoteAccessSessionError::LimitExceeded(ref cause) => cause,
-            GetRemoteAccessSessionError::NotFound(ref cause) => cause,
-            GetRemoteAccessSessionError::ServiceAccount(ref cause) => cause,
+            GetRemoteAccessSessionError::Argument(ref cause) => write!(f, "{}", cause),
+            GetRemoteAccessSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetRemoteAccessSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRemoteAccessSessionError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRemoteAccessSessionError {}
 /// Errors returned by GetRun
 #[derive(Debug, PartialEq)]
 pub enum GetRunError {
@@ -4363,19 +4259,15 @@ impl GetRunError {
 }
 impl fmt::Display for GetRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRunError {
-    fn description(&self) -> &str {
         match *self {
-            GetRunError::Argument(ref cause) => cause,
-            GetRunError::LimitExceeded(ref cause) => cause,
-            GetRunError::NotFound(ref cause) => cause,
-            GetRunError::ServiceAccount(ref cause) => cause,
+            GetRunError::Argument(ref cause) => write!(f, "{}", cause),
+            GetRunError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetRunError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRunError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRunError {}
 /// Errors returned by GetSuite
 #[derive(Debug, PartialEq)]
 pub enum GetSuiteError {
@@ -4414,19 +4306,15 @@ impl GetSuiteError {
 }
 impl fmt::Display for GetSuiteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSuiteError {
-    fn description(&self) -> &str {
         match *self {
-            GetSuiteError::Argument(ref cause) => cause,
-            GetSuiteError::LimitExceeded(ref cause) => cause,
-            GetSuiteError::NotFound(ref cause) => cause,
-            GetSuiteError::ServiceAccount(ref cause) => cause,
+            GetSuiteError::Argument(ref cause) => write!(f, "{}", cause),
+            GetSuiteError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetSuiteError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetSuiteError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSuiteError {}
 /// Errors returned by GetTest
 #[derive(Debug, PartialEq)]
 pub enum GetTestError {
@@ -4465,19 +4353,15 @@ impl GetTestError {
 }
 impl fmt::Display for GetTestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTestError {
-    fn description(&self) -> &str {
         match *self {
-            GetTestError::Argument(ref cause) => cause,
-            GetTestError::LimitExceeded(ref cause) => cause,
-            GetTestError::NotFound(ref cause) => cause,
-            GetTestError::ServiceAccount(ref cause) => cause,
+            GetTestError::Argument(ref cause) => write!(f, "{}", cause),
+            GetTestError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetTestError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetTestError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTestError {}
 /// Errors returned by GetUpload
 #[derive(Debug, PartialEq)]
 pub enum GetUploadError {
@@ -4516,19 +4400,15 @@ impl GetUploadError {
 }
 impl fmt::Display for GetUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUploadError {
-    fn description(&self) -> &str {
         match *self {
-            GetUploadError::Argument(ref cause) => cause,
-            GetUploadError::LimitExceeded(ref cause) => cause,
-            GetUploadError::NotFound(ref cause) => cause,
-            GetUploadError::ServiceAccount(ref cause) => cause,
+            GetUploadError::Argument(ref cause) => write!(f, "{}", cause),
+            GetUploadError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetUploadError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetUploadError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUploadError {}
 /// Errors returned by GetVPCEConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetVPCEConfigurationError {
@@ -4562,18 +4442,14 @@ impl GetVPCEConfigurationError {
 }
 impl fmt::Display for GetVPCEConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVPCEConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetVPCEConfigurationError::Argument(ref cause) => cause,
-            GetVPCEConfigurationError::NotFound(ref cause) => cause,
-            GetVPCEConfigurationError::ServiceAccount(ref cause) => cause,
+            GetVPCEConfigurationError::Argument(ref cause) => write!(f, "{}", cause),
+            GetVPCEConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetVPCEConfigurationError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVPCEConfigurationError {}
 /// Errors returned by InstallToRemoteAccessSession
 #[derive(Debug, PartialEq)]
 pub enum InstallToRemoteAccessSessionError {
@@ -4622,19 +4498,15 @@ impl InstallToRemoteAccessSessionError {
 }
 impl fmt::Display for InstallToRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InstallToRemoteAccessSessionError {
-    fn description(&self) -> &str {
         match *self {
-            InstallToRemoteAccessSessionError::Argument(ref cause) => cause,
-            InstallToRemoteAccessSessionError::LimitExceeded(ref cause) => cause,
-            InstallToRemoteAccessSessionError::NotFound(ref cause) => cause,
-            InstallToRemoteAccessSessionError::ServiceAccount(ref cause) => cause,
+            InstallToRemoteAccessSessionError::Argument(ref cause) => write!(f, "{}", cause),
+            InstallToRemoteAccessSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            InstallToRemoteAccessSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            InstallToRemoteAccessSessionError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InstallToRemoteAccessSessionError {}
 /// Errors returned by ListArtifacts
 #[derive(Debug, PartialEq)]
 pub enum ListArtifactsError {
@@ -4673,19 +4545,15 @@ impl ListArtifactsError {
 }
 impl fmt::Display for ListArtifactsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListArtifactsError {
-    fn description(&self) -> &str {
         match *self {
-            ListArtifactsError::Argument(ref cause) => cause,
-            ListArtifactsError::LimitExceeded(ref cause) => cause,
-            ListArtifactsError::NotFound(ref cause) => cause,
-            ListArtifactsError::ServiceAccount(ref cause) => cause,
+            ListArtifactsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListArtifactsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListArtifactsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListArtifactsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListArtifactsError {}
 /// Errors returned by ListDeviceInstances
 #[derive(Debug, PartialEq)]
 pub enum ListDeviceInstancesError {
@@ -4724,19 +4592,15 @@ impl ListDeviceInstancesError {
 }
 impl fmt::Display for ListDeviceInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeviceInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeviceInstancesError::Argument(ref cause) => cause,
-            ListDeviceInstancesError::LimitExceeded(ref cause) => cause,
-            ListDeviceInstancesError::NotFound(ref cause) => cause,
-            ListDeviceInstancesError::ServiceAccount(ref cause) => cause,
+            ListDeviceInstancesError::Argument(ref cause) => write!(f, "{}", cause),
+            ListDeviceInstancesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListDeviceInstancesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListDeviceInstancesError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeviceInstancesError {}
 /// Errors returned by ListDevicePools
 #[derive(Debug, PartialEq)]
 pub enum ListDevicePoolsError {
@@ -4775,19 +4639,15 @@ impl ListDevicePoolsError {
 }
 impl fmt::Display for ListDevicePoolsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDevicePoolsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDevicePoolsError::Argument(ref cause) => cause,
-            ListDevicePoolsError::LimitExceeded(ref cause) => cause,
-            ListDevicePoolsError::NotFound(ref cause) => cause,
-            ListDevicePoolsError::ServiceAccount(ref cause) => cause,
+            ListDevicePoolsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListDevicePoolsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListDevicePoolsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListDevicePoolsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDevicePoolsError {}
 /// Errors returned by ListDevices
 #[derive(Debug, PartialEq)]
 pub enum ListDevicesError {
@@ -4826,19 +4686,15 @@ impl ListDevicesError {
 }
 impl fmt::Display for ListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDevicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDevicesError::Argument(ref cause) => cause,
-            ListDevicesError::LimitExceeded(ref cause) => cause,
-            ListDevicesError::NotFound(ref cause) => cause,
-            ListDevicesError::ServiceAccount(ref cause) => cause,
+            ListDevicesError::Argument(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDevicesError {}
 /// Errors returned by ListInstanceProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListInstanceProfilesError {
@@ -4877,19 +4733,15 @@ impl ListInstanceProfilesError {
 }
 impl fmt::Display for ListInstanceProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInstanceProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListInstanceProfilesError::Argument(ref cause) => cause,
-            ListInstanceProfilesError::LimitExceeded(ref cause) => cause,
-            ListInstanceProfilesError::NotFound(ref cause) => cause,
-            ListInstanceProfilesError::ServiceAccount(ref cause) => cause,
+            ListInstanceProfilesError::Argument(ref cause) => write!(f, "{}", cause),
+            ListInstanceProfilesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListInstanceProfilesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListInstanceProfilesError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInstanceProfilesError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -4928,19 +4780,15 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::Argument(ref cause) => cause,
-            ListJobsError::LimitExceeded(ref cause) => cause,
-            ListJobsError::NotFound(ref cause) => cause,
-            ListJobsError::ServiceAccount(ref cause) => cause,
+            ListJobsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListJobsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListJobsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListJobsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by ListNetworkProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListNetworkProfilesError {
@@ -4979,19 +4827,15 @@ impl ListNetworkProfilesError {
 }
 impl fmt::Display for ListNetworkProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListNetworkProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListNetworkProfilesError::Argument(ref cause) => cause,
-            ListNetworkProfilesError::LimitExceeded(ref cause) => cause,
-            ListNetworkProfilesError::NotFound(ref cause) => cause,
-            ListNetworkProfilesError::ServiceAccount(ref cause) => cause,
+            ListNetworkProfilesError::Argument(ref cause) => write!(f, "{}", cause),
+            ListNetworkProfilesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListNetworkProfilesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListNetworkProfilesError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListNetworkProfilesError {}
 /// Errors returned by ListOfferingPromotions
 #[derive(Debug, PartialEq)]
 pub enum ListOfferingPromotionsError {
@@ -5039,20 +4883,16 @@ impl ListOfferingPromotionsError {
 }
 impl fmt::Display for ListOfferingPromotionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOfferingPromotionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOfferingPromotionsError::Argument(ref cause) => cause,
-            ListOfferingPromotionsError::LimitExceeded(ref cause) => cause,
-            ListOfferingPromotionsError::NotEligible(ref cause) => cause,
-            ListOfferingPromotionsError::NotFound(ref cause) => cause,
-            ListOfferingPromotionsError::ServiceAccount(ref cause) => cause,
+            ListOfferingPromotionsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListOfferingPromotionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListOfferingPromotionsError::NotEligible(ref cause) => write!(f, "{}", cause),
+            ListOfferingPromotionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListOfferingPromotionsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOfferingPromotionsError {}
 /// Errors returned by ListOfferingTransactions
 #[derive(Debug, PartialEq)]
 pub enum ListOfferingTransactionsError {
@@ -5102,20 +4942,16 @@ impl ListOfferingTransactionsError {
 }
 impl fmt::Display for ListOfferingTransactionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOfferingTransactionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOfferingTransactionsError::Argument(ref cause) => cause,
-            ListOfferingTransactionsError::LimitExceeded(ref cause) => cause,
-            ListOfferingTransactionsError::NotEligible(ref cause) => cause,
-            ListOfferingTransactionsError::NotFound(ref cause) => cause,
-            ListOfferingTransactionsError::ServiceAccount(ref cause) => cause,
+            ListOfferingTransactionsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListOfferingTransactionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListOfferingTransactionsError::NotEligible(ref cause) => write!(f, "{}", cause),
+            ListOfferingTransactionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListOfferingTransactionsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOfferingTransactionsError {}
 /// Errors returned by ListOfferings
 #[derive(Debug, PartialEq)]
 pub enum ListOfferingsError {
@@ -5159,20 +4995,16 @@ impl ListOfferingsError {
 }
 impl fmt::Display for ListOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOfferingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOfferingsError::Argument(ref cause) => cause,
-            ListOfferingsError::LimitExceeded(ref cause) => cause,
-            ListOfferingsError::NotEligible(ref cause) => cause,
-            ListOfferingsError::NotFound(ref cause) => cause,
-            ListOfferingsError::ServiceAccount(ref cause) => cause,
+            ListOfferingsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::NotEligible(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOfferingsError {}
 /// Errors returned by ListProjects
 #[derive(Debug, PartialEq)]
 pub enum ListProjectsError {
@@ -5211,19 +5043,15 @@ impl ListProjectsError {
 }
 impl fmt::Display for ListProjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProjectsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProjectsError::Argument(ref cause) => cause,
-            ListProjectsError::LimitExceeded(ref cause) => cause,
-            ListProjectsError::NotFound(ref cause) => cause,
-            ListProjectsError::ServiceAccount(ref cause) => cause,
+            ListProjectsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProjectsError {}
 /// Errors returned by ListRemoteAccessSessions
 #[derive(Debug, PartialEq)]
 pub enum ListRemoteAccessSessionsError {
@@ -5266,19 +5094,15 @@ impl ListRemoteAccessSessionsError {
 }
 impl fmt::Display for ListRemoteAccessSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRemoteAccessSessionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRemoteAccessSessionsError::Argument(ref cause) => cause,
-            ListRemoteAccessSessionsError::LimitExceeded(ref cause) => cause,
-            ListRemoteAccessSessionsError::NotFound(ref cause) => cause,
-            ListRemoteAccessSessionsError::ServiceAccount(ref cause) => cause,
+            ListRemoteAccessSessionsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListRemoteAccessSessionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListRemoteAccessSessionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListRemoteAccessSessionsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRemoteAccessSessionsError {}
 /// Errors returned by ListRuns
 #[derive(Debug, PartialEq)]
 pub enum ListRunsError {
@@ -5317,19 +5141,15 @@ impl ListRunsError {
 }
 impl fmt::Display for ListRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRunsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRunsError::Argument(ref cause) => cause,
-            ListRunsError::LimitExceeded(ref cause) => cause,
-            ListRunsError::NotFound(ref cause) => cause,
-            ListRunsError::ServiceAccount(ref cause) => cause,
+            ListRunsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListRunsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListRunsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListRunsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRunsError {}
 /// Errors returned by ListSamples
 #[derive(Debug, PartialEq)]
 pub enum ListSamplesError {
@@ -5368,19 +5188,15 @@ impl ListSamplesError {
 }
 impl fmt::Display for ListSamplesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSamplesError {
-    fn description(&self) -> &str {
         match *self {
-            ListSamplesError::Argument(ref cause) => cause,
-            ListSamplesError::LimitExceeded(ref cause) => cause,
-            ListSamplesError::NotFound(ref cause) => cause,
-            ListSamplesError::ServiceAccount(ref cause) => cause,
+            ListSamplesError::Argument(ref cause) => write!(f, "{}", cause),
+            ListSamplesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListSamplesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListSamplesError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSamplesError {}
 /// Errors returned by ListSuites
 #[derive(Debug, PartialEq)]
 pub enum ListSuitesError {
@@ -5419,19 +5235,15 @@ impl ListSuitesError {
 }
 impl fmt::Display for ListSuitesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSuitesError {
-    fn description(&self) -> &str {
         match *self {
-            ListSuitesError::Argument(ref cause) => cause,
-            ListSuitesError::LimitExceeded(ref cause) => cause,
-            ListSuitesError::NotFound(ref cause) => cause,
-            ListSuitesError::ServiceAccount(ref cause) => cause,
+            ListSuitesError::Argument(ref cause) => write!(f, "{}", cause),
+            ListSuitesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListSuitesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListSuitesError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSuitesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -5460,17 +5272,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::NotFound(ref cause) => cause,
-            ListTagsForResourceError::TagOperation(ref cause) => cause,
+            ListTagsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TagOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTests
 #[derive(Debug, PartialEq)]
 pub enum ListTestsError {
@@ -5509,19 +5317,15 @@ impl ListTestsError {
 }
 impl fmt::Display for ListTestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTestsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTestsError::Argument(ref cause) => cause,
-            ListTestsError::LimitExceeded(ref cause) => cause,
-            ListTestsError::NotFound(ref cause) => cause,
-            ListTestsError::ServiceAccount(ref cause) => cause,
+            ListTestsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListTestsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTestsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListTestsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTestsError {}
 /// Errors returned by ListUniqueProblems
 #[derive(Debug, PartialEq)]
 pub enum ListUniqueProblemsError {
@@ -5560,19 +5364,15 @@ impl ListUniqueProblemsError {
 }
 impl fmt::Display for ListUniqueProblemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUniqueProblemsError {
-    fn description(&self) -> &str {
         match *self {
-            ListUniqueProblemsError::Argument(ref cause) => cause,
-            ListUniqueProblemsError::LimitExceeded(ref cause) => cause,
-            ListUniqueProblemsError::NotFound(ref cause) => cause,
-            ListUniqueProblemsError::ServiceAccount(ref cause) => cause,
+            ListUniqueProblemsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListUniqueProblemsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListUniqueProblemsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListUniqueProblemsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUniqueProblemsError {}
 /// Errors returned by ListUploads
 #[derive(Debug, PartialEq)]
 pub enum ListUploadsError {
@@ -5611,19 +5411,15 @@ impl ListUploadsError {
 }
 impl fmt::Display for ListUploadsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUploadsError {
-    fn description(&self) -> &str {
         match *self {
-            ListUploadsError::Argument(ref cause) => cause,
-            ListUploadsError::LimitExceeded(ref cause) => cause,
-            ListUploadsError::NotFound(ref cause) => cause,
-            ListUploadsError::ServiceAccount(ref cause) => cause,
+            ListUploadsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListUploadsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListUploadsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListUploadsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUploadsError {}
 /// Errors returned by ListVPCEConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListVPCEConfigurationsError {
@@ -5654,17 +5450,13 @@ impl ListVPCEConfigurationsError {
 }
 impl fmt::Display for ListVPCEConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVPCEConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVPCEConfigurationsError::Argument(ref cause) => cause,
-            ListVPCEConfigurationsError::ServiceAccount(ref cause) => cause,
+            ListVPCEConfigurationsError::Argument(ref cause) => write!(f, "{}", cause),
+            ListVPCEConfigurationsError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVPCEConfigurationsError {}
 /// Errors returned by PurchaseOffering
 #[derive(Debug, PartialEq)]
 pub enum PurchaseOfferingError {
@@ -5708,20 +5500,16 @@ impl PurchaseOfferingError {
 }
 impl fmt::Display for PurchaseOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PurchaseOfferingError {
-    fn description(&self) -> &str {
         match *self {
-            PurchaseOfferingError::Argument(ref cause) => cause,
-            PurchaseOfferingError::LimitExceeded(ref cause) => cause,
-            PurchaseOfferingError::NotEligible(ref cause) => cause,
-            PurchaseOfferingError::NotFound(ref cause) => cause,
-            PurchaseOfferingError::ServiceAccount(ref cause) => cause,
+            PurchaseOfferingError::Argument(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::NotEligible(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::NotFound(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PurchaseOfferingError {}
 /// Errors returned by RenewOffering
 #[derive(Debug, PartialEq)]
 pub enum RenewOfferingError {
@@ -5765,20 +5553,16 @@ impl RenewOfferingError {
 }
 impl fmt::Display for RenewOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RenewOfferingError {
-    fn description(&self) -> &str {
         match *self {
-            RenewOfferingError::Argument(ref cause) => cause,
-            RenewOfferingError::LimitExceeded(ref cause) => cause,
-            RenewOfferingError::NotEligible(ref cause) => cause,
-            RenewOfferingError::NotFound(ref cause) => cause,
-            RenewOfferingError::ServiceAccount(ref cause) => cause,
+            RenewOfferingError::Argument(ref cause) => write!(f, "{}", cause),
+            RenewOfferingError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RenewOfferingError::NotEligible(ref cause) => write!(f, "{}", cause),
+            RenewOfferingError::NotFound(ref cause) => write!(f, "{}", cause),
+            RenewOfferingError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RenewOfferingError {}
 /// Errors returned by ScheduleRun
 #[derive(Debug, PartialEq)]
 pub enum ScheduleRunError {
@@ -5822,20 +5606,16 @@ impl ScheduleRunError {
 }
 impl fmt::Display for ScheduleRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ScheduleRunError {
-    fn description(&self) -> &str {
         match *self {
-            ScheduleRunError::Argument(ref cause) => cause,
-            ScheduleRunError::Idempotency(ref cause) => cause,
-            ScheduleRunError::LimitExceeded(ref cause) => cause,
-            ScheduleRunError::NotFound(ref cause) => cause,
-            ScheduleRunError::ServiceAccount(ref cause) => cause,
+            ScheduleRunError::Argument(ref cause) => write!(f, "{}", cause),
+            ScheduleRunError::Idempotency(ref cause) => write!(f, "{}", cause),
+            ScheduleRunError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ScheduleRunError::NotFound(ref cause) => write!(f, "{}", cause),
+            ScheduleRunError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ScheduleRunError {}
 /// Errors returned by StopJob
 #[derive(Debug, PartialEq)]
 pub enum StopJobError {
@@ -5874,19 +5654,15 @@ impl StopJobError {
 }
 impl fmt::Display for StopJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopJobError::Argument(ref cause) => cause,
-            StopJobError::LimitExceeded(ref cause) => cause,
-            StopJobError::NotFound(ref cause) => cause,
-            StopJobError::ServiceAccount(ref cause) => cause,
+            StopJobError::Argument(ref cause) => write!(f, "{}", cause),
+            StopJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StopJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopJobError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopJobError {}
 /// Errors returned by StopRemoteAccessSession
 #[derive(Debug, PartialEq)]
 pub enum StopRemoteAccessSessionError {
@@ -5929,19 +5705,15 @@ impl StopRemoteAccessSessionError {
 }
 impl fmt::Display for StopRemoteAccessSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopRemoteAccessSessionError {
-    fn description(&self) -> &str {
         match *self {
-            StopRemoteAccessSessionError::Argument(ref cause) => cause,
-            StopRemoteAccessSessionError::LimitExceeded(ref cause) => cause,
-            StopRemoteAccessSessionError::NotFound(ref cause) => cause,
-            StopRemoteAccessSessionError::ServiceAccount(ref cause) => cause,
+            StopRemoteAccessSessionError::Argument(ref cause) => write!(f, "{}", cause),
+            StopRemoteAccessSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StopRemoteAccessSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopRemoteAccessSessionError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopRemoteAccessSessionError {}
 /// Errors returned by StopRun
 #[derive(Debug, PartialEq)]
 pub enum StopRunError {
@@ -5980,19 +5752,15 @@ impl StopRunError {
 }
 impl fmt::Display for StopRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopRunError {
-    fn description(&self) -> &str {
         match *self {
-            StopRunError::Argument(ref cause) => cause,
-            StopRunError::LimitExceeded(ref cause) => cause,
-            StopRunError::NotFound(ref cause) => cause,
-            StopRunError::ServiceAccount(ref cause) => cause,
+            StopRunError::Argument(ref cause) => write!(f, "{}", cause),
+            StopRunError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StopRunError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopRunError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopRunError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -6031,19 +5799,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::TagOperation(ref cause) => cause,
-            TagResourceError::TagPolicy(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagOperation(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -6072,17 +5836,13 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::TagOperation(ref cause) => cause,
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TagOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateDeviceInstance
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeviceInstanceError {
@@ -6121,19 +5881,15 @@ impl UpdateDeviceInstanceError {
 }
 impl fmt::Display for UpdateDeviceInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeviceInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeviceInstanceError::Argument(ref cause) => cause,
-            UpdateDeviceInstanceError::LimitExceeded(ref cause) => cause,
-            UpdateDeviceInstanceError::NotFound(ref cause) => cause,
-            UpdateDeviceInstanceError::ServiceAccount(ref cause) => cause,
+            UpdateDeviceInstanceError::Argument(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceInstanceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceInstanceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceInstanceError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDeviceInstanceError {}
 /// Errors returned by UpdateDevicePool
 #[derive(Debug, PartialEq)]
 pub enum UpdateDevicePoolError {
@@ -6172,19 +5928,15 @@ impl UpdateDevicePoolError {
 }
 impl fmt::Display for UpdateDevicePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDevicePoolError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDevicePoolError::Argument(ref cause) => cause,
-            UpdateDevicePoolError::LimitExceeded(ref cause) => cause,
-            UpdateDevicePoolError::NotFound(ref cause) => cause,
-            UpdateDevicePoolError::ServiceAccount(ref cause) => cause,
+            UpdateDevicePoolError::Argument(ref cause) => write!(f, "{}", cause),
+            UpdateDevicePoolError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDevicePoolError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDevicePoolError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDevicePoolError {}
 /// Errors returned by UpdateInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateInstanceProfileError {
@@ -6225,19 +5977,15 @@ impl UpdateInstanceProfileError {
 }
 impl fmt::Display for UpdateInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateInstanceProfileError::Argument(ref cause) => cause,
-            UpdateInstanceProfileError::LimitExceeded(ref cause) => cause,
-            UpdateInstanceProfileError::NotFound(ref cause) => cause,
-            UpdateInstanceProfileError::ServiceAccount(ref cause) => cause,
+            UpdateInstanceProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            UpdateInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateInstanceProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateInstanceProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateInstanceProfileError {}
 /// Errors returned by UpdateNetworkProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateNetworkProfileError {
@@ -6276,19 +6024,15 @@ impl UpdateNetworkProfileError {
 }
 impl fmt::Display for UpdateNetworkProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNetworkProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNetworkProfileError::Argument(ref cause) => cause,
-            UpdateNetworkProfileError::LimitExceeded(ref cause) => cause,
-            UpdateNetworkProfileError::NotFound(ref cause) => cause,
-            UpdateNetworkProfileError::ServiceAccount(ref cause) => cause,
+            UpdateNetworkProfileError::Argument(ref cause) => write!(f, "{}", cause),
+            UpdateNetworkProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateNetworkProfileError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateNetworkProfileError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNetworkProfileError {}
 /// Errors returned by UpdateProject
 #[derive(Debug, PartialEq)]
 pub enum UpdateProjectError {
@@ -6327,19 +6071,15 @@ impl UpdateProjectError {
 }
 impl fmt::Display for UpdateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProjectError::Argument(ref cause) => cause,
-            UpdateProjectError::LimitExceeded(ref cause) => cause,
-            UpdateProjectError::NotFound(ref cause) => cause,
-            UpdateProjectError::ServiceAccount(ref cause) => cause,
+            UpdateProjectError::Argument(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProjectError {}
 /// Errors returned by UpdateUpload
 #[derive(Debug, PartialEq)]
 pub enum UpdateUploadError {
@@ -6378,19 +6118,15 @@ impl UpdateUploadError {
 }
 impl fmt::Display for UpdateUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUploadError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUploadError::Argument(ref cause) => cause,
-            UpdateUploadError::LimitExceeded(ref cause) => cause,
-            UpdateUploadError::NotFound(ref cause) => cause,
-            UpdateUploadError::ServiceAccount(ref cause) => cause,
+            UpdateUploadError::Argument(ref cause) => write!(f, "{}", cause),
+            UpdateUploadError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateUploadError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUploadError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUploadError {}
 /// Errors returned by UpdateVPCEConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateVPCEConfigurationError {
@@ -6433,19 +6169,15 @@ impl UpdateVPCEConfigurationError {
 }
 impl fmt::Display for UpdateVPCEConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVPCEConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVPCEConfigurationError::Argument(ref cause) => cause,
-            UpdateVPCEConfigurationError::InvalidOperation(ref cause) => cause,
-            UpdateVPCEConfigurationError::NotFound(ref cause) => cause,
-            UpdateVPCEConfigurationError::ServiceAccount(ref cause) => cause,
+            UpdateVPCEConfigurationError::Argument(ref cause) => write!(f, "{}", cause),
+            UpdateVPCEConfigurationError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateVPCEConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateVPCEConfigurationError::ServiceAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVPCEConfigurationError {}
 /// Trait representing the capabilities of the AWS Device Farm API. AWS Device Farm clients implement this trait.
 pub trait DeviceFarm {
     /// <p>Creates a device pool.</p>

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -1930,21 +1930,17 @@ impl AcceptDirectConnectGatewayAssociationProposalError {
 }
 impl fmt::Display for AcceptDirectConnectGatewayAssociationProposalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptDirectConnectGatewayAssociationProposalError {
-    fn description(&self) -> &str {
         match *self {
             AcceptDirectConnectGatewayAssociationProposalError::DirectConnectClient(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             AcceptDirectConnectGatewayAssociationProposalError::DirectConnectServer(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for AcceptDirectConnectGatewayAssociationProposalError {}
 /// Errors returned by AllocateConnectionOnInterconnect
 #[derive(Debug, PartialEq)]
 pub enum AllocateConnectionOnInterconnectError {
@@ -1979,17 +1975,17 @@ impl AllocateConnectionOnInterconnectError {
 }
 impl fmt::Display for AllocateConnectionOnInterconnectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AllocateConnectionOnInterconnectError {
-    fn description(&self) -> &str {
         match *self {
-            AllocateConnectionOnInterconnectError::DirectConnectClient(ref cause) => cause,
-            AllocateConnectionOnInterconnectError::DirectConnectServer(ref cause) => cause,
+            AllocateConnectionOnInterconnectError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocateConnectionOnInterconnectError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AllocateConnectionOnInterconnectError {}
 /// Errors returned by AllocateHostedConnection
 #[derive(Debug, PartialEq)]
 pub enum AllocateHostedConnectionError {
@@ -2036,19 +2032,15 @@ impl AllocateHostedConnectionError {
 }
 impl fmt::Display for AllocateHostedConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AllocateHostedConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            AllocateHostedConnectionError::DirectConnectClient(ref cause) => cause,
-            AllocateHostedConnectionError::DirectConnectServer(ref cause) => cause,
-            AllocateHostedConnectionError::DuplicateTagKeys(ref cause) => cause,
-            AllocateHostedConnectionError::TooManyTags(ref cause) => cause,
+            AllocateHostedConnectionError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            AllocateHostedConnectionError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
+            AllocateHostedConnectionError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            AllocateHostedConnectionError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AllocateHostedConnectionError {}
 /// Errors returned by AllocatePrivateVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum AllocatePrivateVirtualInterfaceError {
@@ -2097,19 +2089,21 @@ impl AllocatePrivateVirtualInterfaceError {
 }
 impl fmt::Display for AllocatePrivateVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AllocatePrivateVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            AllocatePrivateVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            AllocatePrivateVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
-            AllocatePrivateVirtualInterfaceError::DuplicateTagKeys(ref cause) => cause,
-            AllocatePrivateVirtualInterfaceError::TooManyTags(ref cause) => cause,
+            AllocatePrivateVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocatePrivateVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocatePrivateVirtualInterfaceError::DuplicateTagKeys(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocatePrivateVirtualInterfaceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AllocatePrivateVirtualInterfaceError {}
 /// Errors returned by AllocatePublicVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum AllocatePublicVirtualInterfaceError {
@@ -2158,19 +2152,21 @@ impl AllocatePublicVirtualInterfaceError {
 }
 impl fmt::Display for AllocatePublicVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AllocatePublicVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            AllocatePublicVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            AllocatePublicVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
-            AllocatePublicVirtualInterfaceError::DuplicateTagKeys(ref cause) => cause,
-            AllocatePublicVirtualInterfaceError::TooManyTags(ref cause) => cause,
+            AllocatePublicVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocatePublicVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocatePublicVirtualInterfaceError::DuplicateTagKeys(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocatePublicVirtualInterfaceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AllocatePublicVirtualInterfaceError {}
 /// Errors returned by AllocateTransitVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum AllocateTransitVirtualInterfaceError {
@@ -2219,19 +2215,21 @@ impl AllocateTransitVirtualInterfaceError {
 }
 impl fmt::Display for AllocateTransitVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AllocateTransitVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            AllocateTransitVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            AllocateTransitVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
-            AllocateTransitVirtualInterfaceError::DuplicateTagKeys(ref cause) => cause,
-            AllocateTransitVirtualInterfaceError::TooManyTags(ref cause) => cause,
+            AllocateTransitVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocateTransitVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocateTransitVirtualInterfaceError::DuplicateTagKeys(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AllocateTransitVirtualInterfaceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AllocateTransitVirtualInterfaceError {}
 /// Errors returned by AssociateConnectionWithLag
 #[derive(Debug, PartialEq)]
 pub enum AssociateConnectionWithLagError {
@@ -2266,17 +2264,17 @@ impl AssociateConnectionWithLagError {
 }
 impl fmt::Display for AssociateConnectionWithLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateConnectionWithLagError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateConnectionWithLagError::DirectConnectClient(ref cause) => cause,
-            AssociateConnectionWithLagError::DirectConnectServer(ref cause) => cause,
+            AssociateConnectionWithLagError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateConnectionWithLagError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateConnectionWithLagError {}
 /// Errors returned by AssociateHostedConnection
 #[derive(Debug, PartialEq)]
 pub enum AssociateHostedConnectionError {
@@ -2309,17 +2307,17 @@ impl AssociateHostedConnectionError {
 }
 impl fmt::Display for AssociateHostedConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateHostedConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateHostedConnectionError::DirectConnectClient(ref cause) => cause,
-            AssociateHostedConnectionError::DirectConnectServer(ref cause) => cause,
+            AssociateHostedConnectionError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateHostedConnectionError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateHostedConnectionError {}
 /// Errors returned by AssociateVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum AssociateVirtualInterfaceError {
@@ -2352,17 +2350,17 @@ impl AssociateVirtualInterfaceError {
 }
 impl fmt::Display for AssociateVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            AssociateVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
+            AssociateVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateVirtualInterfaceError {}
 /// Errors returned by ConfirmConnection
 #[derive(Debug, PartialEq)]
 pub enum ConfirmConnectionError {
@@ -2395,17 +2393,13 @@ impl ConfirmConnectionError {
 }
 impl fmt::Display for ConfirmConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmConnectionError::DirectConnectClient(ref cause) => cause,
-            ConfirmConnectionError::DirectConnectServer(ref cause) => cause,
+            ConfirmConnectionError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            ConfirmConnectionError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConfirmConnectionError {}
 /// Errors returned by ConfirmPrivateVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum ConfirmPrivateVirtualInterfaceError {
@@ -2440,17 +2434,17 @@ impl ConfirmPrivateVirtualInterfaceError {
 }
 impl fmt::Display for ConfirmPrivateVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmPrivateVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmPrivateVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            ConfirmPrivateVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
+            ConfirmPrivateVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConfirmPrivateVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ConfirmPrivateVirtualInterfaceError {}
 /// Errors returned by ConfirmPublicVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum ConfirmPublicVirtualInterfaceError {
@@ -2485,17 +2479,17 @@ impl ConfirmPublicVirtualInterfaceError {
 }
 impl fmt::Display for ConfirmPublicVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmPublicVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmPublicVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            ConfirmPublicVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
+            ConfirmPublicVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConfirmPublicVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ConfirmPublicVirtualInterfaceError {}
 /// Errors returned by ConfirmTransitVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum ConfirmTransitVirtualInterfaceError {
@@ -2530,17 +2524,17 @@ impl ConfirmTransitVirtualInterfaceError {
 }
 impl fmt::Display for ConfirmTransitVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmTransitVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmTransitVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            ConfirmTransitVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
+            ConfirmTransitVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConfirmTransitVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ConfirmTransitVirtualInterfaceError {}
 /// Errors returned by CreateBGPPeer
 #[derive(Debug, PartialEq)]
 pub enum CreateBGPPeerError {
@@ -2569,17 +2563,13 @@ impl CreateBGPPeerError {
 }
 impl fmt::Display for CreateBGPPeerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBGPPeerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBGPPeerError::DirectConnectClient(ref cause) => cause,
-            CreateBGPPeerError::DirectConnectServer(ref cause) => cause,
+            CreateBGPPeerError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            CreateBGPPeerError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBGPPeerError {}
 /// Errors returned by CreateConnection
 #[derive(Debug, PartialEq)]
 pub enum CreateConnectionError {
@@ -2622,19 +2612,15 @@ impl CreateConnectionError {
 }
 impl fmt::Display for CreateConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConnectionError::DirectConnectClient(ref cause) => cause,
-            CreateConnectionError::DirectConnectServer(ref cause) => cause,
-            CreateConnectionError::DuplicateTagKeys(ref cause) => cause,
-            CreateConnectionError::TooManyTags(ref cause) => cause,
+            CreateConnectionError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            CreateConnectionError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
+            CreateConnectionError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            CreateConnectionError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConnectionError {}
 /// Errors returned by CreateDirectConnectGateway
 #[derive(Debug, PartialEq)]
 pub enum CreateDirectConnectGatewayError {
@@ -2669,17 +2655,17 @@ impl CreateDirectConnectGatewayError {
 }
 impl fmt::Display for CreateDirectConnectGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDirectConnectGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDirectConnectGatewayError::DirectConnectClient(ref cause) => cause,
-            CreateDirectConnectGatewayError::DirectConnectServer(ref cause) => cause,
+            CreateDirectConnectGatewayError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDirectConnectGatewayError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDirectConnectGatewayError {}
 /// Errors returned by CreateDirectConnectGatewayAssociation
 #[derive(Debug, PartialEq)]
 pub enum CreateDirectConnectGatewayAssociationError {
@@ -2714,17 +2700,17 @@ impl CreateDirectConnectGatewayAssociationError {
 }
 impl fmt::Display for CreateDirectConnectGatewayAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDirectConnectGatewayAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDirectConnectGatewayAssociationError::DirectConnectClient(ref cause) => cause,
-            CreateDirectConnectGatewayAssociationError::DirectConnectServer(ref cause) => cause,
+            CreateDirectConnectGatewayAssociationError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDirectConnectGatewayAssociationError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDirectConnectGatewayAssociationError {}
 /// Errors returned by CreateDirectConnectGatewayAssociationProposal
 #[derive(Debug, PartialEq)]
 pub enum CreateDirectConnectGatewayAssociationProposalError {
@@ -2763,21 +2749,17 @@ impl CreateDirectConnectGatewayAssociationProposalError {
 }
 impl fmt::Display for CreateDirectConnectGatewayAssociationProposalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDirectConnectGatewayAssociationProposalError {
-    fn description(&self) -> &str {
         match *self {
             CreateDirectConnectGatewayAssociationProposalError::DirectConnectClient(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateDirectConnectGatewayAssociationProposalError::DirectConnectServer(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CreateDirectConnectGatewayAssociationProposalError {}
 /// Errors returned by CreateInterconnect
 #[derive(Debug, PartialEq)]
 pub enum CreateInterconnectError {
@@ -2820,19 +2802,15 @@ impl CreateInterconnectError {
 }
 impl fmt::Display for CreateInterconnectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInterconnectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInterconnectError::DirectConnectClient(ref cause) => cause,
-            CreateInterconnectError::DirectConnectServer(ref cause) => cause,
-            CreateInterconnectError::DuplicateTagKeys(ref cause) => cause,
-            CreateInterconnectError::TooManyTags(ref cause) => cause,
+            CreateInterconnectError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            CreateInterconnectError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
+            CreateInterconnectError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            CreateInterconnectError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInterconnectError {}
 /// Errors returned by CreateLag
 #[derive(Debug, PartialEq)]
 pub enum CreateLagError {
@@ -2871,19 +2849,15 @@ impl CreateLagError {
 }
 impl fmt::Display for CreateLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLagError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLagError::DirectConnectClient(ref cause) => cause,
-            CreateLagError::DirectConnectServer(ref cause) => cause,
-            CreateLagError::DuplicateTagKeys(ref cause) => cause,
-            CreateLagError::TooManyTags(ref cause) => cause,
+            CreateLagError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            CreateLagError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
+            CreateLagError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            CreateLagError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLagError {}
 /// Errors returned by CreatePrivateVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum CreatePrivateVirtualInterfaceError {
@@ -2932,19 +2906,21 @@ impl CreatePrivateVirtualInterfaceError {
 }
 impl fmt::Display for CreatePrivateVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePrivateVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePrivateVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            CreatePrivateVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
-            CreatePrivateVirtualInterfaceError::DuplicateTagKeys(ref cause) => cause,
-            CreatePrivateVirtualInterfaceError::TooManyTags(ref cause) => cause,
+            CreatePrivateVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePrivateVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePrivateVirtualInterfaceError::DuplicateTagKeys(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePrivateVirtualInterfaceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePrivateVirtualInterfaceError {}
 /// Errors returned by CreatePublicVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum CreatePublicVirtualInterfaceError {
@@ -2993,19 +2969,21 @@ impl CreatePublicVirtualInterfaceError {
 }
 impl fmt::Display for CreatePublicVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePublicVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePublicVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            CreatePublicVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
-            CreatePublicVirtualInterfaceError::DuplicateTagKeys(ref cause) => cause,
-            CreatePublicVirtualInterfaceError::TooManyTags(ref cause) => cause,
+            CreatePublicVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePublicVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePublicVirtualInterfaceError::DuplicateTagKeys(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePublicVirtualInterfaceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePublicVirtualInterfaceError {}
 /// Errors returned by CreateTransitVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum CreateTransitVirtualInterfaceError {
@@ -3054,19 +3032,21 @@ impl CreateTransitVirtualInterfaceError {
 }
 impl fmt::Display for CreateTransitVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTransitVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTransitVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            CreateTransitVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
-            CreateTransitVirtualInterfaceError::DuplicateTagKeys(ref cause) => cause,
-            CreateTransitVirtualInterfaceError::TooManyTags(ref cause) => cause,
+            CreateTransitVirtualInterfaceError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTransitVirtualInterfaceError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTransitVirtualInterfaceError::DuplicateTagKeys(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTransitVirtualInterfaceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTransitVirtualInterfaceError {}
 /// Errors returned by DeleteBGPPeer
 #[derive(Debug, PartialEq)]
 pub enum DeleteBGPPeerError {
@@ -3095,17 +3075,13 @@ impl DeleteBGPPeerError {
 }
 impl fmt::Display for DeleteBGPPeerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBGPPeerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBGPPeerError::DirectConnectClient(ref cause) => cause,
-            DeleteBGPPeerError::DirectConnectServer(ref cause) => cause,
+            DeleteBGPPeerError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DeleteBGPPeerError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBGPPeerError {}
 /// Errors returned by DeleteConnection
 #[derive(Debug, PartialEq)]
 pub enum DeleteConnectionError {
@@ -3138,17 +3114,13 @@ impl DeleteConnectionError {
 }
 impl fmt::Display for DeleteConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConnectionError::DirectConnectClient(ref cause) => cause,
-            DeleteConnectionError::DirectConnectServer(ref cause) => cause,
+            DeleteConnectionError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DeleteConnectionError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConnectionError {}
 /// Errors returned by DeleteDirectConnectGateway
 #[derive(Debug, PartialEq)]
 pub enum DeleteDirectConnectGatewayError {
@@ -3183,17 +3155,17 @@ impl DeleteDirectConnectGatewayError {
 }
 impl fmt::Display for DeleteDirectConnectGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDirectConnectGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDirectConnectGatewayError::DirectConnectClient(ref cause) => cause,
-            DeleteDirectConnectGatewayError::DirectConnectServer(ref cause) => cause,
+            DeleteDirectConnectGatewayError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDirectConnectGatewayError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDirectConnectGatewayError {}
 /// Errors returned by DeleteDirectConnectGatewayAssociation
 #[derive(Debug, PartialEq)]
 pub enum DeleteDirectConnectGatewayAssociationError {
@@ -3228,17 +3200,17 @@ impl DeleteDirectConnectGatewayAssociationError {
 }
 impl fmt::Display for DeleteDirectConnectGatewayAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDirectConnectGatewayAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDirectConnectGatewayAssociationError::DirectConnectClient(ref cause) => cause,
-            DeleteDirectConnectGatewayAssociationError::DirectConnectServer(ref cause) => cause,
+            DeleteDirectConnectGatewayAssociationError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDirectConnectGatewayAssociationError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDirectConnectGatewayAssociationError {}
 /// Errors returned by DeleteDirectConnectGatewayAssociationProposal
 #[derive(Debug, PartialEq)]
 pub enum DeleteDirectConnectGatewayAssociationProposalError {
@@ -3277,21 +3249,17 @@ impl DeleteDirectConnectGatewayAssociationProposalError {
 }
 impl fmt::Display for DeleteDirectConnectGatewayAssociationProposalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDirectConnectGatewayAssociationProposalError {
-    fn description(&self) -> &str {
         match *self {
             DeleteDirectConnectGatewayAssociationProposalError::DirectConnectClient(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DeleteDirectConnectGatewayAssociationProposalError::DirectConnectServer(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteDirectConnectGatewayAssociationProposalError {}
 /// Errors returned by DeleteInterconnect
 #[derive(Debug, PartialEq)]
 pub enum DeleteInterconnectError {
@@ -3324,17 +3292,13 @@ impl DeleteInterconnectError {
 }
 impl fmt::Display for DeleteInterconnectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInterconnectError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInterconnectError::DirectConnectClient(ref cause) => cause,
-            DeleteInterconnectError::DirectConnectServer(ref cause) => cause,
+            DeleteInterconnectError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DeleteInterconnectError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInterconnectError {}
 /// Errors returned by DeleteLag
 #[derive(Debug, PartialEq)]
 pub enum DeleteLagError {
@@ -3363,17 +3327,13 @@ impl DeleteLagError {
 }
 impl fmt::Display for DeleteLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLagError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLagError::DirectConnectClient(ref cause) => cause,
-            DeleteLagError::DirectConnectServer(ref cause) => cause,
+            DeleteLagError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DeleteLagError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLagError {}
 /// Errors returned by DeleteVirtualInterface
 #[derive(Debug, PartialEq)]
 pub enum DeleteVirtualInterfaceError {
@@ -3406,17 +3366,13 @@ impl DeleteVirtualInterfaceError {
 }
 impl fmt::Display for DeleteVirtualInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVirtualInterfaceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVirtualInterfaceError::DirectConnectClient(ref cause) => cause,
-            DeleteVirtualInterfaceError::DirectConnectServer(ref cause) => cause,
+            DeleteVirtualInterfaceError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualInterfaceError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVirtualInterfaceError {}
 /// Errors returned by DescribeConnectionLoa
 #[derive(Debug, PartialEq)]
 pub enum DescribeConnectionLoaError {
@@ -3449,17 +3405,13 @@ impl DescribeConnectionLoaError {
 }
 impl fmt::Display for DescribeConnectionLoaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConnectionLoaError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConnectionLoaError::DirectConnectClient(ref cause) => cause,
-            DescribeConnectionLoaError::DirectConnectServer(ref cause) => cause,
+            DescribeConnectionLoaError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeConnectionLoaError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConnectionLoaError {}
 /// Errors returned by DescribeConnections
 #[derive(Debug, PartialEq)]
 pub enum DescribeConnectionsError {
@@ -3492,17 +3444,13 @@ impl DescribeConnectionsError {
 }
 impl fmt::Display for DescribeConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConnectionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConnectionsError::DirectConnectClient(ref cause) => cause,
-            DescribeConnectionsError::DirectConnectServer(ref cause) => cause,
+            DescribeConnectionsError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeConnectionsError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConnectionsError {}
 /// Errors returned by DescribeConnectionsOnInterconnect
 #[derive(Debug, PartialEq)]
 pub enum DescribeConnectionsOnInterconnectError {
@@ -3537,17 +3485,17 @@ impl DescribeConnectionsOnInterconnectError {
 }
 impl fmt::Display for DescribeConnectionsOnInterconnectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConnectionsOnInterconnectError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConnectionsOnInterconnectError::DirectConnectClient(ref cause) => cause,
-            DescribeConnectionsOnInterconnectError::DirectConnectServer(ref cause) => cause,
+            DescribeConnectionsOnInterconnectError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConnectionsOnInterconnectError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConnectionsOnInterconnectError {}
 /// Errors returned by DescribeDirectConnectGatewayAssociationProposals
 #[derive(Debug, PartialEq)]
 pub enum DescribeDirectConnectGatewayAssociationProposalsError {
@@ -3586,21 +3534,17 @@ impl DescribeDirectConnectGatewayAssociationProposalsError {
 }
 impl fmt::Display for DescribeDirectConnectGatewayAssociationProposalsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDirectConnectGatewayAssociationProposalsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDirectConnectGatewayAssociationProposalsError::DirectConnectClient(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             DescribeDirectConnectGatewayAssociationProposalsError::DirectConnectServer(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDirectConnectGatewayAssociationProposalsError {}
 /// Errors returned by DescribeDirectConnectGatewayAssociations
 #[derive(Debug, PartialEq)]
 pub enum DescribeDirectConnectGatewayAssociationsError {
@@ -3635,17 +3579,17 @@ impl DescribeDirectConnectGatewayAssociationsError {
 }
 impl fmt::Display for DescribeDirectConnectGatewayAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDirectConnectGatewayAssociationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDirectConnectGatewayAssociationsError::DirectConnectClient(ref cause) => cause,
-            DescribeDirectConnectGatewayAssociationsError::DirectConnectServer(ref cause) => cause,
+            DescribeDirectConnectGatewayAssociationsError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDirectConnectGatewayAssociationsError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDirectConnectGatewayAssociationsError {}
 /// Errors returned by DescribeDirectConnectGatewayAttachments
 #[derive(Debug, PartialEq)]
 pub enum DescribeDirectConnectGatewayAttachmentsError {
@@ -3680,17 +3624,17 @@ impl DescribeDirectConnectGatewayAttachmentsError {
 }
 impl fmt::Display for DescribeDirectConnectGatewayAttachmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDirectConnectGatewayAttachmentsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDirectConnectGatewayAttachmentsError::DirectConnectClient(ref cause) => cause,
-            DescribeDirectConnectGatewayAttachmentsError::DirectConnectServer(ref cause) => cause,
+            DescribeDirectConnectGatewayAttachmentsError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDirectConnectGatewayAttachmentsError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDirectConnectGatewayAttachmentsError {}
 /// Errors returned by DescribeDirectConnectGateways
 #[derive(Debug, PartialEq)]
 pub enum DescribeDirectConnectGatewaysError {
@@ -3725,17 +3669,17 @@ impl DescribeDirectConnectGatewaysError {
 }
 impl fmt::Display for DescribeDirectConnectGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDirectConnectGatewaysError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDirectConnectGatewaysError::DirectConnectClient(ref cause) => cause,
-            DescribeDirectConnectGatewaysError::DirectConnectServer(ref cause) => cause,
+            DescribeDirectConnectGatewaysError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDirectConnectGatewaysError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDirectConnectGatewaysError {}
 /// Errors returned by DescribeHostedConnections
 #[derive(Debug, PartialEq)]
 pub enum DescribeHostedConnectionsError {
@@ -3768,17 +3712,17 @@ impl DescribeHostedConnectionsError {
 }
 impl fmt::Display for DescribeHostedConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHostedConnectionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHostedConnectionsError::DirectConnectClient(ref cause) => cause,
-            DescribeHostedConnectionsError::DirectConnectServer(ref cause) => cause,
+            DescribeHostedConnectionsError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeHostedConnectionsError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeHostedConnectionsError {}
 /// Errors returned by DescribeInterconnectLoa
 #[derive(Debug, PartialEq)]
 pub enum DescribeInterconnectLoaError {
@@ -3811,17 +3755,13 @@ impl DescribeInterconnectLoaError {
 }
 impl fmt::Display for DescribeInterconnectLoaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInterconnectLoaError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInterconnectLoaError::DirectConnectClient(ref cause) => cause,
-            DescribeInterconnectLoaError::DirectConnectServer(ref cause) => cause,
+            DescribeInterconnectLoaError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeInterconnectLoaError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInterconnectLoaError {}
 /// Errors returned by DescribeInterconnects
 #[derive(Debug, PartialEq)]
 pub enum DescribeInterconnectsError {
@@ -3854,17 +3794,13 @@ impl DescribeInterconnectsError {
 }
 impl fmt::Display for DescribeInterconnectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInterconnectsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInterconnectsError::DirectConnectClient(ref cause) => cause,
-            DescribeInterconnectsError::DirectConnectServer(ref cause) => cause,
+            DescribeInterconnectsError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeInterconnectsError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInterconnectsError {}
 /// Errors returned by DescribeLags
 #[derive(Debug, PartialEq)]
 pub enum DescribeLagsError {
@@ -3893,17 +3829,13 @@ impl DescribeLagsError {
 }
 impl fmt::Display for DescribeLagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLagsError::DirectConnectClient(ref cause) => cause,
-            DescribeLagsError::DirectConnectServer(ref cause) => cause,
+            DescribeLagsError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeLagsError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLagsError {}
 /// Errors returned by DescribeLoa
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoaError {
@@ -3932,17 +3864,13 @@ impl DescribeLoaError {
 }
 impl fmt::Display for DescribeLoaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoaError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoaError::DirectConnectClient(ref cause) => cause,
-            DescribeLoaError::DirectConnectServer(ref cause) => cause,
+            DescribeLoaError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeLoaError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLoaError {}
 /// Errors returned by DescribeLocations
 #[derive(Debug, PartialEq)]
 pub enum DescribeLocationsError {
@@ -3975,17 +3903,13 @@ impl DescribeLocationsError {
 }
 impl fmt::Display for DescribeLocationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLocationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLocationsError::DirectConnectClient(ref cause) => cause,
-            DescribeLocationsError::DirectConnectServer(ref cause) => cause,
+            DescribeLocationsError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeLocationsError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLocationsError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -4014,17 +3938,13 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::DirectConnectClient(ref cause) => cause,
-            DescribeTagsError::DirectConnectServer(ref cause) => cause,
+            DescribeTagsError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by DescribeVirtualGateways
 #[derive(Debug, PartialEq)]
 pub enum DescribeVirtualGatewaysError {
@@ -4057,17 +3977,13 @@ impl DescribeVirtualGatewaysError {
 }
 impl fmt::Display for DescribeVirtualGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVirtualGatewaysError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVirtualGatewaysError::DirectConnectClient(ref cause) => cause,
-            DescribeVirtualGatewaysError::DirectConnectServer(ref cause) => cause,
+            DescribeVirtualGatewaysError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            DescribeVirtualGatewaysError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVirtualGatewaysError {}
 /// Errors returned by DescribeVirtualInterfaces
 #[derive(Debug, PartialEq)]
 pub enum DescribeVirtualInterfacesError {
@@ -4100,17 +4016,17 @@ impl DescribeVirtualInterfacesError {
 }
 impl fmt::Display for DescribeVirtualInterfacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVirtualInterfacesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVirtualInterfacesError::DirectConnectClient(ref cause) => cause,
-            DescribeVirtualInterfacesError::DirectConnectServer(ref cause) => cause,
+            DescribeVirtualInterfacesError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeVirtualInterfacesError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeVirtualInterfacesError {}
 /// Errors returned by DisassociateConnectionFromLag
 #[derive(Debug, PartialEq)]
 pub enum DisassociateConnectionFromLagError {
@@ -4145,17 +4061,17 @@ impl DisassociateConnectionFromLagError {
 }
 impl fmt::Display for DisassociateConnectionFromLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateConnectionFromLagError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateConnectionFromLagError::DirectConnectClient(ref cause) => cause,
-            DisassociateConnectionFromLagError::DirectConnectServer(ref cause) => cause,
+            DisassociateConnectionFromLagError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateConnectionFromLagError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateConnectionFromLagError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -4194,19 +4110,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::DirectConnectClient(ref cause) => cause,
-            TagResourceError::DirectConnectServer(ref cause) => cause,
-            TagResourceError::DuplicateTagKeys(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            TagResourceError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
+            TagResourceError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -4235,17 +4147,13 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::DirectConnectClient(ref cause) => cause,
-            UntagResourceError::DirectConnectServer(ref cause) => cause,
+            UntagResourceError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateDirectConnectGatewayAssociation
 #[derive(Debug, PartialEq)]
 pub enum UpdateDirectConnectGatewayAssociationError {
@@ -4280,17 +4188,17 @@ impl UpdateDirectConnectGatewayAssociationError {
 }
 impl fmt::Display for UpdateDirectConnectGatewayAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDirectConnectGatewayAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDirectConnectGatewayAssociationError::DirectConnectClient(ref cause) => cause,
-            UpdateDirectConnectGatewayAssociationError::DirectConnectServer(ref cause) => cause,
+            UpdateDirectConnectGatewayAssociationError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDirectConnectGatewayAssociationError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateDirectConnectGatewayAssociationError {}
 /// Errors returned by UpdateLag
 #[derive(Debug, PartialEq)]
 pub enum UpdateLagError {
@@ -4319,17 +4227,13 @@ impl UpdateLagError {
 }
 impl fmt::Display for UpdateLagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLagError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLagError::DirectConnectClient(ref cause) => cause,
-            UpdateLagError::DirectConnectServer(ref cause) => cause,
+            UpdateLagError::DirectConnectClient(ref cause) => write!(f, "{}", cause),
+            UpdateLagError::DirectConnectServer(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLagError {}
 /// Errors returned by UpdateVirtualInterfaceAttributes
 #[derive(Debug, PartialEq)]
 pub enum UpdateVirtualInterfaceAttributesError {
@@ -4364,17 +4268,17 @@ impl UpdateVirtualInterfaceAttributesError {
 }
 impl fmt::Display for UpdateVirtualInterfaceAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVirtualInterfaceAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVirtualInterfaceAttributesError::DirectConnectClient(ref cause) => cause,
-            UpdateVirtualInterfaceAttributesError::DirectConnectServer(ref cause) => cause,
+            UpdateVirtualInterfaceAttributesError::DirectConnectClient(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateVirtualInterfaceAttributesError::DirectConnectServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateVirtualInterfaceAttributesError {}
 /// Trait representing the capabilities of the AWS Direct Connect API. AWS Direct Connect clients implement this trait.
 pub trait DirectConnect {
     /// <p>Accepts a proposal request to attach a virtual private gateway or transit gateway to a Direct Connect gateway.</p>

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -1053,22 +1053,26 @@ impl AssociateConfigurationItemsToApplicationError {
 }
 impl fmt::Display for AssociateConfigurationItemsToApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateConfigurationItemsToApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateConfigurationItemsToApplicationError::AuthorizationError(ref cause) => cause,
-            AssociateConfigurationItemsToApplicationError::HomeRegionNotSet(ref cause) => cause,
-            AssociateConfigurationItemsToApplicationError::InvalidParameter(ref cause) => cause,
-            AssociateConfigurationItemsToApplicationError::InvalidParameterValue(ref cause) => {
-                cause
+            AssociateConfigurationItemsToApplicationError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
             }
-            AssociateConfigurationItemsToApplicationError::ServerInternalError(ref cause) => cause,
+            AssociateConfigurationItemsToApplicationError::HomeRegionNotSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateConfigurationItemsToApplicationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateConfigurationItemsToApplicationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateConfigurationItemsToApplicationError::ServerInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateConfigurationItemsToApplicationError {}
 /// Errors returned by BatchDeleteImportData
 #[derive(Debug, PartialEq)]
 pub enum BatchDeleteImportDataError {
@@ -1122,20 +1126,16 @@ impl BatchDeleteImportDataError {
 }
 impl fmt::Display for BatchDeleteImportDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteImportDataError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeleteImportDataError::AuthorizationError(ref cause) => cause,
-            BatchDeleteImportDataError::HomeRegionNotSet(ref cause) => cause,
-            BatchDeleteImportDataError::InvalidParameter(ref cause) => cause,
-            BatchDeleteImportDataError::InvalidParameterValue(ref cause) => cause,
-            BatchDeleteImportDataError::ServerInternalError(ref cause) => cause,
+            BatchDeleteImportDataError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            BatchDeleteImportDataError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            BatchDeleteImportDataError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            BatchDeleteImportDataError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            BatchDeleteImportDataError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeleteImportDataError {}
 /// Errors returned by CreateApplication
 #[derive(Debug, PartialEq)]
 pub enum CreateApplicationError {
@@ -1185,20 +1185,16 @@ impl CreateApplicationError {
 }
 impl fmt::Display for CreateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApplicationError::AuthorizationError(ref cause) => cause,
-            CreateApplicationError::HomeRegionNotSet(ref cause) => cause,
-            CreateApplicationError::InvalidParameter(ref cause) => cause,
-            CreateApplicationError::InvalidParameterValue(ref cause) => cause,
-            CreateApplicationError::ServerInternalError(ref cause) => cause,
+            CreateApplicationError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApplicationError {}
 /// Errors returned by CreateTags
 #[derive(Debug, PartialEq)]
 pub enum CreateTagsError {
@@ -1247,21 +1243,17 @@ impl CreateTagsError {
 }
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTagsError::AuthorizationError(ref cause) => cause,
-            CreateTagsError::HomeRegionNotSet(ref cause) => cause,
-            CreateTagsError::InvalidParameter(ref cause) => cause,
-            CreateTagsError::InvalidParameterValue(ref cause) => cause,
-            CreateTagsError::ResourceNotFound(ref cause) => cause,
-            CreateTagsError::ServerInternalError(ref cause) => cause,
+            CreateTagsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTagsError {}
 /// Errors returned by DeleteApplications
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationsError {
@@ -1311,20 +1303,16 @@ impl DeleteApplicationsError {
 }
 impl fmt::Display for DeleteApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationsError::AuthorizationError(ref cause) => cause,
-            DeleteApplicationsError::HomeRegionNotSet(ref cause) => cause,
-            DeleteApplicationsError::InvalidParameter(ref cause) => cause,
-            DeleteApplicationsError::InvalidParameterValue(ref cause) => cause,
-            DeleteApplicationsError::ServerInternalError(ref cause) => cause,
+            DeleteApplicationsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApplicationsError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -1373,21 +1361,17 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::AuthorizationError(ref cause) => cause,
-            DeleteTagsError::HomeRegionNotSet(ref cause) => cause,
-            DeleteTagsError::InvalidParameter(ref cause) => cause,
-            DeleteTagsError::InvalidParameterValue(ref cause) => cause,
-            DeleteTagsError::ResourceNotFound(ref cause) => cause,
-            DeleteTagsError::ServerInternalError(ref cause) => cause,
+            DeleteTagsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DescribeAgents
 #[derive(Debug, PartialEq)]
 pub enum DescribeAgentsError {
@@ -1433,20 +1417,16 @@ impl DescribeAgentsError {
 }
 impl fmt::Display for DescribeAgentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAgentsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAgentsError::AuthorizationError(ref cause) => cause,
-            DescribeAgentsError::HomeRegionNotSet(ref cause) => cause,
-            DescribeAgentsError::InvalidParameter(ref cause) => cause,
-            DescribeAgentsError::InvalidParameterValue(ref cause) => cause,
-            DescribeAgentsError::ServerInternalError(ref cause) => cause,
+            DescribeAgentsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DescribeAgentsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeAgentsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeAgentsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeAgentsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAgentsError {}
 /// Errors returned by DescribeConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationsError {
@@ -1500,20 +1480,16 @@ impl DescribeConfigurationsError {
 }
 impl fmt::Display for DescribeConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationsError::AuthorizationError(ref cause) => cause,
-            DescribeConfigurationsError::HomeRegionNotSet(ref cause) => cause,
-            DescribeConfigurationsError::InvalidParameter(ref cause) => cause,
-            DescribeConfigurationsError::InvalidParameterValue(ref cause) => cause,
-            DescribeConfigurationsError::ServerInternalError(ref cause) => cause,
+            DescribeConfigurationsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationsError {}
 /// Errors returned by DescribeContinuousExports
 #[derive(Debug, PartialEq)]
 pub enum DescribeContinuousExportsError {
@@ -1581,22 +1557,24 @@ impl DescribeContinuousExportsError {
 }
 impl fmt::Display for DescribeContinuousExportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeContinuousExportsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeContinuousExportsError::AuthorizationError(ref cause) => cause,
-            DescribeContinuousExportsError::HomeRegionNotSet(ref cause) => cause,
-            DescribeContinuousExportsError::InvalidParameter(ref cause) => cause,
-            DescribeContinuousExportsError::InvalidParameterValue(ref cause) => cause,
-            DescribeContinuousExportsError::OperationNotPermitted(ref cause) => cause,
-            DescribeContinuousExportsError::ResourceNotFound(ref cause) => cause,
-            DescribeContinuousExportsError::ServerInternalError(ref cause) => cause,
+            DescribeContinuousExportsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DescribeContinuousExportsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeContinuousExportsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeContinuousExportsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeContinuousExportsError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeContinuousExportsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeContinuousExportsError::ServerInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeContinuousExportsError {}
 /// Errors returned by DescribeExportConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeExportConfigurationsError {
@@ -1659,21 +1637,29 @@ impl DescribeExportConfigurationsError {
 }
 impl fmt::Display for DescribeExportConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeExportConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeExportConfigurationsError::AuthorizationError(ref cause) => cause,
-            DescribeExportConfigurationsError::HomeRegionNotSet(ref cause) => cause,
-            DescribeExportConfigurationsError::InvalidParameter(ref cause) => cause,
-            DescribeExportConfigurationsError::InvalidParameterValue(ref cause) => cause,
-            DescribeExportConfigurationsError::ResourceNotFound(ref cause) => cause,
-            DescribeExportConfigurationsError::ServerInternalError(ref cause) => cause,
+            DescribeExportConfigurationsError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeExportConfigurationsError::HomeRegionNotSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeExportConfigurationsError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeExportConfigurationsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeExportConfigurationsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeExportConfigurationsError::ServerInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeExportConfigurationsError {}
 /// Errors returned by DescribeExportTasks
 #[derive(Debug, PartialEq)]
 pub enum DescribeExportTasksError {
@@ -1727,20 +1713,16 @@ impl DescribeExportTasksError {
 }
 impl fmt::Display for DescribeExportTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeExportTasksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeExportTasksError::AuthorizationError(ref cause) => cause,
-            DescribeExportTasksError::HomeRegionNotSet(ref cause) => cause,
-            DescribeExportTasksError::InvalidParameter(ref cause) => cause,
-            DescribeExportTasksError::InvalidParameterValue(ref cause) => cause,
-            DescribeExportTasksError::ServerInternalError(ref cause) => cause,
+            DescribeExportTasksError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DescribeExportTasksError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeExportTasksError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeExportTasksError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeExportTasksError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeExportTasksError {}
 /// Errors returned by DescribeImportTasks
 #[derive(Debug, PartialEq)]
 pub enum DescribeImportTasksError {
@@ -1794,20 +1776,16 @@ impl DescribeImportTasksError {
 }
 impl fmt::Display for DescribeImportTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeImportTasksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeImportTasksError::AuthorizationError(ref cause) => cause,
-            DescribeImportTasksError::HomeRegionNotSet(ref cause) => cause,
-            DescribeImportTasksError::InvalidParameter(ref cause) => cause,
-            DescribeImportTasksError::InvalidParameterValue(ref cause) => cause,
-            DescribeImportTasksError::ServerInternalError(ref cause) => cause,
+            DescribeImportTasksError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DescribeImportTasksError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeImportTasksError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeImportTasksError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeImportTasksError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeImportTasksError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -1856,21 +1834,17 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::AuthorizationError(ref cause) => cause,
-            DescribeTagsError::HomeRegionNotSet(ref cause) => cause,
-            DescribeTagsError::InvalidParameter(ref cause) => cause,
-            DescribeTagsError::InvalidParameterValue(ref cause) => cause,
-            DescribeTagsError::ResourceNotFound(ref cause) => cause,
-            DescribeTagsError::ServerInternalError(ref cause) => cause,
+            DescribeTagsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by DisassociateConfigurationItemsFromApplication
 #[derive(Debug, PartialEq)]
 pub enum DisassociateConfigurationItemsFromApplicationError {
@@ -1936,30 +1910,26 @@ impl DisassociateConfigurationItemsFromApplicationError {
 }
 impl fmt::Display for DisassociateConfigurationItemsFromApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateConfigurationItemsFromApplicationError {
-    fn description(&self) -> &str {
         match *self {
             DisassociateConfigurationItemsFromApplicationError::AuthorizationError(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DisassociateConfigurationItemsFromApplicationError::HomeRegionNotSet(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DisassociateConfigurationItemsFromApplicationError::InvalidParameter(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DisassociateConfigurationItemsFromApplicationError::InvalidParameterValue(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             DisassociateConfigurationItemsFromApplicationError::ServerInternalError(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DisassociateConfigurationItemsFromApplicationError {}
 /// Errors returned by ExportConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ExportConfigurationsError {
@@ -2020,21 +1990,17 @@ impl ExportConfigurationsError {
 }
 impl fmt::Display for ExportConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExportConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ExportConfigurationsError::AuthorizationError(ref cause) => cause,
-            ExportConfigurationsError::HomeRegionNotSet(ref cause) => cause,
-            ExportConfigurationsError::InvalidParameter(ref cause) => cause,
-            ExportConfigurationsError::InvalidParameterValue(ref cause) => cause,
-            ExportConfigurationsError::OperationNotPermitted(ref cause) => cause,
-            ExportConfigurationsError::ServerInternalError(ref cause) => cause,
+            ExportConfigurationsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ExportConfigurationsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ExportConfigurationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ExportConfigurationsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ExportConfigurationsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ExportConfigurationsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExportConfigurationsError {}
 /// Errors returned by GetDiscoverySummary
 #[derive(Debug, PartialEq)]
 pub enum GetDiscoverySummaryError {
@@ -2088,20 +2054,16 @@ impl GetDiscoverySummaryError {
 }
 impl fmt::Display for GetDiscoverySummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDiscoverySummaryError {
-    fn description(&self) -> &str {
         match *self {
-            GetDiscoverySummaryError::AuthorizationError(ref cause) => cause,
-            GetDiscoverySummaryError::HomeRegionNotSet(ref cause) => cause,
-            GetDiscoverySummaryError::InvalidParameter(ref cause) => cause,
-            GetDiscoverySummaryError::InvalidParameterValue(ref cause) => cause,
-            GetDiscoverySummaryError::ServerInternalError(ref cause) => cause,
+            GetDiscoverySummaryError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            GetDiscoverySummaryError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            GetDiscoverySummaryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetDiscoverySummaryError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetDiscoverySummaryError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDiscoverySummaryError {}
 /// Errors returned by ListConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListConfigurationsError {
@@ -2156,21 +2118,17 @@ impl ListConfigurationsError {
 }
 impl fmt::Display for ListConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListConfigurationsError::AuthorizationError(ref cause) => cause,
-            ListConfigurationsError::HomeRegionNotSet(ref cause) => cause,
-            ListConfigurationsError::InvalidParameter(ref cause) => cause,
-            ListConfigurationsError::InvalidParameterValue(ref cause) => cause,
-            ListConfigurationsError::ResourceNotFound(ref cause) => cause,
-            ListConfigurationsError::ServerInternalError(ref cause) => cause,
+            ListConfigurationsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListConfigurationsError {}
 /// Errors returned by ListServerNeighbors
 #[derive(Debug, PartialEq)]
 pub enum ListServerNeighborsError {
@@ -2224,20 +2182,16 @@ impl ListServerNeighborsError {
 }
 impl fmt::Display for ListServerNeighborsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServerNeighborsError {
-    fn description(&self) -> &str {
         match *self {
-            ListServerNeighborsError::AuthorizationError(ref cause) => cause,
-            ListServerNeighborsError::HomeRegionNotSet(ref cause) => cause,
-            ListServerNeighborsError::InvalidParameter(ref cause) => cause,
-            ListServerNeighborsError::InvalidParameterValue(ref cause) => cause,
-            ListServerNeighborsError::ServerInternalError(ref cause) => cause,
+            ListServerNeighborsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListServerNeighborsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ListServerNeighborsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListServerNeighborsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListServerNeighborsError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListServerNeighborsError {}
 /// Errors returned by StartContinuousExport
 #[derive(Debug, PartialEq)]
 pub enum StartContinuousExportError {
@@ -2308,23 +2262,19 @@ impl StartContinuousExportError {
 }
 impl fmt::Display for StartContinuousExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartContinuousExportError {
-    fn description(&self) -> &str {
         match *self {
-            StartContinuousExportError::AuthorizationError(ref cause) => cause,
-            StartContinuousExportError::ConflictError(ref cause) => cause,
-            StartContinuousExportError::HomeRegionNotSet(ref cause) => cause,
-            StartContinuousExportError::InvalidParameter(ref cause) => cause,
-            StartContinuousExportError::InvalidParameterValue(ref cause) => cause,
-            StartContinuousExportError::OperationNotPermitted(ref cause) => cause,
-            StartContinuousExportError::ResourceInUse(ref cause) => cause,
-            StartContinuousExportError::ServerInternalError(ref cause) => cause,
+            StartContinuousExportError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            StartContinuousExportError::ConflictError(ref cause) => write!(f, "{}", cause),
+            StartContinuousExportError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            StartContinuousExportError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartContinuousExportError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            StartContinuousExportError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StartContinuousExportError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StartContinuousExportError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartContinuousExportError {}
 /// Errors returned by StartDataCollectionByAgentIds
 #[derive(Debug, PartialEq)]
 pub enum StartDataCollectionByAgentIdsError {
@@ -2380,20 +2330,26 @@ impl StartDataCollectionByAgentIdsError {
 }
 impl fmt::Display for StartDataCollectionByAgentIdsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDataCollectionByAgentIdsError {
-    fn description(&self) -> &str {
         match *self {
-            StartDataCollectionByAgentIdsError::AuthorizationError(ref cause) => cause,
-            StartDataCollectionByAgentIdsError::HomeRegionNotSet(ref cause) => cause,
-            StartDataCollectionByAgentIdsError::InvalidParameter(ref cause) => cause,
-            StartDataCollectionByAgentIdsError::InvalidParameterValue(ref cause) => cause,
-            StartDataCollectionByAgentIdsError::ServerInternalError(ref cause) => cause,
+            StartDataCollectionByAgentIdsError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDataCollectionByAgentIdsError::HomeRegionNotSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDataCollectionByAgentIdsError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDataCollectionByAgentIdsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDataCollectionByAgentIdsError::ServerInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartDataCollectionByAgentIdsError {}
 /// Errors returned by StartExportTask
 #[derive(Debug, PartialEq)]
 pub enum StartExportTaskError {
@@ -2446,21 +2402,17 @@ impl StartExportTaskError {
 }
 impl fmt::Display for StartExportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartExportTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartExportTaskError::AuthorizationError(ref cause) => cause,
-            StartExportTaskError::HomeRegionNotSet(ref cause) => cause,
-            StartExportTaskError::InvalidParameter(ref cause) => cause,
-            StartExportTaskError::InvalidParameterValue(ref cause) => cause,
-            StartExportTaskError::OperationNotPermitted(ref cause) => cause,
-            StartExportTaskError::ServerInternalError(ref cause) => cause,
+            StartExportTaskError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            StartExportTaskError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            StartExportTaskError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartExportTaskError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            StartExportTaskError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StartExportTaskError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartExportTaskError {}
 /// Errors returned by StartImportTask
 #[derive(Debug, PartialEq)]
 pub enum StartImportTaskError {
@@ -2511,21 +2463,17 @@ impl StartImportTaskError {
 }
 impl fmt::Display for StartImportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartImportTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartImportTaskError::AuthorizationError(ref cause) => cause,
-            StartImportTaskError::HomeRegionNotSet(ref cause) => cause,
-            StartImportTaskError::InvalidParameter(ref cause) => cause,
-            StartImportTaskError::InvalidParameterValue(ref cause) => cause,
-            StartImportTaskError::ResourceInUse(ref cause) => cause,
-            StartImportTaskError::ServerInternalError(ref cause) => cause,
+            StartImportTaskError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            StartImportTaskError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            StartImportTaskError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartImportTaskError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            StartImportTaskError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StartImportTaskError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartImportTaskError {}
 /// Errors returned by StopContinuousExport
 #[derive(Debug, PartialEq)]
 pub enum StopContinuousExportError {
@@ -2598,23 +2546,19 @@ impl StopContinuousExportError {
 }
 impl fmt::Display for StopContinuousExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopContinuousExportError {
-    fn description(&self) -> &str {
         match *self {
-            StopContinuousExportError::AuthorizationError(ref cause) => cause,
-            StopContinuousExportError::HomeRegionNotSet(ref cause) => cause,
-            StopContinuousExportError::InvalidParameter(ref cause) => cause,
-            StopContinuousExportError::InvalidParameterValue(ref cause) => cause,
-            StopContinuousExportError::OperationNotPermitted(ref cause) => cause,
-            StopContinuousExportError::ResourceInUse(ref cause) => cause,
-            StopContinuousExportError::ResourceNotFound(ref cause) => cause,
-            StopContinuousExportError::ServerInternalError(ref cause) => cause,
+            StopContinuousExportError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            StopContinuousExportError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            StopContinuousExportError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopContinuousExportError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            StopContinuousExportError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StopContinuousExportError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StopContinuousExportError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopContinuousExportError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopContinuousExportError {}
 /// Errors returned by StopDataCollectionByAgentIds
 #[derive(Debug, PartialEq)]
 pub enum StopDataCollectionByAgentIdsError {
@@ -2670,20 +2614,26 @@ impl StopDataCollectionByAgentIdsError {
 }
 impl fmt::Display for StopDataCollectionByAgentIdsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopDataCollectionByAgentIdsError {
-    fn description(&self) -> &str {
         match *self {
-            StopDataCollectionByAgentIdsError::AuthorizationError(ref cause) => cause,
-            StopDataCollectionByAgentIdsError::HomeRegionNotSet(ref cause) => cause,
-            StopDataCollectionByAgentIdsError::InvalidParameter(ref cause) => cause,
-            StopDataCollectionByAgentIdsError::InvalidParameterValue(ref cause) => cause,
-            StopDataCollectionByAgentIdsError::ServerInternalError(ref cause) => cause,
+            StopDataCollectionByAgentIdsError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopDataCollectionByAgentIdsError::HomeRegionNotSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopDataCollectionByAgentIdsError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopDataCollectionByAgentIdsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopDataCollectionByAgentIdsError::ServerInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StopDataCollectionByAgentIdsError {}
 /// Errors returned by UpdateApplication
 #[derive(Debug, PartialEq)]
 pub enum UpdateApplicationError {
@@ -2733,20 +2683,16 @@ impl UpdateApplicationError {
 }
 impl fmt::Display for UpdateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApplicationError::AuthorizationError(ref cause) => cause,
-            UpdateApplicationError::HomeRegionNotSet(ref cause) => cause,
-            UpdateApplicationError::InvalidParameter(ref cause) => cause,
-            UpdateApplicationError::InvalidParameterValue(ref cause) => cause,
-            UpdateApplicationError::ServerInternalError(ref cause) => cause,
+            UpdateApplicationError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::ServerInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApplicationError {}
 /// Trait representing the capabilities of the AWS Application Discovery Service API. AWS Application Discovery Service clients implement this trait.
 pub trait Discovery {
     /// <p>Associates one or more configuration items with an application.</p>

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -2726,16 +2726,12 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::ResourceNotFoundFault(ref cause) => cause,
+            AddTagsToResourceError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by ApplyPendingMaintenanceAction
 #[derive(Debug, PartialEq)]
 pub enum ApplyPendingMaintenanceActionError {
@@ -2763,16 +2759,14 @@ impl ApplyPendingMaintenanceActionError {
 }
 impl fmt::Display for ApplyPendingMaintenanceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApplyPendingMaintenanceActionError {
-    fn description(&self) -> &str {
         match *self {
-            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => cause,
+            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ApplyPendingMaintenanceActionError {}
 /// Errors returned by CreateEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateEndpointError {
@@ -2831,21 +2825,17 @@ impl CreateEndpointError {
 }
 impl fmt::Display for CreateEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEndpointError::AccessDeniedFault(ref cause) => cause,
-            CreateEndpointError::InvalidResourceStateFault(ref cause) => cause,
-            CreateEndpointError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateEndpointError::ResourceAlreadyExistsFault(ref cause) => cause,
-            CreateEndpointError::ResourceNotFoundFault(ref cause) => cause,
-            CreateEndpointError::ResourceQuotaExceededFault(ref cause) => cause,
+            CreateEndpointError::AccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::ResourceAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateEndpointError::ResourceQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEndpointError {}
 /// Errors returned by CreateEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateEventSubscriptionError {
@@ -2934,25 +2924,29 @@ impl CreateEventSubscriptionError {
 }
 impl fmt::Display for CreateEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEventSubscriptionError::KMSAccessDeniedFault(ref cause) => cause,
-            CreateEventSubscriptionError::KMSDisabledFault(ref cause) => cause,
-            CreateEventSubscriptionError::KMSInvalidStateFault(ref cause) => cause,
-            CreateEventSubscriptionError::KMSNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::KMSThrottlingFault(ref cause) => cause,
-            CreateEventSubscriptionError::ResourceAlreadyExistsFault(ref cause) => cause,
-            CreateEventSubscriptionError::ResourceNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::ResourceQuotaExceededFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
+            CreateEventSubscriptionError::KMSAccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::KMSDisabledFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::KMSInvalidStateFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::KMSNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::KMSThrottlingFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::ResourceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::ResourceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateEventSubscriptionError {}
 /// Errors returned by CreateReplicationInstance
 #[derive(Debug, PartialEq)]
 pub enum CreateReplicationInstanceError {
@@ -3043,27 +3037,37 @@ impl CreateReplicationInstanceError {
 }
 impl fmt::Display for CreateReplicationInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReplicationInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReplicationInstanceError::AccessDeniedFault(ref cause) => cause,
-            CreateReplicationInstanceError::InsufficientResourceCapacityFault(ref cause) => cause,
-            CreateReplicationInstanceError::InvalidResourceStateFault(ref cause) => cause,
-            CreateReplicationInstanceError::InvalidSubnet(ref cause) => cause,
-            CreateReplicationInstanceError::KMSKeyNotAccessibleFault(ref cause) => cause,
+            CreateReplicationInstanceError::AccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            CreateReplicationInstanceError::InsufficientResourceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationInstanceError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationInstanceError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateReplicationInstanceError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateReplicationInstanceError::ReplicationSubnetGroupDoesNotCoverEnoughAZs(
                 ref cause,
-            ) => cause,
-            CreateReplicationInstanceError::ResourceAlreadyExistsFault(ref cause) => cause,
-            CreateReplicationInstanceError::ResourceNotFoundFault(ref cause) => cause,
-            CreateReplicationInstanceError::ResourceQuotaExceededFault(ref cause) => cause,
-            CreateReplicationInstanceError::StorageQuotaExceededFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            CreateReplicationInstanceError::ResourceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationInstanceError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationInstanceError::ResourceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationInstanceError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateReplicationInstanceError {}
 /// Errors returned by CreateReplicationSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateReplicationSubnetGroupError {
@@ -3126,23 +3130,27 @@ impl CreateReplicationSubnetGroupError {
 }
 impl fmt::Display for CreateReplicationSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReplicationSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReplicationSubnetGroupError::AccessDeniedFault(ref cause) => cause,
-            CreateReplicationSubnetGroupError::InvalidSubnet(ref cause) => cause,
+            CreateReplicationSubnetGroupError::AccessDeniedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
             CreateReplicationSubnetGroupError::ReplicationSubnetGroupDoesNotCoverEnoughAZs(
                 ref cause,
-            ) => cause,
-            CreateReplicationSubnetGroupError::ResourceAlreadyExistsFault(ref cause) => cause,
-            CreateReplicationSubnetGroupError::ResourceNotFoundFault(ref cause) => cause,
-            CreateReplicationSubnetGroupError::ResourceQuotaExceededFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            CreateReplicationSubnetGroupError::ResourceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationSubnetGroupError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationSubnetGroupError::ResourceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateReplicationSubnetGroupError {}
 /// Errors returned by CreateReplicationTask
 #[derive(Debug, PartialEq)]
 pub enum CreateReplicationTaskError {
@@ -3203,21 +3211,25 @@ impl CreateReplicationTaskError {
 }
 impl fmt::Display for CreateReplicationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReplicationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReplicationTaskError::AccessDeniedFault(ref cause) => cause,
-            CreateReplicationTaskError::InvalidResourceStateFault(ref cause) => cause,
-            CreateReplicationTaskError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateReplicationTaskError::ResourceAlreadyExistsFault(ref cause) => cause,
-            CreateReplicationTaskError::ResourceNotFoundFault(ref cause) => cause,
-            CreateReplicationTaskError::ResourceQuotaExceededFault(ref cause) => cause,
+            CreateReplicationTaskError::AccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            CreateReplicationTaskError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationTaskError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationTaskError::ResourceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationTaskError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateReplicationTaskError::ResourceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateReplicationTaskError {}
 /// Errors returned by DeleteCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteCertificateError {
@@ -3250,17 +3262,13 @@ impl DeleteCertificateError {
 }
 impl fmt::Display for DeleteCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCertificateError::InvalidResourceStateFault(ref cause) => cause,
-            DeleteCertificateError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteCertificateError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCertificateError {}
 /// Errors returned by DeleteConnection
 #[derive(Debug, PartialEq)]
 pub enum DeleteConnectionError {
@@ -3298,18 +3306,14 @@ impl DeleteConnectionError {
 }
 impl fmt::Display for DeleteConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConnectionError::AccessDeniedFault(ref cause) => cause,
-            DeleteConnectionError::InvalidResourceStateFault(ref cause) => cause,
-            DeleteConnectionError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteConnectionError::AccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            DeleteConnectionError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteConnectionError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConnectionError {}
 /// Errors returned by DeleteEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteEndpointError {
@@ -3342,17 +3346,13 @@ impl DeleteEndpointError {
 }
 impl fmt::Display for DeleteEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEndpointError::InvalidResourceStateFault(ref cause) => cause,
-            DeleteEndpointError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteEndpointError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteEndpointError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEndpointError {}
 /// Errors returned by DeleteEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteEventSubscriptionError {
@@ -3385,17 +3385,17 @@ impl DeleteEventSubscriptionError {
 }
 impl fmt::Display for DeleteEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEventSubscriptionError::InvalidResourceStateFault(ref cause) => cause,
-            DeleteEventSubscriptionError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteEventSubscriptionError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteEventSubscriptionError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteEventSubscriptionError {}
 /// Errors returned by DeleteReplicationInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteReplicationInstanceError {
@@ -3428,17 +3428,17 @@ impl DeleteReplicationInstanceError {
 }
 impl fmt::Display for DeleteReplicationInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReplicationInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReplicationInstanceError::InvalidResourceStateFault(ref cause) => cause,
-            DeleteReplicationInstanceError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteReplicationInstanceError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationInstanceError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteReplicationInstanceError {}
 /// Errors returned by DeleteReplicationSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteReplicationSubnetGroupError {
@@ -3473,17 +3473,17 @@ impl DeleteReplicationSubnetGroupError {
 }
 impl fmt::Display for DeleteReplicationSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReplicationSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReplicationSubnetGroupError::InvalidResourceStateFault(ref cause) => cause,
-            DeleteReplicationSubnetGroupError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteReplicationSubnetGroupError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationSubnetGroupError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteReplicationSubnetGroupError {}
 /// Errors returned by DeleteReplicationTask
 #[derive(Debug, PartialEq)]
 pub enum DeleteReplicationTaskError {
@@ -3516,17 +3516,15 @@ impl DeleteReplicationTaskError {
 }
 impl fmt::Display for DeleteReplicationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReplicationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReplicationTaskError::InvalidResourceStateFault(ref cause) => cause,
-            DeleteReplicationTaskError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteReplicationTaskError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationTaskError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReplicationTaskError {}
 /// Errors returned by DescribeAccountAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountAttributesError {}
@@ -3544,14 +3542,10 @@ impl DescribeAccountAttributesError {
 }
 impl fmt::Display for DescribeAccountAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAccountAttributesError {}
 /// Errors returned by DescribeCertificates
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificatesError {
@@ -3577,16 +3571,12 @@ impl DescribeCertificatesError {
 }
 impl fmt::Display for DescribeCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificatesError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeCertificatesError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCertificatesError {}
 /// Errors returned by DescribeConnections
 #[derive(Debug, PartialEq)]
 pub enum DescribeConnectionsError {
@@ -3612,16 +3602,12 @@ impl DescribeConnectionsError {
 }
 impl fmt::Display for DescribeConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConnectionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConnectionsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeConnectionsError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConnectionsError {}
 /// Errors returned by DescribeEndpointTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointTypesError {}
@@ -3639,14 +3625,10 @@ impl DescribeEndpointTypesError {
 }
 impl fmt::Display for DescribeEndpointTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointTypesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEndpointTypesError {}
 /// Errors returned by DescribeEndpoints
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointsError {
@@ -3672,16 +3654,12 @@ impl DescribeEndpointsError {
 }
 impl fmt::Display for DescribeEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEndpointsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeEndpointsError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEndpointsError {}
 /// Errors returned by DescribeEventCategories
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventCategoriesError {}
@@ -3699,14 +3677,10 @@ impl DescribeEventCategoriesError {
 }
 impl fmt::Display for DescribeEventCategoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventCategoriesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventCategoriesError {}
 /// Errors returned by DescribeEventSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventSubscriptionsError {
@@ -3734,16 +3708,14 @@ impl DescribeEventSubscriptionsError {
 }
 impl fmt::Display for DescribeEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventSubscriptionsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeEventSubscriptionsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEventSubscriptionsError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {}
@@ -3761,14 +3733,10 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeOrderableReplicationInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrderableReplicationInstancesError {}
@@ -3788,14 +3756,10 @@ impl DescribeOrderableReplicationInstancesError {
 }
 impl fmt::Display for DescribeOrderableReplicationInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrderableReplicationInstancesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeOrderableReplicationInstancesError {}
 /// Errors returned by DescribePendingMaintenanceActions
 #[derive(Debug, PartialEq)]
 pub enum DescribePendingMaintenanceActionsError {
@@ -3823,16 +3787,14 @@ impl DescribePendingMaintenanceActionsError {
 }
 impl fmt::Display for DescribePendingMaintenanceActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePendingMaintenanceActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePendingMaintenanceActionsError {}
 /// Errors returned by DescribeRefreshSchemasStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeRefreshSchemasStatusError {
@@ -3867,17 +3829,17 @@ impl DescribeRefreshSchemasStatusError {
 }
 impl fmt::Display for DescribeRefreshSchemasStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRefreshSchemasStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRefreshSchemasStatusError::InvalidResourceStateFault(ref cause) => cause,
-            DescribeRefreshSchemasStatusError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeRefreshSchemasStatusError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeRefreshSchemasStatusError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeRefreshSchemasStatusError {}
 /// Errors returned by DescribeReplicationInstanceTaskLogs
 #[derive(Debug, PartialEq)]
 pub enum DescribeReplicationInstanceTaskLogsError {
@@ -3914,17 +3876,17 @@ impl DescribeReplicationInstanceTaskLogsError {
 }
 impl fmt::Display for DescribeReplicationInstanceTaskLogsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReplicationInstanceTaskLogsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReplicationInstanceTaskLogsError::InvalidResourceStateFault(ref cause) => cause,
-            DescribeReplicationInstanceTaskLogsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeReplicationInstanceTaskLogsError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeReplicationInstanceTaskLogsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReplicationInstanceTaskLogsError {}
 /// Errors returned by DescribeReplicationInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeReplicationInstancesError {
@@ -3952,16 +3914,14 @@ impl DescribeReplicationInstancesError {
 }
 impl fmt::Display for DescribeReplicationInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReplicationInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReplicationInstancesError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeReplicationInstancesError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReplicationInstancesError {}
 /// Errors returned by DescribeReplicationSubnetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeReplicationSubnetGroupsError {
@@ -3989,16 +3949,14 @@ impl DescribeReplicationSubnetGroupsError {
 }
 impl fmt::Display for DescribeReplicationSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReplicationSubnetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReplicationSubnetGroupsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeReplicationSubnetGroupsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReplicationSubnetGroupsError {}
 /// Errors returned by DescribeReplicationTaskAssessmentResults
 #[derive(Debug, PartialEq)]
 pub enum DescribeReplicationTaskAssessmentResultsError {
@@ -4028,18 +3986,14 @@ impl DescribeReplicationTaskAssessmentResultsError {
 }
 impl fmt::Display for DescribeReplicationTaskAssessmentResultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReplicationTaskAssessmentResultsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeReplicationTaskAssessmentResultsError::ResourceNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeReplicationTaskAssessmentResultsError {}
 /// Errors returned by DescribeReplicationTasks
 #[derive(Debug, PartialEq)]
 pub enum DescribeReplicationTasksError {
@@ -4065,16 +4019,14 @@ impl DescribeReplicationTasksError {
 }
 impl fmt::Display for DescribeReplicationTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReplicationTasksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReplicationTasksError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeReplicationTasksError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReplicationTasksError {}
 /// Errors returned by DescribeSchemas
 #[derive(Debug, PartialEq)]
 pub enum DescribeSchemasError {
@@ -4107,17 +4059,13 @@ impl DescribeSchemasError {
 }
 impl fmt::Display for DescribeSchemasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSchemasError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSchemasError::InvalidResourceStateFault(ref cause) => cause,
-            DescribeSchemasError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeSchemasError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            DescribeSchemasError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSchemasError {}
 /// Errors returned by DescribeTableStatistics
 #[derive(Debug, PartialEq)]
 pub enum DescribeTableStatisticsError {
@@ -4150,17 +4098,17 @@ impl DescribeTableStatisticsError {
 }
 impl fmt::Display for DescribeTableStatisticsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTableStatisticsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTableStatisticsError::InvalidResourceStateFault(ref cause) => cause,
-            DescribeTableStatisticsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeTableStatisticsError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeTableStatisticsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTableStatisticsError {}
 /// Errors returned by ImportCertificate
 #[derive(Debug, PartialEq)]
 pub enum ImportCertificateError {
@@ -4200,18 +4148,14 @@ impl ImportCertificateError {
 }
 impl fmt::Display for ImportCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            ImportCertificateError::InvalidCertificateFault(ref cause) => cause,
-            ImportCertificateError::ResourceAlreadyExistsFault(ref cause) => cause,
-            ImportCertificateError::ResourceQuotaExceededFault(ref cause) => cause,
+            ImportCertificateError::InvalidCertificateFault(ref cause) => write!(f, "{}", cause),
+            ImportCertificateError::ResourceAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            ImportCertificateError::ResourceQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportCertificateError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -4237,16 +4181,12 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::ResourceNotFoundFault(ref cause) => cause,
+            ListTagsForResourceError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ModifyEndpoint
 #[derive(Debug, PartialEq)]
 pub enum ModifyEndpointError {
@@ -4298,20 +4238,16 @@ impl ModifyEndpointError {
 }
 impl fmt::Display for ModifyEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyEndpointError::AccessDeniedFault(ref cause) => cause,
-            ModifyEndpointError::InvalidResourceStateFault(ref cause) => cause,
-            ModifyEndpointError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            ModifyEndpointError::ResourceAlreadyExistsFault(ref cause) => cause,
-            ModifyEndpointError::ResourceNotFoundFault(ref cause) => cause,
+            ModifyEndpointError::AccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            ModifyEndpointError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyEndpointError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            ModifyEndpointError::ResourceAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            ModifyEndpointError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyEndpointError {}
 /// Errors returned by ModifyEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum ModifyEventSubscriptionError {
@@ -4393,24 +4329,26 @@ impl ModifyEventSubscriptionError {
 }
 impl fmt::Display for ModifyEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyEventSubscriptionError::KMSAccessDeniedFault(ref cause) => cause,
-            ModifyEventSubscriptionError::KMSDisabledFault(ref cause) => cause,
-            ModifyEventSubscriptionError::KMSInvalidStateFault(ref cause) => cause,
-            ModifyEventSubscriptionError::KMSNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::KMSThrottlingFault(ref cause) => cause,
-            ModifyEventSubscriptionError::ResourceNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::ResourceQuotaExceededFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
+            ModifyEventSubscriptionError::KMSAccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::KMSDisabledFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::KMSInvalidStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::KMSNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::KMSThrottlingFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::ResourceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyEventSubscriptionError {}
 /// Errors returned by ModifyReplicationInstance
 #[derive(Debug, PartialEq)]
 pub enum ModifyReplicationInstanceError {
@@ -4478,22 +4416,30 @@ impl ModifyReplicationInstanceError {
 }
 impl fmt::Display for ModifyReplicationInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyReplicationInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyReplicationInstanceError::AccessDeniedFault(ref cause) => cause,
-            ModifyReplicationInstanceError::InsufficientResourceCapacityFault(ref cause) => cause,
-            ModifyReplicationInstanceError::InvalidResourceStateFault(ref cause) => cause,
-            ModifyReplicationInstanceError::ResourceAlreadyExistsFault(ref cause) => cause,
-            ModifyReplicationInstanceError::ResourceNotFoundFault(ref cause) => cause,
-            ModifyReplicationInstanceError::StorageQuotaExceededFault(ref cause) => cause,
-            ModifyReplicationInstanceError::UpgradeDependencyFailureFault(ref cause) => cause,
+            ModifyReplicationInstanceError::AccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            ModifyReplicationInstanceError::InsufficientResourceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationInstanceError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationInstanceError::ResourceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationInstanceError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationInstanceError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationInstanceError::UpgradeDependencyFailureFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyReplicationInstanceError {}
 /// Errors returned by ModifyReplicationSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyReplicationSubnetGroupError {
@@ -4556,23 +4502,27 @@ impl ModifyReplicationSubnetGroupError {
 }
 impl fmt::Display for ModifyReplicationSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyReplicationSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyReplicationSubnetGroupError::AccessDeniedFault(ref cause) => cause,
-            ModifyReplicationSubnetGroupError::InvalidSubnet(ref cause) => cause,
+            ModifyReplicationSubnetGroupError::AccessDeniedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
             ModifyReplicationSubnetGroupError::ReplicationSubnetGroupDoesNotCoverEnoughAZs(
                 ref cause,
-            ) => cause,
-            ModifyReplicationSubnetGroupError::ResourceNotFoundFault(ref cause) => cause,
-            ModifyReplicationSubnetGroupError::ResourceQuotaExceededFault(ref cause) => cause,
-            ModifyReplicationSubnetGroupError::SubnetAlreadyInUse(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            ModifyReplicationSubnetGroupError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationSubnetGroupError::ResourceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationSubnetGroupError::SubnetAlreadyInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyReplicationSubnetGroupError {}
 /// Errors returned by ModifyReplicationTask
 #[derive(Debug, PartialEq)]
 pub enum ModifyReplicationTaskError {
@@ -4619,19 +4569,21 @@ impl ModifyReplicationTaskError {
 }
 impl fmt::Display for ModifyReplicationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyReplicationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyReplicationTaskError::InvalidResourceStateFault(ref cause) => cause,
-            ModifyReplicationTaskError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            ModifyReplicationTaskError::ResourceAlreadyExistsFault(ref cause) => cause,
-            ModifyReplicationTaskError::ResourceNotFoundFault(ref cause) => cause,
+            ModifyReplicationTaskError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationTaskError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationTaskError::ResourceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationTaskError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyReplicationTaskError {}
 /// Errors returned by RebootReplicationInstance
 #[derive(Debug, PartialEq)]
 pub enum RebootReplicationInstanceError {
@@ -4664,17 +4616,17 @@ impl RebootReplicationInstanceError {
 }
 impl fmt::Display for RebootReplicationInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootReplicationInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RebootReplicationInstanceError::InvalidResourceStateFault(ref cause) => cause,
-            RebootReplicationInstanceError::ResourceNotFoundFault(ref cause) => cause,
+            RebootReplicationInstanceError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RebootReplicationInstanceError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RebootReplicationInstanceError {}
 /// Errors returned by RefreshSchemas
 #[derive(Debug, PartialEq)]
 pub enum RefreshSchemasError {
@@ -4721,19 +4673,15 @@ impl RefreshSchemasError {
 }
 impl fmt::Display for RefreshSchemasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RefreshSchemasError {
-    fn description(&self) -> &str {
         match *self {
-            RefreshSchemasError::InvalidResourceStateFault(ref cause) => cause,
-            RefreshSchemasError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RefreshSchemasError::ResourceNotFoundFault(ref cause) => cause,
-            RefreshSchemasError::ResourceQuotaExceededFault(ref cause) => cause,
+            RefreshSchemasError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            RefreshSchemasError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            RefreshSchemasError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RefreshSchemasError::ResourceQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RefreshSchemasError {}
 /// Errors returned by ReloadTables
 #[derive(Debug, PartialEq)]
 pub enum ReloadTablesError {
@@ -4764,17 +4712,13 @@ impl ReloadTablesError {
 }
 impl fmt::Display for ReloadTablesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReloadTablesError {
-    fn description(&self) -> &str {
         match *self {
-            ReloadTablesError::InvalidResourceStateFault(ref cause) => cause,
-            ReloadTablesError::ResourceNotFoundFault(ref cause) => cause,
+            ReloadTablesError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            ReloadTablesError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReloadTablesError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -4800,16 +4744,12 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::ResourceNotFoundFault(ref cause) => cause,
+            RemoveTagsFromResourceError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by StartReplicationTask
 #[derive(Debug, PartialEq)]
 pub enum StartReplicationTaskError {
@@ -4849,18 +4789,16 @@ impl StartReplicationTaskError {
 }
 impl fmt::Display for StartReplicationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartReplicationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartReplicationTaskError::AccessDeniedFault(ref cause) => cause,
-            StartReplicationTaskError::InvalidResourceStateFault(ref cause) => cause,
-            StartReplicationTaskError::ResourceNotFoundFault(ref cause) => cause,
+            StartReplicationTaskError::AccessDeniedFault(ref cause) => write!(f, "{}", cause),
+            StartReplicationTaskError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartReplicationTaskError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartReplicationTaskError {}
 /// Errors returned by StartReplicationTaskAssessment
 #[derive(Debug, PartialEq)]
 pub enum StartReplicationTaskAssessmentError {
@@ -4895,17 +4833,17 @@ impl StartReplicationTaskAssessmentError {
 }
 impl fmt::Display for StartReplicationTaskAssessmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartReplicationTaskAssessmentError {
-    fn description(&self) -> &str {
         match *self {
-            StartReplicationTaskAssessmentError::InvalidResourceStateFault(ref cause) => cause,
-            StartReplicationTaskAssessmentError::ResourceNotFoundFault(ref cause) => cause,
+            StartReplicationTaskAssessmentError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartReplicationTaskAssessmentError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartReplicationTaskAssessmentError {}
 /// Errors returned by StopReplicationTask
 #[derive(Debug, PartialEq)]
 pub enum StopReplicationTaskError {
@@ -4938,17 +4876,15 @@ impl StopReplicationTaskError {
 }
 impl fmt::Display for StopReplicationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopReplicationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StopReplicationTaskError::InvalidResourceStateFault(ref cause) => cause,
-            StopReplicationTaskError::ResourceNotFoundFault(ref cause) => cause,
+            StopReplicationTaskError::InvalidResourceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopReplicationTaskError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopReplicationTaskError {}
 /// Errors returned by TestConnection
 #[derive(Debug, PartialEq)]
 pub enum TestConnectionError {
@@ -4995,19 +4931,15 @@ impl TestConnectionError {
 }
 impl fmt::Display for TestConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            TestConnectionError::InvalidResourceStateFault(ref cause) => cause,
-            TestConnectionError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            TestConnectionError::ResourceNotFoundFault(ref cause) => cause,
-            TestConnectionError::ResourceQuotaExceededFault(ref cause) => cause,
+            TestConnectionError::InvalidResourceStateFault(ref cause) => write!(f, "{}", cause),
+            TestConnectionError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            TestConnectionError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            TestConnectionError::ResourceQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestConnectionError {}
 /// Trait representing the capabilities of the AWS Database Migration Service API. AWS Database Migration Service clients implement this trait.
 pub trait DatabaseMigrationService {
     /// <p>Adds metadata tags to an AWS DMS resource, including replication instance, endpoint, security group, and migration task. These tags can also be used with cost allocation reporting to track cost associated with DMS resources, or used in a Condition statement in an IAM policy for DMS.</p>

--- a/rusoto/services/docdb/src/generated.rs
+++ b/rusoto/services/docdb/src/generated.rs
@@ -5667,18 +5667,14 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            AddTagsToResourceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by ApplyPendingMaintenanceAction
 #[derive(Debug, PartialEq)]
 pub enum ApplyPendingMaintenanceActionError {
@@ -5738,18 +5734,20 @@ impl ApplyPendingMaintenanceActionError {
 }
 impl fmt::Display for ApplyPendingMaintenanceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApplyPendingMaintenanceActionError {
-    fn description(&self) -> &str {
         match *self {
-            ApplyPendingMaintenanceActionError::InvalidDBClusterStateFault(ref cause) => cause,
-            ApplyPendingMaintenanceActionError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => cause,
+            ApplyPendingMaintenanceActionError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ApplyPendingMaintenanceActionError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ApplyPendingMaintenanceActionError {}
 /// Errors returned by CopyDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CopyDBClusterParameterGroupError {
@@ -5809,22 +5807,20 @@ impl CopyDBClusterParameterGroupError {
 }
 impl fmt::Display for CopyDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CopyDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CopyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            CopyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CopyDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CopyDBClusterParameterGroupError {}
 /// Errors returned by CopyDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CopyDBClusterSnapshotError {
@@ -5909,21 +5905,29 @@ impl CopyDBClusterSnapshotError {
 }
 impl fmt::Display for CopyDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CopyDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CopyDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CopyDBClusterSnapshotError {}
 /// Errors returned by CreateDBCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterError {
@@ -6067,30 +6071,34 @@ impl CreateDBClusterError {
 }
 impl fmt::Display for CreateDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBClusterError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterQuotaExceededFault(ref cause) => cause,
-            CreateDBClusterError::DBInstanceNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::InsufficientStorageClusterCapacityFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidSubnet(ref cause) => cause,
-            CreateDBClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateDBClusterError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateDBClusterError::StorageQuotaExceededFault(ref cause) => cause,
+            CreateDBClusterError::DBClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::DBClusterQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InsufficientStorageClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBClusterError {}
 /// Errors returned by CreateDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterParameterGroupError {
@@ -6141,21 +6149,17 @@ impl CreateDBClusterParameterGroupError {
 }
 impl fmt::Display for CreateDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CreateDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CreateDBClusterParameterGroupError {}
 /// Errors returned by CreateDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterSnapshotError {
@@ -6231,20 +6235,26 @@ impl CreateDBClusterSnapshotError {
 }
 impl fmt::Display for CreateDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBClusterSnapshotError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CreateDBClusterSnapshotError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBClusterSnapshotError {}
 /// Errors returned by CreateDBInstance
 #[derive(Debug, PartialEq)]
 pub enum CreateDBInstanceError {
@@ -6394,30 +6404,38 @@ impl CreateDBInstanceError {
 }
 impl fmt::Display for CreateDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBInstanceError::AuthorizationNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            CreateDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::InstanceQuotaExceededFault(ref cause) => cause,
-            CreateDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            CreateDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBInstanceError::InvalidSubnet(ref cause) => cause,
-            CreateDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateDBInstanceError::StorageQuotaExceededFault(ref cause) => cause,
-            CreateDBInstanceError::StorageTypeNotSupportedFault(ref cause) => cause,
+            CreateDBInstanceError::AuthorizationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InstanceQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBInstanceError {}
 /// Errors returned by CreateDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBSubnetGroupError {
@@ -6491,20 +6509,24 @@ impl CreateDBSubnetGroupError {
 }
 impl fmt::Display for CreateDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetGroupQuotaExceededFault(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => cause,
-            CreateDBSubnetGroupError::InvalidSubnet(ref cause) => cause,
+            CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBSubnetGroupError {}
 /// Errors returned by DeleteDBCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterError {
@@ -6574,20 +6596,20 @@ impl DeleteDBClusterError {
 }
 impl fmt::Display for DeleteDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            DeleteDBClusterError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteDBClusterError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            DeleteDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            DeleteDBClusterError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBClusterError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBClusterError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBClusterError {}
 /// Errors returned by DeleteDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterParameterGroupError {
@@ -6638,19 +6660,17 @@ impl DeleteDBClusterParameterGroupError {
 }
 impl fmt::Display for DeleteDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteDBClusterParameterGroupError {}
 /// Errors returned by DeleteDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterSnapshotError {
@@ -6699,17 +6719,17 @@ impl DeleteDBClusterSnapshotError {
 }
 impl fmt::Display for DeleteDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            DeleteDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
+            DeleteDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBClusterSnapshotError {}
 /// Errors returned by DeleteDBInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBInstanceError {
@@ -6779,20 +6799,18 @@ impl DeleteDBInstanceError {
 }
 impl fmt::Display for DeleteDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            DeleteDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            DeleteDBInstanceError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBInstanceError {}
 /// Errors returned by DeleteDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBSubnetGroupError {
@@ -6850,18 +6868,20 @@ impl DeleteDBSubnetGroupError {
 }
 impl fmt::Display for DeleteDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            DeleteDBSubnetGroupError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            DeleteDBSubnetGroupError::InvalidDBSubnetStateFault(ref cause) => cause,
+            DeleteDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBSubnetGroupError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBSubnetGroupError::InvalidDBSubnetStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBSubnetGroupError {}
 /// Errors returned by DescribeCertificates
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificatesError {
@@ -6901,16 +6921,14 @@ impl DescribeCertificatesError {
 }
 impl fmt::Display for DescribeCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificatesError::CertificateNotFoundFault(ref cause) => cause,
+            DescribeCertificatesError::CertificateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCertificatesError {}
 /// Errors returned by DescribeDBClusterParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterParameterGroupsError {
@@ -6952,18 +6970,14 @@ impl DescribeDBClusterParameterGroupsError {
 }
 impl fmt::Display for DescribeDBClusterParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDBClusterParameterGroupsError::DBParameterGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeDBClusterParameterGroupsError {}
 /// Errors returned by DescribeDBClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterParametersError {
@@ -7005,16 +7019,14 @@ impl DescribeDBClusterParametersError {
 }
 impl fmt::Display for DescribeDBClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterParametersError {}
 /// Errors returned by DescribeDBClusterSnapshotAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterSnapshotAttributesError {
@@ -7054,18 +7066,14 @@ impl DescribeDBClusterSnapshotAttributesError {
 }
 impl fmt::Display for DescribeDBClusterSnapshotAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterSnapshotAttributesError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDBClusterSnapshotAttributesError::DBClusterSnapshotNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeDBClusterSnapshotAttributesError {}
 /// Errors returned by DescribeDBClusterSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterSnapshotsError {
@@ -7107,16 +7115,14 @@ impl DescribeDBClusterSnapshotsError {
 }
 impl fmt::Display for DescribeDBClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterSnapshotsError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
+            DescribeDBClusterSnapshotsError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterSnapshotsError {}
 /// Errors returned by DescribeDBClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClustersError {
@@ -7154,16 +7160,12 @@ impl DescribeDBClustersError {
 }
 impl fmt::Display for DescribeDBClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClustersError::DBClusterNotFoundFault(ref cause) => cause,
+            DescribeDBClustersError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBClustersError {}
 /// Errors returned by DescribeDBEngineVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBEngineVersionsError {}
@@ -7193,14 +7195,10 @@ impl DescribeDBEngineVersionsError {
 }
 impl fmt::Display for DescribeDBEngineVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBEngineVersionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeDBEngineVersionsError {}
 /// Errors returned by DescribeDBInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBInstancesError {
@@ -7238,16 +7236,12 @@ impl DescribeDBInstancesError {
 }
 impl fmt::Display for DescribeDBInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBInstancesError::DBInstanceNotFoundFault(ref cause) => cause,
+            DescribeDBInstancesError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBInstancesError {}
 /// Errors returned by DescribeDBSubnetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBSubnetGroupsError {
@@ -7287,16 +7281,14 @@ impl DescribeDBSubnetGroupsError {
 }
 impl fmt::Display for DescribeDBSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBSubnetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBSubnetGroupsError::DBSubnetGroupNotFoundFault(ref cause) => cause,
+            DescribeDBSubnetGroupsError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBSubnetGroupsError {}
 /// Errors returned by DescribeEngineDefaultClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeEngineDefaultClusterParametersError {}
@@ -7328,14 +7320,10 @@ impl DescribeEngineDefaultClusterParametersError {
 }
 impl fmt::Display for DescribeEngineDefaultClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEngineDefaultClusterParametersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEngineDefaultClusterParametersError {}
 /// Errors returned by DescribeEventCategories
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventCategoriesError {}
@@ -7365,14 +7353,10 @@ impl DescribeEventCategoriesError {
 }
 impl fmt::Display for DescribeEventCategoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventCategoriesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventCategoriesError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {}
@@ -7402,14 +7386,10 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeOrderableDBInstanceOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrderableDBInstanceOptionsError {}
@@ -7441,14 +7421,10 @@ impl DescribeOrderableDBInstanceOptionsError {
 }
 impl fmt::Display for DescribeOrderableDBInstanceOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrderableDBInstanceOptionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeOrderableDBInstanceOptionsError {}
 /// Errors returned by DescribePendingMaintenanceActions
 #[derive(Debug, PartialEq)]
 pub enum DescribePendingMaintenanceActionsError {
@@ -7490,16 +7466,14 @@ impl DescribePendingMaintenanceActionsError {
 }
 impl fmt::Display for DescribePendingMaintenanceActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePendingMaintenanceActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePendingMaintenanceActionsError {}
 /// Errors returned by FailoverDBCluster
 #[derive(Debug, PartialEq)]
 pub enum FailoverDBClusterError {
@@ -7555,18 +7529,16 @@ impl FailoverDBClusterError {
 }
 impl fmt::Display for FailoverDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FailoverDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            FailoverDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            FailoverDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            FailoverDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
+            FailoverDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            FailoverDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            FailoverDBClusterError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for FailoverDBClusterError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -7618,18 +7590,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            ListTagsForResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            ListTagsForResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            ListTagsForResourceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ModifyDBCluster
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterError {
@@ -7743,26 +7711,28 @@ impl ModifyDBClusterError {
 }
 impl fmt::Display for ModifyDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBClusterError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            ModifyDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidSubnet(ref cause) => cause,
-            ModifyDBClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyDBClusterError::StorageQuotaExceededFault(ref cause) => cause,
+            ModifyDBClusterError::DBClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBClusterError {}
 /// Errors returned by ModifyDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterParameterGroupError {
@@ -7813,19 +7783,17 @@ impl ModifyDBClusterParameterGroupError {
 }
 impl fmt::Display for ModifyDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ModifyDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ModifyDBClusterParameterGroupError {}
 /// Errors returned by ModifyDBClusterSnapshotAttribute
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterSnapshotAttributeError {
@@ -7883,24 +7851,20 @@ impl ModifyDBClusterSnapshotAttributeError {
 }
 impl fmt::Display for ModifyDBClusterSnapshotAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterSnapshotAttributeError {
-    fn description(&self) -> &str {
         match *self {
             ModifyDBClusterSnapshotAttributeError::DBClusterSnapshotNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             ModifyDBClusterSnapshotAttributeError::InvalidDBClusterSnapshotStateFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ModifyDBClusterSnapshotAttributeError::SharedSnapshotQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ModifyDBClusterSnapshotAttributeError {}
 /// Errors returned by ModifyDBInstance
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBInstanceError {
@@ -8040,28 +8004,38 @@ impl ModifyDBInstanceError {
 }
 impl fmt::Display for ModifyDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBInstanceError::AuthorizationNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::CertificateNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            ModifyDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBUpgradeDependencyFailureFault(ref cause) => cause,
-            ModifyDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyDBInstanceError::StorageQuotaExceededFault(ref cause) => cause,
-            ModifyDBInstanceError::StorageTypeNotSupportedFault(ref cause) => cause,
+            ModifyDBInstanceError::AuthorizationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::CertificateNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBUpgradeDependencyFailureFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBInstanceError {}
 /// Errors returned by ModifyDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBSubnetGroupError {
@@ -8133,20 +8107,22 @@ impl ModifyDBSubnetGroupError {
 }
 impl fmt::Display for ModifyDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            ModifyDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => cause,
-            ModifyDBSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            ModifyDBSubnetGroupError::SubnetAlreadyInUse(ref cause) => cause,
+            ModifyDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyDBSubnetGroupError::SubnetAlreadyInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBSubnetGroupError {}
 /// Errors returned by RebootDBInstance
 #[derive(Debug, PartialEq)]
 pub enum RebootDBInstanceError {
@@ -8193,17 +8169,13 @@ impl RebootDBInstanceError {
 }
 impl fmt::Display for RebootDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RebootDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            RebootDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
+            RebootDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RebootDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootDBInstanceError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -8261,18 +8233,20 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            RemoveTagsFromResourceError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromResourceError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromResourceError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by ResetDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ResetDBClusterParameterGroupError {
@@ -8323,19 +8297,17 @@ impl ResetDBClusterParameterGroupError {
 }
 impl fmt::Display for ResetDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ResetDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ResetDBClusterParameterGroupError {}
 /// Errors returned by RestoreDBClusterFromSnapshot
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBClusterFromSnapshotError {
@@ -8490,35 +8462,51 @@ impl RestoreDBClusterFromSnapshotError {
 }
 impl fmt::Display for RestoreDBClusterFromSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBClusterFromSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBClusterFromSnapshotError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBClusterQuotaExceededFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => cause,
+            RestoreDBClusterFromSnapshotError::DBClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBClusterFromSnapshotError::InsufficientDBClusterCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RestoreDBClusterFromSnapshotError::InsufficientStorageClusterCapacityFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RestoreDBClusterFromSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterFromSnapshotError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidSubnet(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::StorageQuotaExceededFault(ref cause) => cause,
+            RestoreDBClusterFromSnapshotError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterFromSnapshotError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBClusterFromSnapshotError {}
 /// Errors returned by RestoreDBClusterToPointInTime
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBClusterToPointInTimeError {
@@ -8682,36 +8670,54 @@ impl RestoreDBClusterToPointInTimeError {
 }
 impl fmt::Display for RestoreDBClusterToPointInTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBClusterToPointInTimeError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBClusterToPointInTimeError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterQuotaExceededFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => cause,
+            RestoreDBClusterToPointInTimeError::DBClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBClusterToPointInTimeError::InsufficientDBClusterCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RestoreDBClusterToPointInTimeError::InsufficientStorageClusterCapacityFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RestoreDBClusterToPointInTimeError::InvalidDBClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterToPointInTimeError::InvalidDBClusterStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidSubnet(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::StorageQuotaExceededFault(ref cause) => cause,
+            RestoreDBClusterToPointInTimeError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBClusterToPointInTimeError {}
 /// Errors returned by StartDBCluster
 #[derive(Debug, PartialEq)]
 pub enum StartDBClusterError {
@@ -8763,18 +8769,14 @@ impl StartDBClusterError {
 }
 impl fmt::Display for StartDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            StartDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            StartDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            StartDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
+            StartDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            StartDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartDBClusterError {}
 /// Errors returned by StopDBCluster
 #[derive(Debug, PartialEq)]
 pub enum StopDBClusterError {
@@ -8826,18 +8828,14 @@ impl StopDBClusterError {
 }
 impl fmt::Display for StopDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            StopDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            StopDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            StopDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
+            StopDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StopDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            StopDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopDBClusterError {}
 /// Trait representing the capabilities of the Amazon DocDB API. Amazon DocDB clients implement this trait.
 pub trait Docdb {
     /// <p>Adds metadata tags to an Amazon DocumentDB resource. You can use these tags with cost allocation reporting to track costs that are associated with Amazon DocumentDB resources. or in a <code>Condition</code> statement in an AWS Identity and Access Management (IAM) policy for Amazon DocumentDB.</p>

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -2069,20 +2069,16 @@ impl AcceptSharedDirectoryError {
 }
 impl fmt::Display for AcceptSharedDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptSharedDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptSharedDirectoryError::Client(ref cause) => cause,
-            AcceptSharedDirectoryError::DirectoryAlreadyShared(ref cause) => cause,
-            AcceptSharedDirectoryError::EntityDoesNotExist(ref cause) => cause,
-            AcceptSharedDirectoryError::InvalidParameter(ref cause) => cause,
-            AcceptSharedDirectoryError::Service(ref cause) => cause,
+            AcceptSharedDirectoryError::Client(ref cause) => write!(f, "{}", cause),
+            AcceptSharedDirectoryError::DirectoryAlreadyShared(ref cause) => write!(f, "{}", cause),
+            AcceptSharedDirectoryError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            AcceptSharedDirectoryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AcceptSharedDirectoryError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptSharedDirectoryError {}
 /// Errors returned by AddIpRoutes
 #[derive(Debug, PartialEq)]
 pub enum AddIpRoutesError {
@@ -2136,22 +2132,18 @@ impl AddIpRoutesError {
 }
 impl fmt::Display for AddIpRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddIpRoutesError {
-    fn description(&self) -> &str {
         match *self {
-            AddIpRoutesError::Client(ref cause) => cause,
-            AddIpRoutesError::DirectoryUnavailable(ref cause) => cause,
-            AddIpRoutesError::EntityAlreadyExists(ref cause) => cause,
-            AddIpRoutesError::EntityDoesNotExist(ref cause) => cause,
-            AddIpRoutesError::InvalidParameter(ref cause) => cause,
-            AddIpRoutesError::IpRouteLimitExceeded(ref cause) => cause,
-            AddIpRoutesError::Service(ref cause) => cause,
+            AddIpRoutesError::Client(ref cause) => write!(f, "{}", cause),
+            AddIpRoutesError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            AddIpRoutesError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            AddIpRoutesError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            AddIpRoutesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AddIpRoutesError::IpRouteLimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddIpRoutesError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddIpRoutesError {}
 /// Errors returned by AddTagsToResource
 #[derive(Debug, PartialEq)]
 pub enum AddTagsToResourceError {
@@ -2197,20 +2189,16 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::Client(ref cause) => cause,
-            AddTagsToResourceError::EntityDoesNotExist(ref cause) => cause,
-            AddTagsToResourceError::InvalidParameter(ref cause) => cause,
-            AddTagsToResourceError::Service(ref cause) => cause,
-            AddTagsToResourceError::TagLimitExceeded(ref cause) => cause,
+            AddTagsToResourceError::Client(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::Service(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::TagLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by CancelSchemaExtension
 #[derive(Debug, PartialEq)]
 pub enum CancelSchemaExtensionError {
@@ -2246,18 +2234,14 @@ impl CancelSchemaExtensionError {
 }
 impl fmt::Display for CancelSchemaExtensionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelSchemaExtensionError {
-    fn description(&self) -> &str {
         match *self {
-            CancelSchemaExtensionError::Client(ref cause) => cause,
-            CancelSchemaExtensionError::EntityDoesNotExist(ref cause) => cause,
-            CancelSchemaExtensionError::Service(ref cause) => cause,
+            CancelSchemaExtensionError::Client(ref cause) => write!(f, "{}", cause),
+            CancelSchemaExtensionError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CancelSchemaExtensionError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelSchemaExtensionError {}
 /// Errors returned by ConnectDirectory
 #[derive(Debug, PartialEq)]
 pub enum ConnectDirectoryError {
@@ -2298,19 +2282,15 @@ impl ConnectDirectoryError {
 }
 impl fmt::Display for ConnectDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConnectDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            ConnectDirectoryError::Client(ref cause) => cause,
-            ConnectDirectoryError::DirectoryLimitExceeded(ref cause) => cause,
-            ConnectDirectoryError::InvalidParameter(ref cause) => cause,
-            ConnectDirectoryError::Service(ref cause) => cause,
+            ConnectDirectoryError::Client(ref cause) => write!(f, "{}", cause),
+            ConnectDirectoryError::DirectoryLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ConnectDirectoryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ConnectDirectoryError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConnectDirectoryError {}
 /// Errors returned by CreateAlias
 #[derive(Debug, PartialEq)]
 pub enum CreateAliasError {
@@ -2354,20 +2334,16 @@ impl CreateAliasError {
 }
 impl fmt::Display for CreateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAliasError::Client(ref cause) => cause,
-            CreateAliasError::EntityAlreadyExists(ref cause) => cause,
-            CreateAliasError::EntityDoesNotExist(ref cause) => cause,
-            CreateAliasError::InvalidParameter(ref cause) => cause,
-            CreateAliasError::Service(ref cause) => cause,
+            CreateAliasError::Client(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAliasError {}
 /// Errors returned by CreateComputer
 #[derive(Debug, PartialEq)]
 pub enum CreateComputerError {
@@ -2426,23 +2402,19 @@ impl CreateComputerError {
 }
 impl fmt::Display for CreateComputerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateComputerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateComputerError::AuthenticationFailed(ref cause) => cause,
-            CreateComputerError::Client(ref cause) => cause,
-            CreateComputerError::DirectoryUnavailable(ref cause) => cause,
-            CreateComputerError::EntityAlreadyExists(ref cause) => cause,
-            CreateComputerError::EntityDoesNotExist(ref cause) => cause,
-            CreateComputerError::InvalidParameter(ref cause) => cause,
-            CreateComputerError::Service(ref cause) => cause,
-            CreateComputerError::UnsupportedOperation(ref cause) => cause,
+            CreateComputerError::AuthenticationFailed(ref cause) => write!(f, "{}", cause),
+            CreateComputerError::Client(ref cause) => write!(f, "{}", cause),
+            CreateComputerError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateComputerError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateComputerError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateComputerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateComputerError::Service(ref cause) => write!(f, "{}", cause),
+            CreateComputerError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateComputerError {}
 /// Errors returned by CreateConditionalForwarder
 #[derive(Debug, PartialEq)]
 pub enum CreateConditionalForwarderError {
@@ -2508,22 +2480,26 @@ impl CreateConditionalForwarderError {
 }
 impl fmt::Display for CreateConditionalForwarderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConditionalForwarderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConditionalForwarderError::Client(ref cause) => cause,
-            CreateConditionalForwarderError::DirectoryUnavailable(ref cause) => cause,
-            CreateConditionalForwarderError::EntityAlreadyExists(ref cause) => cause,
-            CreateConditionalForwarderError::EntityDoesNotExist(ref cause) => cause,
-            CreateConditionalForwarderError::InvalidParameter(ref cause) => cause,
-            CreateConditionalForwarderError::Service(ref cause) => cause,
-            CreateConditionalForwarderError::UnsupportedOperation(ref cause) => cause,
+            CreateConditionalForwarderError::Client(ref cause) => write!(f, "{}", cause),
+            CreateConditionalForwarderError::DirectoryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateConditionalForwarderError::EntityAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateConditionalForwarderError::EntityDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateConditionalForwarderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateConditionalForwarderError::Service(ref cause) => write!(f, "{}", cause),
+            CreateConditionalForwarderError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateConditionalForwarderError {}
 /// Errors returned by CreateDirectory
 #[derive(Debug, PartialEq)]
 pub enum CreateDirectoryError {
@@ -2564,19 +2540,15 @@ impl CreateDirectoryError {
 }
 impl fmt::Display for CreateDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDirectoryError::Client(ref cause) => cause,
-            CreateDirectoryError::DirectoryLimitExceeded(ref cause) => cause,
-            CreateDirectoryError::InvalidParameter(ref cause) => cause,
-            CreateDirectoryError::Service(ref cause) => cause,
+            CreateDirectoryError::Client(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::DirectoryLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateDirectoryError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDirectoryError {}
 /// Errors returned by CreateLogSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateLogSubscriptionError {
@@ -2633,21 +2605,19 @@ impl CreateLogSubscriptionError {
 }
 impl fmt::Display for CreateLogSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLogSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLogSubscriptionError::Client(ref cause) => cause,
-            CreateLogSubscriptionError::EntityAlreadyExists(ref cause) => cause,
-            CreateLogSubscriptionError::EntityDoesNotExist(ref cause) => cause,
-            CreateLogSubscriptionError::InsufficientPermissions(ref cause) => cause,
-            CreateLogSubscriptionError::Service(ref cause) => cause,
-            CreateLogSubscriptionError::UnsupportedOperation(ref cause) => cause,
+            CreateLogSubscriptionError::Client(ref cause) => write!(f, "{}", cause),
+            CreateLogSubscriptionError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateLogSubscriptionError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateLogSubscriptionError::InsufficientPermissions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLogSubscriptionError::Service(ref cause) => write!(f, "{}", cause),
+            CreateLogSubscriptionError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLogSubscriptionError {}
 /// Errors returned by CreateMicrosoftAD
 #[derive(Debug, PartialEq)]
 pub enum CreateMicrosoftADError {
@@ -2695,20 +2665,16 @@ impl CreateMicrosoftADError {
 }
 impl fmt::Display for CreateMicrosoftADError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMicrosoftADError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMicrosoftADError::Client(ref cause) => cause,
-            CreateMicrosoftADError::DirectoryLimitExceeded(ref cause) => cause,
-            CreateMicrosoftADError::InvalidParameter(ref cause) => cause,
-            CreateMicrosoftADError::Service(ref cause) => cause,
-            CreateMicrosoftADError::UnsupportedOperation(ref cause) => cause,
+            CreateMicrosoftADError::Client(ref cause) => write!(f, "{}", cause),
+            CreateMicrosoftADError::DirectoryLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateMicrosoftADError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateMicrosoftADError::Service(ref cause) => write!(f, "{}", cause),
+            CreateMicrosoftADError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMicrosoftADError {}
 /// Errors returned by CreateSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateSnapshotError {
@@ -2754,20 +2720,16 @@ impl CreateSnapshotError {
 }
 impl fmt::Display for CreateSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSnapshotError::Client(ref cause) => cause,
-            CreateSnapshotError::EntityDoesNotExist(ref cause) => cause,
-            CreateSnapshotError::InvalidParameter(ref cause) => cause,
-            CreateSnapshotError::Service(ref cause) => cause,
-            CreateSnapshotError::SnapshotLimitExceeded(ref cause) => cause,
+            CreateSnapshotError::Client(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::SnapshotLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSnapshotError {}
 /// Errors returned by CreateTrust
 #[derive(Debug, PartialEq)]
 pub enum CreateTrustError {
@@ -2816,21 +2778,17 @@ impl CreateTrustError {
 }
 impl fmt::Display for CreateTrustError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrustError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrustError::Client(ref cause) => cause,
-            CreateTrustError::EntityAlreadyExists(ref cause) => cause,
-            CreateTrustError::EntityDoesNotExist(ref cause) => cause,
-            CreateTrustError::InvalidParameter(ref cause) => cause,
-            CreateTrustError::Service(ref cause) => cause,
-            CreateTrustError::UnsupportedOperation(ref cause) => cause,
+            CreateTrustError::Client(ref cause) => write!(f, "{}", cause),
+            CreateTrustError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateTrustError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateTrustError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateTrustError::Service(ref cause) => write!(f, "{}", cause),
+            CreateTrustError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTrustError {}
 /// Errors returned by DeleteConditionalForwarder
 #[derive(Debug, PartialEq)]
 pub enum DeleteConditionalForwarderError {
@@ -2889,21 +2847,23 @@ impl DeleteConditionalForwarderError {
 }
 impl fmt::Display for DeleteConditionalForwarderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConditionalForwarderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConditionalForwarderError::Client(ref cause) => cause,
-            DeleteConditionalForwarderError::DirectoryUnavailable(ref cause) => cause,
-            DeleteConditionalForwarderError::EntityDoesNotExist(ref cause) => cause,
-            DeleteConditionalForwarderError::InvalidParameter(ref cause) => cause,
-            DeleteConditionalForwarderError::Service(ref cause) => cause,
-            DeleteConditionalForwarderError::UnsupportedOperation(ref cause) => cause,
+            DeleteConditionalForwarderError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteConditionalForwarderError::DirectoryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteConditionalForwarderError::EntityDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteConditionalForwarderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteConditionalForwarderError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteConditionalForwarderError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteConditionalForwarderError {}
 /// Errors returned by DeleteDirectory
 #[derive(Debug, PartialEq)]
 pub enum DeleteDirectoryError {
@@ -2937,18 +2897,14 @@ impl DeleteDirectoryError {
 }
 impl fmt::Display for DeleteDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDirectoryError::Client(ref cause) => cause,
-            DeleteDirectoryError::EntityDoesNotExist(ref cause) => cause,
-            DeleteDirectoryError::Service(ref cause) => cause,
+            DeleteDirectoryError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteDirectoryError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDirectoryError {}
 /// Errors returned by DeleteLogSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteLogSubscriptionError {
@@ -2991,19 +2947,15 @@ impl DeleteLogSubscriptionError {
 }
 impl fmt::Display for DeleteLogSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLogSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLogSubscriptionError::Client(ref cause) => cause,
-            DeleteLogSubscriptionError::EntityDoesNotExist(ref cause) => cause,
-            DeleteLogSubscriptionError::Service(ref cause) => cause,
-            DeleteLogSubscriptionError::UnsupportedOperation(ref cause) => cause,
+            DeleteLogSubscriptionError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteLogSubscriptionError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteLogSubscriptionError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteLogSubscriptionError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLogSubscriptionError {}
 /// Errors returned by DeleteSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteSnapshotError {
@@ -3042,19 +2994,15 @@ impl DeleteSnapshotError {
 }
 impl fmt::Display for DeleteSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSnapshotError::Client(ref cause) => cause,
-            DeleteSnapshotError::EntityDoesNotExist(ref cause) => cause,
-            DeleteSnapshotError::InvalidParameter(ref cause) => cause,
-            DeleteSnapshotError::Service(ref cause) => cause,
+            DeleteSnapshotError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteSnapshotError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteSnapshotError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteSnapshotError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSnapshotError {}
 /// Errors returned by DeleteTrust
 #[derive(Debug, PartialEq)]
 pub enum DeleteTrustError {
@@ -3098,20 +3046,16 @@ impl DeleteTrustError {
 }
 impl fmt::Display for DeleteTrustError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTrustError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTrustError::Client(ref cause) => cause,
-            DeleteTrustError::EntityDoesNotExist(ref cause) => cause,
-            DeleteTrustError::InvalidParameter(ref cause) => cause,
-            DeleteTrustError::Service(ref cause) => cause,
-            DeleteTrustError::UnsupportedOperation(ref cause) => cause,
+            DeleteTrustError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteTrustError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteTrustError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteTrustError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteTrustError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTrustError {}
 /// Errors returned by DeregisterCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeregisterCertificateError {
@@ -3182,23 +3126,21 @@ impl DeregisterCertificateError {
 }
 impl fmt::Display for DeregisterCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterCertificateError::CertificateDoesNotExist(ref cause) => cause,
-            DeregisterCertificateError::CertificateInUse(ref cause) => cause,
-            DeregisterCertificateError::Client(ref cause) => cause,
-            DeregisterCertificateError::DirectoryDoesNotExist(ref cause) => cause,
-            DeregisterCertificateError::DirectoryUnavailable(ref cause) => cause,
-            DeregisterCertificateError::InvalidParameter(ref cause) => cause,
-            DeregisterCertificateError::Service(ref cause) => cause,
-            DeregisterCertificateError::UnsupportedOperation(ref cause) => cause,
+            DeregisterCertificateError::CertificateDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterCertificateError::CertificateInUse(ref cause) => write!(f, "{}", cause),
+            DeregisterCertificateError::Client(ref cause) => write!(f, "{}", cause),
+            DeregisterCertificateError::DirectoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeregisterCertificateError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            DeregisterCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeregisterCertificateError::Service(ref cause) => write!(f, "{}", cause),
+            DeregisterCertificateError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterCertificateError {}
 /// Errors returned by DeregisterEventTopic
 #[derive(Debug, PartialEq)]
 pub enum DeregisterEventTopicError {
@@ -3241,19 +3183,15 @@ impl DeregisterEventTopicError {
 }
 impl fmt::Display for DeregisterEventTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterEventTopicError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterEventTopicError::Client(ref cause) => cause,
-            DeregisterEventTopicError::EntityDoesNotExist(ref cause) => cause,
-            DeregisterEventTopicError::InvalidParameter(ref cause) => cause,
-            DeregisterEventTopicError::Service(ref cause) => cause,
+            DeregisterEventTopicError::Client(ref cause) => write!(f, "{}", cause),
+            DeregisterEventTopicError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeregisterEventTopicError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeregisterEventTopicError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterEventTopicError {}
 /// Errors returned by DescribeCertificate
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificateError {
@@ -3310,21 +3248,17 @@ impl DescribeCertificateError {
 }
 impl fmt::Display for DescribeCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificateError::CertificateDoesNotExist(ref cause) => cause,
-            DescribeCertificateError::Client(ref cause) => cause,
-            DescribeCertificateError::DirectoryDoesNotExist(ref cause) => cause,
-            DescribeCertificateError::InvalidParameter(ref cause) => cause,
-            DescribeCertificateError::Service(ref cause) => cause,
-            DescribeCertificateError::UnsupportedOperation(ref cause) => cause,
+            DescribeCertificateError::CertificateDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::DirectoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCertificateError {}
 /// Errors returned by DescribeConditionalForwarders
 #[derive(Debug, PartialEq)]
 pub enum DescribeConditionalForwardersError {
@@ -3387,21 +3321,25 @@ impl DescribeConditionalForwardersError {
 }
 impl fmt::Display for DescribeConditionalForwardersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConditionalForwardersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConditionalForwardersError::Client(ref cause) => cause,
-            DescribeConditionalForwardersError::DirectoryUnavailable(ref cause) => cause,
-            DescribeConditionalForwardersError::EntityDoesNotExist(ref cause) => cause,
-            DescribeConditionalForwardersError::InvalidParameter(ref cause) => cause,
-            DescribeConditionalForwardersError::Service(ref cause) => cause,
-            DescribeConditionalForwardersError::UnsupportedOperation(ref cause) => cause,
+            DescribeConditionalForwardersError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeConditionalForwardersError::DirectoryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConditionalForwardersError::EntityDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConditionalForwardersError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConditionalForwardersError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeConditionalForwardersError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConditionalForwardersError {}
 /// Errors returned by DescribeDirectories
 #[derive(Debug, PartialEq)]
 pub enum DescribeDirectoriesError {
@@ -3451,20 +3389,16 @@ impl DescribeDirectoriesError {
 }
 impl fmt::Display for DescribeDirectoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDirectoriesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDirectoriesError::Client(ref cause) => cause,
-            DescribeDirectoriesError::EntityDoesNotExist(ref cause) => cause,
-            DescribeDirectoriesError::InvalidNextToken(ref cause) => cause,
-            DescribeDirectoriesError::InvalidParameter(ref cause) => cause,
-            DescribeDirectoriesError::Service(ref cause) => cause,
+            DescribeDirectoriesError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeDirectoriesError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeDirectoriesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeDirectoriesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeDirectoriesError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDirectoriesError {}
 /// Errors returned by DescribeDomainControllers
 #[derive(Debug, PartialEq)]
 pub enum DescribeDomainControllersError {
@@ -3521,21 +3455,19 @@ impl DescribeDomainControllersError {
 }
 impl fmt::Display for DescribeDomainControllersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDomainControllersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDomainControllersError::Client(ref cause) => cause,
-            DescribeDomainControllersError::EntityDoesNotExist(ref cause) => cause,
-            DescribeDomainControllersError::InvalidNextToken(ref cause) => cause,
-            DescribeDomainControllersError::InvalidParameter(ref cause) => cause,
-            DescribeDomainControllersError::Service(ref cause) => cause,
-            DescribeDomainControllersError::UnsupportedOperation(ref cause) => cause,
+            DescribeDomainControllersError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeDomainControllersError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeDomainControllersError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeDomainControllersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeDomainControllersError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeDomainControllersError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDomainControllersError {}
 /// Errors returned by DescribeEventTopics
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventTopicsError {
@@ -3578,19 +3510,15 @@ impl DescribeEventTopicsError {
 }
 impl fmt::Display for DescribeEventTopicsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventTopicsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventTopicsError::Client(ref cause) => cause,
-            DescribeEventTopicsError::EntityDoesNotExist(ref cause) => cause,
-            DescribeEventTopicsError::InvalidParameter(ref cause) => cause,
-            DescribeEventTopicsError::Service(ref cause) => cause,
+            DescribeEventTopicsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeEventTopicsError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeEventTopicsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeEventTopicsError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventTopicsError {}
 /// Errors returned by DescribeLDAPSSettings
 #[derive(Debug, PartialEq)]
 pub enum DescribeLDAPSSettingsError {
@@ -3647,21 +3575,17 @@ impl DescribeLDAPSSettingsError {
 }
 impl fmt::Display for DescribeLDAPSSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLDAPSSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLDAPSSettingsError::Client(ref cause) => cause,
-            DescribeLDAPSSettingsError::DirectoryDoesNotExist(ref cause) => cause,
-            DescribeLDAPSSettingsError::InvalidNextToken(ref cause) => cause,
-            DescribeLDAPSSettingsError::InvalidParameter(ref cause) => cause,
-            DescribeLDAPSSettingsError::Service(ref cause) => cause,
-            DescribeLDAPSSettingsError::UnsupportedOperation(ref cause) => cause,
+            DescribeLDAPSSettingsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeLDAPSSettingsError::DirectoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeLDAPSSettingsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeLDAPSSettingsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeLDAPSSettingsError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeLDAPSSettingsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLDAPSSettingsError {}
 /// Errors returned by DescribeSharedDirectories
 #[derive(Debug, PartialEq)]
 pub enum DescribeSharedDirectoriesError {
@@ -3718,21 +3642,19 @@ impl DescribeSharedDirectoriesError {
 }
 impl fmt::Display for DescribeSharedDirectoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSharedDirectoriesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSharedDirectoriesError::Client(ref cause) => cause,
-            DescribeSharedDirectoriesError::EntityDoesNotExist(ref cause) => cause,
-            DescribeSharedDirectoriesError::InvalidNextToken(ref cause) => cause,
-            DescribeSharedDirectoriesError::InvalidParameter(ref cause) => cause,
-            DescribeSharedDirectoriesError::Service(ref cause) => cause,
-            DescribeSharedDirectoriesError::UnsupportedOperation(ref cause) => cause,
+            DescribeSharedDirectoriesError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeSharedDirectoriesError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeSharedDirectoriesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeSharedDirectoriesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeSharedDirectoriesError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeSharedDirectoriesError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeSharedDirectoriesError {}
 /// Errors returned by DescribeSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeSnapshotsError {
@@ -3778,20 +3700,16 @@ impl DescribeSnapshotsError {
 }
 impl fmt::Display for DescribeSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSnapshotsError::Client(ref cause) => cause,
-            DescribeSnapshotsError::EntityDoesNotExist(ref cause) => cause,
-            DescribeSnapshotsError::InvalidNextToken(ref cause) => cause,
-            DescribeSnapshotsError::InvalidParameter(ref cause) => cause,
-            DescribeSnapshotsError::Service(ref cause) => cause,
+            DescribeSnapshotsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotsError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotsError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSnapshotsError {}
 /// Errors returned by DescribeTrusts
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrustsError {
@@ -3840,21 +3758,17 @@ impl DescribeTrustsError {
 }
 impl fmt::Display for DescribeTrustsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrustsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrustsError::Client(ref cause) => cause,
-            DescribeTrustsError::EntityDoesNotExist(ref cause) => cause,
-            DescribeTrustsError::InvalidNextToken(ref cause) => cause,
-            DescribeTrustsError::InvalidParameter(ref cause) => cause,
-            DescribeTrustsError::Service(ref cause) => cause,
-            DescribeTrustsError::UnsupportedOperation(ref cause) => cause,
+            DescribeTrustsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeTrustsError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeTrustsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeTrustsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeTrustsError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeTrustsError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTrustsError {}
 /// Errors returned by DisableLDAPS
 #[derive(Debug, PartialEq)]
 pub enum DisableLDAPSError {
@@ -3908,22 +3822,18 @@ impl DisableLDAPSError {
 }
 impl fmt::Display for DisableLDAPSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableLDAPSError {
-    fn description(&self) -> &str {
         match *self {
-            DisableLDAPSError::Client(ref cause) => cause,
-            DisableLDAPSError::DirectoryDoesNotExist(ref cause) => cause,
-            DisableLDAPSError::DirectoryUnavailable(ref cause) => cause,
-            DisableLDAPSError::InvalidLDAPSStatus(ref cause) => cause,
-            DisableLDAPSError::InvalidParameter(ref cause) => cause,
-            DisableLDAPSError::Service(ref cause) => cause,
-            DisableLDAPSError::UnsupportedOperation(ref cause) => cause,
+            DisableLDAPSError::Client(ref cause) => write!(f, "{}", cause),
+            DisableLDAPSError::DirectoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DisableLDAPSError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            DisableLDAPSError::InvalidLDAPSStatus(ref cause) => write!(f, "{}", cause),
+            DisableLDAPSError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DisableLDAPSError::Service(ref cause) => write!(f, "{}", cause),
+            DisableLDAPSError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableLDAPSError {}
 /// Errors returned by DisableRadius
 #[derive(Debug, PartialEq)]
 pub enum DisableRadiusError {
@@ -3957,18 +3867,14 @@ impl DisableRadiusError {
 }
 impl fmt::Display for DisableRadiusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableRadiusError {
-    fn description(&self) -> &str {
         match *self {
-            DisableRadiusError::Client(ref cause) => cause,
-            DisableRadiusError::EntityDoesNotExist(ref cause) => cause,
-            DisableRadiusError::Service(ref cause) => cause,
+            DisableRadiusError::Client(ref cause) => write!(f, "{}", cause),
+            DisableRadiusError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DisableRadiusError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableRadiusError {}
 /// Errors returned by DisableSso
 #[derive(Debug, PartialEq)]
 pub enum DisableSsoError {
@@ -4010,20 +3916,16 @@ impl DisableSsoError {
 }
 impl fmt::Display for DisableSsoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableSsoError {
-    fn description(&self) -> &str {
         match *self {
-            DisableSsoError::AuthenticationFailed(ref cause) => cause,
-            DisableSsoError::Client(ref cause) => cause,
-            DisableSsoError::EntityDoesNotExist(ref cause) => cause,
-            DisableSsoError::InsufficientPermissions(ref cause) => cause,
-            DisableSsoError::Service(ref cause) => cause,
+            DisableSsoError::AuthenticationFailed(ref cause) => write!(f, "{}", cause),
+            DisableSsoError::Client(ref cause) => write!(f, "{}", cause),
+            DisableSsoError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DisableSsoError::InsufficientPermissions(ref cause) => write!(f, "{}", cause),
+            DisableSsoError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableSsoError {}
 /// Errors returned by EnableLDAPS
 #[derive(Debug, PartialEq)]
 pub enum EnableLDAPSError {
@@ -4082,23 +3984,19 @@ impl EnableLDAPSError {
 }
 impl fmt::Display for EnableLDAPSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableLDAPSError {
-    fn description(&self) -> &str {
         match *self {
-            EnableLDAPSError::Client(ref cause) => cause,
-            EnableLDAPSError::DirectoryDoesNotExist(ref cause) => cause,
-            EnableLDAPSError::DirectoryUnavailable(ref cause) => cause,
-            EnableLDAPSError::InvalidLDAPSStatus(ref cause) => cause,
-            EnableLDAPSError::InvalidParameter(ref cause) => cause,
-            EnableLDAPSError::NoAvailableCertificate(ref cause) => cause,
-            EnableLDAPSError::Service(ref cause) => cause,
-            EnableLDAPSError::UnsupportedOperation(ref cause) => cause,
+            EnableLDAPSError::Client(ref cause) => write!(f, "{}", cause),
+            EnableLDAPSError::DirectoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            EnableLDAPSError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            EnableLDAPSError::InvalidLDAPSStatus(ref cause) => write!(f, "{}", cause),
+            EnableLDAPSError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            EnableLDAPSError::NoAvailableCertificate(ref cause) => write!(f, "{}", cause),
+            EnableLDAPSError::Service(ref cause) => write!(f, "{}", cause),
+            EnableLDAPSError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableLDAPSError {}
 /// Errors returned by EnableRadius
 #[derive(Debug, PartialEq)]
 pub enum EnableRadiusError {
@@ -4142,20 +4040,16 @@ impl EnableRadiusError {
 }
 impl fmt::Display for EnableRadiusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableRadiusError {
-    fn description(&self) -> &str {
         match *self {
-            EnableRadiusError::Client(ref cause) => cause,
-            EnableRadiusError::EntityAlreadyExists(ref cause) => cause,
-            EnableRadiusError::EntityDoesNotExist(ref cause) => cause,
-            EnableRadiusError::InvalidParameter(ref cause) => cause,
-            EnableRadiusError::Service(ref cause) => cause,
+            EnableRadiusError::Client(ref cause) => write!(f, "{}", cause),
+            EnableRadiusError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            EnableRadiusError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            EnableRadiusError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            EnableRadiusError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableRadiusError {}
 /// Errors returned by EnableSso
 #[derive(Debug, PartialEq)]
 pub enum EnableSsoError {
@@ -4197,20 +4091,16 @@ impl EnableSsoError {
 }
 impl fmt::Display for EnableSsoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableSsoError {
-    fn description(&self) -> &str {
         match *self {
-            EnableSsoError::AuthenticationFailed(ref cause) => cause,
-            EnableSsoError::Client(ref cause) => cause,
-            EnableSsoError::EntityDoesNotExist(ref cause) => cause,
-            EnableSsoError::InsufficientPermissions(ref cause) => cause,
-            EnableSsoError::Service(ref cause) => cause,
+            EnableSsoError::AuthenticationFailed(ref cause) => write!(f, "{}", cause),
+            EnableSsoError::Client(ref cause) => write!(f, "{}", cause),
+            EnableSsoError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            EnableSsoError::InsufficientPermissions(ref cause) => write!(f, "{}", cause),
+            EnableSsoError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableSsoError {}
 /// Errors returned by GetDirectoryLimits
 #[derive(Debug, PartialEq)]
 pub enum GetDirectoryLimitsError {
@@ -4246,18 +4136,14 @@ impl GetDirectoryLimitsError {
 }
 impl fmt::Display for GetDirectoryLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDirectoryLimitsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDirectoryLimitsError::Client(ref cause) => cause,
-            GetDirectoryLimitsError::EntityDoesNotExist(ref cause) => cause,
-            GetDirectoryLimitsError::Service(ref cause) => cause,
+            GetDirectoryLimitsError::Client(ref cause) => write!(f, "{}", cause),
+            GetDirectoryLimitsError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetDirectoryLimitsError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDirectoryLimitsError {}
 /// Errors returned by GetSnapshotLimits
 #[derive(Debug, PartialEq)]
 pub enum GetSnapshotLimitsError {
@@ -4293,18 +4179,14 @@ impl GetSnapshotLimitsError {
 }
 impl fmt::Display for GetSnapshotLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSnapshotLimitsError {
-    fn description(&self) -> &str {
         match *self {
-            GetSnapshotLimitsError::Client(ref cause) => cause,
-            GetSnapshotLimitsError::EntityDoesNotExist(ref cause) => cause,
-            GetSnapshotLimitsError::Service(ref cause) => cause,
+            GetSnapshotLimitsError::Client(ref cause) => write!(f, "{}", cause),
+            GetSnapshotLimitsError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetSnapshotLimitsError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSnapshotLimitsError {}
 /// Errors returned by ListCertificates
 #[derive(Debug, PartialEq)]
 pub enum ListCertificatesError {
@@ -4357,21 +4239,17 @@ impl ListCertificatesError {
 }
 impl fmt::Display for ListCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListCertificatesError::Client(ref cause) => cause,
-            ListCertificatesError::DirectoryDoesNotExist(ref cause) => cause,
-            ListCertificatesError::InvalidNextToken(ref cause) => cause,
-            ListCertificatesError::InvalidParameter(ref cause) => cause,
-            ListCertificatesError::Service(ref cause) => cause,
-            ListCertificatesError::UnsupportedOperation(ref cause) => cause,
+            ListCertificatesError::Client(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::DirectoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::Service(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCertificatesError {}
 /// Errors returned by ListIpRoutes
 #[derive(Debug, PartialEq)]
 pub enum ListIpRoutesError {
@@ -4415,20 +4293,16 @@ impl ListIpRoutesError {
 }
 impl fmt::Display for ListIpRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIpRoutesError {
-    fn description(&self) -> &str {
         match *self {
-            ListIpRoutesError::Client(ref cause) => cause,
-            ListIpRoutesError::EntityDoesNotExist(ref cause) => cause,
-            ListIpRoutesError::InvalidNextToken(ref cause) => cause,
-            ListIpRoutesError::InvalidParameter(ref cause) => cause,
-            ListIpRoutesError::Service(ref cause) => cause,
+            ListIpRoutesError::Client(ref cause) => write!(f, "{}", cause),
+            ListIpRoutesError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListIpRoutesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListIpRoutesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListIpRoutesError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIpRoutesError {}
 /// Errors returned by ListLogSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum ListLogSubscriptionsError {
@@ -4471,19 +4345,15 @@ impl ListLogSubscriptionsError {
 }
 impl fmt::Display for ListLogSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLogSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLogSubscriptionsError::Client(ref cause) => cause,
-            ListLogSubscriptionsError::EntityDoesNotExist(ref cause) => cause,
-            ListLogSubscriptionsError::InvalidNextToken(ref cause) => cause,
-            ListLogSubscriptionsError::Service(ref cause) => cause,
+            ListLogSubscriptionsError::Client(ref cause) => write!(f, "{}", cause),
+            ListLogSubscriptionsError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListLogSubscriptionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListLogSubscriptionsError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLogSubscriptionsError {}
 /// Errors returned by ListSchemaExtensions
 #[derive(Debug, PartialEq)]
 pub enum ListSchemaExtensionsError {
@@ -4526,19 +4396,15 @@ impl ListSchemaExtensionsError {
 }
 impl fmt::Display for ListSchemaExtensionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSchemaExtensionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSchemaExtensionsError::Client(ref cause) => cause,
-            ListSchemaExtensionsError::EntityDoesNotExist(ref cause) => cause,
-            ListSchemaExtensionsError::InvalidNextToken(ref cause) => cause,
-            ListSchemaExtensionsError::Service(ref cause) => cause,
+            ListSchemaExtensionsError::Client(ref cause) => write!(f, "{}", cause),
+            ListSchemaExtensionsError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListSchemaExtensionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListSchemaExtensionsError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSchemaExtensionsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -4588,20 +4454,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::Client(ref cause) => cause,
-            ListTagsForResourceError::EntityDoesNotExist(ref cause) => cause,
-            ListTagsForResourceError::InvalidNextToken(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::Service(ref cause) => cause,
+            ListTagsForResourceError::Client(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by RegisterCertificate
 #[derive(Debug, PartialEq)]
 pub enum RegisterCertificateError {
@@ -4679,24 +4541,20 @@ impl RegisterCertificateError {
 }
 impl fmt::Display for RegisterCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterCertificateError::CertificateAlreadyExists(ref cause) => cause,
-            RegisterCertificateError::CertificateLimitExceeded(ref cause) => cause,
-            RegisterCertificateError::Client(ref cause) => cause,
-            RegisterCertificateError::DirectoryDoesNotExist(ref cause) => cause,
-            RegisterCertificateError::DirectoryUnavailable(ref cause) => cause,
-            RegisterCertificateError::InvalidCertificate(ref cause) => cause,
-            RegisterCertificateError::InvalidParameter(ref cause) => cause,
-            RegisterCertificateError::Service(ref cause) => cause,
-            RegisterCertificateError::UnsupportedOperation(ref cause) => cause,
+            RegisterCertificateError::CertificateAlreadyExists(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::CertificateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::Client(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::DirectoryDoesNotExist(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::InvalidCertificate(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::Service(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterCertificateError {}
 /// Errors returned by RegisterEventTopic
 #[derive(Debug, PartialEq)]
 pub enum RegisterEventTopicError {
@@ -4737,19 +4595,15 @@ impl RegisterEventTopicError {
 }
 impl fmt::Display for RegisterEventTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterEventTopicError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterEventTopicError::Client(ref cause) => cause,
-            RegisterEventTopicError::EntityDoesNotExist(ref cause) => cause,
-            RegisterEventTopicError::InvalidParameter(ref cause) => cause,
-            RegisterEventTopicError::Service(ref cause) => cause,
+            RegisterEventTopicError::Client(ref cause) => write!(f, "{}", cause),
+            RegisterEventTopicError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            RegisterEventTopicError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RegisterEventTopicError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterEventTopicError {}
 /// Errors returned by RejectSharedDirectory
 #[derive(Debug, PartialEq)]
 pub enum RejectSharedDirectoryError {
@@ -4799,20 +4653,16 @@ impl RejectSharedDirectoryError {
 }
 impl fmt::Display for RejectSharedDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RejectSharedDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            RejectSharedDirectoryError::Client(ref cause) => cause,
-            RejectSharedDirectoryError::DirectoryAlreadyShared(ref cause) => cause,
-            RejectSharedDirectoryError::EntityDoesNotExist(ref cause) => cause,
-            RejectSharedDirectoryError::InvalidParameter(ref cause) => cause,
-            RejectSharedDirectoryError::Service(ref cause) => cause,
+            RejectSharedDirectoryError::Client(ref cause) => write!(f, "{}", cause),
+            RejectSharedDirectoryError::DirectoryAlreadyShared(ref cause) => write!(f, "{}", cause),
+            RejectSharedDirectoryError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            RejectSharedDirectoryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RejectSharedDirectoryError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RejectSharedDirectoryError {}
 /// Errors returned by RemoveIpRoutes
 #[derive(Debug, PartialEq)]
 pub enum RemoveIpRoutesError {
@@ -4856,20 +4706,16 @@ impl RemoveIpRoutesError {
 }
 impl fmt::Display for RemoveIpRoutesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveIpRoutesError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveIpRoutesError::Client(ref cause) => cause,
-            RemoveIpRoutesError::DirectoryUnavailable(ref cause) => cause,
-            RemoveIpRoutesError::EntityDoesNotExist(ref cause) => cause,
-            RemoveIpRoutesError::InvalidParameter(ref cause) => cause,
-            RemoveIpRoutesError::Service(ref cause) => cause,
+            RemoveIpRoutesError::Client(ref cause) => write!(f, "{}", cause),
+            RemoveIpRoutesError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            RemoveIpRoutesError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            RemoveIpRoutesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RemoveIpRoutesError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveIpRoutesError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -4912,19 +4758,15 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::Client(ref cause) => cause,
-            RemoveTagsFromResourceError::EntityDoesNotExist(ref cause) => cause,
-            RemoveTagsFromResourceError::InvalidParameter(ref cause) => cause,
-            RemoveTagsFromResourceError::Service(ref cause) => cause,
+            RemoveTagsFromResourceError::Client(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by ResetUserPassword
 #[derive(Debug, PartialEq)]
 pub enum ResetUserPasswordError {
@@ -4984,22 +4826,18 @@ impl ResetUserPasswordError {
 }
 impl fmt::Display for ResetUserPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetUserPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            ResetUserPasswordError::Client(ref cause) => cause,
-            ResetUserPasswordError::DirectoryUnavailable(ref cause) => cause,
-            ResetUserPasswordError::EntityDoesNotExist(ref cause) => cause,
-            ResetUserPasswordError::InvalidPassword(ref cause) => cause,
-            ResetUserPasswordError::Service(ref cause) => cause,
-            ResetUserPasswordError::UnsupportedOperation(ref cause) => cause,
-            ResetUserPasswordError::UserDoesNotExist(ref cause) => cause,
+            ResetUserPasswordError::Client(ref cause) => write!(f, "{}", cause),
+            ResetUserPasswordError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            ResetUserPasswordError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ResetUserPasswordError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            ResetUserPasswordError::Service(ref cause) => write!(f, "{}", cause),
+            ResetUserPasswordError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
+            ResetUserPasswordError::UserDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetUserPasswordError {}
 /// Errors returned by RestoreFromSnapshot
 #[derive(Debug, PartialEq)]
 pub enum RestoreFromSnapshotError {
@@ -5042,19 +4880,15 @@ impl RestoreFromSnapshotError {
 }
 impl fmt::Display for RestoreFromSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreFromSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreFromSnapshotError::Client(ref cause) => cause,
-            RestoreFromSnapshotError::EntityDoesNotExist(ref cause) => cause,
-            RestoreFromSnapshotError::InvalidParameter(ref cause) => cause,
-            RestoreFromSnapshotError::Service(ref cause) => cause,
+            RestoreFromSnapshotError::Client(ref cause) => write!(f, "{}", cause),
+            RestoreFromSnapshotError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            RestoreFromSnapshotError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RestoreFromSnapshotError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreFromSnapshotError {}
 /// Errors returned by ShareDirectory
 #[derive(Debug, PartialEq)]
 pub enum ShareDirectoryError {
@@ -5125,25 +4959,21 @@ impl ShareDirectoryError {
 }
 impl fmt::Display for ShareDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ShareDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            ShareDirectoryError::AccessDenied(ref cause) => cause,
-            ShareDirectoryError::Client(ref cause) => cause,
-            ShareDirectoryError::DirectoryAlreadyShared(ref cause) => cause,
-            ShareDirectoryError::EntityDoesNotExist(ref cause) => cause,
-            ShareDirectoryError::InvalidParameter(ref cause) => cause,
-            ShareDirectoryError::InvalidTarget(ref cause) => cause,
-            ShareDirectoryError::Organizations(ref cause) => cause,
-            ShareDirectoryError::Service(ref cause) => cause,
-            ShareDirectoryError::ShareLimitExceeded(ref cause) => cause,
-            ShareDirectoryError::UnsupportedOperation(ref cause) => cause,
+            ShareDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::Client(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::DirectoryAlreadyShared(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::Organizations(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::Service(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::ShareLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ShareDirectoryError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ShareDirectoryError {}
 /// Errors returned by StartSchemaExtension
 #[derive(Debug, PartialEq)]
 pub enum StartSchemaExtensionError {
@@ -5200,21 +5030,17 @@ impl StartSchemaExtensionError {
 }
 impl fmt::Display for StartSchemaExtensionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartSchemaExtensionError {
-    fn description(&self) -> &str {
         match *self {
-            StartSchemaExtensionError::Client(ref cause) => cause,
-            StartSchemaExtensionError::DirectoryUnavailable(ref cause) => cause,
-            StartSchemaExtensionError::EntityDoesNotExist(ref cause) => cause,
-            StartSchemaExtensionError::InvalidParameter(ref cause) => cause,
-            StartSchemaExtensionError::Service(ref cause) => cause,
-            StartSchemaExtensionError::SnapshotLimitExceeded(ref cause) => cause,
+            StartSchemaExtensionError::Client(ref cause) => write!(f, "{}", cause),
+            StartSchemaExtensionError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            StartSchemaExtensionError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            StartSchemaExtensionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartSchemaExtensionError::Service(ref cause) => write!(f, "{}", cause),
+            StartSchemaExtensionError::SnapshotLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartSchemaExtensionError {}
 /// Errors returned by UnshareDirectory
 #[derive(Debug, PartialEq)]
 pub enum UnshareDirectoryError {
@@ -5258,20 +5084,16 @@ impl UnshareDirectoryError {
 }
 impl fmt::Display for UnshareDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnshareDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            UnshareDirectoryError::Client(ref cause) => cause,
-            UnshareDirectoryError::DirectoryNotShared(ref cause) => cause,
-            UnshareDirectoryError::EntityDoesNotExist(ref cause) => cause,
-            UnshareDirectoryError::InvalidTarget(ref cause) => cause,
-            UnshareDirectoryError::Service(ref cause) => cause,
+            UnshareDirectoryError::Client(ref cause) => write!(f, "{}", cause),
+            UnshareDirectoryError::DirectoryNotShared(ref cause) => write!(f, "{}", cause),
+            UnshareDirectoryError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UnshareDirectoryError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            UnshareDirectoryError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnshareDirectoryError {}
 /// Errors returned by UpdateConditionalForwarder
 #[derive(Debug, PartialEq)]
 pub enum UpdateConditionalForwarderError {
@@ -5330,21 +5152,23 @@ impl UpdateConditionalForwarderError {
 }
 impl fmt::Display for UpdateConditionalForwarderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConditionalForwarderError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConditionalForwarderError::Client(ref cause) => cause,
-            UpdateConditionalForwarderError::DirectoryUnavailable(ref cause) => cause,
-            UpdateConditionalForwarderError::EntityDoesNotExist(ref cause) => cause,
-            UpdateConditionalForwarderError::InvalidParameter(ref cause) => cause,
-            UpdateConditionalForwarderError::Service(ref cause) => cause,
-            UpdateConditionalForwarderError::UnsupportedOperation(ref cause) => cause,
+            UpdateConditionalForwarderError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateConditionalForwarderError::DirectoryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateConditionalForwarderError::EntityDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateConditionalForwarderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateConditionalForwarderError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateConditionalForwarderError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateConditionalForwarderError {}
 /// Errors returned by UpdateNumberOfDomainControllers
 #[derive(Debug, PartialEq)]
 pub enum UpdateNumberOfDomainControllersError {
@@ -5416,22 +5240,28 @@ impl UpdateNumberOfDomainControllersError {
 }
 impl fmt::Display for UpdateNumberOfDomainControllersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNumberOfDomainControllersError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNumberOfDomainControllersError::Client(ref cause) => cause,
-            UpdateNumberOfDomainControllersError::DirectoryUnavailable(ref cause) => cause,
-            UpdateNumberOfDomainControllersError::DomainControllerLimitExceeded(ref cause) => cause,
-            UpdateNumberOfDomainControllersError::EntityDoesNotExist(ref cause) => cause,
-            UpdateNumberOfDomainControllersError::InvalidParameter(ref cause) => cause,
-            UpdateNumberOfDomainControllersError::Service(ref cause) => cause,
-            UpdateNumberOfDomainControllersError::UnsupportedOperation(ref cause) => cause,
+            UpdateNumberOfDomainControllersError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateNumberOfDomainControllersError::DirectoryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateNumberOfDomainControllersError::DomainControllerLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateNumberOfDomainControllersError::EntityDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateNumberOfDomainControllersError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateNumberOfDomainControllersError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateNumberOfDomainControllersError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateNumberOfDomainControllersError {}
 /// Errors returned by UpdateRadius
 #[derive(Debug, PartialEq)]
 pub enum UpdateRadiusError {
@@ -5470,19 +5300,15 @@ impl UpdateRadiusError {
 }
 impl fmt::Display for UpdateRadiusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRadiusError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRadiusError::Client(ref cause) => cause,
-            UpdateRadiusError::EntityDoesNotExist(ref cause) => cause,
-            UpdateRadiusError::InvalidParameter(ref cause) => cause,
-            UpdateRadiusError::Service(ref cause) => cause,
+            UpdateRadiusError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateRadiusError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateRadiusError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRadiusError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRadiusError {}
 /// Errors returned by UpdateTrust
 #[derive(Debug, PartialEq)]
 pub enum UpdateTrustError {
@@ -5521,19 +5347,15 @@ impl UpdateTrustError {
 }
 impl fmt::Display for UpdateTrustError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTrustError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTrustError::Client(ref cause) => cause,
-            UpdateTrustError::EntityDoesNotExist(ref cause) => cause,
-            UpdateTrustError::InvalidParameter(ref cause) => cause,
-            UpdateTrustError::Service(ref cause) => cause,
+            UpdateTrustError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateTrustError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateTrustError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateTrustError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTrustError {}
 /// Errors returned by VerifyTrust
 #[derive(Debug, PartialEq)]
 pub enum VerifyTrustError {
@@ -5577,20 +5399,16 @@ impl VerifyTrustError {
 }
 impl fmt::Display for VerifyTrustError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifyTrustError {
-    fn description(&self) -> &str {
         match *self {
-            VerifyTrustError::Client(ref cause) => cause,
-            VerifyTrustError::EntityDoesNotExist(ref cause) => cause,
-            VerifyTrustError::InvalidParameter(ref cause) => cause,
-            VerifyTrustError::Service(ref cause) => cause,
-            VerifyTrustError::UnsupportedOperation(ref cause) => cause,
+            VerifyTrustError::Client(ref cause) => write!(f, "{}", cause),
+            VerifyTrustError::EntityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            VerifyTrustError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            VerifyTrustError::Service(ref cause) => write!(f, "{}", cause),
+            VerifyTrustError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for VerifyTrustError {}
 /// Trait representing the capabilities of the Directory Service API. Directory Service clients implement this trait.
 pub trait DirectoryService {
     /// <p>Accepts a directory sharing request that was sent from the directory owner account.</p>

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -3076,19 +3076,15 @@ impl BatchGetItemError {
 }
 impl fmt::Display for BatchGetItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetItemError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetItemError::InternalServerError(ref cause) => cause,
-            BatchGetItemError::ProvisionedThroughputExceeded(ref cause) => cause,
-            BatchGetItemError::RequestLimitExceeded(ref cause) => cause,
-            BatchGetItemError::ResourceNotFound(ref cause) => cause,
+            BatchGetItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            BatchGetItemError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            BatchGetItemError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchGetItemError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetItemError {}
 /// Errors returned by BatchWriteItem
 #[derive(Debug, PartialEq)]
 pub enum BatchWriteItemError {
@@ -3136,20 +3132,18 @@ impl BatchWriteItemError {
 }
 impl fmt::Display for BatchWriteItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchWriteItemError {
-    fn description(&self) -> &str {
         match *self {
-            BatchWriteItemError::InternalServerError(ref cause) => cause,
-            BatchWriteItemError::ItemCollectionSizeLimitExceeded(ref cause) => cause,
-            BatchWriteItemError::ProvisionedThroughputExceeded(ref cause) => cause,
-            BatchWriteItemError::RequestLimitExceeded(ref cause) => cause,
-            BatchWriteItemError::ResourceNotFound(ref cause) => cause,
+            BatchWriteItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            BatchWriteItemError::ItemCollectionSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchWriteItemError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            BatchWriteItemError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            BatchWriteItemError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchWriteItemError {}
 /// Errors returned by CreateBackup
 #[derive(Debug, PartialEq)]
 pub enum CreateBackupError {
@@ -3200,21 +3194,17 @@ impl CreateBackupError {
 }
 impl fmt::Display for CreateBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBackupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBackupError::BackupInUse(ref cause) => cause,
-            CreateBackupError::ContinuousBackupsUnavailable(ref cause) => cause,
-            CreateBackupError::InternalServerError(ref cause) => cause,
-            CreateBackupError::LimitExceeded(ref cause) => cause,
-            CreateBackupError::TableInUse(ref cause) => cause,
-            CreateBackupError::TableNotFound(ref cause) => cause,
+            CreateBackupError::BackupInUse(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::ContinuousBackupsUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::TableInUse(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::TableNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBackupError {}
 /// Errors returned by CreateGlobalTable
 #[derive(Debug, PartialEq)]
 pub enum CreateGlobalTableError {
@@ -3257,19 +3247,15 @@ impl CreateGlobalTableError {
 }
 impl fmt::Display for CreateGlobalTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGlobalTableError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGlobalTableError::GlobalTableAlreadyExists(ref cause) => cause,
-            CreateGlobalTableError::InternalServerError(ref cause) => cause,
-            CreateGlobalTableError::LimitExceeded(ref cause) => cause,
-            CreateGlobalTableError::TableNotFound(ref cause) => cause,
+            CreateGlobalTableError::GlobalTableAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateGlobalTableError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateGlobalTableError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGlobalTableError::TableNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGlobalTableError {}
 /// Errors returned by CreateTable
 #[derive(Debug, PartialEq)]
 pub enum CreateTableError {
@@ -3303,18 +3289,14 @@ impl CreateTableError {
 }
 impl fmt::Display for CreateTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTableError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTableError::InternalServerError(ref cause) => cause,
-            CreateTableError::LimitExceeded(ref cause) => cause,
-            CreateTableError::ResourceInUse(ref cause) => cause,
+            CreateTableError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateTableError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTableError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTableError {}
 /// Errors returned by DeleteBackup
 #[derive(Debug, PartialEq)]
 pub enum DeleteBackupError {
@@ -3353,19 +3335,15 @@ impl DeleteBackupError {
 }
 impl fmt::Display for DeleteBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBackupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBackupError::BackupInUse(ref cause) => cause,
-            DeleteBackupError::BackupNotFound(ref cause) => cause,
-            DeleteBackupError::InternalServerError(ref cause) => cause,
-            DeleteBackupError::LimitExceeded(ref cause) => cause,
+            DeleteBackupError::BackupInUse(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::BackupNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBackupError {}
 /// Errors returned by DeleteItem
 #[derive(Debug, PartialEq)]
 pub enum DeleteItemError {
@@ -3423,22 +3401,18 @@ impl DeleteItemError {
 }
 impl fmt::Display for DeleteItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteItemError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteItemError::ConditionalCheckFailed(ref cause) => cause,
-            DeleteItemError::InternalServerError(ref cause) => cause,
-            DeleteItemError::ItemCollectionSizeLimitExceeded(ref cause) => cause,
-            DeleteItemError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DeleteItemError::RequestLimitExceeded(ref cause) => cause,
-            DeleteItemError::ResourceNotFound(ref cause) => cause,
-            DeleteItemError::TransactionConflict(ref cause) => cause,
+            DeleteItemError::ConditionalCheckFailed(ref cause) => write!(f, "{}", cause),
+            DeleteItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteItemError::ItemCollectionSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteItemError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteItemError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteItemError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteItemError::TransactionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteItemError {}
 /// Errors returned by DeleteTable
 #[derive(Debug, PartialEq)]
 pub enum DeleteTableError {
@@ -3477,19 +3451,15 @@ impl DeleteTableError {
 }
 impl fmt::Display for DeleteTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTableError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTableError::InternalServerError(ref cause) => cause,
-            DeleteTableError::LimitExceeded(ref cause) => cause,
-            DeleteTableError::ResourceInUse(ref cause) => cause,
-            DeleteTableError::ResourceNotFound(ref cause) => cause,
+            DeleteTableError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteTableError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteTableError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteTableError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTableError {}
 /// Errors returned by DescribeBackup
 #[derive(Debug, PartialEq)]
 pub enum DescribeBackupError {
@@ -3518,17 +3488,13 @@ impl DescribeBackupError {
 }
 impl fmt::Display for DescribeBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBackupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBackupError::BackupNotFound(ref cause) => cause,
-            DescribeBackupError::InternalServerError(ref cause) => cause,
+            DescribeBackupError::BackupNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeBackupError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBackupError {}
 /// Errors returned by DescribeContinuousBackups
 #[derive(Debug, PartialEq)]
 pub enum DescribeContinuousBackupsError {
@@ -3561,17 +3527,15 @@ impl DescribeContinuousBackupsError {
 }
 impl fmt::Display for DescribeContinuousBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeContinuousBackupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeContinuousBackupsError::InternalServerError(ref cause) => cause,
-            DescribeContinuousBackupsError::TableNotFound(ref cause) => cause,
+            DescribeContinuousBackupsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeContinuousBackupsError::TableNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeContinuousBackupsError {}
 /// Errors returned by DescribeContributorInsights
 #[derive(Debug, PartialEq)]
 pub enum DescribeContributorInsightsError {
@@ -3606,17 +3570,15 @@ impl DescribeContributorInsightsError {
 }
 impl fmt::Display for DescribeContributorInsightsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeContributorInsightsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeContributorInsightsError::InternalServerError(ref cause) => cause,
-            DescribeContributorInsightsError::ResourceNotFound(ref cause) => cause,
+            DescribeContributorInsightsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeContributorInsightsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeContributorInsightsError {}
 /// Errors returned by DescribeEndpoints
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointsError {}
@@ -3634,14 +3596,10 @@ impl DescribeEndpointsError {
 }
 impl fmt::Display for DescribeEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEndpointsError {}
 /// Errors returned by DescribeGlobalTable
 #[derive(Debug, PartialEq)]
 pub enum DescribeGlobalTableError {
@@ -3674,17 +3632,13 @@ impl DescribeGlobalTableError {
 }
 impl fmt::Display for DescribeGlobalTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGlobalTableError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGlobalTableError::GlobalTableNotFound(ref cause) => cause,
-            DescribeGlobalTableError::InternalServerError(ref cause) => cause,
+            DescribeGlobalTableError::GlobalTableNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeGlobalTableError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeGlobalTableError {}
 /// Errors returned by DescribeGlobalTableSettings
 #[derive(Debug, PartialEq)]
 pub enum DescribeGlobalTableSettingsError {
@@ -3719,17 +3673,17 @@ impl DescribeGlobalTableSettingsError {
 }
 impl fmt::Display for DescribeGlobalTableSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGlobalTableSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGlobalTableSettingsError::GlobalTableNotFound(ref cause) => cause,
-            DescribeGlobalTableSettingsError::InternalServerError(ref cause) => cause,
+            DescribeGlobalTableSettingsError::GlobalTableNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeGlobalTableSettingsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeGlobalTableSettingsError {}
 /// Errors returned by DescribeLimits
 #[derive(Debug, PartialEq)]
 pub enum DescribeLimitsError {
@@ -3753,16 +3707,12 @@ impl DescribeLimitsError {
 }
 impl fmt::Display for DescribeLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLimitsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLimitsError::InternalServerError(ref cause) => cause,
+            DescribeLimitsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLimitsError {}
 /// Errors returned by DescribeTable
 #[derive(Debug, PartialEq)]
 pub enum DescribeTableError {
@@ -3791,17 +3741,13 @@ impl DescribeTableError {
 }
 impl fmt::Display for DescribeTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTableError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTableError::InternalServerError(ref cause) => cause,
-            DescribeTableError::ResourceNotFound(ref cause) => cause,
+            DescribeTableError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeTableError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTableError {}
 /// Errors returned by DescribeTableReplicaAutoScaling
 #[derive(Debug, PartialEq)]
 pub enum DescribeTableReplicaAutoScalingError {
@@ -3836,17 +3782,17 @@ impl DescribeTableReplicaAutoScalingError {
 }
 impl fmt::Display for DescribeTableReplicaAutoScalingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTableReplicaAutoScalingError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTableReplicaAutoScalingError::InternalServerError(ref cause) => cause,
-            DescribeTableReplicaAutoScalingError::ResourceNotFound(ref cause) => cause,
+            DescribeTableReplicaAutoScalingError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeTableReplicaAutoScalingError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTableReplicaAutoScalingError {}
 /// Errors returned by DescribeTimeToLive
 #[derive(Debug, PartialEq)]
 pub enum DescribeTimeToLiveError {
@@ -3877,17 +3823,13 @@ impl DescribeTimeToLiveError {
 }
 impl fmt::Display for DescribeTimeToLiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTimeToLiveError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTimeToLiveError::InternalServerError(ref cause) => cause,
-            DescribeTimeToLiveError::ResourceNotFound(ref cause) => cause,
+            DescribeTimeToLiveError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeTimeToLiveError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTimeToLiveError {}
 /// Errors returned by GetItem
 #[derive(Debug, PartialEq)]
 pub enum GetItemError {
@@ -3928,19 +3870,15 @@ impl GetItemError {
 }
 impl fmt::Display for GetItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetItemError {
-    fn description(&self) -> &str {
         match *self {
-            GetItemError::InternalServerError(ref cause) => cause,
-            GetItemError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetItemError::RequestLimitExceeded(ref cause) => cause,
-            GetItemError::ResourceNotFound(ref cause) => cause,
+            GetItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetItemError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            GetItemError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetItemError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetItemError {}
 /// Errors returned by ListBackups
 #[derive(Debug, PartialEq)]
 pub enum ListBackupsError {
@@ -3964,16 +3902,12 @@ impl ListBackupsError {
 }
 impl fmt::Display for ListBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBackupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBackupsError::InternalServerError(ref cause) => cause,
+            ListBackupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBackupsError {}
 /// Errors returned by ListContributorInsights
 #[derive(Debug, PartialEq)]
 pub enum ListContributorInsightsError {
@@ -4006,17 +3940,13 @@ impl ListContributorInsightsError {
 }
 impl fmt::Display for ListContributorInsightsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListContributorInsightsError {
-    fn description(&self) -> &str {
         match *self {
-            ListContributorInsightsError::InternalServerError(ref cause) => cause,
-            ListContributorInsightsError::ResourceNotFound(ref cause) => cause,
+            ListContributorInsightsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListContributorInsightsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListContributorInsightsError {}
 /// Errors returned by ListGlobalTables
 #[derive(Debug, PartialEq)]
 pub enum ListGlobalTablesError {
@@ -4042,16 +3972,12 @@ impl ListGlobalTablesError {
 }
 impl fmt::Display for ListGlobalTablesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGlobalTablesError {
-    fn description(&self) -> &str {
         match *self {
-            ListGlobalTablesError::InternalServerError(ref cause) => cause,
+            ListGlobalTablesError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGlobalTablesError {}
 /// Errors returned by ListTables
 #[derive(Debug, PartialEq)]
 pub enum ListTablesError {
@@ -4075,16 +4001,12 @@ impl ListTablesError {
 }
 impl fmt::Display for ListTablesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTablesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTablesError::InternalServerError(ref cause) => cause,
+            ListTablesError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTablesError {}
 /// Errors returned by ListTagsOfResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsOfResourceError {
@@ -4115,17 +4037,13 @@ impl ListTagsOfResourceError {
 }
 impl fmt::Display for ListTagsOfResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsOfResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsOfResourceError::InternalServerError(ref cause) => cause,
-            ListTagsOfResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsOfResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsOfResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsOfResourceError {}
 /// Errors returned by PutItem
 #[derive(Debug, PartialEq)]
 pub enum PutItemError {
@@ -4183,22 +4101,18 @@ impl PutItemError {
 }
 impl fmt::Display for PutItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutItemError {
-    fn description(&self) -> &str {
         match *self {
-            PutItemError::ConditionalCheckFailed(ref cause) => cause,
-            PutItemError::InternalServerError(ref cause) => cause,
-            PutItemError::ItemCollectionSizeLimitExceeded(ref cause) => cause,
-            PutItemError::ProvisionedThroughputExceeded(ref cause) => cause,
-            PutItemError::RequestLimitExceeded(ref cause) => cause,
-            PutItemError::ResourceNotFound(ref cause) => cause,
-            PutItemError::TransactionConflict(ref cause) => cause,
+            PutItemError::ConditionalCheckFailed(ref cause) => write!(f, "{}", cause),
+            PutItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            PutItemError::ItemCollectionSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutItemError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            PutItemError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutItemError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutItemError::TransactionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutItemError {}
 /// Errors returned by Query
 #[derive(Debug, PartialEq)]
 pub enum QueryError {
@@ -4237,19 +4151,15 @@ impl QueryError {
 }
 impl fmt::Display for QueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for QueryError {
-    fn description(&self) -> &str {
         match *self {
-            QueryError::InternalServerError(ref cause) => cause,
-            QueryError::ProvisionedThroughputExceeded(ref cause) => cause,
-            QueryError::RequestLimitExceeded(ref cause) => cause,
-            QueryError::ResourceNotFound(ref cause) => cause,
+            QueryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            QueryError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            QueryError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            QueryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for QueryError {}
 /// Errors returned by RestoreTableFromBackup
 #[derive(Debug, PartialEq)]
 pub enum RestoreTableFromBackupError {
@@ -4306,21 +4216,17 @@ impl RestoreTableFromBackupError {
 }
 impl fmt::Display for RestoreTableFromBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreTableFromBackupError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreTableFromBackupError::BackupInUse(ref cause) => cause,
-            RestoreTableFromBackupError::BackupNotFound(ref cause) => cause,
-            RestoreTableFromBackupError::InternalServerError(ref cause) => cause,
-            RestoreTableFromBackupError::LimitExceeded(ref cause) => cause,
-            RestoreTableFromBackupError::TableAlreadyExists(ref cause) => cause,
-            RestoreTableFromBackupError::TableInUse(ref cause) => cause,
+            RestoreTableFromBackupError::BackupInUse(ref cause) => write!(f, "{}", cause),
+            RestoreTableFromBackupError::BackupNotFound(ref cause) => write!(f, "{}", cause),
+            RestoreTableFromBackupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RestoreTableFromBackupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RestoreTableFromBackupError::TableAlreadyExists(ref cause) => write!(f, "{}", cause),
+            RestoreTableFromBackupError::TableInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreTableFromBackupError {}
 /// Errors returned by RestoreTableToPointInTime
 #[derive(Debug, PartialEq)]
 pub enum RestoreTableToPointInTimeError {
@@ -4388,22 +4294,22 @@ impl RestoreTableToPointInTimeError {
 }
 impl fmt::Display for RestoreTableToPointInTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreTableToPointInTimeError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreTableToPointInTimeError::InternalServerError(ref cause) => cause,
-            RestoreTableToPointInTimeError::InvalidRestoreTime(ref cause) => cause,
-            RestoreTableToPointInTimeError::LimitExceeded(ref cause) => cause,
-            RestoreTableToPointInTimeError::PointInTimeRecoveryUnavailable(ref cause) => cause,
-            RestoreTableToPointInTimeError::TableAlreadyExists(ref cause) => cause,
-            RestoreTableToPointInTimeError::TableInUse(ref cause) => cause,
-            RestoreTableToPointInTimeError::TableNotFound(ref cause) => cause,
+            RestoreTableToPointInTimeError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreTableToPointInTimeError::InvalidRestoreTime(ref cause) => write!(f, "{}", cause),
+            RestoreTableToPointInTimeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RestoreTableToPointInTimeError::PointInTimeRecoveryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreTableToPointInTimeError::TableAlreadyExists(ref cause) => write!(f, "{}", cause),
+            RestoreTableToPointInTimeError::TableInUse(ref cause) => write!(f, "{}", cause),
+            RestoreTableToPointInTimeError::TableNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreTableToPointInTimeError {}
 /// Errors returned by Scan
 #[derive(Debug, PartialEq)]
 pub enum ScanError {
@@ -4442,19 +4348,15 @@ impl ScanError {
 }
 impl fmt::Display for ScanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ScanError {
-    fn description(&self) -> &str {
         match *self {
-            ScanError::InternalServerError(ref cause) => cause,
-            ScanError::ProvisionedThroughputExceeded(ref cause) => cause,
-            ScanError::RequestLimitExceeded(ref cause) => cause,
-            ScanError::ResourceNotFound(ref cause) => cause,
+            ScanError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ScanError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            ScanError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ScanError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ScanError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -4493,19 +4395,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalServerError(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::ResourceInUse(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TransactGetItems
 #[derive(Debug, PartialEq)]
 pub enum TransactGetItemsError {
@@ -4557,20 +4455,18 @@ impl TransactGetItemsError {
 }
 impl fmt::Display for TransactGetItemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TransactGetItemsError {
-    fn description(&self) -> &str {
         match *self {
-            TransactGetItemsError::InternalServerError(ref cause) => cause,
-            TransactGetItemsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            TransactGetItemsError::RequestLimitExceeded(ref cause) => cause,
-            TransactGetItemsError::ResourceNotFound(ref cause) => cause,
-            TransactGetItemsError::TransactionCanceled(ref cause) => cause,
+            TransactGetItemsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TransactGetItemsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TransactGetItemsError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TransactGetItemsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TransactGetItemsError::TransactionCanceled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TransactGetItemsError {}
 /// Errors returned by TransactWriteItems
 #[derive(Debug, PartialEq)]
 pub enum TransactWriteItemsError {
@@ -4636,22 +4532,22 @@ impl TransactWriteItemsError {
 }
 impl fmt::Display for TransactWriteItemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TransactWriteItemsError {
-    fn description(&self) -> &str {
         match *self {
-            TransactWriteItemsError::IdempotentParameterMismatch(ref cause) => cause,
-            TransactWriteItemsError::InternalServerError(ref cause) => cause,
-            TransactWriteItemsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            TransactWriteItemsError::RequestLimitExceeded(ref cause) => cause,
-            TransactWriteItemsError::ResourceNotFound(ref cause) => cause,
-            TransactWriteItemsError::TransactionCanceled(ref cause) => cause,
-            TransactWriteItemsError::TransactionInProgress(ref cause) => cause,
+            TransactWriteItemsError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TransactWriteItemsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TransactWriteItemsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TransactWriteItemsError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TransactWriteItemsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TransactWriteItemsError::TransactionCanceled(ref cause) => write!(f, "{}", cause),
+            TransactWriteItemsError::TransactionInProgress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TransactWriteItemsError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -4690,19 +4586,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalServerError(ref cause) => cause,
-            UntagResourceError::LimitExceeded(ref cause) => cause,
-            UntagResourceError::ResourceInUse(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateContinuousBackups
 #[derive(Debug, PartialEq)]
 pub enum UpdateContinuousBackupsError {
@@ -4742,18 +4634,16 @@ impl UpdateContinuousBackupsError {
 }
 impl fmt::Display for UpdateContinuousBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateContinuousBackupsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateContinuousBackupsError::ContinuousBackupsUnavailable(ref cause) => cause,
-            UpdateContinuousBackupsError::InternalServerError(ref cause) => cause,
-            UpdateContinuousBackupsError::TableNotFound(ref cause) => cause,
+            UpdateContinuousBackupsError::ContinuousBackupsUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateContinuousBackupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateContinuousBackupsError::TableNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateContinuousBackupsError {}
 /// Errors returned by UpdateContributorInsights
 #[derive(Debug, PartialEq)]
 pub enum UpdateContributorInsightsError {
@@ -4786,17 +4676,15 @@ impl UpdateContributorInsightsError {
 }
 impl fmt::Display for UpdateContributorInsightsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateContributorInsightsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateContributorInsightsError::InternalServerError(ref cause) => cause,
-            UpdateContributorInsightsError::ResourceNotFound(ref cause) => cause,
+            UpdateContributorInsightsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateContributorInsightsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateContributorInsightsError {}
 /// Errors returned by UpdateGlobalTable
 #[derive(Debug, PartialEq)]
 pub enum UpdateGlobalTableError {
@@ -4846,20 +4734,16 @@ impl UpdateGlobalTableError {
 }
 impl fmt::Display for UpdateGlobalTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGlobalTableError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGlobalTableError::GlobalTableNotFound(ref cause) => cause,
-            UpdateGlobalTableError::InternalServerError(ref cause) => cause,
-            UpdateGlobalTableError::ReplicaAlreadyExists(ref cause) => cause,
-            UpdateGlobalTableError::ReplicaNotFound(ref cause) => cause,
-            UpdateGlobalTableError::TableNotFound(ref cause) => cause,
+            UpdateGlobalTableError::GlobalTableNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalTableError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalTableError::ReplicaAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalTableError::ReplicaNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalTableError::TableNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGlobalTableError {}
 /// Errors returned by UpdateGlobalTableSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateGlobalTableSettingsError {
@@ -4920,21 +4804,21 @@ impl UpdateGlobalTableSettingsError {
 }
 impl fmt::Display for UpdateGlobalTableSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGlobalTableSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGlobalTableSettingsError::GlobalTableNotFound(ref cause) => cause,
-            UpdateGlobalTableSettingsError::IndexNotFound(ref cause) => cause,
-            UpdateGlobalTableSettingsError::InternalServerError(ref cause) => cause,
-            UpdateGlobalTableSettingsError::LimitExceeded(ref cause) => cause,
-            UpdateGlobalTableSettingsError::ReplicaNotFound(ref cause) => cause,
-            UpdateGlobalTableSettingsError::ResourceInUse(ref cause) => cause,
+            UpdateGlobalTableSettingsError::GlobalTableNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateGlobalTableSettingsError::IndexNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalTableSettingsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateGlobalTableSettingsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalTableSettingsError::ReplicaNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGlobalTableSettingsError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGlobalTableSettingsError {}
 /// Errors returned by UpdateItem
 #[derive(Debug, PartialEq)]
 pub enum UpdateItemError {
@@ -4992,22 +4876,18 @@ impl UpdateItemError {
 }
 impl fmt::Display for UpdateItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateItemError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateItemError::ConditionalCheckFailed(ref cause) => cause,
-            UpdateItemError::InternalServerError(ref cause) => cause,
-            UpdateItemError::ItemCollectionSizeLimitExceeded(ref cause) => cause,
-            UpdateItemError::ProvisionedThroughputExceeded(ref cause) => cause,
-            UpdateItemError::RequestLimitExceeded(ref cause) => cause,
-            UpdateItemError::ResourceNotFound(ref cause) => cause,
-            UpdateItemError::TransactionConflict(ref cause) => cause,
+            UpdateItemError::ConditionalCheckFailed(ref cause) => write!(f, "{}", cause),
+            UpdateItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateItemError::ItemCollectionSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateItemError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateItemError::RequestLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateItemError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateItemError::TransactionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateItemError {}
 /// Errors returned by UpdateTable
 #[derive(Debug, PartialEq)]
 pub enum UpdateTableError {
@@ -5046,19 +4926,15 @@ impl UpdateTableError {
 }
 impl fmt::Display for UpdateTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTableError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTableError::InternalServerError(ref cause) => cause,
-            UpdateTableError::LimitExceeded(ref cause) => cause,
-            UpdateTableError::ResourceInUse(ref cause) => cause,
-            UpdateTableError::ResourceNotFound(ref cause) => cause,
+            UpdateTableError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTableError {}
 /// Errors returned by UpdateTableReplicaAutoScaling
 #[derive(Debug, PartialEq)]
 pub enum UpdateTableReplicaAutoScalingError {
@@ -5107,19 +4983,19 @@ impl UpdateTableReplicaAutoScalingError {
 }
 impl fmt::Display for UpdateTableReplicaAutoScalingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTableReplicaAutoScalingError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTableReplicaAutoScalingError::InternalServerError(ref cause) => cause,
-            UpdateTableReplicaAutoScalingError::LimitExceeded(ref cause) => cause,
-            UpdateTableReplicaAutoScalingError::ResourceInUse(ref cause) => cause,
-            UpdateTableReplicaAutoScalingError::ResourceNotFound(ref cause) => cause,
+            UpdateTableReplicaAutoScalingError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTableReplicaAutoScalingError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateTableReplicaAutoScalingError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateTableReplicaAutoScalingError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateTableReplicaAutoScalingError {}
 /// Errors returned by UpdateTimeToLive
 #[derive(Debug, PartialEq)]
 pub enum UpdateTimeToLiveError {
@@ -5160,19 +5036,15 @@ impl UpdateTimeToLiveError {
 }
 impl fmt::Display for UpdateTimeToLiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTimeToLiveError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTimeToLiveError::InternalServerError(ref cause) => cause,
-            UpdateTimeToLiveError::LimitExceeded(ref cause) => cause,
-            UpdateTimeToLiveError::ResourceInUse(ref cause) => cause,
-            UpdateTimeToLiveError::ResourceNotFound(ref cause) => cause,
+            UpdateTimeToLiveError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateTimeToLiveError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateTimeToLiveError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateTimeToLiveError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTimeToLiveError {}
 /// Trait representing the capabilities of the DynamoDB API. DynamoDB clients implement this trait.
 pub trait DynamoDb {
     /// <p>The <code>BatchGetItem</code> operation returns the attributes of one or more items from one or more tables. You identify requested items by primary key.</p> <p>A single operation can retrieve up to 16 MB of data, which can contain as many as 100 items. <code>BatchGetItem</code> returns a partial result if the response size limit is exceeded, the table's provisioned throughput is exceeded, or an internal processing failure occurs. If a partial result is returned, the operation returns a value for <code>UnprocessedKeys</code>. You can use this value to retry the operation starting with the next item to get.</p> <important> <p>If you request more than 100 items, <code>BatchGetItem</code> returns a <code>ValidationException</code> with the message "Too many items requested for the BatchGetItem call."</p> </important> <p>For example, if you ask to retrieve 100 items, but each individual item is 300 KB in size, the system returns 52 items (so as not to exceed the 16 MB limit). It also returns an appropriate <code>UnprocessedKeys</code> value so you can get the next page of results. If desired, your application can include its own logic to assemble the pages of results into one dataset.</p> <p>If <i>none</i> of the items can be processed due to insufficient provisioned throughput on all of the tables in the request, then <code>BatchGetItem</code> returns a <code>ProvisionedThroughputExceededException</code>. If <i>at least one</i> of the items is successfully processed, then <code>BatchGetItem</code> completes successfully, while returning the keys of the unread items in <code>UnprocessedKeys</code>.</p> <important> <p>If DynamoDB returns any unprocessed items, you should retry the batch operation on those items. However, <i>we strongly recommend that you use an exponential backoff algorithm</i>. If you retry the batch operation immediately, the underlying read or write requests can still fail due to throttling on the individual tables. If you delay the batch operation using exponential backoff, the individual requests in the batch are much more likely to succeed.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#BatchOperations">Batch Operations and Error Handling</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> </important> <p>By default, <code>BatchGetItem</code> performs eventually consistent reads on every table in the request. If you want strongly consistent reads instead, you can set <code>ConsistentRead</code> to <code>true</code> for any or all tables.</p> <p>In order to minimize response latency, <code>BatchGetItem</code> retrieves items in parallel.</p> <p>When designing your application, keep in mind that DynamoDB does not return items in any particular order. To help parse the response by item, include the primary key values for the items in your request in the <code>ProjectionExpression</code> parameter.</p> <p>If a requested item does not exist, it is not returned in the result. Requests for nonexistent items consume the minimum read capacity units according to the type of read. For more information, see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#CapacityUnitCalculations">Working with Tables</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -404,17 +404,13 @@ impl DescribeStreamError {
 }
 impl fmt::Display for DescribeStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStreamError::InternalServerError(ref cause) => cause,
-            DescribeStreamError::ResourceNotFound(ref cause) => cause,
+            DescribeStreamError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStreamError {}
 /// Errors returned by GetRecords
 #[derive(Debug, PartialEq)]
 pub enum GetRecordsError {
@@ -458,20 +454,16 @@ impl GetRecordsError {
 }
 impl fmt::Display for GetRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRecordsError::ExpiredIterator(ref cause) => cause,
-            GetRecordsError::InternalServerError(ref cause) => cause,
-            GetRecordsError::LimitExceeded(ref cause) => cause,
-            GetRecordsError::ResourceNotFound(ref cause) => cause,
-            GetRecordsError::TrimmedDataAccess(ref cause) => cause,
+            GetRecordsError::ExpiredIterator(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::TrimmedDataAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRecordsError {}
 /// Errors returned by GetShardIterator
 #[derive(Debug, PartialEq)]
 pub enum GetShardIteratorError {
@@ -507,18 +499,14 @@ impl GetShardIteratorError {
 }
 impl fmt::Display for GetShardIteratorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetShardIteratorError {
-    fn description(&self) -> &str {
         match *self {
-            GetShardIteratorError::InternalServerError(ref cause) => cause,
-            GetShardIteratorError::ResourceNotFound(ref cause) => cause,
-            GetShardIteratorError::TrimmedDataAccess(ref cause) => cause,
+            GetShardIteratorError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetShardIteratorError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetShardIteratorError::TrimmedDataAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetShardIteratorError {}
 /// Errors returned by ListStreams
 #[derive(Debug, PartialEq)]
 pub enum ListStreamsError {
@@ -547,17 +535,13 @@ impl ListStreamsError {
 }
 impl fmt::Display for ListStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStreamsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStreamsError::InternalServerError(ref cause) => cause,
-            ListStreamsError::ResourceNotFound(ref cause) => cause,
+            ListStreamsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListStreamsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStreamsError {}
 /// Trait representing the capabilities of the Amazon DynamoDB Streams API. Amazon DynamoDB Streams clients implement this trait.
 pub trait DynamoDbStreams {
     /// <p>Returns information about a stream, including the current status of the stream, its Amazon Resource Name (ARN), the composition of its shards, and its corresponding DynamoDB table.</p> <note> <p>You can call <code>DescribeStream</code> at a maximum rate of 10 times per second.</p> </note> <p>Each shard in the stream has a <code>SequenceNumberRange</code> associated with it. If the <code>SequenceNumberRange</code> has a <code>StartingSequenceNumber</code> but no <code>EndingSequenceNumber</code>, then the shard is still open (able to receive more stream records). If both <code>StartingSequenceNumber</code> and <code>EndingSequenceNumber</code> are present, then that shard is closed and can no longer receive more data.</p>

--- a/rusoto/services/ec2-instance-connect/src/generated.rs
+++ b/rusoto/services/ec2-instance-connect/src/generated.rs
@@ -97,20 +97,16 @@ impl SendSSHPublicKeyError {
 }
 impl fmt::Display for SendSSHPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendSSHPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            SendSSHPublicKeyError::Auth(ref cause) => cause,
-            SendSSHPublicKeyError::EC2InstanceNotFound(ref cause) => cause,
-            SendSSHPublicKeyError::InvalidArgs(ref cause) => cause,
-            SendSSHPublicKeyError::Service(ref cause) => cause,
-            SendSSHPublicKeyError::Throttling(ref cause) => cause,
+            SendSSHPublicKeyError::Auth(ref cause) => write!(f, "{}", cause),
+            SendSSHPublicKeyError::EC2InstanceNotFound(ref cause) => write!(f, "{}", cause),
+            SendSSHPublicKeyError::InvalidArgs(ref cause) => write!(f, "{}", cause),
+            SendSSHPublicKeyError::Service(ref cause) => write!(f, "{}", cause),
+            SendSSHPublicKeyError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendSSHPublicKeyError {}
 /// Trait representing the capabilities of the EC2 Instance Connect API. EC2 Instance Connect clients implement this trait.
 pub trait Ec2InstanceConnect {
     /// <p>Pushes an SSH public key to a particular OS user on a given EC2 instance for 60 seconds.</p>

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -1331,18 +1331,16 @@ impl BatchCheckLayerAvailabilityError {
 }
 impl fmt::Display for BatchCheckLayerAvailabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchCheckLayerAvailabilityError {
-    fn description(&self) -> &str {
         match *self {
-            BatchCheckLayerAvailabilityError::InvalidParameter(ref cause) => cause,
-            BatchCheckLayerAvailabilityError::RepositoryNotFound(ref cause) => cause,
-            BatchCheckLayerAvailabilityError::Server(ref cause) => cause,
+            BatchCheckLayerAvailabilityError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            BatchCheckLayerAvailabilityError::RepositoryNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchCheckLayerAvailabilityError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchCheckLayerAvailabilityError {}
 /// Errors returned by BatchDeleteImage
 #[derive(Debug, PartialEq)]
 pub enum BatchDeleteImageError {
@@ -1376,18 +1374,14 @@ impl BatchDeleteImageError {
 }
 impl fmt::Display for BatchDeleteImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteImageError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeleteImageError::InvalidParameter(ref cause) => cause,
-            BatchDeleteImageError::RepositoryNotFound(ref cause) => cause,
-            BatchDeleteImageError::Server(ref cause) => cause,
+            BatchDeleteImageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            BatchDeleteImageError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            BatchDeleteImageError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeleteImageError {}
 /// Errors returned by BatchGetImage
 #[derive(Debug, PartialEq)]
 pub enum BatchGetImageError {
@@ -1421,18 +1415,14 @@ impl BatchGetImageError {
 }
 impl fmt::Display for BatchGetImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetImageError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetImageError::InvalidParameter(ref cause) => cause,
-            BatchGetImageError::RepositoryNotFound(ref cause) => cause,
-            BatchGetImageError::Server(ref cause) => cause,
+            BatchGetImageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            BatchGetImageError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            BatchGetImageError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetImageError {}
 /// Errors returned by CompleteLayerUpload
 #[derive(Debug, PartialEq)]
 pub enum CompleteLayerUploadError {
@@ -1499,23 +1489,19 @@ impl CompleteLayerUploadError {
 }
 impl fmt::Display for CompleteLayerUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CompleteLayerUploadError {
-    fn description(&self) -> &str {
         match *self {
-            CompleteLayerUploadError::EmptyUpload(ref cause) => cause,
-            CompleteLayerUploadError::InvalidLayer(ref cause) => cause,
-            CompleteLayerUploadError::InvalidParameter(ref cause) => cause,
-            CompleteLayerUploadError::LayerAlreadyExists(ref cause) => cause,
-            CompleteLayerUploadError::LayerPartTooSmall(ref cause) => cause,
-            CompleteLayerUploadError::RepositoryNotFound(ref cause) => cause,
-            CompleteLayerUploadError::Server(ref cause) => cause,
-            CompleteLayerUploadError::UploadNotFound(ref cause) => cause,
+            CompleteLayerUploadError::EmptyUpload(ref cause) => write!(f, "{}", cause),
+            CompleteLayerUploadError::InvalidLayer(ref cause) => write!(f, "{}", cause),
+            CompleteLayerUploadError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CompleteLayerUploadError::LayerAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CompleteLayerUploadError::LayerPartTooSmall(ref cause) => write!(f, "{}", cause),
+            CompleteLayerUploadError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            CompleteLayerUploadError::Server(ref cause) => write!(f, "{}", cause),
+            CompleteLayerUploadError::UploadNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CompleteLayerUploadError {}
 /// Errors returned by CreateRepository
 #[derive(Debug, PartialEq)]
 pub enum CreateRepositoryError {
@@ -1568,21 +1554,17 @@ impl CreateRepositoryError {
 }
 impl fmt::Display for CreateRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRepositoryError::InvalidParameter(ref cause) => cause,
-            CreateRepositoryError::InvalidTagParameter(ref cause) => cause,
-            CreateRepositoryError::LimitExceeded(ref cause) => cause,
-            CreateRepositoryError::RepositoryAlreadyExists(ref cause) => cause,
-            CreateRepositoryError::Server(ref cause) => cause,
-            CreateRepositoryError::TooManyTags(ref cause) => cause,
+            CreateRepositoryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::InvalidTagParameter(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::RepositoryAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::Server(ref cause) => write!(f, "{}", cause),
+            CreateRepositoryError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRepositoryError {}
 /// Errors returned by DeleteLifecyclePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteLifecyclePolicyError {
@@ -1627,19 +1609,17 @@ impl DeleteLifecyclePolicyError {
 }
 impl fmt::Display for DeleteLifecyclePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLifecyclePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLifecyclePolicyError::InvalidParameter(ref cause) => cause,
-            DeleteLifecyclePolicyError::LifecyclePolicyNotFound(ref cause) => cause,
-            DeleteLifecyclePolicyError::RepositoryNotFound(ref cause) => cause,
-            DeleteLifecyclePolicyError::Server(ref cause) => cause,
+            DeleteLifecyclePolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteLifecyclePolicyError::LifecyclePolicyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLifecyclePolicyError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLifecyclePolicyError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLifecyclePolicyError {}
 /// Errors returned by DeleteRepository
 #[derive(Debug, PartialEq)]
 pub enum DeleteRepositoryError {
@@ -1678,19 +1658,15 @@ impl DeleteRepositoryError {
 }
 impl fmt::Display for DeleteRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRepositoryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRepositoryError::InvalidParameter(ref cause) => cause,
-            DeleteRepositoryError::RepositoryNotEmpty(ref cause) => cause,
-            DeleteRepositoryError::RepositoryNotFound(ref cause) => cause,
-            DeleteRepositoryError::Server(ref cause) => cause,
+            DeleteRepositoryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::RepositoryNotEmpty(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRepositoryError {}
 /// Errors returned by DeleteRepositoryPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteRepositoryPolicyError {
@@ -1735,19 +1711,17 @@ impl DeleteRepositoryPolicyError {
 }
 impl fmt::Display for DeleteRepositoryPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRepositoryPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRepositoryPolicyError::InvalidParameter(ref cause) => cause,
-            DeleteRepositoryPolicyError::RepositoryNotFound(ref cause) => cause,
-            DeleteRepositoryPolicyError::RepositoryPolicyNotFound(ref cause) => cause,
-            DeleteRepositoryPolicyError::Server(ref cause) => cause,
+            DeleteRepositoryPolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryPolicyError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRepositoryPolicyError::RepositoryPolicyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRepositoryPolicyError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRepositoryPolicyError {}
 /// Errors returned by DescribeImageScanFindings
 #[derive(Debug, PartialEq)]
 pub enum DescribeImageScanFindingsError {
@@ -1799,20 +1773,16 @@ impl DescribeImageScanFindingsError {
 }
 impl fmt::Display for DescribeImageScanFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeImageScanFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeImageScanFindingsError::ImageNotFound(ref cause) => cause,
-            DescribeImageScanFindingsError::InvalidParameter(ref cause) => cause,
-            DescribeImageScanFindingsError::RepositoryNotFound(ref cause) => cause,
-            DescribeImageScanFindingsError::ScanNotFound(ref cause) => cause,
-            DescribeImageScanFindingsError::Server(ref cause) => cause,
+            DescribeImageScanFindingsError::ImageNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeImageScanFindingsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeImageScanFindingsError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeImageScanFindingsError::ScanNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeImageScanFindingsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeImageScanFindingsError {}
 /// Errors returned by DescribeImages
 #[derive(Debug, PartialEq)]
 pub enum DescribeImagesError {
@@ -1851,19 +1821,15 @@ impl DescribeImagesError {
 }
 impl fmt::Display for DescribeImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeImagesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeImagesError::ImageNotFound(ref cause) => cause,
-            DescribeImagesError::InvalidParameter(ref cause) => cause,
-            DescribeImagesError::RepositoryNotFound(ref cause) => cause,
-            DescribeImagesError::Server(ref cause) => cause,
+            DescribeImagesError::ImageNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeImagesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeImagesError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeImagesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeImagesError {}
 /// Errors returned by DescribeRepositories
 #[derive(Debug, PartialEq)]
 pub enum DescribeRepositoriesError {
@@ -1901,18 +1867,14 @@ impl DescribeRepositoriesError {
 }
 impl fmt::Display for DescribeRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRepositoriesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRepositoriesError::InvalidParameter(ref cause) => cause,
-            DescribeRepositoriesError::RepositoryNotFound(ref cause) => cause,
-            DescribeRepositoriesError::Server(ref cause) => cause,
+            DescribeRepositoriesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeRepositoriesError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeRepositoriesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRepositoriesError {}
 /// Errors returned by GetAuthorizationToken
 #[derive(Debug, PartialEq)]
 pub enum GetAuthorizationTokenError {
@@ -1943,17 +1905,13 @@ impl GetAuthorizationTokenError {
 }
 impl fmt::Display for GetAuthorizationTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAuthorizationTokenError {
-    fn description(&self) -> &str {
         match *self {
-            GetAuthorizationTokenError::InvalidParameter(ref cause) => cause,
-            GetAuthorizationTokenError::Server(ref cause) => cause,
+            GetAuthorizationTokenError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetAuthorizationTokenError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAuthorizationTokenError {}
 /// Errors returned by GetDownloadUrlForLayer
 #[derive(Debug, PartialEq)]
 pub enum GetDownloadUrlForLayerError {
@@ -2005,20 +1963,16 @@ impl GetDownloadUrlForLayerError {
 }
 impl fmt::Display for GetDownloadUrlForLayerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDownloadUrlForLayerError {
-    fn description(&self) -> &str {
         match *self {
-            GetDownloadUrlForLayerError::InvalidParameter(ref cause) => cause,
-            GetDownloadUrlForLayerError::LayerInaccessible(ref cause) => cause,
-            GetDownloadUrlForLayerError::LayersNotFound(ref cause) => cause,
-            GetDownloadUrlForLayerError::RepositoryNotFound(ref cause) => cause,
-            GetDownloadUrlForLayerError::Server(ref cause) => cause,
+            GetDownloadUrlForLayerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetDownloadUrlForLayerError::LayerInaccessible(ref cause) => write!(f, "{}", cause),
+            GetDownloadUrlForLayerError::LayersNotFound(ref cause) => write!(f, "{}", cause),
+            GetDownloadUrlForLayerError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            GetDownloadUrlForLayerError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDownloadUrlForLayerError {}
 /// Errors returned by GetLifecyclePolicy
 #[derive(Debug, PartialEq)]
 pub enum GetLifecyclePolicyError {
@@ -2061,19 +2015,15 @@ impl GetLifecyclePolicyError {
 }
 impl fmt::Display for GetLifecyclePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLifecyclePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetLifecyclePolicyError::InvalidParameter(ref cause) => cause,
-            GetLifecyclePolicyError::LifecyclePolicyNotFound(ref cause) => cause,
-            GetLifecyclePolicyError::RepositoryNotFound(ref cause) => cause,
-            GetLifecyclePolicyError::Server(ref cause) => cause,
+            GetLifecyclePolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyError::LifecyclePolicyNotFound(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLifecyclePolicyError {}
 /// Errors returned by GetLifecyclePolicyPreview
 #[derive(Debug, PartialEq)]
 pub enum GetLifecyclePolicyPreviewError {
@@ -2118,19 +2068,17 @@ impl GetLifecyclePolicyPreviewError {
 }
 impl fmt::Display for GetLifecyclePolicyPreviewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLifecyclePolicyPreviewError {
-    fn description(&self) -> &str {
         match *self {
-            GetLifecyclePolicyPreviewError::InvalidParameter(ref cause) => cause,
-            GetLifecyclePolicyPreviewError::LifecyclePolicyPreviewNotFound(ref cause) => cause,
-            GetLifecyclePolicyPreviewError::RepositoryNotFound(ref cause) => cause,
-            GetLifecyclePolicyPreviewError::Server(ref cause) => cause,
+            GetLifecyclePolicyPreviewError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyPreviewError::LifecyclePolicyPreviewNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetLifecyclePolicyPreviewError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyPreviewError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLifecyclePolicyPreviewError {}
 /// Errors returned by GetRepositoryPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetRepositoryPolicyError {
@@ -2175,19 +2123,15 @@ impl GetRepositoryPolicyError {
 }
 impl fmt::Display for GetRepositoryPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRepositoryPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetRepositoryPolicyError::InvalidParameter(ref cause) => cause,
-            GetRepositoryPolicyError::RepositoryNotFound(ref cause) => cause,
-            GetRepositoryPolicyError::RepositoryPolicyNotFound(ref cause) => cause,
-            GetRepositoryPolicyError::Server(ref cause) => cause,
+            GetRepositoryPolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetRepositoryPolicyError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            GetRepositoryPolicyError::RepositoryPolicyNotFound(ref cause) => write!(f, "{}", cause),
+            GetRepositoryPolicyError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRepositoryPolicyError {}
 /// Errors returned by InitiateLayerUpload
 #[derive(Debug, PartialEq)]
 pub enum InitiateLayerUploadError {
@@ -2225,18 +2169,14 @@ impl InitiateLayerUploadError {
 }
 impl fmt::Display for InitiateLayerUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitiateLayerUploadError {
-    fn description(&self) -> &str {
         match *self {
-            InitiateLayerUploadError::InvalidParameter(ref cause) => cause,
-            InitiateLayerUploadError::RepositoryNotFound(ref cause) => cause,
-            InitiateLayerUploadError::Server(ref cause) => cause,
+            InitiateLayerUploadError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            InitiateLayerUploadError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            InitiateLayerUploadError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InitiateLayerUploadError {}
 /// Errors returned by ListImages
 #[derive(Debug, PartialEq)]
 pub enum ListImagesError {
@@ -2268,18 +2208,14 @@ impl ListImagesError {
 }
 impl fmt::Display for ListImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListImagesError {
-    fn description(&self) -> &str {
         match *self {
-            ListImagesError::InvalidParameter(ref cause) => cause,
-            ListImagesError::RepositoryNotFound(ref cause) => cause,
-            ListImagesError::Server(ref cause) => cause,
+            ListImagesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListImagesError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            ListImagesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListImagesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2317,18 +2253,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::RepositoryNotFound(ref cause) => cause,
-            ListTagsForResourceError::Server(ref cause) => cause,
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PutImage
 #[derive(Debug, PartialEq)]
 pub enum PutImageError {
@@ -2380,22 +2312,18 @@ impl PutImageError {
 }
 impl fmt::Display for PutImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutImageError {
-    fn description(&self) -> &str {
         match *self {
-            PutImageError::ImageAlreadyExists(ref cause) => cause,
-            PutImageError::ImageTagAlreadyExists(ref cause) => cause,
-            PutImageError::InvalidParameter(ref cause) => cause,
-            PutImageError::LayersNotFound(ref cause) => cause,
-            PutImageError::LimitExceeded(ref cause) => cause,
-            PutImageError::RepositoryNotFound(ref cause) => cause,
-            PutImageError::Server(ref cause) => cause,
+            PutImageError::ImageAlreadyExists(ref cause) => write!(f, "{}", cause),
+            PutImageError::ImageTagAlreadyExists(ref cause) => write!(f, "{}", cause),
+            PutImageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutImageError::LayersNotFound(ref cause) => write!(f, "{}", cause),
+            PutImageError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutImageError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            PutImageError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutImageError {}
 /// Errors returned by PutImageScanningConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutImageScanningConfigurationError {
@@ -2437,18 +2365,18 @@ impl PutImageScanningConfigurationError {
 }
 impl fmt::Display for PutImageScanningConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutImageScanningConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutImageScanningConfigurationError::InvalidParameter(ref cause) => cause,
-            PutImageScanningConfigurationError::RepositoryNotFound(ref cause) => cause,
-            PutImageScanningConfigurationError::Server(ref cause) => cause,
+            PutImageScanningConfigurationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutImageScanningConfigurationError::RepositoryNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutImageScanningConfigurationError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutImageScanningConfigurationError {}
 /// Errors returned by PutImageTagMutability
 #[derive(Debug, PartialEq)]
 pub enum PutImageTagMutabilityError {
@@ -2486,18 +2414,14 @@ impl PutImageTagMutabilityError {
 }
 impl fmt::Display for PutImageTagMutabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutImageTagMutabilityError {
-    fn description(&self) -> &str {
         match *self {
-            PutImageTagMutabilityError::InvalidParameter(ref cause) => cause,
-            PutImageTagMutabilityError::RepositoryNotFound(ref cause) => cause,
-            PutImageTagMutabilityError::Server(ref cause) => cause,
+            PutImageTagMutabilityError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutImageTagMutabilityError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            PutImageTagMutabilityError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutImageTagMutabilityError {}
 /// Errors returned by PutLifecyclePolicy
 #[derive(Debug, PartialEq)]
 pub enum PutLifecyclePolicyError {
@@ -2533,18 +2457,14 @@ impl PutLifecyclePolicyError {
 }
 impl fmt::Display for PutLifecyclePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLifecyclePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutLifecyclePolicyError::InvalidParameter(ref cause) => cause,
-            PutLifecyclePolicyError::RepositoryNotFound(ref cause) => cause,
-            PutLifecyclePolicyError::Server(ref cause) => cause,
+            PutLifecyclePolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutLifecyclePolicyError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            PutLifecyclePolicyError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLifecyclePolicyError {}
 /// Errors returned by SetRepositoryPolicy
 #[derive(Debug, PartialEq)]
 pub enum SetRepositoryPolicyError {
@@ -2582,18 +2502,14 @@ impl SetRepositoryPolicyError {
 }
 impl fmt::Display for SetRepositoryPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetRepositoryPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            SetRepositoryPolicyError::InvalidParameter(ref cause) => cause,
-            SetRepositoryPolicyError::RepositoryNotFound(ref cause) => cause,
-            SetRepositoryPolicyError::Server(ref cause) => cause,
+            SetRepositoryPolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetRepositoryPolicyError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            SetRepositoryPolicyError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetRepositoryPolicyError {}
 /// Errors returned by StartImageScan
 #[derive(Debug, PartialEq)]
 pub enum StartImageScanError {
@@ -2632,19 +2548,15 @@ impl StartImageScanError {
 }
 impl fmt::Display for StartImageScanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartImageScanError {
-    fn description(&self) -> &str {
         match *self {
-            StartImageScanError::ImageNotFound(ref cause) => cause,
-            StartImageScanError::InvalidParameter(ref cause) => cause,
-            StartImageScanError::RepositoryNotFound(ref cause) => cause,
-            StartImageScanError::Server(ref cause) => cause,
+            StartImageScanError::ImageNotFound(ref cause) => write!(f, "{}", cause),
+            StartImageScanError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartImageScanError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            StartImageScanError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartImageScanError {}
 /// Errors returned by StartLifecyclePolicyPreview
 #[derive(Debug, PartialEq)]
 pub enum StartLifecyclePolicyPreviewError {
@@ -2698,20 +2610,22 @@ impl StartLifecyclePolicyPreviewError {
 }
 impl fmt::Display for StartLifecyclePolicyPreviewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartLifecyclePolicyPreviewError {
-    fn description(&self) -> &str {
         match *self {
-            StartLifecyclePolicyPreviewError::InvalidParameter(ref cause) => cause,
-            StartLifecyclePolicyPreviewError::LifecyclePolicyNotFound(ref cause) => cause,
-            StartLifecyclePolicyPreviewError::LifecyclePolicyPreviewInProgress(ref cause) => cause,
-            StartLifecyclePolicyPreviewError::RepositoryNotFound(ref cause) => cause,
-            StartLifecyclePolicyPreviewError::Server(ref cause) => cause,
+            StartLifecyclePolicyPreviewError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartLifecyclePolicyPreviewError::LifecyclePolicyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartLifecyclePolicyPreviewError::LifecyclePolicyPreviewInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartLifecyclePolicyPreviewError::RepositoryNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartLifecyclePolicyPreviewError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartLifecyclePolicyPreviewError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2755,20 +2669,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::InvalidTagParameter(ref cause) => cause,
-            TagResourceError::RepositoryNotFound(ref cause) => cause,
-            TagResourceError::Server(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidTagParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Server(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2812,20 +2722,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::InvalidTagParameter(ref cause) => cause,
-            UntagResourceError::RepositoryNotFound(ref cause) => cause,
-            UntagResourceError::Server(ref cause) => cause,
-            UntagResourceError::TooManyTags(ref cause) => cause,
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidTagParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Server(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UploadLayerPart
 #[derive(Debug, PartialEq)]
 pub enum UploadLayerPartError {
@@ -2874,21 +2780,17 @@ impl UploadLayerPartError {
 }
 impl fmt::Display for UploadLayerPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadLayerPartError {
-    fn description(&self) -> &str {
         match *self {
-            UploadLayerPartError::InvalidLayerPart(ref cause) => cause,
-            UploadLayerPartError::InvalidParameter(ref cause) => cause,
-            UploadLayerPartError::LimitExceeded(ref cause) => cause,
-            UploadLayerPartError::RepositoryNotFound(ref cause) => cause,
-            UploadLayerPartError::Server(ref cause) => cause,
-            UploadLayerPartError::UploadNotFound(ref cause) => cause,
+            UploadLayerPartError::InvalidLayerPart(ref cause) => write!(f, "{}", cause),
+            UploadLayerPartError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UploadLayerPartError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UploadLayerPartError::RepositoryNotFound(ref cause) => write!(f, "{}", cause),
+            UploadLayerPartError::Server(ref cause) => write!(f, "{}", cause),
+            UploadLayerPartError::UploadNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UploadLayerPartError {}
 /// Trait representing the capabilities of the Amazon ECR API. Amazon ECR clients implement this trait.
 pub trait Ecr {
     /// <p><p>Check the availability of multiple image layers in a specified registry and repository.</p> <note> <p>This operation is used by the Amazon ECR proxy, and it is not intended for general use by customers for pulling and pushing images. In most cases, you should use the <code>docker</code> CLI to pull, tag, and push images.</p> </note></p>

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -3383,19 +3383,15 @@ impl CreateCapacityProviderError {
 }
 impl fmt::Display for CreateCapacityProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCapacityProviderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCapacityProviderError::Client(ref cause) => cause,
-            CreateCapacityProviderError::InvalidParameter(ref cause) => cause,
-            CreateCapacityProviderError::LimitExceeded(ref cause) => cause,
-            CreateCapacityProviderError::Server(ref cause) => cause,
+            CreateCapacityProviderError::Client(ref cause) => write!(f, "{}", cause),
+            CreateCapacityProviderError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateCapacityProviderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCapacityProviderError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCapacityProviderError {}
 /// Errors returned by CreateCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterError {
@@ -3429,18 +3425,14 @@ impl CreateClusterError {
 }
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterError::Client(ref cause) => cause,
-            CreateClusterError::InvalidParameter(ref cause) => cause,
-            CreateClusterError::Server(ref cause) => cause,
+            CreateClusterError::Client(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterError {}
 /// Errors returned by CreateService
 #[derive(Debug, PartialEq)]
 pub enum CreateServiceError {
@@ -3501,23 +3493,21 @@ impl CreateServiceError {
 }
 impl fmt::Display for CreateServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateServiceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateServiceError::AccessDenied(ref cause) => cause,
-            CreateServiceError::Client(ref cause) => cause,
-            CreateServiceError::ClusterNotFound(ref cause) => cause,
-            CreateServiceError::InvalidParameter(ref cause) => cause,
-            CreateServiceError::PlatformTaskDefinitionIncompatibility(ref cause) => cause,
-            CreateServiceError::PlatformUnknown(ref cause) => cause,
-            CreateServiceError::Server(ref cause) => cause,
-            CreateServiceError::UnsupportedFeature(ref cause) => cause,
+            CreateServiceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::Client(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::PlatformTaskDefinitionIncompatibility(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateServiceError::PlatformUnknown(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::Server(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::UnsupportedFeature(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateServiceError {}
 /// Errors returned by CreateTaskSet
 #[derive(Debug, PartialEq)]
 pub enum CreateTaskSetError {
@@ -3588,25 +3578,23 @@ impl CreateTaskSetError {
 }
 impl fmt::Display for CreateTaskSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTaskSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTaskSetError::AccessDenied(ref cause) => cause,
-            CreateTaskSetError::Client(ref cause) => cause,
-            CreateTaskSetError::ClusterNotFound(ref cause) => cause,
-            CreateTaskSetError::InvalidParameter(ref cause) => cause,
-            CreateTaskSetError::PlatformTaskDefinitionIncompatibility(ref cause) => cause,
-            CreateTaskSetError::PlatformUnknown(ref cause) => cause,
-            CreateTaskSetError::Server(ref cause) => cause,
-            CreateTaskSetError::ServiceNotActive(ref cause) => cause,
-            CreateTaskSetError::ServiceNotFound(ref cause) => cause,
-            CreateTaskSetError::UnsupportedFeature(ref cause) => cause,
+            CreateTaskSetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::Client(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::PlatformTaskDefinitionIncompatibility(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTaskSetError::PlatformUnknown(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::Server(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::ServiceNotActive(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTaskSetError::UnsupportedFeature(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTaskSetError {}
 /// Errors returned by DeleteAccountSetting
 #[derive(Debug, PartialEq)]
 pub enum DeleteAccountSettingError {
@@ -3642,18 +3630,14 @@ impl DeleteAccountSettingError {
 }
 impl fmt::Display for DeleteAccountSettingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAccountSettingError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAccountSettingError::Client(ref cause) => cause,
-            DeleteAccountSettingError::InvalidParameter(ref cause) => cause,
-            DeleteAccountSettingError::Server(ref cause) => cause,
+            DeleteAccountSettingError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteAccountSettingError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteAccountSettingError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAccountSettingError {}
 /// Errors returned by DeleteAttributes
 #[derive(Debug, PartialEq)]
 pub enum DeleteAttributesError {
@@ -3687,18 +3671,14 @@ impl DeleteAttributesError {
 }
 impl fmt::Display for DeleteAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAttributesError::ClusterNotFound(ref cause) => cause,
-            DeleteAttributesError::InvalidParameter(ref cause) => cause,
-            DeleteAttributesError::TargetNotFound(ref cause) => cause,
+            DeleteAttributesError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteAttributesError::TargetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAttributesError {}
 /// Errors returned by DeleteCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterError {
@@ -3761,23 +3741,21 @@ impl DeleteClusterError {
 }
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterError::Client(ref cause) => cause,
-            DeleteClusterError::ClusterContainsContainerInstances(ref cause) => cause,
-            DeleteClusterError::ClusterContainsServices(ref cause) => cause,
-            DeleteClusterError::ClusterContainsTasks(ref cause) => cause,
-            DeleteClusterError::ClusterNotFound(ref cause) => cause,
-            DeleteClusterError::InvalidParameter(ref cause) => cause,
-            DeleteClusterError::Server(ref cause) => cause,
-            DeleteClusterError::UpdateInProgress(ref cause) => cause,
+            DeleteClusterError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ClusterContainsContainerInstances(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteClusterError::ClusterContainsServices(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ClusterContainsTasks(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::Server(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::UpdateInProgress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClusterError {}
 /// Errors returned by DeleteService
 #[derive(Debug, PartialEq)]
 pub enum DeleteServiceError {
@@ -3821,20 +3799,16 @@ impl DeleteServiceError {
 }
 impl fmt::Display for DeleteServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServiceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServiceError::Client(ref cause) => cause,
-            DeleteServiceError::ClusterNotFound(ref cause) => cause,
-            DeleteServiceError::InvalidParameter(ref cause) => cause,
-            DeleteServiceError::Server(ref cause) => cause,
-            DeleteServiceError::ServiceNotFound(ref cause) => cause,
+            DeleteServiceError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteServiceError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteServiceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteServiceError::Server(ref cause) => write!(f, "{}", cause),
+            DeleteServiceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServiceError {}
 /// Errors returned by DeleteTaskSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteTaskSetError {
@@ -3898,24 +3872,20 @@ impl DeleteTaskSetError {
 }
 impl fmt::Display for DeleteTaskSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTaskSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTaskSetError::AccessDenied(ref cause) => cause,
-            DeleteTaskSetError::Client(ref cause) => cause,
-            DeleteTaskSetError::ClusterNotFound(ref cause) => cause,
-            DeleteTaskSetError::InvalidParameter(ref cause) => cause,
-            DeleteTaskSetError::Server(ref cause) => cause,
-            DeleteTaskSetError::ServiceNotActive(ref cause) => cause,
-            DeleteTaskSetError::ServiceNotFound(ref cause) => cause,
-            DeleteTaskSetError::TaskSetNotFound(ref cause) => cause,
-            DeleteTaskSetError::UnsupportedFeature(ref cause) => cause,
+            DeleteTaskSetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::Server(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::ServiceNotActive(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::TaskSetNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTaskSetError::UnsupportedFeature(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTaskSetError {}
 /// Errors returned by DeregisterContainerInstance
 #[derive(Debug, PartialEq)]
 pub enum DeregisterContainerInstanceError {
@@ -3960,19 +3930,15 @@ impl DeregisterContainerInstanceError {
 }
 impl fmt::Display for DeregisterContainerInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterContainerInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterContainerInstanceError::Client(ref cause) => cause,
-            DeregisterContainerInstanceError::ClusterNotFound(ref cause) => cause,
-            DeregisterContainerInstanceError::InvalidParameter(ref cause) => cause,
-            DeregisterContainerInstanceError::Server(ref cause) => cause,
+            DeregisterContainerInstanceError::Client(ref cause) => write!(f, "{}", cause),
+            DeregisterContainerInstanceError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DeregisterContainerInstanceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeregisterContainerInstanceError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterContainerInstanceError {}
 /// Errors returned by DeregisterTaskDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeregisterTaskDefinitionError {
@@ -4008,18 +3974,14 @@ impl DeregisterTaskDefinitionError {
 }
 impl fmt::Display for DeregisterTaskDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterTaskDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterTaskDefinitionError::Client(ref cause) => cause,
-            DeregisterTaskDefinitionError::InvalidParameter(ref cause) => cause,
-            DeregisterTaskDefinitionError::Server(ref cause) => cause,
+            DeregisterTaskDefinitionError::Client(ref cause) => write!(f, "{}", cause),
+            DeregisterTaskDefinitionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeregisterTaskDefinitionError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterTaskDefinitionError {}
 /// Errors returned by DescribeCapacityProviders
 #[derive(Debug, PartialEq)]
 pub enum DescribeCapacityProvidersError {
@@ -4055,18 +4017,14 @@ impl DescribeCapacityProvidersError {
 }
 impl fmt::Display for DescribeCapacityProvidersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCapacityProvidersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCapacityProvidersError::Client(ref cause) => cause,
-            DescribeCapacityProvidersError::InvalidParameter(ref cause) => cause,
-            DescribeCapacityProvidersError::Server(ref cause) => cause,
+            DescribeCapacityProvidersError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeCapacityProvidersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeCapacityProvidersError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCapacityProvidersError {}
 /// Errors returned by DescribeClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeClustersError {
@@ -4100,18 +4058,14 @@ impl DescribeClustersError {
 }
 impl fmt::Display for DescribeClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClustersError::Client(ref cause) => cause,
-            DescribeClustersError::InvalidParameter(ref cause) => cause,
-            DescribeClustersError::Server(ref cause) => cause,
+            DescribeClustersError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClustersError {}
 /// Errors returned by DescribeContainerInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeContainerInstancesError {
@@ -4156,19 +4110,15 @@ impl DescribeContainerInstancesError {
 }
 impl fmt::Display for DescribeContainerInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeContainerInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeContainerInstancesError::Client(ref cause) => cause,
-            DescribeContainerInstancesError::ClusterNotFound(ref cause) => cause,
-            DescribeContainerInstancesError::InvalidParameter(ref cause) => cause,
-            DescribeContainerInstancesError::Server(ref cause) => cause,
+            DescribeContainerInstancesError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeContainerInstancesError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeContainerInstancesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeContainerInstancesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeContainerInstancesError {}
 /// Errors returned by DescribeServices
 #[derive(Debug, PartialEq)]
 pub enum DescribeServicesError {
@@ -4207,19 +4157,15 @@ impl DescribeServicesError {
 }
 impl fmt::Display for DescribeServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServicesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServicesError::Client(ref cause) => cause,
-            DescribeServicesError::ClusterNotFound(ref cause) => cause,
-            DescribeServicesError::InvalidParameter(ref cause) => cause,
-            DescribeServicesError::Server(ref cause) => cause,
+            DescribeServicesError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeServicesError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeServicesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeServicesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeServicesError {}
 /// Errors returned by DescribeTaskDefinition
 #[derive(Debug, PartialEq)]
 pub enum DescribeTaskDefinitionError {
@@ -4255,18 +4201,14 @@ impl DescribeTaskDefinitionError {
 }
 impl fmt::Display for DescribeTaskDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTaskDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTaskDefinitionError::Client(ref cause) => cause,
-            DescribeTaskDefinitionError::InvalidParameter(ref cause) => cause,
-            DescribeTaskDefinitionError::Server(ref cause) => cause,
+            DescribeTaskDefinitionError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeTaskDefinitionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeTaskDefinitionError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTaskDefinitionError {}
 /// Errors returned by DescribeTaskSets
 #[derive(Debug, PartialEq)]
 pub enum DescribeTaskSetsError {
@@ -4325,23 +4267,19 @@ impl DescribeTaskSetsError {
 }
 impl fmt::Display for DescribeTaskSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTaskSetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTaskSetsError::AccessDenied(ref cause) => cause,
-            DescribeTaskSetsError::Client(ref cause) => cause,
-            DescribeTaskSetsError::ClusterNotFound(ref cause) => cause,
-            DescribeTaskSetsError::InvalidParameter(ref cause) => cause,
-            DescribeTaskSetsError::Server(ref cause) => cause,
-            DescribeTaskSetsError::ServiceNotActive(ref cause) => cause,
-            DescribeTaskSetsError::ServiceNotFound(ref cause) => cause,
-            DescribeTaskSetsError::UnsupportedFeature(ref cause) => cause,
+            DescribeTaskSetsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeTaskSetsError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeTaskSetsError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTaskSetsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeTaskSetsError::Server(ref cause) => write!(f, "{}", cause),
+            DescribeTaskSetsError::ServiceNotActive(ref cause) => write!(f, "{}", cause),
+            DescribeTaskSetsError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTaskSetsError::UnsupportedFeature(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTaskSetsError {}
 /// Errors returned by DescribeTasks
 #[derive(Debug, PartialEq)]
 pub enum DescribeTasksError {
@@ -4380,19 +4318,15 @@ impl DescribeTasksError {
 }
 impl fmt::Display for DescribeTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTasksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTasksError::Client(ref cause) => cause,
-            DescribeTasksError::ClusterNotFound(ref cause) => cause,
-            DescribeTasksError::InvalidParameter(ref cause) => cause,
-            DescribeTasksError::Server(ref cause) => cause,
+            DescribeTasksError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeTasksError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTasksError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeTasksError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTasksError {}
 /// Errors returned by DiscoverPollEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DiscoverPollEndpointError {
@@ -4421,17 +4355,13 @@ impl DiscoverPollEndpointError {
 }
 impl fmt::Display for DiscoverPollEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DiscoverPollEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DiscoverPollEndpointError::Client(ref cause) => cause,
-            DiscoverPollEndpointError::Server(ref cause) => cause,
+            DiscoverPollEndpointError::Client(ref cause) => write!(f, "{}", cause),
+            DiscoverPollEndpointError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DiscoverPollEndpointError {}
 /// Errors returned by ListAccountSettings
 #[derive(Debug, PartialEq)]
 pub enum ListAccountSettingsError {
@@ -4467,18 +4397,14 @@ impl ListAccountSettingsError {
 }
 impl fmt::Display for ListAccountSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAccountSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAccountSettingsError::Client(ref cause) => cause,
-            ListAccountSettingsError::InvalidParameter(ref cause) => cause,
-            ListAccountSettingsError::Server(ref cause) => cause,
+            ListAccountSettingsError::Client(ref cause) => write!(f, "{}", cause),
+            ListAccountSettingsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListAccountSettingsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAccountSettingsError {}
 /// Errors returned by ListAttributes
 #[derive(Debug, PartialEq)]
 pub enum ListAttributesError {
@@ -4507,17 +4433,13 @@ impl ListAttributesError {
 }
 impl fmt::Display for ListAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttributesError::ClusterNotFound(ref cause) => cause,
-            ListAttributesError::InvalidParameter(ref cause) => cause,
+            ListAttributesError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            ListAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttributesError {}
 /// Errors returned by ListClusters
 #[derive(Debug, PartialEq)]
 pub enum ListClustersError {
@@ -4551,18 +4473,14 @@ impl ListClustersError {
 }
 impl fmt::Display for ListClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClustersError {
-    fn description(&self) -> &str {
         match *self {
-            ListClustersError::Client(ref cause) => cause,
-            ListClustersError::InvalidParameter(ref cause) => cause,
-            ListClustersError::Server(ref cause) => cause,
+            ListClustersError::Client(ref cause) => write!(f, "{}", cause),
+            ListClustersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListClustersError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListClustersError {}
 /// Errors returned by ListContainerInstances
 #[derive(Debug, PartialEq)]
 pub enum ListContainerInstancesError {
@@ -4605,19 +4523,15 @@ impl ListContainerInstancesError {
 }
 impl fmt::Display for ListContainerInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListContainerInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListContainerInstancesError::Client(ref cause) => cause,
-            ListContainerInstancesError::ClusterNotFound(ref cause) => cause,
-            ListContainerInstancesError::InvalidParameter(ref cause) => cause,
-            ListContainerInstancesError::Server(ref cause) => cause,
+            ListContainerInstancesError::Client(ref cause) => write!(f, "{}", cause),
+            ListContainerInstancesError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            ListContainerInstancesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListContainerInstancesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListContainerInstancesError {}
 /// Errors returned by ListServices
 #[derive(Debug, PartialEq)]
 pub enum ListServicesError {
@@ -4656,19 +4570,15 @@ impl ListServicesError {
 }
 impl fmt::Display for ListServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListServicesError::Client(ref cause) => cause,
-            ListServicesError::ClusterNotFound(ref cause) => cause,
-            ListServicesError::InvalidParameter(ref cause) => cause,
-            ListServicesError::Server(ref cause) => cause,
+            ListServicesError::Client(ref cause) => write!(f, "{}", cause),
+            ListServicesError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            ListServicesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListServicesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListServicesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -4709,19 +4619,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::Client(ref cause) => cause,
-            ListTagsForResourceError::ClusterNotFound(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::Server(ref cause) => cause,
+            ListTagsForResourceError::Client(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTaskDefinitionFamilies
 #[derive(Debug, PartialEq)]
 pub enum ListTaskDefinitionFamiliesError {
@@ -4759,18 +4665,14 @@ impl ListTaskDefinitionFamiliesError {
 }
 impl fmt::Display for ListTaskDefinitionFamiliesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTaskDefinitionFamiliesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTaskDefinitionFamiliesError::Client(ref cause) => cause,
-            ListTaskDefinitionFamiliesError::InvalidParameter(ref cause) => cause,
-            ListTaskDefinitionFamiliesError::Server(ref cause) => cause,
+            ListTaskDefinitionFamiliesError::Client(ref cause) => write!(f, "{}", cause),
+            ListTaskDefinitionFamiliesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTaskDefinitionFamiliesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTaskDefinitionFamiliesError {}
 /// Errors returned by ListTaskDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListTaskDefinitionsError {
@@ -4806,18 +4708,14 @@ impl ListTaskDefinitionsError {
 }
 impl fmt::Display for ListTaskDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTaskDefinitionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTaskDefinitionsError::Client(ref cause) => cause,
-            ListTaskDefinitionsError::InvalidParameter(ref cause) => cause,
-            ListTaskDefinitionsError::Server(ref cause) => cause,
+            ListTaskDefinitionsError::Client(ref cause) => write!(f, "{}", cause),
+            ListTaskDefinitionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTaskDefinitionsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTaskDefinitionsError {}
 /// Errors returned by ListTasks
 #[derive(Debug, PartialEq)]
 pub enum ListTasksError {
@@ -4857,20 +4755,16 @@ impl ListTasksError {
 }
 impl fmt::Display for ListTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTasksError {
-    fn description(&self) -> &str {
         match *self {
-            ListTasksError::Client(ref cause) => cause,
-            ListTasksError::ClusterNotFound(ref cause) => cause,
-            ListTasksError::InvalidParameter(ref cause) => cause,
-            ListTasksError::Server(ref cause) => cause,
-            ListTasksError::ServiceNotFound(ref cause) => cause,
+            ListTasksError::Client(ref cause) => write!(f, "{}", cause),
+            ListTasksError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            ListTasksError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTasksError::Server(ref cause) => write!(f, "{}", cause),
+            ListTasksError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTasksError {}
 /// Errors returned by PutAccountSetting
 #[derive(Debug, PartialEq)]
 pub enum PutAccountSettingError {
@@ -4904,18 +4798,14 @@ impl PutAccountSettingError {
 }
 impl fmt::Display for PutAccountSettingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAccountSettingError {
-    fn description(&self) -> &str {
         match *self {
-            PutAccountSettingError::Client(ref cause) => cause,
-            PutAccountSettingError::InvalidParameter(ref cause) => cause,
-            PutAccountSettingError::Server(ref cause) => cause,
+            PutAccountSettingError::Client(ref cause) => write!(f, "{}", cause),
+            PutAccountSettingError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutAccountSettingError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutAccountSettingError {}
 /// Errors returned by PutAccountSettingDefault
 #[derive(Debug, PartialEq)]
 pub enum PutAccountSettingDefaultError {
@@ -4951,18 +4841,14 @@ impl PutAccountSettingDefaultError {
 }
 impl fmt::Display for PutAccountSettingDefaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAccountSettingDefaultError {
-    fn description(&self) -> &str {
         match *self {
-            PutAccountSettingDefaultError::Client(ref cause) => cause,
-            PutAccountSettingDefaultError::InvalidParameter(ref cause) => cause,
-            PutAccountSettingDefaultError::Server(ref cause) => cause,
+            PutAccountSettingDefaultError::Client(ref cause) => write!(f, "{}", cause),
+            PutAccountSettingDefaultError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutAccountSettingDefaultError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutAccountSettingDefaultError {}
 /// Errors returned by PutAttributes
 #[derive(Debug, PartialEq)]
 pub enum PutAttributesError {
@@ -5003,19 +4889,15 @@ impl PutAttributesError {
 }
 impl fmt::Display for PutAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            PutAttributesError::AttributeLimitExceeded(ref cause) => cause,
-            PutAttributesError::ClusterNotFound(ref cause) => cause,
-            PutAttributesError::InvalidParameter(ref cause) => cause,
-            PutAttributesError::TargetNotFound(ref cause) => cause,
+            PutAttributesError::AttributeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::TargetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutAttributesError {}
 /// Errors returned by PutClusterCapacityProviders
 #[derive(Debug, PartialEq)]
 pub enum PutClusterCapacityProvidersError {
@@ -5074,21 +4956,17 @@ impl PutClusterCapacityProvidersError {
 }
 impl fmt::Display for PutClusterCapacityProvidersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutClusterCapacityProvidersError {
-    fn description(&self) -> &str {
         match *self {
-            PutClusterCapacityProvidersError::Client(ref cause) => cause,
-            PutClusterCapacityProvidersError::ClusterNotFound(ref cause) => cause,
-            PutClusterCapacityProvidersError::InvalidParameter(ref cause) => cause,
-            PutClusterCapacityProvidersError::ResourceInUse(ref cause) => cause,
-            PutClusterCapacityProvidersError::Server(ref cause) => cause,
-            PutClusterCapacityProvidersError::UpdateInProgress(ref cause) => cause,
+            PutClusterCapacityProvidersError::Client(ref cause) => write!(f, "{}", cause),
+            PutClusterCapacityProvidersError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            PutClusterCapacityProvidersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutClusterCapacityProvidersError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            PutClusterCapacityProvidersError::Server(ref cause) => write!(f, "{}", cause),
+            PutClusterCapacityProvidersError::UpdateInProgress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutClusterCapacityProvidersError {}
 /// Errors returned by RegisterContainerInstance
 #[derive(Debug, PartialEq)]
 pub enum RegisterContainerInstanceError {
@@ -5124,18 +5002,14 @@ impl RegisterContainerInstanceError {
 }
 impl fmt::Display for RegisterContainerInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterContainerInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterContainerInstanceError::Client(ref cause) => cause,
-            RegisterContainerInstanceError::InvalidParameter(ref cause) => cause,
-            RegisterContainerInstanceError::Server(ref cause) => cause,
+            RegisterContainerInstanceError::Client(ref cause) => write!(f, "{}", cause),
+            RegisterContainerInstanceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RegisterContainerInstanceError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterContainerInstanceError {}
 /// Errors returned by RegisterTaskDefinition
 #[derive(Debug, PartialEq)]
 pub enum RegisterTaskDefinitionError {
@@ -5171,18 +5045,14 @@ impl RegisterTaskDefinitionError {
 }
 impl fmt::Display for RegisterTaskDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterTaskDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterTaskDefinitionError::Client(ref cause) => cause,
-            RegisterTaskDefinitionError::InvalidParameter(ref cause) => cause,
-            RegisterTaskDefinitionError::Server(ref cause) => cause,
+            RegisterTaskDefinitionError::Client(ref cause) => write!(f, "{}", cause),
+            RegisterTaskDefinitionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RegisterTaskDefinitionError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterTaskDefinitionError {}
 /// Errors returned by RunTask
 #[derive(Debug, PartialEq)]
 pub enum RunTaskError {
@@ -5242,24 +5112,22 @@ impl RunTaskError {
 }
 impl fmt::Display for RunTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RunTaskError {
-    fn description(&self) -> &str {
         match *self {
-            RunTaskError::AccessDenied(ref cause) => cause,
-            RunTaskError::Blocked(ref cause) => cause,
-            RunTaskError::Client(ref cause) => cause,
-            RunTaskError::ClusterNotFound(ref cause) => cause,
-            RunTaskError::InvalidParameter(ref cause) => cause,
-            RunTaskError::PlatformTaskDefinitionIncompatibility(ref cause) => cause,
-            RunTaskError::PlatformUnknown(ref cause) => cause,
-            RunTaskError::Server(ref cause) => cause,
-            RunTaskError::UnsupportedFeature(ref cause) => cause,
+            RunTaskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RunTaskError::Blocked(ref cause) => write!(f, "{}", cause),
+            RunTaskError::Client(ref cause) => write!(f, "{}", cause),
+            RunTaskError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            RunTaskError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RunTaskError::PlatformTaskDefinitionIncompatibility(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RunTaskError::PlatformUnknown(ref cause) => write!(f, "{}", cause),
+            RunTaskError::Server(ref cause) => write!(f, "{}", cause),
+            RunTaskError::UnsupportedFeature(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RunTaskError {}
 /// Errors returned by StartTask
 #[derive(Debug, PartialEq)]
 pub enum StartTaskError {
@@ -5294,19 +5162,15 @@ impl StartTaskError {
 }
 impl fmt::Display for StartTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartTaskError::Client(ref cause) => cause,
-            StartTaskError::ClusterNotFound(ref cause) => cause,
-            StartTaskError::InvalidParameter(ref cause) => cause,
-            StartTaskError::Server(ref cause) => cause,
+            StartTaskError::Client(ref cause) => write!(f, "{}", cause),
+            StartTaskError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            StartTaskError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartTaskError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartTaskError {}
 /// Errors returned by StopTask
 #[derive(Debug, PartialEq)]
 pub enum StopTaskError {
@@ -5341,19 +5205,15 @@ impl StopTaskError {
 }
 impl fmt::Display for StopTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StopTaskError::Client(ref cause) => cause,
-            StopTaskError::ClusterNotFound(ref cause) => cause,
-            StopTaskError::InvalidParameter(ref cause) => cause,
-            StopTaskError::Server(ref cause) => cause,
+            StopTaskError::Client(ref cause) => write!(f, "{}", cause),
+            StopTaskError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            StopTaskError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopTaskError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopTaskError {}
 /// Errors returned by SubmitAttachmentStateChanges
 #[derive(Debug, PartialEq)]
 pub enum SubmitAttachmentStateChangesError {
@@ -5398,19 +5258,17 @@ impl SubmitAttachmentStateChangesError {
 }
 impl fmt::Display for SubmitAttachmentStateChangesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubmitAttachmentStateChangesError {
-    fn description(&self) -> &str {
         match *self {
-            SubmitAttachmentStateChangesError::AccessDenied(ref cause) => cause,
-            SubmitAttachmentStateChangesError::Client(ref cause) => cause,
-            SubmitAttachmentStateChangesError::InvalidParameter(ref cause) => cause,
-            SubmitAttachmentStateChangesError::Server(ref cause) => cause,
+            SubmitAttachmentStateChangesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SubmitAttachmentStateChangesError::Client(ref cause) => write!(f, "{}", cause),
+            SubmitAttachmentStateChangesError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SubmitAttachmentStateChangesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SubmitAttachmentStateChangesError {}
 /// Errors returned by SubmitContainerStateChange
 #[derive(Debug, PartialEq)]
 pub enum SubmitContainerStateChangeError {
@@ -5448,18 +5306,14 @@ impl SubmitContainerStateChangeError {
 }
 impl fmt::Display for SubmitContainerStateChangeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubmitContainerStateChangeError {
-    fn description(&self) -> &str {
         match *self {
-            SubmitContainerStateChangeError::AccessDenied(ref cause) => cause,
-            SubmitContainerStateChangeError::Client(ref cause) => cause,
-            SubmitContainerStateChangeError::Server(ref cause) => cause,
+            SubmitContainerStateChangeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SubmitContainerStateChangeError::Client(ref cause) => write!(f, "{}", cause),
+            SubmitContainerStateChangeError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SubmitContainerStateChangeError {}
 /// Errors returned by SubmitTaskStateChange
 #[derive(Debug, PartialEq)]
 pub enum SubmitTaskStateChangeError {
@@ -5500,19 +5354,15 @@ impl SubmitTaskStateChangeError {
 }
 impl fmt::Display for SubmitTaskStateChangeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubmitTaskStateChangeError {
-    fn description(&self) -> &str {
         match *self {
-            SubmitTaskStateChangeError::AccessDenied(ref cause) => cause,
-            SubmitTaskStateChangeError::Client(ref cause) => cause,
-            SubmitTaskStateChangeError::InvalidParameter(ref cause) => cause,
-            SubmitTaskStateChangeError::Server(ref cause) => cause,
+            SubmitTaskStateChangeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SubmitTaskStateChangeError::Client(ref cause) => write!(f, "{}", cause),
+            SubmitTaskStateChangeError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SubmitTaskStateChangeError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SubmitTaskStateChangeError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5556,20 +5406,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::Client(ref cause) => cause,
-            TagResourceError::ClusterNotFound(ref cause) => cause,
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::Server(ref cause) => cause,
+            TagResourceError::Client(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -5613,20 +5459,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::Client(ref cause) => cause,
-            UntagResourceError::ClusterNotFound(ref cause) => cause,
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::Server(ref cause) => cause,
+            UntagResourceError::Client(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateClusterSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateClusterSettingsError {
@@ -5669,19 +5511,15 @@ impl UpdateClusterSettingsError {
 }
 impl fmt::Display for UpdateClusterSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClusterSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClusterSettingsError::Client(ref cause) => cause,
-            UpdateClusterSettingsError::ClusterNotFound(ref cause) => cause,
-            UpdateClusterSettingsError::InvalidParameter(ref cause) => cause,
-            UpdateClusterSettingsError::Server(ref cause) => cause,
+            UpdateClusterSettingsError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateClusterSettingsError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateClusterSettingsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateClusterSettingsError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClusterSettingsError {}
 /// Errors returned by UpdateContainerAgent
 #[derive(Debug, PartialEq)]
 pub enum UpdateContainerAgentError {
@@ -5743,22 +5581,18 @@ impl UpdateContainerAgentError {
 }
 impl fmt::Display for UpdateContainerAgentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateContainerAgentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateContainerAgentError::Client(ref cause) => cause,
-            UpdateContainerAgentError::ClusterNotFound(ref cause) => cause,
-            UpdateContainerAgentError::InvalidParameter(ref cause) => cause,
-            UpdateContainerAgentError::MissingVersion(ref cause) => cause,
-            UpdateContainerAgentError::NoUpdateAvailable(ref cause) => cause,
-            UpdateContainerAgentError::Server(ref cause) => cause,
-            UpdateContainerAgentError::UpdateInProgress(ref cause) => cause,
+            UpdateContainerAgentError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateContainerAgentError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateContainerAgentError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateContainerAgentError::MissingVersion(ref cause) => write!(f, "{}", cause),
+            UpdateContainerAgentError::NoUpdateAvailable(ref cause) => write!(f, "{}", cause),
+            UpdateContainerAgentError::Server(ref cause) => write!(f, "{}", cause),
+            UpdateContainerAgentError::UpdateInProgress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateContainerAgentError {}
 /// Errors returned by UpdateContainerInstancesState
 #[derive(Debug, PartialEq)]
 pub enum UpdateContainerInstancesStateError {
@@ -5807,19 +5641,19 @@ impl UpdateContainerInstancesStateError {
 }
 impl fmt::Display for UpdateContainerInstancesStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateContainerInstancesStateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateContainerInstancesStateError::Client(ref cause) => cause,
-            UpdateContainerInstancesStateError::ClusterNotFound(ref cause) => cause,
-            UpdateContainerInstancesStateError::InvalidParameter(ref cause) => cause,
-            UpdateContainerInstancesStateError::Server(ref cause) => cause,
+            UpdateContainerInstancesStateError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateContainerInstancesStateError::ClusterNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateContainerInstancesStateError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateContainerInstancesStateError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateContainerInstancesStateError {}
 /// Errors returned by UpdateService
 #[derive(Debug, PartialEq)]
 pub enum UpdateServiceError {
@@ -5885,24 +5719,22 @@ impl UpdateServiceError {
 }
 impl fmt::Display for UpdateServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServiceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServiceError::AccessDenied(ref cause) => cause,
-            UpdateServiceError::Client(ref cause) => cause,
-            UpdateServiceError::ClusterNotFound(ref cause) => cause,
-            UpdateServiceError::InvalidParameter(ref cause) => cause,
-            UpdateServiceError::PlatformTaskDefinitionIncompatibility(ref cause) => cause,
-            UpdateServiceError::PlatformUnknown(ref cause) => cause,
-            UpdateServiceError::Server(ref cause) => cause,
-            UpdateServiceError::ServiceNotActive(ref cause) => cause,
-            UpdateServiceError::ServiceNotFound(ref cause) => cause,
+            UpdateServiceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::PlatformTaskDefinitionIncompatibility(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateServiceError::PlatformUnknown(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::Server(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::ServiceNotActive(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServiceError {}
 /// Errors returned by UpdateServicePrimaryTaskSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateServicePrimaryTaskSetError {
@@ -5982,24 +5814,22 @@ impl UpdateServicePrimaryTaskSetError {
 }
 impl fmt::Display for UpdateServicePrimaryTaskSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServicePrimaryTaskSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServicePrimaryTaskSetError::AccessDenied(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::Client(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::ClusterNotFound(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::InvalidParameter(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::Server(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::ServiceNotActive(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::ServiceNotFound(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::TaskSetNotFound(ref cause) => cause,
-            UpdateServicePrimaryTaskSetError::UnsupportedFeature(ref cause) => cause,
+            UpdateServicePrimaryTaskSetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::Server(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::ServiceNotActive(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::TaskSetNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateServicePrimaryTaskSetError::UnsupportedFeature(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateServicePrimaryTaskSetError {}
 /// Errors returned by UpdateTaskSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateTaskSetError {
@@ -6063,24 +5893,20 @@ impl UpdateTaskSetError {
 }
 impl fmt::Display for UpdateTaskSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTaskSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTaskSetError::AccessDenied(ref cause) => cause,
-            UpdateTaskSetError::Client(ref cause) => cause,
-            UpdateTaskSetError::ClusterNotFound(ref cause) => cause,
-            UpdateTaskSetError::InvalidParameter(ref cause) => cause,
-            UpdateTaskSetError::Server(ref cause) => cause,
-            UpdateTaskSetError::ServiceNotActive(ref cause) => cause,
-            UpdateTaskSetError::ServiceNotFound(ref cause) => cause,
-            UpdateTaskSetError::TaskSetNotFound(ref cause) => cause,
-            UpdateTaskSetError::UnsupportedFeature(ref cause) => cause,
+            UpdateTaskSetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::ClusterNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::Server(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::ServiceNotActive(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::TaskSetNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTaskSetError::UnsupportedFeature(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTaskSetError {}
 /// Trait representing the capabilities of the Amazon ECS API. Amazon ECS clients implement this trait.
 pub trait Ecs {
     /// <p>Creates a new capacity provider. Capacity providers are associated with an Amazon ECS cluster and are used in capacity provider strategies to facilitate cluster auto scaling.</p> <p>Only capacity providers using an Auto Scaling group can be created. Amazon ECS tasks on AWS Fargate use the <code>FARGATE</code> and <code>FARGATE_SPOT</code> capacity providers which are already created and available to all accounts in Regions supported by AWS Fargate.</p>

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -473,21 +473,19 @@ impl CreateFileSystemError {
 }
 impl fmt::Display for CreateFileSystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFileSystemError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFileSystemError::BadRequest(ref cause) => cause,
-            CreateFileSystemError::FileSystemAlreadyExists(ref cause) => cause,
-            CreateFileSystemError::FileSystemLimitExceeded(ref cause) => cause,
-            CreateFileSystemError::InsufficientThroughputCapacity(ref cause) => cause,
-            CreateFileSystemError::InternalServerError(ref cause) => cause,
-            CreateFileSystemError::ThroughputLimitExceeded(ref cause) => cause,
+            CreateFileSystemError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::FileSystemAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::FileSystemLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::InsufficientThroughputCapacity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateFileSystemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::ThroughputLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFileSystemError {}
 /// Errors returned by CreateMountTarget
 #[derive(Debug, PartialEq)]
 pub enum CreateMountTargetError {
@@ -584,27 +582,29 @@ impl CreateMountTargetError {
 }
 impl fmt::Display for CreateMountTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMountTargetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMountTargetError::BadRequest(ref cause) => cause,
-            CreateMountTargetError::FileSystemNotFound(ref cause) => cause,
-            CreateMountTargetError::IncorrectFileSystemLifeCycleState(ref cause) => cause,
-            CreateMountTargetError::InternalServerError(ref cause) => cause,
-            CreateMountTargetError::IpAddressInUse(ref cause) => cause,
-            CreateMountTargetError::MountTargetConflict(ref cause) => cause,
-            CreateMountTargetError::NetworkInterfaceLimitExceeded(ref cause) => cause,
-            CreateMountTargetError::NoFreeAddressesInSubnet(ref cause) => cause,
-            CreateMountTargetError::SecurityGroupLimitExceeded(ref cause) => cause,
-            CreateMountTargetError::SecurityGroupNotFound(ref cause) => cause,
-            CreateMountTargetError::SubnetNotFound(ref cause) => cause,
-            CreateMountTargetError::UnsupportedAvailabilityZone(ref cause) => cause,
+            CreateMountTargetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::IncorrectFileSystemLifeCycleState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateMountTargetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::IpAddressInUse(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::MountTargetConflict(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::NetworkInterfaceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateMountTargetError::NoFreeAddressesInSubnet(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::SecurityGroupLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::SecurityGroupNotFound(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::SubnetNotFound(ref cause) => write!(f, "{}", cause),
+            CreateMountTargetError::UnsupportedAvailabilityZone(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateMountTargetError {}
 /// Errors returned by CreateTags
 #[derive(Debug, PartialEq)]
 pub enum CreateTagsError {
@@ -636,18 +636,14 @@ impl CreateTagsError {
 }
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTagsError::BadRequest(ref cause) => cause,
-            CreateTagsError::FileSystemNotFound(ref cause) => cause,
-            CreateTagsError::InternalServerError(ref cause) => cause,
+            CreateTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTagsError {}
 /// Errors returned by DeleteFileSystem
 #[derive(Debug, PartialEq)]
 pub enum DeleteFileSystemError {
@@ -688,19 +684,15 @@ impl DeleteFileSystemError {
 }
 impl fmt::Display for DeleteFileSystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFileSystemError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFileSystemError::BadRequest(ref cause) => cause,
-            DeleteFileSystemError::FileSystemInUse(ref cause) => cause,
-            DeleteFileSystemError::FileSystemNotFound(ref cause) => cause,
-            DeleteFileSystemError::InternalServerError(ref cause) => cause,
+            DeleteFileSystemError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteFileSystemError::FileSystemInUse(ref cause) => write!(f, "{}", cause),
+            DeleteFileSystemError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFileSystemError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFileSystemError {}
 /// Errors returned by DeleteMountTarget
 #[derive(Debug, PartialEq)]
 pub enum DeleteMountTargetError {
@@ -743,19 +735,15 @@ impl DeleteMountTargetError {
 }
 impl fmt::Display for DeleteMountTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMountTargetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMountTargetError::BadRequest(ref cause) => cause,
-            DeleteMountTargetError::DependencyTimeout(ref cause) => cause,
-            DeleteMountTargetError::InternalServerError(ref cause) => cause,
-            DeleteMountTargetError::MountTargetNotFound(ref cause) => cause,
+            DeleteMountTargetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMountTargetError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteMountTargetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteMountTargetError::MountTargetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMountTargetError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -787,18 +775,14 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::BadRequest(ref cause) => cause,
-            DeleteTagsError::FileSystemNotFound(ref cause) => cause,
-            DeleteTagsError::InternalServerError(ref cause) => cause,
+            DeleteTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DescribeFileSystems
 #[derive(Debug, PartialEq)]
 pub enum DescribeFileSystemsError {
@@ -836,18 +820,14 @@ impl DescribeFileSystemsError {
 }
 impl fmt::Display for DescribeFileSystemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFileSystemsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFileSystemsError::BadRequest(ref cause) => cause,
-            DescribeFileSystemsError::FileSystemNotFound(ref cause) => cause,
-            DescribeFileSystemsError::InternalServerError(ref cause) => cause,
+            DescribeFileSystemsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFileSystemsError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFileSystemsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFileSystemsError {}
 /// Errors returned by DescribeLifecycleConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeLifecycleConfigurationError {
@@ -889,18 +869,18 @@ impl DescribeLifecycleConfigurationError {
 }
 impl fmt::Display for DescribeLifecycleConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLifecycleConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLifecycleConfigurationError::BadRequest(ref cause) => cause,
-            DescribeLifecycleConfigurationError::FileSystemNotFound(ref cause) => cause,
-            DescribeLifecycleConfigurationError::InternalServerError(ref cause) => cause,
+            DescribeLifecycleConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeLifecycleConfigurationError::FileSystemNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeLifecycleConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLifecycleConfigurationError {}
 /// Errors returned by DescribeMountTargetSecurityGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeMountTargetSecurityGroupsError {
@@ -949,19 +929,21 @@ impl DescribeMountTargetSecurityGroupsError {
 }
 impl fmt::Display for DescribeMountTargetSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMountTargetSecurityGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMountTargetSecurityGroupsError::BadRequest(ref cause) => cause,
-            DescribeMountTargetSecurityGroupsError::IncorrectMountTargetState(ref cause) => cause,
-            DescribeMountTargetSecurityGroupsError::InternalServerError(ref cause) => cause,
-            DescribeMountTargetSecurityGroupsError::MountTargetNotFound(ref cause) => cause,
+            DescribeMountTargetSecurityGroupsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMountTargetSecurityGroupsError::IncorrectMountTargetState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMountTargetSecurityGroupsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMountTargetSecurityGroupsError::MountTargetNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMountTargetSecurityGroupsError {}
 /// Errors returned by DescribeMountTargets
 #[derive(Debug, PartialEq)]
 pub enum DescribeMountTargetsError {
@@ -1006,19 +988,15 @@ impl DescribeMountTargetsError {
 }
 impl fmt::Display for DescribeMountTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMountTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMountTargetsError::BadRequest(ref cause) => cause,
-            DescribeMountTargetsError::FileSystemNotFound(ref cause) => cause,
-            DescribeMountTargetsError::InternalServerError(ref cause) => cause,
-            DescribeMountTargetsError::MountTargetNotFound(ref cause) => cause,
+            DescribeMountTargetsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMountTargetsError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMountTargetsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeMountTargetsError::MountTargetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMountTargetsError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -1052,18 +1030,14 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::BadRequest(ref cause) => cause,
-            DescribeTagsError::FileSystemNotFound(ref cause) => cause,
-            DescribeTagsError::InternalServerError(ref cause) => cause,
+            DescribeTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by ModifyMountTargetSecurityGroups
 #[derive(Debug, PartialEq)]
 pub enum ModifyMountTargetSecurityGroupsError {
@@ -1126,21 +1100,27 @@ impl ModifyMountTargetSecurityGroupsError {
 }
 impl fmt::Display for ModifyMountTargetSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyMountTargetSecurityGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyMountTargetSecurityGroupsError::BadRequest(ref cause) => cause,
-            ModifyMountTargetSecurityGroupsError::IncorrectMountTargetState(ref cause) => cause,
-            ModifyMountTargetSecurityGroupsError::InternalServerError(ref cause) => cause,
-            ModifyMountTargetSecurityGroupsError::MountTargetNotFound(ref cause) => cause,
-            ModifyMountTargetSecurityGroupsError::SecurityGroupLimitExceeded(ref cause) => cause,
-            ModifyMountTargetSecurityGroupsError::SecurityGroupNotFound(ref cause) => cause,
+            ModifyMountTargetSecurityGroupsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ModifyMountTargetSecurityGroupsError::IncorrectMountTargetState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyMountTargetSecurityGroupsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyMountTargetSecurityGroupsError::MountTargetNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyMountTargetSecurityGroupsError::SecurityGroupLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyMountTargetSecurityGroupsError::SecurityGroupNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyMountTargetSecurityGroupsError {}
 /// Errors returned by PutLifecycleConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutLifecycleConfigurationError {
@@ -1187,19 +1167,19 @@ impl PutLifecycleConfigurationError {
 }
 impl fmt::Display for PutLifecycleConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLifecycleConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutLifecycleConfigurationError::BadRequest(ref cause) => cause,
-            PutLifecycleConfigurationError::FileSystemNotFound(ref cause) => cause,
-            PutLifecycleConfigurationError::IncorrectFileSystemLifeCycleState(ref cause) => cause,
-            PutLifecycleConfigurationError::InternalServerError(ref cause) => cause,
+            PutLifecycleConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutLifecycleConfigurationError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            PutLifecycleConfigurationError::IncorrectFileSystemLifeCycleState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutLifecycleConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutLifecycleConfigurationError {}
 /// Errors returned by UpdateFileSystem
 #[derive(Debug, PartialEq)]
 pub enum UpdateFileSystemError {
@@ -1261,22 +1241,22 @@ impl UpdateFileSystemError {
 }
 impl fmt::Display for UpdateFileSystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFileSystemError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFileSystemError::BadRequest(ref cause) => cause,
-            UpdateFileSystemError::FileSystemNotFound(ref cause) => cause,
-            UpdateFileSystemError::IncorrectFileSystemLifeCycleState(ref cause) => cause,
-            UpdateFileSystemError::InsufficientThroughputCapacity(ref cause) => cause,
-            UpdateFileSystemError::InternalServerError(ref cause) => cause,
-            UpdateFileSystemError::ThroughputLimitExceeded(ref cause) => cause,
-            UpdateFileSystemError::TooManyRequests(ref cause) => cause,
+            UpdateFileSystemError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::IncorrectFileSystemLifeCycleState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateFileSystemError::InsufficientThroughputCapacity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateFileSystemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::ThroughputLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFileSystemError {}
 /// Trait representing the capabilities of the EFS API. EFS clients implement this trait.
 pub trait Efs {
     /// <p>Creates a new, empty file system. The operation requires a creation token in the request that Amazon EFS uses to ensure idempotent creation (calling the operation with same creation token has no effect). If a file system does not currently exist that is owned by the caller's AWS account with the specified creation token, this operation does the following:</p> <ul> <li> <p>Creates a new, empty file system. The file system will have an Amazon EFS assigned ID, and an initial lifecycle state <code>creating</code>.</p> </li> <li> <p>Returns with the description of the created file system.</p> </li> </ul> <p>Otherwise, this operation returns a <code>FileSystemAlreadyExists</code> error with the ID of the existing file system.</p> <note> <p>For basic use cases, you can use a randomly generated UUID for the creation token.</p> </note> <p> The idempotent operation allows you to retry a <code>CreateFileSystem</code> call without risk of creating an extra file system. This can happen when an initial call fails in a way that leaves it uncertain whether or not a file system was actually created. An example might be that a transport level timeout occurred or your connection was reset. As long as you use the same creation token, if the initial call had succeeded in creating a file system, the client can learn of its existence from the <code>FileSystemAlreadyExists</code> error.</p> <note> <p>The <code>CreateFileSystem</code> call returns while the file system's lifecycle state is still <code>creating</code>. You can check the file system creation status by calling the <a>DescribeFileSystems</a> operation, which among other things returns the file system state.</p> </note> <p>This operation also takes an optional <code>PerformanceMode</code> parameter that you choose for your file system. We recommend <code>generalPurpose</code> performance mode for most file systems. File systems using the <code>maxIO</code> performance mode can scale to higher levels of aggregate throughput and operations per second with a tradeoff of slightly higher latencies for most file operations. The performance mode can't be changed after the file system has been created. For more information, see <a href="https://docs.aws.amazon.com/efs/latest/ug/performance.html#performancemodes.html">Amazon EFS: Performance Modes</a>.</p> <p>After the file system is fully created, Amazon EFS sets its lifecycle state to <code>available</code>, at which point you can create one or more mount targets for the file system in your VPC. For more information, see <a>CreateMountTarget</a>. You mount your Amazon EFS file system on an EC2 instances in your VPC by using the mount target. For more information, see <a href="https://docs.aws.amazon.com/efs/latest/ug/how-it-works.html">Amazon EFS: How it Works</a>. </p> <p> This operation requires permissions for the <code>elasticfilesystem:CreateFileSystem</code> action. </p>

--- a/rusoto/services/eks/src/generated.rs
+++ b/rusoto/services/eks/src/generated.rs
@@ -1080,22 +1080,18 @@ impl CreateClusterError {
 }
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterError::Client(ref cause) => cause,
-            CreateClusterError::InvalidParameter(ref cause) => cause,
-            CreateClusterError::ResourceInUse(ref cause) => cause,
-            CreateClusterError::ResourceLimitExceeded(ref cause) => cause,
-            CreateClusterError::Server(ref cause) => cause,
-            CreateClusterError::ServiceUnavailable(ref cause) => cause,
-            CreateClusterError::UnsupportedAvailabilityZone(ref cause) => cause,
+            CreateClusterError::Client(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::Server(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::UnsupportedAvailabilityZone(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterError {}
 /// Errors returned by CreateFargateProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateFargateProfileError {
@@ -1150,21 +1146,19 @@ impl CreateFargateProfileError {
 }
 impl fmt::Display for CreateFargateProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFargateProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFargateProfileError::Client(ref cause) => cause,
-            CreateFargateProfileError::InvalidParameter(ref cause) => cause,
-            CreateFargateProfileError::InvalidRequest(ref cause) => cause,
-            CreateFargateProfileError::ResourceLimitExceeded(ref cause) => cause,
-            CreateFargateProfileError::Server(ref cause) => cause,
-            CreateFargateProfileError::UnsupportedAvailabilityZone(ref cause) => cause,
+            CreateFargateProfileError::Client(ref cause) => write!(f, "{}", cause),
+            CreateFargateProfileError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateFargateProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateFargateProfileError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateFargateProfileError::Server(ref cause) => write!(f, "{}", cause),
+            CreateFargateProfileError::UnsupportedAvailabilityZone(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateFargateProfileError {}
 /// Errors returned by CreateNodegroup
 #[derive(Debug, PartialEq)]
 pub enum CreateNodegroupError {
@@ -1220,22 +1214,18 @@ impl CreateNodegroupError {
 }
 impl fmt::Display for CreateNodegroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNodegroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNodegroupError::Client(ref cause) => cause,
-            CreateNodegroupError::InvalidParameter(ref cause) => cause,
-            CreateNodegroupError::InvalidRequest(ref cause) => cause,
-            CreateNodegroupError::ResourceInUse(ref cause) => cause,
-            CreateNodegroupError::ResourceLimitExceeded(ref cause) => cause,
-            CreateNodegroupError::Server(ref cause) => cause,
-            CreateNodegroupError::ServiceUnavailable(ref cause) => cause,
+            CreateNodegroupError::Client(ref cause) => write!(f, "{}", cause),
+            CreateNodegroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateNodegroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateNodegroupError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateNodegroupError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateNodegroupError::Server(ref cause) => write!(f, "{}", cause),
+            CreateNodegroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateNodegroupError {}
 /// Errors returned by DeleteCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterError {
@@ -1279,20 +1269,16 @@ impl DeleteClusterError {
 }
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterError::Client(ref cause) => cause,
-            DeleteClusterError::ResourceInUse(ref cause) => cause,
-            DeleteClusterError::ResourceNotFound(ref cause) => cause,
-            DeleteClusterError::Server(ref cause) => cause,
-            DeleteClusterError::ServiceUnavailable(ref cause) => cause,
+            DeleteClusterError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::Server(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClusterError {}
 /// Errors returned by DeleteFargateProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteFargateProfileError {
@@ -1335,19 +1321,15 @@ impl DeleteFargateProfileError {
 }
 impl fmt::Display for DeleteFargateProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFargateProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFargateProfileError::Client(ref cause) => cause,
-            DeleteFargateProfileError::InvalidParameter(ref cause) => cause,
-            DeleteFargateProfileError::ResourceNotFound(ref cause) => cause,
-            DeleteFargateProfileError::Server(ref cause) => cause,
+            DeleteFargateProfileError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteFargateProfileError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteFargateProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFargateProfileError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFargateProfileError {}
 /// Errors returned by DeleteNodegroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteNodegroupError {
@@ -1396,21 +1378,17 @@ impl DeleteNodegroupError {
 }
 impl fmt::Display for DeleteNodegroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNodegroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNodegroupError::Client(ref cause) => cause,
-            DeleteNodegroupError::InvalidParameter(ref cause) => cause,
-            DeleteNodegroupError::ResourceInUse(ref cause) => cause,
-            DeleteNodegroupError::ResourceNotFound(ref cause) => cause,
-            DeleteNodegroupError::Server(ref cause) => cause,
-            DeleteNodegroupError::ServiceUnavailable(ref cause) => cause,
+            DeleteNodegroupError::Client(ref cause) => write!(f, "{}", cause),
+            DeleteNodegroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteNodegroupError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteNodegroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteNodegroupError::Server(ref cause) => write!(f, "{}", cause),
+            DeleteNodegroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteNodegroupError {}
 /// Errors returned by DescribeCluster
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterError {
@@ -1449,19 +1427,15 @@ impl DescribeClusterError {
 }
 impl fmt::Display for DescribeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterError::Client(ref cause) => cause,
-            DescribeClusterError::ResourceNotFound(ref cause) => cause,
-            DescribeClusterError::Server(ref cause) => cause,
-            DescribeClusterError::ServiceUnavailable(ref cause) => cause,
+            DescribeClusterError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::Server(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterError {}
 /// Errors returned by DescribeFargateProfile
 #[derive(Debug, PartialEq)]
 pub enum DescribeFargateProfileError {
@@ -1504,19 +1478,15 @@ impl DescribeFargateProfileError {
 }
 impl fmt::Display for DescribeFargateProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFargateProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFargateProfileError::Client(ref cause) => cause,
-            DescribeFargateProfileError::InvalidParameter(ref cause) => cause,
-            DescribeFargateProfileError::ResourceNotFound(ref cause) => cause,
-            DescribeFargateProfileError::Server(ref cause) => cause,
+            DescribeFargateProfileError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeFargateProfileError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeFargateProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFargateProfileError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFargateProfileError {}
 /// Errors returned by DescribeNodegroup
 #[derive(Debug, PartialEq)]
 pub enum DescribeNodegroupError {
@@ -1562,20 +1532,16 @@ impl DescribeNodegroupError {
 }
 impl fmt::Display for DescribeNodegroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNodegroupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeNodegroupError::Client(ref cause) => cause,
-            DescribeNodegroupError::InvalidParameter(ref cause) => cause,
-            DescribeNodegroupError::ResourceNotFound(ref cause) => cause,
-            DescribeNodegroupError::Server(ref cause) => cause,
-            DescribeNodegroupError::ServiceUnavailable(ref cause) => cause,
+            DescribeNodegroupError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeNodegroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeNodegroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeNodegroupError::Server(ref cause) => write!(f, "{}", cause),
+            DescribeNodegroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeNodegroupError {}
 /// Errors returned by DescribeUpdate
 #[derive(Debug, PartialEq)]
 pub enum DescribeUpdateError {
@@ -1614,19 +1580,15 @@ impl DescribeUpdateError {
 }
 impl fmt::Display for DescribeUpdateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUpdateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUpdateError::Client(ref cause) => cause,
-            DescribeUpdateError::InvalidParameter(ref cause) => cause,
-            DescribeUpdateError::ResourceNotFound(ref cause) => cause,
-            DescribeUpdateError::Server(ref cause) => cause,
+            DescribeUpdateError::Client(ref cause) => write!(f, "{}", cause),
+            DescribeUpdateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUpdateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUpdateError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUpdateError {}
 /// Errors returned by ListClusters
 #[derive(Debug, PartialEq)]
 pub enum ListClustersError {
@@ -1665,19 +1627,15 @@ impl ListClustersError {
 }
 impl fmt::Display for ListClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClustersError {
-    fn description(&self) -> &str {
         match *self {
-            ListClustersError::Client(ref cause) => cause,
-            ListClustersError::InvalidParameter(ref cause) => cause,
-            ListClustersError::Server(ref cause) => cause,
-            ListClustersError::ServiceUnavailable(ref cause) => cause,
+            ListClustersError::Client(ref cause) => write!(f, "{}", cause),
+            ListClustersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListClustersError::Server(ref cause) => write!(f, "{}", cause),
+            ListClustersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListClustersError {}
 /// Errors returned by ListFargateProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListFargateProfilesError {
@@ -1720,19 +1678,15 @@ impl ListFargateProfilesError {
 }
 impl fmt::Display for ListFargateProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFargateProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListFargateProfilesError::Client(ref cause) => cause,
-            ListFargateProfilesError::InvalidParameter(ref cause) => cause,
-            ListFargateProfilesError::ResourceNotFound(ref cause) => cause,
-            ListFargateProfilesError::Server(ref cause) => cause,
+            ListFargateProfilesError::Client(ref cause) => write!(f, "{}", cause),
+            ListFargateProfilesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListFargateProfilesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListFargateProfilesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFargateProfilesError {}
 /// Errors returned by ListNodegroups
 #[derive(Debug, PartialEq)]
 pub enum ListNodegroupsError {
@@ -1776,20 +1730,16 @@ impl ListNodegroupsError {
 }
 impl fmt::Display for ListNodegroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListNodegroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListNodegroupsError::Client(ref cause) => cause,
-            ListNodegroupsError::InvalidParameter(ref cause) => cause,
-            ListNodegroupsError::ResourceNotFound(ref cause) => cause,
-            ListNodegroupsError::Server(ref cause) => cause,
-            ListNodegroupsError::ServiceUnavailable(ref cause) => cause,
+            ListNodegroupsError::Client(ref cause) => write!(f, "{}", cause),
+            ListNodegroupsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListNodegroupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListNodegroupsError::Server(ref cause) => write!(f, "{}", cause),
+            ListNodegroupsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListNodegroupsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1818,17 +1768,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::NotFound(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListUpdates
 #[derive(Debug, PartialEq)]
 pub enum ListUpdatesError {
@@ -1867,19 +1813,15 @@ impl ListUpdatesError {
 }
 impl fmt::Display for ListUpdatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUpdatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListUpdatesError::Client(ref cause) => cause,
-            ListUpdatesError::InvalidParameter(ref cause) => cause,
-            ListUpdatesError::ResourceNotFound(ref cause) => cause,
-            ListUpdatesError::Server(ref cause) => cause,
+            ListUpdatesError::Client(ref cause) => write!(f, "{}", cause),
+            ListUpdatesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUpdatesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUpdatesError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUpdatesError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1908,17 +1850,13 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1947,17 +1885,13 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateClusterConfig
 #[derive(Debug, PartialEq)]
 pub enum UpdateClusterConfigError {
@@ -2010,21 +1944,17 @@ impl UpdateClusterConfigError {
 }
 impl fmt::Display for UpdateClusterConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClusterConfigError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClusterConfigError::Client(ref cause) => cause,
-            UpdateClusterConfigError::InvalidParameter(ref cause) => cause,
-            UpdateClusterConfigError::InvalidRequest(ref cause) => cause,
-            UpdateClusterConfigError::ResourceInUse(ref cause) => cause,
-            UpdateClusterConfigError::ResourceNotFound(ref cause) => cause,
-            UpdateClusterConfigError::Server(ref cause) => cause,
+            UpdateClusterConfigError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClusterConfigError {}
 /// Errors returned by UpdateClusterVersion
 #[derive(Debug, PartialEq)]
 pub enum UpdateClusterVersionError {
@@ -2077,21 +2007,17 @@ impl UpdateClusterVersionError {
 }
 impl fmt::Display for UpdateClusterVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClusterVersionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClusterVersionError::Client(ref cause) => cause,
-            UpdateClusterVersionError::InvalidParameter(ref cause) => cause,
-            UpdateClusterVersionError::InvalidRequest(ref cause) => cause,
-            UpdateClusterVersionError::ResourceInUse(ref cause) => cause,
-            UpdateClusterVersionError::ResourceNotFound(ref cause) => cause,
-            UpdateClusterVersionError::Server(ref cause) => cause,
+            UpdateClusterVersionError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateClusterVersionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateClusterVersionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateClusterVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateClusterVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateClusterVersionError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClusterVersionError {}
 /// Errors returned by UpdateNodegroupConfig
 #[derive(Debug, PartialEq)]
 pub enum UpdateNodegroupConfigError {
@@ -2146,21 +2072,17 @@ impl UpdateNodegroupConfigError {
 }
 impl fmt::Display for UpdateNodegroupConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNodegroupConfigError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNodegroupConfigError::Client(ref cause) => cause,
-            UpdateNodegroupConfigError::InvalidParameter(ref cause) => cause,
-            UpdateNodegroupConfigError::InvalidRequest(ref cause) => cause,
-            UpdateNodegroupConfigError::ResourceInUse(ref cause) => cause,
-            UpdateNodegroupConfigError::ResourceNotFound(ref cause) => cause,
-            UpdateNodegroupConfigError::Server(ref cause) => cause,
+            UpdateNodegroupConfigError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupConfigError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupConfigError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupConfigError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupConfigError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupConfigError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNodegroupConfigError {}
 /// Errors returned by UpdateNodegroupVersion
 #[derive(Debug, PartialEq)]
 pub enum UpdateNodegroupVersionError {
@@ -2217,21 +2139,17 @@ impl UpdateNodegroupVersionError {
 }
 impl fmt::Display for UpdateNodegroupVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNodegroupVersionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNodegroupVersionError::Client(ref cause) => cause,
-            UpdateNodegroupVersionError::InvalidParameter(ref cause) => cause,
-            UpdateNodegroupVersionError::InvalidRequest(ref cause) => cause,
-            UpdateNodegroupVersionError::ResourceInUse(ref cause) => cause,
-            UpdateNodegroupVersionError::ResourceNotFound(ref cause) => cause,
-            UpdateNodegroupVersionError::Server(ref cause) => cause,
+            UpdateNodegroupVersionError::Client(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupVersionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupVersionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateNodegroupVersionError::Server(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNodegroupVersionError {}
 /// Trait representing the capabilities of the Amazon EKS API. Amazon EKS clients implement this trait.
 pub trait Eks {
     /// <p>Creates an Amazon EKS control plane. </p> <p>The Amazon EKS control plane consists of control plane instances that run the Kubernetes software, such as <code>etcd</code> and the API server. The control plane runs in an account managed by AWS, and the Kubernetes API is exposed via the Amazon EKS API server endpoint. Each Amazon EKS cluster control plane is single-tenant and unique and runs on its own set of Amazon EC2 instances.</p> <p>The cluster control plane is provisioned across multiple Availability Zones and fronted by an Elastic Load Balancing Network Load Balancer. Amazon EKS also provisions elastic network interfaces in your VPC subnets to provide connectivity from the control plane instances to the worker nodes (for example, to support <code>kubectl exec</code>, <code>logs</code>, and <code>proxy</code> data flows).</p> <p>Amazon EKS worker nodes run in your AWS account and connect to your cluster's control plane via the Kubernetes API server endpoint and a certificate file that is created for your cluster.</p> <p>You can use the <code>endpointPublicAccess</code> and <code>endpointPrivateAccess</code> parameters to enable or disable public and private access to your cluster's Kubernetes API server endpoint. By default, public access is enabled, and private access is disabled. For more information, see <a href="https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html">Amazon EKS Cluster Endpoint Access Control</a> in the <i> <i>Amazon EKS User Guide</i> </i>. </p> <p>You can use the <code>logging</code> parameter to enable or disable exporting the Kubernetes control plane logs for your cluster to CloudWatch Logs. By default, cluster control plane logs aren't exported to CloudWatch Logs. For more information, see <a href="https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html">Amazon EKS Cluster Control Plane Logs</a> in the <i> <i>Amazon EKS User Guide</i> </i>.</p> <note> <p>CloudWatch Logs ingestion, archive storage, and data scanning rates apply to exported control plane logs. For more information, see <a href="http://aws.amazon.com/cloudwatch/pricing/">Amazon CloudWatch Pricing</a>.</p> </note> <p>Cluster creation typically takes between 10 and 15 minutes. After you create an Amazon EKS cluster, you must configure your Kubernetes tooling to communicate with the API server and launch worker nodes into your cluster. For more information, see <a href="https://docs.aws.amazon.com/eks/latest/userguide/managing-auth.html">Managing Cluster Authentication</a> and <a href="https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html">Launching Amazon EKS Worker Nodes</a> in the <i>Amazon EKS User Guide</i>.</p>

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -7646,19 +7646,17 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::CacheClusterNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::InvalidARNFault(ref cause) => cause,
-            AddTagsToResourceError::SnapshotNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::TagQuotaPerResourceExceeded(ref cause) => cause,
+            AddTagsToResourceError::CacheClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::InvalidARNFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::SnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::TagQuotaPerResourceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by AuthorizeCacheSecurityGroupIngress
 #[derive(Debug, PartialEq)]
 pub enum AuthorizeCacheSecurityGroupIngressError {
@@ -7701,28 +7699,26 @@ impl AuthorizeCacheSecurityGroupIngressError {
 }
 impl fmt::Display for AuthorizeCacheSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AuthorizeCacheSecurityGroupIngressError {
-    fn description(&self) -> &str {
         match *self {
             AuthorizeCacheSecurityGroupIngressError::AuthorizationAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             AuthorizeCacheSecurityGroupIngressError::CacheSecurityGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             AuthorizeCacheSecurityGroupIngressError::InvalidCacheSecurityGroupStateFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             AuthorizeCacheSecurityGroupIngressError::InvalidParameterCombination(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            AuthorizeCacheSecurityGroupIngressError::InvalidParameterValue(ref cause) => cause,
+            AuthorizeCacheSecurityGroupIngressError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AuthorizeCacheSecurityGroupIngressError {}
 /// Errors returned by BatchApplyUpdateAction
 #[derive(Debug, PartialEq)]
 pub enum BatchApplyUpdateActionError {
@@ -7771,17 +7767,15 @@ impl BatchApplyUpdateActionError {
 }
 impl fmt::Display for BatchApplyUpdateActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchApplyUpdateActionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchApplyUpdateActionError::InvalidParameterValue(ref cause) => cause,
-            BatchApplyUpdateActionError::ServiceUpdateNotFoundFault(ref cause) => cause,
+            BatchApplyUpdateActionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            BatchApplyUpdateActionError::ServiceUpdateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchApplyUpdateActionError {}
 /// Errors returned by BatchStopUpdateAction
 #[derive(Debug, PartialEq)]
 pub enum BatchStopUpdateActionError {
@@ -7828,17 +7822,15 @@ impl BatchStopUpdateActionError {
 }
 impl fmt::Display for BatchStopUpdateActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchStopUpdateActionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchStopUpdateActionError::InvalidParameterValue(ref cause) => cause,
-            BatchStopUpdateActionError::ServiceUpdateNotFoundFault(ref cause) => cause,
+            BatchStopUpdateActionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            BatchStopUpdateActionError::ServiceUpdateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchStopUpdateActionError {}
 /// Errors returned by CompleteMigration
 #[derive(Debug, PartialEq)]
 pub enum CompleteMigrationError {
@@ -7896,18 +7888,20 @@ impl CompleteMigrationError {
 }
 impl fmt::Display for CompleteMigrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CompleteMigrationError {
-    fn description(&self) -> &str {
         match *self {
-            CompleteMigrationError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            CompleteMigrationError::ReplicationGroupNotFoundFault(ref cause) => cause,
-            CompleteMigrationError::ReplicationGroupNotUnderMigrationFault(ref cause) => cause,
+            CompleteMigrationError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CompleteMigrationError::ReplicationGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CompleteMigrationError::ReplicationGroupNotUnderMigrationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CompleteMigrationError {}
 /// Errors returned by CopySnapshot
 #[derive(Debug, PartialEq)]
 pub enum CopySnapshotError {
@@ -7980,21 +7974,17 @@ impl CopySnapshotError {
 }
 impl fmt::Display for CopySnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopySnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CopySnapshotError::InvalidParameterCombination(ref cause) => cause,
-            CopySnapshotError::InvalidParameterValue(ref cause) => cause,
-            CopySnapshotError::InvalidSnapshotStateFault(ref cause) => cause,
-            CopySnapshotError::SnapshotAlreadyExistsFault(ref cause) => cause,
-            CopySnapshotError::SnapshotNotFoundFault(ref cause) => cause,
-            CopySnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CopySnapshotError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::InvalidSnapshotStateFault(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::SnapshotAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::SnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopySnapshotError {}
 /// Errors returned by CreateCacheCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateCacheClusterError {
@@ -8149,29 +8139,51 @@ impl CreateCacheClusterError {
 }
 impl fmt::Display for CreateCacheClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCacheClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCacheClusterError::CacheClusterAlreadyExistsFault(ref cause) => cause,
-            CreateCacheClusterError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            CreateCacheClusterError::CacheSecurityGroupNotFoundFault(ref cause) => cause,
-            CreateCacheClusterError::CacheSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateCacheClusterError::ClusterQuotaForCustomerExceededFault(ref cause) => cause,
-            CreateCacheClusterError::InsufficientCacheClusterCapacityFault(ref cause) => cause,
-            CreateCacheClusterError::InvalidParameterCombination(ref cause) => cause,
-            CreateCacheClusterError::InvalidParameterValue(ref cause) => cause,
-            CreateCacheClusterError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            CreateCacheClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateCacheClusterError::NodeQuotaForClusterExceededFault(ref cause) => cause,
-            CreateCacheClusterError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-            CreateCacheClusterError::ReplicationGroupNotFoundFault(ref cause) => cause,
-            CreateCacheClusterError::TagQuotaPerResourceExceeded(ref cause) => cause,
+            CreateCacheClusterError::CacheClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::CacheSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::CacheSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::ClusterQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::InsufficientCacheClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateCacheClusterError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::NodeQuotaForClusterExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::ReplicationGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheClusterError::TagQuotaPerResourceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCacheClusterError {}
 /// Errors returned by CreateCacheParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateCacheParameterGroupError {
@@ -8247,26 +8259,26 @@ impl CreateCacheParameterGroupError {
 }
 impl fmt::Display for CreateCacheParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCacheParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CreateCacheParameterGroupError::CacheParameterGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateCacheParameterGroupError::CacheParameterGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateCacheParameterGroupError::InvalidCacheParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateCacheParameterGroupError::InvalidParameterCombination(ref cause) => cause,
-            CreateCacheParameterGroupError::InvalidParameterValue(ref cause) => cause,
+            CreateCacheParameterGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheParameterGroupError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCacheParameterGroupError {}
 /// Errors returned by CreateCacheSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateCacheSecurityGroupError {
@@ -8333,19 +8345,23 @@ impl CreateCacheSecurityGroupError {
 }
 impl fmt::Display for CreateCacheSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCacheSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCacheSecurityGroupError::CacheSecurityGroupAlreadyExistsFault(ref cause) => cause,
-            CreateCacheSecurityGroupError::CacheSecurityGroupQuotaExceededFault(ref cause) => cause,
-            CreateCacheSecurityGroupError::InvalidParameterCombination(ref cause) => cause,
-            CreateCacheSecurityGroupError::InvalidParameterValue(ref cause) => cause,
+            CreateCacheSecurityGroupError::CacheSecurityGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheSecurityGroupError::CacheSecurityGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheSecurityGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheSecurityGroupError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCacheSecurityGroupError {}
 /// Errors returned by CreateCacheSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateCacheSubnetGroupError {
@@ -8410,19 +8426,21 @@ impl CreateCacheSubnetGroupError {
 }
 impl fmt::Display for CreateCacheSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCacheSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCacheSubnetGroupError::CacheSubnetGroupAlreadyExistsFault(ref cause) => cause,
-            CreateCacheSubnetGroupError::CacheSubnetGroupQuotaExceededFault(ref cause) => cause,
-            CreateCacheSubnetGroupError::CacheSubnetQuotaExceededFault(ref cause) => cause,
-            CreateCacheSubnetGroupError::InvalidSubnet(ref cause) => cause,
+            CreateCacheSubnetGroupError::CacheSubnetGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheSubnetGroupError::CacheSubnetGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheSubnetGroupError::CacheSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCacheSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCacheSubnetGroupError {}
 /// Errors returned by CreateReplicationGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateReplicationGroupError {
@@ -8483,32 +8501,54 @@ impl CreateReplicationGroupError {
 }
 impl fmt::Display for CreateReplicationGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReplicationGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReplicationGroupError::CacheClusterNotFoundFault(ref cause) => cause,
-            CreateReplicationGroupError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            CreateReplicationGroupError::CacheSecurityGroupNotFoundFault(ref cause) => cause,
-            CreateReplicationGroupError::CacheSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateReplicationGroupError::ClusterQuotaForCustomerExceededFault(ref cause) => cause,
-            CreateReplicationGroupError::InsufficientCacheClusterCapacityFault(ref cause) => cause,
-            CreateReplicationGroupError::InvalidCacheClusterStateFault(ref cause) => cause,
-            CreateReplicationGroupError::InvalidParameterCombination(ref cause) => cause,
-            CreateReplicationGroupError::InvalidParameterValue(ref cause) => cause,
-            CreateReplicationGroupError::InvalidVPCNetworkStateFault(ref cause) => cause,
+            CreateReplicationGroupError::CacheClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::CacheSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::CacheSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::ClusterQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::InsufficientCacheClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::InvalidCacheClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateReplicationGroupError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateReplicationGroupError::NodeGroupsPerReplicationGroupQuotaExceededFault(
                 ref cause,
-            ) => cause,
-            CreateReplicationGroupError::NodeQuotaForClusterExceededFault(ref cause) => cause,
-            CreateReplicationGroupError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-            CreateReplicationGroupError::ReplicationGroupAlreadyExistsFault(ref cause) => cause,
-            CreateReplicationGroupError::TagQuotaPerResourceExceeded(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            CreateReplicationGroupError::NodeQuotaForClusterExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::ReplicationGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationGroupError::TagQuotaPerResourceExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateReplicationGroupError {}
 /// Errors returned by CreateSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateSnapshotError {
@@ -8610,24 +8650,24 @@ impl CreateSnapshotError {
 }
 impl fmt::Display for CreateSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSnapshotError::CacheClusterNotFoundFault(ref cause) => cause,
-            CreateSnapshotError::InvalidCacheClusterStateFault(ref cause) => cause,
-            CreateSnapshotError::InvalidParameterCombination(ref cause) => cause,
-            CreateSnapshotError::InvalidParameterValue(ref cause) => cause,
-            CreateSnapshotError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            CreateSnapshotError::ReplicationGroupNotFoundFault(ref cause) => cause,
-            CreateSnapshotError::SnapshotAlreadyExistsFault(ref cause) => cause,
-            CreateSnapshotError::SnapshotFeatureNotSupportedFault(ref cause) => cause,
-            CreateSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CreateSnapshotError::CacheClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::InvalidCacheClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotError::ReplicationGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::SnapshotAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::SnapshotFeatureNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSnapshotError {}
 /// Errors returned by DecreaseReplicaCount
 #[derive(Debug, PartialEq)]
 pub enum DecreaseReplicaCountError {
@@ -8760,29 +8800,43 @@ impl DecreaseReplicaCountError {
 }
 impl fmt::Display for DecreaseReplicaCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DecreaseReplicaCountError {
-    fn description(&self) -> &str {
         match *self {
-            DecreaseReplicaCountError::ClusterQuotaForCustomerExceededFault(ref cause) => cause,
-            DecreaseReplicaCountError::InsufficientCacheClusterCapacityFault(ref cause) => cause,
-            DecreaseReplicaCountError::InvalidCacheClusterStateFault(ref cause) => cause,
-            DecreaseReplicaCountError::InvalidParameterCombination(ref cause) => cause,
-            DecreaseReplicaCountError::InvalidParameterValue(ref cause) => cause,
-            DecreaseReplicaCountError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            DecreaseReplicaCountError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            DecreaseReplicaCountError::NoOperationFault(ref cause) => cause,
+            DecreaseReplicaCountError::ClusterQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::InsufficientCacheClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::InvalidCacheClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DecreaseReplicaCountError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::NoOperationFault(ref cause) => write!(f, "{}", cause),
             DecreaseReplicaCountError::NodeGroupsPerReplicationGroupQuotaExceededFault(
                 ref cause,
-            ) => cause,
-            DecreaseReplicaCountError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-            DecreaseReplicaCountError::ReplicationGroupNotFoundFault(ref cause) => cause,
-            DecreaseReplicaCountError::ServiceLinkedRoleNotFoundFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DecreaseReplicaCountError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::ReplicationGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseReplicaCountError::ServiceLinkedRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DecreaseReplicaCountError {}
 /// Errors returned by DeleteCacheCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteCacheClusterError {
@@ -8874,22 +8928,28 @@ impl DeleteCacheClusterError {
 }
 impl fmt::Display for DeleteCacheClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCacheClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCacheClusterError::CacheClusterNotFoundFault(ref cause) => cause,
-            DeleteCacheClusterError::InvalidCacheClusterStateFault(ref cause) => cause,
-            DeleteCacheClusterError::InvalidParameterCombination(ref cause) => cause,
-            DeleteCacheClusterError::InvalidParameterValue(ref cause) => cause,
-            DeleteCacheClusterError::SnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteCacheClusterError::SnapshotFeatureNotSupportedFault(ref cause) => cause,
-            DeleteCacheClusterError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteCacheClusterError::CacheClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteCacheClusterError::InvalidCacheClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheClusterError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheClusterError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteCacheClusterError::SnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheClusterError::SnapshotFeatureNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheClusterError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCacheClusterError {}
 /// Errors returned by DeleteCacheParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteCacheParameterGroupError {
@@ -8956,21 +9016,23 @@ impl DeleteCacheParameterGroupError {
 }
 impl fmt::Display for DeleteCacheParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCacheParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCacheParameterGroupError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            DeleteCacheParameterGroupError::InvalidCacheParameterGroupStateFault(ref cause) => {
-                cause
+            DeleteCacheParameterGroupError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            DeleteCacheParameterGroupError::InvalidParameterCombination(ref cause) => cause,
-            DeleteCacheParameterGroupError::InvalidParameterValue(ref cause) => cause,
+            DeleteCacheParameterGroupError::InvalidCacheParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheParameterGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheParameterGroupError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCacheParameterGroupError {}
 /// Errors returned by DeleteCacheSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteCacheSecurityGroupError {
@@ -9037,19 +9099,23 @@ impl DeleteCacheSecurityGroupError {
 }
 impl fmt::Display for DeleteCacheSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCacheSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCacheSecurityGroupError::CacheSecurityGroupNotFoundFault(ref cause) => cause,
-            DeleteCacheSecurityGroupError::InvalidCacheSecurityGroupStateFault(ref cause) => cause,
-            DeleteCacheSecurityGroupError::InvalidParameterCombination(ref cause) => cause,
-            DeleteCacheSecurityGroupError::InvalidParameterValue(ref cause) => cause,
+            DeleteCacheSecurityGroupError::CacheSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheSecurityGroupError::InvalidCacheSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheSecurityGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCacheSecurityGroupError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCacheSecurityGroupError {}
 /// Errors returned by DeleteCacheSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteCacheSubnetGroupError {
@@ -9098,17 +9164,15 @@ impl DeleteCacheSubnetGroupError {
 }
 impl fmt::Display for DeleteCacheSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCacheSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCacheSubnetGroupError::CacheSubnetGroupInUse(ref cause) => cause,
-            DeleteCacheSubnetGroupError::CacheSubnetGroupNotFoundFault(ref cause) => cause,
+            DeleteCacheSubnetGroupError::CacheSubnetGroupInUse(ref cause) => write!(f, "{}", cause),
+            DeleteCacheSubnetGroupError::CacheSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCacheSubnetGroupError {}
 /// Errors returned by DeleteReplicationGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteReplicationGroupError {
@@ -9202,22 +9266,30 @@ impl DeleteReplicationGroupError {
 }
 impl fmt::Display for DeleteReplicationGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReplicationGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReplicationGroupError::InvalidParameterCombination(ref cause) => cause,
-            DeleteReplicationGroupError::InvalidParameterValue(ref cause) => cause,
-            DeleteReplicationGroupError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            DeleteReplicationGroupError::ReplicationGroupNotFoundFault(ref cause) => cause,
-            DeleteReplicationGroupError::SnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteReplicationGroupError::SnapshotFeatureNotSupportedFault(ref cause) => cause,
-            DeleteReplicationGroupError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteReplicationGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationGroupError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteReplicationGroupError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationGroupError::ReplicationGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationGroupError::SnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationGroupError::SnapshotFeatureNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationGroupError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteReplicationGroupError {}
 /// Errors returned by DeleteSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteSnapshotError {
@@ -9276,19 +9348,15 @@ impl DeleteSnapshotError {
 }
 impl fmt::Display for DeleteSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSnapshotError::InvalidParameterCombination(ref cause) => cause,
-            DeleteSnapshotError::InvalidParameterValue(ref cause) => cause,
-            DeleteSnapshotError::InvalidSnapshotStateFault(ref cause) => cause,
-            DeleteSnapshotError::SnapshotNotFoundFault(ref cause) => cause,
+            DeleteSnapshotError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            DeleteSnapshotError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteSnapshotError::InvalidSnapshotStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteSnapshotError::SnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSnapshotError {}
 /// Errors returned by DescribeCacheClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeCacheClustersError {
@@ -9344,18 +9412,18 @@ impl DescribeCacheClustersError {
 }
 impl fmt::Display for DescribeCacheClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCacheClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCacheClustersError::CacheClusterNotFoundFault(ref cause) => cause,
-            DescribeCacheClustersError::InvalidParameterCombination(ref cause) => cause,
-            DescribeCacheClustersError::InvalidParameterValue(ref cause) => cause,
+            DescribeCacheClustersError::CacheClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheClustersError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheClustersError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCacheClustersError {}
 /// Errors returned by DescribeCacheEngineVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeCacheEngineVersionsError {}
@@ -9387,14 +9455,10 @@ impl DescribeCacheEngineVersionsError {
 }
 impl fmt::Display for DescribeCacheEngineVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCacheEngineVersionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeCacheEngineVersionsError {}
 /// Errors returned by DescribeCacheParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeCacheParameterGroupsError {
@@ -9454,18 +9518,20 @@ impl DescribeCacheParameterGroupsError {
 }
 impl fmt::Display for DescribeCacheParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCacheParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCacheParameterGroupsError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            DescribeCacheParameterGroupsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeCacheParameterGroupsError::InvalidParameterValue(ref cause) => cause,
+            DescribeCacheParameterGroupsError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheParameterGroupsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheParameterGroupsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCacheParameterGroupsError {}
 /// Errors returned by DescribeCacheParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeCacheParametersError {
@@ -9523,18 +9589,20 @@ impl DescribeCacheParametersError {
 }
 impl fmt::Display for DescribeCacheParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCacheParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCacheParametersError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            DescribeCacheParametersError::InvalidParameterCombination(ref cause) => cause,
-            DescribeCacheParametersError::InvalidParameterValue(ref cause) => cause,
+            DescribeCacheParametersError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheParametersError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheParametersError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCacheParametersError {}
 /// Errors returned by DescribeCacheSecurityGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeCacheSecurityGroupsError {
@@ -9594,18 +9662,20 @@ impl DescribeCacheSecurityGroupsError {
 }
 impl fmt::Display for DescribeCacheSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCacheSecurityGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCacheSecurityGroupsError::CacheSecurityGroupNotFoundFault(ref cause) => cause,
-            DescribeCacheSecurityGroupsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeCacheSecurityGroupsError::InvalidParameterValue(ref cause) => cause,
+            DescribeCacheSecurityGroupsError::CacheSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheSecurityGroupsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCacheSecurityGroupsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCacheSecurityGroupsError {}
 /// Errors returned by DescribeCacheSubnetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeCacheSubnetGroupsError {
@@ -9645,16 +9715,14 @@ impl DescribeCacheSubnetGroupsError {
 }
 impl fmt::Display for DescribeCacheSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCacheSubnetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCacheSubnetGroupsError::CacheSubnetGroupNotFoundFault(ref cause) => cause,
+            DescribeCacheSubnetGroupsError::CacheSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCacheSubnetGroupsError {}
 /// Errors returned by DescribeEngineDefaultParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeEngineDefaultParametersError {
@@ -9705,17 +9773,17 @@ impl DescribeEngineDefaultParametersError {
 }
 impl fmt::Display for DescribeEngineDefaultParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEngineDefaultParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEngineDefaultParametersError::InvalidParameterCombination(ref cause) => cause,
-            DescribeEngineDefaultParametersError::InvalidParameterValue(ref cause) => cause,
+            DescribeEngineDefaultParametersError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEngineDefaultParametersError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEngineDefaultParametersError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {
@@ -9760,17 +9828,13 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeEventsError::InvalidParameterValue(ref cause) => cause,
+            DescribeEventsError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            DescribeEventsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeReplicationGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeReplicationGroupsError {
@@ -9828,18 +9892,20 @@ impl DescribeReplicationGroupsError {
 }
 impl fmt::Display for DescribeReplicationGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReplicationGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReplicationGroupsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeReplicationGroupsError::InvalidParameterValue(ref cause) => cause,
-            DescribeReplicationGroupsError::ReplicationGroupNotFoundFault(ref cause) => cause,
+            DescribeReplicationGroupsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeReplicationGroupsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeReplicationGroupsError::ReplicationGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReplicationGroupsError {}
 /// Errors returned by DescribeReservedCacheNodes
 #[derive(Debug, PartialEq)]
 pub enum DescribeReservedCacheNodesError {
@@ -9899,18 +9965,20 @@ impl DescribeReservedCacheNodesError {
 }
 impl fmt::Display for DescribeReservedCacheNodesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReservedCacheNodesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReservedCacheNodesError::InvalidParameterCombination(ref cause) => cause,
-            DescribeReservedCacheNodesError::InvalidParameterValue(ref cause) => cause,
-            DescribeReservedCacheNodesError::ReservedCacheNodeNotFoundFault(ref cause) => cause,
+            DescribeReservedCacheNodesError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeReservedCacheNodesError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeReservedCacheNodesError::ReservedCacheNodeNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReservedCacheNodesError {}
 /// Errors returned by DescribeReservedCacheNodesOfferings
 #[derive(Debug, PartialEq)]
 pub enum DescribeReservedCacheNodesOfferingsError {
@@ -9949,22 +10017,20 @@ impl DescribeReservedCacheNodesOfferingsError {
 }
 impl fmt::Display for DescribeReservedCacheNodesOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReservedCacheNodesOfferingsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeReservedCacheNodesOfferingsError::InvalidParameterCombination(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DescribeReservedCacheNodesOfferingsError::InvalidParameterValue(ref cause) => cause,
+            DescribeReservedCacheNodesOfferingsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeReservedCacheNodesOfferingsError::ReservedCacheNodesOfferingNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeReservedCacheNodesOfferingsError {}
 /// Errors returned by DescribeServiceUpdates
 #[derive(Debug, PartialEq)]
 pub enum DescribeServiceUpdatesError {
@@ -10022,18 +10088,18 @@ impl DescribeServiceUpdatesError {
 }
 impl fmt::Display for DescribeServiceUpdatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServiceUpdatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServiceUpdatesError::InvalidParameterCombination(ref cause) => cause,
-            DescribeServiceUpdatesError::InvalidParameterValue(ref cause) => cause,
-            DescribeServiceUpdatesError::ServiceUpdateNotFoundFault(ref cause) => cause,
+            DescribeServiceUpdatesError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeServiceUpdatesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeServiceUpdatesError::ServiceUpdateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeServiceUpdatesError {}
 /// Errors returned by DescribeSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeSnapshotsError {
@@ -10094,19 +10160,17 @@ impl DescribeSnapshotsError {
 }
 impl fmt::Display for DescribeSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSnapshotsError::CacheClusterNotFoundFault(ref cause) => cause,
-            DescribeSnapshotsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeSnapshotsError::InvalidParameterValue(ref cause) => cause,
-            DescribeSnapshotsError::SnapshotNotFoundFault(ref cause) => cause,
+            DescribeSnapshotsError::CacheClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeSnapshotsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotsError::SnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSnapshotsError {}
 /// Errors returned by DescribeUpdateActions
 #[derive(Debug, PartialEq)]
 pub enum DescribeUpdateActionsError {
@@ -10153,17 +10217,15 @@ impl DescribeUpdateActionsError {
 }
 impl fmt::Display for DescribeUpdateActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUpdateActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUpdateActionsError::InvalidParameterCombination(ref cause) => cause,
-            DescribeUpdateActionsError::InvalidParameterValue(ref cause) => cause,
+            DescribeUpdateActionsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeUpdateActionsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUpdateActionsError {}
 /// Errors returned by IncreaseReplicaCount
 #[derive(Debug, PartialEq)]
 pub enum IncreaseReplicaCountError {
@@ -10294,29 +10356,41 @@ impl IncreaseReplicaCountError {
 }
 impl fmt::Display for IncreaseReplicaCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for IncreaseReplicaCountError {
-    fn description(&self) -> &str {
         match *self {
-            IncreaseReplicaCountError::ClusterQuotaForCustomerExceededFault(ref cause) => cause,
-            IncreaseReplicaCountError::InsufficientCacheClusterCapacityFault(ref cause) => cause,
-            IncreaseReplicaCountError::InvalidCacheClusterStateFault(ref cause) => cause,
-            IncreaseReplicaCountError::InvalidKMSKeyFault(ref cause) => cause,
-            IncreaseReplicaCountError::InvalidParameterCombination(ref cause) => cause,
-            IncreaseReplicaCountError::InvalidParameterValue(ref cause) => cause,
-            IncreaseReplicaCountError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            IncreaseReplicaCountError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            IncreaseReplicaCountError::NoOperationFault(ref cause) => cause,
+            IncreaseReplicaCountError::ClusterQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicaCountError::InsufficientCacheClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicaCountError::InvalidCacheClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicaCountError::InvalidKMSKeyFault(ref cause) => write!(f, "{}", cause),
+            IncreaseReplicaCountError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicaCountError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            IncreaseReplicaCountError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicaCountError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicaCountError::NoOperationFault(ref cause) => write!(f, "{}", cause),
             IncreaseReplicaCountError::NodeGroupsPerReplicationGroupQuotaExceededFault(
                 ref cause,
-            ) => cause,
-            IncreaseReplicaCountError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-            IncreaseReplicaCountError::ReplicationGroupNotFoundFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            IncreaseReplicaCountError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseReplicaCountError::ReplicationGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for IncreaseReplicaCountError {}
 /// Errors returned by ListAllowedNodeTypeModifications
 #[derive(Debug, PartialEq)]
 pub enum ListAllowedNodeTypeModificationsError {
@@ -10385,21 +10459,23 @@ impl ListAllowedNodeTypeModificationsError {
 }
 impl fmt::Display for ListAllowedNodeTypeModificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAllowedNodeTypeModificationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAllowedNodeTypeModificationsError::CacheClusterNotFoundFault(ref cause) => cause,
-            ListAllowedNodeTypeModificationsError::InvalidParameterCombination(ref cause) => cause,
-            ListAllowedNodeTypeModificationsError::InvalidParameterValue(ref cause) => cause,
+            ListAllowedNodeTypeModificationsError::CacheClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAllowedNodeTypeModificationsError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAllowedNodeTypeModificationsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ListAllowedNodeTypeModificationsError::ReplicationGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ListAllowedNodeTypeModificationsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -10453,18 +10529,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::CacheClusterNotFoundFault(ref cause) => cause,
-            ListTagsForResourceError::InvalidARNFault(ref cause) => cause,
-            ListTagsForResourceError::SnapshotNotFoundFault(ref cause) => cause,
+            ListTagsForResourceError::CacheClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTagsForResourceError::InvalidARNFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::SnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ModifyCacheCluster
 #[derive(Debug, PartialEq)]
 pub enum ModifyCacheClusterError {
@@ -10592,26 +10666,40 @@ impl ModifyCacheClusterError {
 }
 impl fmt::Display for ModifyCacheClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyCacheClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyCacheClusterError::CacheClusterNotFoundFault(ref cause) => cause,
-            ModifyCacheClusterError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyCacheClusterError::CacheSecurityGroupNotFoundFault(ref cause) => cause,
-            ModifyCacheClusterError::InsufficientCacheClusterCapacityFault(ref cause) => cause,
-            ModifyCacheClusterError::InvalidCacheClusterStateFault(ref cause) => cause,
-            ModifyCacheClusterError::InvalidCacheSecurityGroupStateFault(ref cause) => cause,
-            ModifyCacheClusterError::InvalidParameterCombination(ref cause) => cause,
-            ModifyCacheClusterError::InvalidParameterValue(ref cause) => cause,
-            ModifyCacheClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyCacheClusterError::NodeQuotaForClusterExceededFault(ref cause) => cause,
-            ModifyCacheClusterError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
+            ModifyCacheClusterError::CacheClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyCacheClusterError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::CacheSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::InsufficientCacheClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::InvalidCacheClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::InvalidCacheSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ModifyCacheClusterError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::NodeQuotaForClusterExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheClusterError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyCacheClusterError {}
 /// Errors returned by ModifyCacheParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyCacheParameterGroupError {
@@ -10678,21 +10766,23 @@ impl ModifyCacheParameterGroupError {
 }
 impl fmt::Display for ModifyCacheParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyCacheParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyCacheParameterGroupError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyCacheParameterGroupError::InvalidCacheParameterGroupStateFault(ref cause) => {
-                cause
+            ModifyCacheParameterGroupError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            ModifyCacheParameterGroupError::InvalidParameterCombination(ref cause) => cause,
-            ModifyCacheParameterGroupError::InvalidParameterValue(ref cause) => cause,
+            ModifyCacheParameterGroupError::InvalidCacheParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheParameterGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheParameterGroupError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyCacheParameterGroupError {}
 /// Errors returned by ModifyCacheSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyCacheSubnetGroupError {
@@ -10755,19 +10845,19 @@ impl ModifyCacheSubnetGroupError {
 }
 impl fmt::Display for ModifyCacheSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyCacheSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyCacheSubnetGroupError::CacheSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyCacheSubnetGroupError::CacheSubnetQuotaExceededFault(ref cause) => cause,
-            ModifyCacheSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            ModifyCacheSubnetGroupError::SubnetInUse(ref cause) => cause,
+            ModifyCacheSubnetGroupError::CacheSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheSubnetGroupError::CacheSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCacheSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyCacheSubnetGroupError::SubnetInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyCacheSubnetGroupError {}
 /// Errors returned by ModifyReplicationGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyReplicationGroupError {
@@ -10922,29 +11012,49 @@ impl ModifyReplicationGroupError {
 }
 impl fmt::Display for ModifyReplicationGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyReplicationGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyReplicationGroupError::CacheClusterNotFoundFault(ref cause) => cause,
-            ModifyReplicationGroupError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyReplicationGroupError::CacheSecurityGroupNotFoundFault(ref cause) => cause,
-            ModifyReplicationGroupError::InsufficientCacheClusterCapacityFault(ref cause) => cause,
-            ModifyReplicationGroupError::InvalidCacheClusterStateFault(ref cause) => cause,
-            ModifyReplicationGroupError::InvalidCacheSecurityGroupStateFault(ref cause) => cause,
-            ModifyReplicationGroupError::InvalidKMSKeyFault(ref cause) => cause,
-            ModifyReplicationGroupError::InvalidParameterCombination(ref cause) => cause,
-            ModifyReplicationGroupError::InvalidParameterValue(ref cause) => cause,
-            ModifyReplicationGroupError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            ModifyReplicationGroupError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyReplicationGroupError::NodeQuotaForClusterExceededFault(ref cause) => cause,
-            ModifyReplicationGroupError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-            ModifyReplicationGroupError::ReplicationGroupNotFoundFault(ref cause) => cause,
+            ModifyReplicationGroupError::CacheClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::CacheSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::InsufficientCacheClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::InvalidCacheClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::InvalidCacheSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::InvalidKMSKeyFault(ref cause) => write!(f, "{}", cause),
+            ModifyReplicationGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ModifyReplicationGroupError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::NodeQuotaForClusterExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::NodeQuotaForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyReplicationGroupError::ReplicationGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyReplicationGroupError {}
 /// Errors returned by ModifyReplicationGroupShardConfiguration
 #[derive(Debug, PartialEq)]
 pub enum ModifyReplicationGroupShardConfigurationError {
@@ -10997,25 +11107,21 @@ impl ModifyReplicationGroupShardConfigurationError {
 }
 impl fmt::Display for ModifyReplicationGroupShardConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyReplicationGroupShardConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-                            ModifyReplicationGroupShardConfigurationError::InsufficientCacheClusterCapacityFault(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::InvalidCacheClusterStateFault(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::InvalidKMSKeyFault(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::InvalidParameterCombination(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::InvalidParameterValue(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::InvalidReplicationGroupStateFault(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::InvalidVPCNetworkStateFault(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::NodeGroupsPerReplicationGroupQuotaExceededFault(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::NodeQuotaForCustomerExceededFault(ref cause) => cause,
-ModifyReplicationGroupShardConfigurationError::ReplicationGroupNotFoundFault(ref cause) => cause
+                            ModifyReplicationGroupShardConfigurationError::InsufficientCacheClusterCapacityFault(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::InvalidCacheClusterStateFault(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::InvalidKMSKeyFault(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::InvalidReplicationGroupStateFault(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::NodeGroupsPerReplicationGroupQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::NodeQuotaForCustomerExceededFault(ref cause) => write!(f, "{}", cause),
+ModifyReplicationGroupShardConfigurationError::ReplicationGroupNotFoundFault(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for ModifyReplicationGroupShardConfigurationError {}
 /// Errors returned by PurchaseReservedCacheNodesOffering
 #[derive(Debug, PartialEq)]
 pub enum PurchaseReservedCacheNodesOfferingError {
@@ -11058,28 +11164,26 @@ impl PurchaseReservedCacheNodesOfferingError {
 }
 impl fmt::Display for PurchaseReservedCacheNodesOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PurchaseReservedCacheNodesOfferingError {
-    fn description(&self) -> &str {
         match *self {
             PurchaseReservedCacheNodesOfferingError::InvalidParameterCombination(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            PurchaseReservedCacheNodesOfferingError::InvalidParameterValue(ref cause) => cause,
+            PurchaseReservedCacheNodesOfferingError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeAlreadyExistsFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeQuotaExceededFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             PurchaseReservedCacheNodesOfferingError::ReservedCacheNodesOfferingNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PurchaseReservedCacheNodesOfferingError {}
 /// Errors returned by RebootCacheCluster
 #[derive(Debug, PartialEq)]
 pub enum RebootCacheClusterError {
@@ -11128,17 +11232,15 @@ impl RebootCacheClusterError {
 }
 impl fmt::Display for RebootCacheClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootCacheClusterError {
-    fn description(&self) -> &str {
         match *self {
-            RebootCacheClusterError::CacheClusterNotFoundFault(ref cause) => cause,
-            RebootCacheClusterError::InvalidCacheClusterStateFault(ref cause) => cause,
+            RebootCacheClusterError::CacheClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RebootCacheClusterError::InvalidCacheClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RebootCacheClusterError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -11201,19 +11303,17 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::CacheClusterNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::InvalidARNFault(ref cause) => cause,
-            RemoveTagsFromResourceError::SnapshotNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::TagNotFoundFault(ref cause) => cause,
+            RemoveTagsFromResourceError::CacheClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromResourceError::InvalidARNFault(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::SnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::TagNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by ResetCacheParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ResetCacheParameterGroupError {
@@ -11280,19 +11380,23 @@ impl ResetCacheParameterGroupError {
 }
 impl fmt::Display for ResetCacheParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetCacheParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ResetCacheParameterGroupError::CacheParameterGroupNotFoundFault(ref cause) => cause,
-            ResetCacheParameterGroupError::InvalidCacheParameterGroupStateFault(ref cause) => cause,
-            ResetCacheParameterGroupError::InvalidParameterCombination(ref cause) => cause,
-            ResetCacheParameterGroupError::InvalidParameterValue(ref cause) => cause,
+            ResetCacheParameterGroupError::CacheParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResetCacheParameterGroupError::InvalidCacheParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResetCacheParameterGroupError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResetCacheParameterGroupError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ResetCacheParameterGroupError {}
 /// Errors returned by RevokeCacheSecurityGroupIngress
 #[derive(Debug, PartialEq)]
 pub enum RevokeCacheSecurityGroupIngressError {
@@ -11368,24 +11472,26 @@ impl RevokeCacheSecurityGroupIngressError {
 }
 impl fmt::Display for RevokeCacheSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeCacheSecurityGroupIngressError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeCacheSecurityGroupIngressError::AuthorizationNotFoundFault(ref cause) => cause,
+            RevokeCacheSecurityGroupIngressError::AuthorizationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RevokeCacheSecurityGroupIngressError::CacheSecurityGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RevokeCacheSecurityGroupIngressError::InvalidCacheSecurityGroupStateFault(
                 ref cause,
-            ) => cause,
-            RevokeCacheSecurityGroupIngressError::InvalidParameterCombination(ref cause) => cause,
-            RevokeCacheSecurityGroupIngressError::InvalidParameterValue(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            RevokeCacheSecurityGroupIngressError::InvalidParameterCombination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RevokeCacheSecurityGroupIngressError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RevokeCacheSecurityGroupIngressError {}
 /// Errors returned by StartMigration
 #[derive(Debug, PartialEq)]
 pub enum StartMigrationError {
@@ -11450,19 +11556,19 @@ impl StartMigrationError {
 }
 impl fmt::Display for StartMigrationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMigrationError {
-    fn description(&self) -> &str {
         match *self {
-            StartMigrationError::InvalidParameterValue(ref cause) => cause,
-            StartMigrationError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            StartMigrationError::ReplicationGroupAlreadyUnderMigrationFault(ref cause) => cause,
-            StartMigrationError::ReplicationGroupNotFoundFault(ref cause) => cause,
+            StartMigrationError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            StartMigrationError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartMigrationError::ReplicationGroupAlreadyUnderMigrationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartMigrationError::ReplicationGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMigrationError {}
 /// Errors returned by TestFailover
 #[derive(Debug, PartialEq)]
 pub enum TestFailoverError {
@@ -11560,24 +11666,24 @@ impl TestFailoverError {
 }
 impl fmt::Display for TestFailoverError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestFailoverError {
-    fn description(&self) -> &str {
         match *self {
-            TestFailoverError::APICallRateForCustomerExceededFault(ref cause) => cause,
-            TestFailoverError::InvalidCacheClusterStateFault(ref cause) => cause,
-            TestFailoverError::InvalidKMSKeyFault(ref cause) => cause,
-            TestFailoverError::InvalidParameterCombination(ref cause) => cause,
-            TestFailoverError::InvalidParameterValue(ref cause) => cause,
-            TestFailoverError::InvalidReplicationGroupStateFault(ref cause) => cause,
-            TestFailoverError::NodeGroupNotFoundFault(ref cause) => cause,
-            TestFailoverError::ReplicationGroupNotFoundFault(ref cause) => cause,
-            TestFailoverError::TestFailoverNotAvailableFault(ref cause) => cause,
+            TestFailoverError::APICallRateForCustomerExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestFailoverError::InvalidCacheClusterStateFault(ref cause) => write!(f, "{}", cause),
+            TestFailoverError::InvalidKMSKeyFault(ref cause) => write!(f, "{}", cause),
+            TestFailoverError::InvalidParameterCombination(ref cause) => write!(f, "{}", cause),
+            TestFailoverError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            TestFailoverError::InvalidReplicationGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TestFailoverError::NodeGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            TestFailoverError::ReplicationGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            TestFailoverError::TestFailoverNotAvailableFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestFailoverError {}
 /// Trait representing the capabilities of the Amazon ElastiCache API. Amazon ElastiCache clients implement this trait.
 pub trait ElastiCache {
     /// <p>Adds up to 50 cost allocation tags to the named resource. A cost allocation tag is a key-value pair where the key and value are case-sensitive. You can use cost allocation tags to categorize and track your AWS costs.</p> <p> When you apply tags to your ElastiCache resources, AWS generates a cost allocation report as a comma-separated value (CSV) file with your usage and costs aggregated by your tags. You can apply tags that represent business categories (such as cost centers, application names, or owners) to organize your costs across multiple services. For more information, see <a href="https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Tagging.html">Using Cost Allocation Tags in Amazon ElastiCache</a> in the <i>ElastiCache User Guide</i>.</p>

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -7374,16 +7374,14 @@ impl AbortEnvironmentUpdateError {
 }
 impl fmt::Display for AbortEnvironmentUpdateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AbortEnvironmentUpdateError {
-    fn description(&self) -> &str {
         match *self {
-            AbortEnvironmentUpdateError::InsufficientPrivileges(ref cause) => cause,
+            AbortEnvironmentUpdateError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AbortEnvironmentUpdateError {}
 /// Errors returned by ApplyEnvironmentManagedAction
 #[derive(Debug, PartialEq)]
 pub enum ApplyEnvironmentManagedActionError {
@@ -7434,17 +7432,17 @@ impl ApplyEnvironmentManagedActionError {
 }
 impl fmt::Display for ApplyEnvironmentManagedActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApplyEnvironmentManagedActionError {
-    fn description(&self) -> &str {
         match *self {
-            ApplyEnvironmentManagedActionError::ElasticBeanstalkService(ref cause) => cause,
-            ApplyEnvironmentManagedActionError::ManagedActionInvalidState(ref cause) => cause,
+            ApplyEnvironmentManagedActionError::ElasticBeanstalkService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ApplyEnvironmentManagedActionError::ManagedActionInvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ApplyEnvironmentManagedActionError {}
 /// Errors returned by CheckDNSAvailability
 #[derive(Debug, PartialEq)]
 pub enum CheckDNSAvailabilityError {}
@@ -7474,14 +7472,10 @@ impl CheckDNSAvailabilityError {
 }
 impl fmt::Display for CheckDNSAvailabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CheckDNSAvailabilityError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CheckDNSAvailabilityError {}
 /// Errors returned by ComposeEnvironments
 #[derive(Debug, PartialEq)]
 pub enum ComposeEnvironmentsError {
@@ -7526,17 +7520,13 @@ impl ComposeEnvironmentsError {
 }
 impl fmt::Display for ComposeEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ComposeEnvironmentsError {
-    fn description(&self) -> &str {
         match *self {
-            ComposeEnvironmentsError::InsufficientPrivileges(ref cause) => cause,
-            ComposeEnvironmentsError::TooManyEnvironments(ref cause) => cause,
+            ComposeEnvironmentsError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            ComposeEnvironmentsError::TooManyEnvironments(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ComposeEnvironmentsError {}
 /// Errors returned by CreateApplication
 #[derive(Debug, PartialEq)]
 pub enum CreateApplicationError {
@@ -7574,16 +7564,12 @@ impl CreateApplicationError {
 }
 impl fmt::Display for CreateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApplicationError::TooManyApplications(ref cause) => cause,
+            CreateApplicationError::TooManyApplications(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApplicationError {}
 /// Errors returned by CreateApplicationVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateApplicationVersionError {
@@ -7659,20 +7645,24 @@ impl CreateApplicationVersionError {
 }
 impl fmt::Display for CreateApplicationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApplicationVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApplicationVersionError::CodeBuildNotInServiceRegion(ref cause) => cause,
-            CreateApplicationVersionError::InsufficientPrivileges(ref cause) => cause,
-            CreateApplicationVersionError::S3LocationNotInServiceRegion(ref cause) => cause,
-            CreateApplicationVersionError::TooManyApplicationVersions(ref cause) => cause,
-            CreateApplicationVersionError::TooManyApplications(ref cause) => cause,
+            CreateApplicationVersionError::CodeBuildNotInServiceRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateApplicationVersionError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateApplicationVersionError::S3LocationNotInServiceRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateApplicationVersionError::TooManyApplicationVersions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateApplicationVersionError::TooManyApplications(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApplicationVersionError {}
 /// Errors returned by CreateConfigurationTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateConfigurationTemplateError {
@@ -7730,18 +7720,18 @@ impl CreateConfigurationTemplateError {
 }
 impl fmt::Display for CreateConfigurationTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConfigurationTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConfigurationTemplateError::InsufficientPrivileges(ref cause) => cause,
-            CreateConfigurationTemplateError::TooManyBuckets(ref cause) => cause,
-            CreateConfigurationTemplateError::TooManyConfigurationTemplates(ref cause) => cause,
+            CreateConfigurationTemplateError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateConfigurationTemplateError::TooManyBuckets(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationTemplateError::TooManyConfigurationTemplates(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateConfigurationTemplateError {}
 /// Errors returned by CreateEnvironment
 #[derive(Debug, PartialEq)]
 pub enum CreateEnvironmentError {
@@ -7786,17 +7776,13 @@ impl CreateEnvironmentError {
 }
 impl fmt::Display for CreateEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEnvironmentError::InsufficientPrivileges(ref cause) => cause,
-            CreateEnvironmentError::TooManyEnvironments(ref cause) => cause,
+            CreateEnvironmentError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            CreateEnvironmentError::TooManyEnvironments(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEnvironmentError {}
 /// Errors returned by CreatePlatformVersion
 #[derive(Debug, PartialEq)]
 pub enum CreatePlatformVersionError {
@@ -7852,18 +7838,16 @@ impl CreatePlatformVersionError {
 }
 impl fmt::Display for CreatePlatformVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePlatformVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePlatformVersionError::ElasticBeanstalkService(ref cause) => cause,
-            CreatePlatformVersionError::InsufficientPrivileges(ref cause) => cause,
-            CreatePlatformVersionError::TooManyPlatforms(ref cause) => cause,
+            CreatePlatformVersionError::ElasticBeanstalkService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePlatformVersionError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            CreatePlatformVersionError::TooManyPlatforms(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePlatformVersionError {}
 /// Errors returned by CreateStorageLocation
 #[derive(Debug, PartialEq)]
 pub enum CreateStorageLocationError {
@@ -7919,18 +7903,14 @@ impl CreateStorageLocationError {
 }
 impl fmt::Display for CreateStorageLocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStorageLocationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStorageLocationError::InsufficientPrivileges(ref cause) => cause,
-            CreateStorageLocationError::S3SubscriptionRequired(ref cause) => cause,
-            CreateStorageLocationError::TooManyBuckets(ref cause) => cause,
+            CreateStorageLocationError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            CreateStorageLocationError::S3SubscriptionRequired(ref cause) => write!(f, "{}", cause),
+            CreateStorageLocationError::TooManyBuckets(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStorageLocationError {}
 /// Errors returned by DeleteApplication
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationError {
@@ -7968,16 +7948,12 @@ impl DeleteApplicationError {
 }
 impl fmt::Display for DeleteApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationError::OperationInProgress(ref cause) => cause,
+            DeleteApplicationError::OperationInProgress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApplicationError {}
 /// Errors returned by DeleteApplicationVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationVersionError {
@@ -8044,19 +8020,21 @@ impl DeleteApplicationVersionError {
 }
 impl fmt::Display for DeleteApplicationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationVersionError::InsufficientPrivileges(ref cause) => cause,
-            DeleteApplicationVersionError::OperationInProgress(ref cause) => cause,
-            DeleteApplicationVersionError::S3LocationNotInServiceRegion(ref cause) => cause,
-            DeleteApplicationVersionError::SourceBundleDeletion(ref cause) => cause,
+            DeleteApplicationVersionError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationVersionError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationVersionError::S3LocationNotInServiceRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationVersionError::SourceBundleDeletion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteApplicationVersionError {}
 /// Errors returned by DeleteConfigurationTemplate
 #[derive(Debug, PartialEq)]
 pub enum DeleteConfigurationTemplateError {
@@ -8098,16 +8076,14 @@ impl DeleteConfigurationTemplateError {
 }
 impl fmt::Display for DeleteConfigurationTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConfigurationTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConfigurationTemplateError::OperationInProgress(ref cause) => cause,
+            DeleteConfigurationTemplateError::OperationInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteConfigurationTemplateError {}
 /// Errors returned by DeleteEnvironmentConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteEnvironmentConfigurationError {}
@@ -8139,14 +8115,10 @@ impl DeleteEnvironmentConfigurationError {
 }
 impl fmt::Display for DeleteEnvironmentConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEnvironmentConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteEnvironmentConfigurationError {}
 /// Errors returned by DeletePlatformVersion
 #[derive(Debug, PartialEq)]
 pub enum DeletePlatformVersionError {
@@ -8211,19 +8183,19 @@ impl DeletePlatformVersionError {
 }
 impl fmt::Display for DeletePlatformVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePlatformVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePlatformVersionError::ElasticBeanstalkService(ref cause) => cause,
-            DeletePlatformVersionError::InsufficientPrivileges(ref cause) => cause,
-            DeletePlatformVersionError::OperationInProgress(ref cause) => cause,
-            DeletePlatformVersionError::PlatformVersionStillReferenced(ref cause) => cause,
+            DeletePlatformVersionError::ElasticBeanstalkService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeletePlatformVersionError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            DeletePlatformVersionError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            DeletePlatformVersionError::PlatformVersionStillReferenced(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeletePlatformVersionError {}
 /// Errors returned by DescribeAccountAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountAttributesError {
@@ -8263,16 +8235,14 @@ impl DescribeAccountAttributesError {
 }
 impl fmt::Display for DescribeAccountAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAccountAttributesError::InsufficientPrivileges(ref cause) => cause,
+            DescribeAccountAttributesError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAccountAttributesError {}
 /// Errors returned by DescribeApplicationVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeApplicationVersionsError {}
@@ -8304,14 +8274,10 @@ impl DescribeApplicationVersionsError {
 }
 impl fmt::Display for DescribeApplicationVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeApplicationVersionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeApplicationVersionsError {}
 /// Errors returned by DescribeApplications
 #[derive(Debug, PartialEq)]
 pub enum DescribeApplicationsError {}
@@ -8341,14 +8307,10 @@ impl DescribeApplicationsError {
 }
 impl fmt::Display for DescribeApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeApplicationsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeApplicationsError {}
 /// Errors returned by DescribeConfigurationOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationOptionsError {
@@ -8388,16 +8350,12 @@ impl DescribeConfigurationOptionsError {
 }
 impl fmt::Display for DescribeConfigurationOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationOptionsError::TooManyBuckets(ref cause) => cause,
+            DescribeConfigurationOptionsError::TooManyBuckets(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationOptionsError {}
 /// Errors returned by DescribeConfigurationSettings
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationSettingsError {
@@ -8439,16 +8397,12 @@ impl DescribeConfigurationSettingsError {
 }
 impl fmt::Display for DescribeConfigurationSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationSettingsError::TooManyBuckets(ref cause) => cause,
+            DescribeConfigurationSettingsError::TooManyBuckets(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationSettingsError {}
 /// Errors returned by DescribeEnvironmentHealth
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentHealthError {
@@ -8495,17 +8449,15 @@ impl DescribeEnvironmentHealthError {
 }
 impl fmt::Display for DescribeEnvironmentHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentHealthError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEnvironmentHealthError::ElasticBeanstalkService(ref cause) => cause,
-            DescribeEnvironmentHealthError::InvalidRequest(ref cause) => cause,
+            DescribeEnvironmentHealthError::ElasticBeanstalkService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEnvironmentHealthError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEnvironmentHealthError {}
 /// Errors returned by DescribeEnvironmentManagedActionHistory
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentManagedActionHistoryError {
@@ -8547,18 +8499,14 @@ impl DescribeEnvironmentManagedActionHistoryError {
 }
 impl fmt::Display for DescribeEnvironmentManagedActionHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentManagedActionHistoryError {
-    fn description(&self) -> &str {
         match *self {
             DescribeEnvironmentManagedActionHistoryError::ElasticBeanstalkService(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeEnvironmentManagedActionHistoryError {}
 /// Errors returned by DescribeEnvironmentManagedActions
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentManagedActionsError {
@@ -8600,16 +8548,14 @@ impl DescribeEnvironmentManagedActionsError {
 }
 impl fmt::Display for DescribeEnvironmentManagedActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentManagedActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEnvironmentManagedActionsError::ElasticBeanstalkService(ref cause) => cause,
+            DescribeEnvironmentManagedActionsError::ElasticBeanstalkService(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEnvironmentManagedActionsError {}
 /// Errors returned by DescribeEnvironmentResources
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentResourcesError {
@@ -8651,16 +8597,14 @@ impl DescribeEnvironmentResourcesError {
 }
 impl fmt::Display for DescribeEnvironmentResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEnvironmentResourcesError::InsufficientPrivileges(ref cause) => cause,
+            DescribeEnvironmentResourcesError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEnvironmentResourcesError {}
 /// Errors returned by DescribeEnvironments
 #[derive(Debug, PartialEq)]
 pub enum DescribeEnvironmentsError {}
@@ -8690,14 +8634,10 @@ impl DescribeEnvironmentsError {
 }
 impl fmt::Display for DescribeEnvironmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEnvironmentsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEnvironmentsError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {}
@@ -8727,14 +8667,10 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeInstancesHealth
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstancesHealthError {
@@ -8781,17 +8717,15 @@ impl DescribeInstancesHealthError {
 }
 impl fmt::Display for DescribeInstancesHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstancesHealthError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstancesHealthError::ElasticBeanstalkService(ref cause) => cause,
-            DescribeInstancesHealthError::InvalidRequest(ref cause) => cause,
+            DescribeInstancesHealthError::ElasticBeanstalkService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstancesHealthError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInstancesHealthError {}
 /// Errors returned by DescribePlatformVersion
 #[derive(Debug, PartialEq)]
 pub enum DescribePlatformVersionError {
@@ -8840,17 +8774,17 @@ impl DescribePlatformVersionError {
 }
 impl fmt::Display for DescribePlatformVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePlatformVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePlatformVersionError::ElasticBeanstalkService(ref cause) => cause,
-            DescribePlatformVersionError::InsufficientPrivileges(ref cause) => cause,
+            DescribePlatformVersionError::ElasticBeanstalkService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePlatformVersionError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePlatformVersionError {}
 /// Errors returned by ListAvailableSolutionStacks
 #[derive(Debug, PartialEq)]
 pub enum ListAvailableSolutionStacksError {}
@@ -8882,14 +8816,10 @@ impl ListAvailableSolutionStacksError {
 }
 impl fmt::Display for ListAvailableSolutionStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAvailableSolutionStacksError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListAvailableSolutionStacksError {}
 /// Errors returned by ListPlatformVersions
 #[derive(Debug, PartialEq)]
 pub enum ListPlatformVersionsError {
@@ -8936,17 +8866,13 @@ impl ListPlatformVersionsError {
 }
 impl fmt::Display for ListPlatformVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPlatformVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPlatformVersionsError::ElasticBeanstalkService(ref cause) => cause,
-            ListPlatformVersionsError::InsufficientPrivileges(ref cause) => cause,
+            ListPlatformVersionsError::ElasticBeanstalkService(ref cause) => write!(f, "{}", cause),
+            ListPlatformVersionsError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPlatformVersionsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -9000,18 +8926,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InsufficientPrivileges(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::ResourceTypeNotSupported(ref cause) => cause,
+            ListTagsForResourceError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceTypeNotSupported(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by RebuildEnvironment
 #[derive(Debug, PartialEq)]
 pub enum RebuildEnvironmentError {
@@ -9049,16 +8971,12 @@ impl RebuildEnvironmentError {
 }
 impl fmt::Display for RebuildEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebuildEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            RebuildEnvironmentError::InsufficientPrivileges(ref cause) => cause,
+            RebuildEnvironmentError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebuildEnvironmentError {}
 /// Errors returned by RequestEnvironmentInfo
 #[derive(Debug, PartialEq)]
 pub enum RequestEnvironmentInfoError {}
@@ -9088,14 +9006,10 @@ impl RequestEnvironmentInfoError {
 }
 impl fmt::Display for RequestEnvironmentInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RequestEnvironmentInfoError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RequestEnvironmentInfoError {}
 /// Errors returned by RestartAppServer
 #[derive(Debug, PartialEq)]
 pub enum RestartAppServerError {}
@@ -9125,14 +9039,10 @@ impl RestartAppServerError {
 }
 impl fmt::Display for RestartAppServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestartAppServerError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RestartAppServerError {}
 /// Errors returned by RetrieveEnvironmentInfo
 #[derive(Debug, PartialEq)]
 pub enum RetrieveEnvironmentInfoError {}
@@ -9162,14 +9072,10 @@ impl RetrieveEnvironmentInfoError {
 }
 impl fmt::Display for RetrieveEnvironmentInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RetrieveEnvironmentInfoError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RetrieveEnvironmentInfoError {}
 /// Errors returned by SwapEnvironmentCNAMEs
 #[derive(Debug, PartialEq)]
 pub enum SwapEnvironmentCNAMEsError {}
@@ -9199,14 +9105,10 @@ impl SwapEnvironmentCNAMEsError {
 }
 impl fmt::Display for SwapEnvironmentCNAMEsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SwapEnvironmentCNAMEsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SwapEnvironmentCNAMEsError {}
 /// Errors returned by TerminateEnvironment
 #[derive(Debug, PartialEq)]
 pub enum TerminateEnvironmentError {
@@ -9244,16 +9146,12 @@ impl TerminateEnvironmentError {
 }
 impl fmt::Display for TerminateEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateEnvironmentError::InsufficientPrivileges(ref cause) => cause,
+            TerminateEnvironmentError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TerminateEnvironmentError {}
 /// Errors returned by UpdateApplication
 #[derive(Debug, PartialEq)]
 pub enum UpdateApplicationError {}
@@ -9283,14 +9181,10 @@ impl UpdateApplicationError {
 }
 impl fmt::Display for UpdateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApplicationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UpdateApplicationError {}
 /// Errors returned by UpdateApplicationResourceLifecycle
 #[derive(Debug, PartialEq)]
 pub enum UpdateApplicationResourceLifecycleError {
@@ -9332,16 +9226,14 @@ impl UpdateApplicationResourceLifecycleError {
 }
 impl fmt::Display for UpdateApplicationResourceLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApplicationResourceLifecycleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApplicationResourceLifecycleError::InsufficientPrivileges(ref cause) => cause,
+            UpdateApplicationResourceLifecycleError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateApplicationResourceLifecycleError {}
 /// Errors returned by UpdateApplicationVersion
 #[derive(Debug, PartialEq)]
 pub enum UpdateApplicationVersionError {}
@@ -9371,14 +9263,10 @@ impl UpdateApplicationVersionError {
 }
 impl fmt::Display for UpdateApplicationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApplicationVersionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UpdateApplicationVersionError {}
 /// Errors returned by UpdateConfigurationTemplate
 #[derive(Debug, PartialEq)]
 pub enum UpdateConfigurationTemplateError {
@@ -9427,17 +9315,15 @@ impl UpdateConfigurationTemplateError {
 }
 impl fmt::Display for UpdateConfigurationTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConfigurationTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConfigurationTemplateError::InsufficientPrivileges(ref cause) => cause,
-            UpdateConfigurationTemplateError::TooManyBuckets(ref cause) => cause,
+            UpdateConfigurationTemplateError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateConfigurationTemplateError::TooManyBuckets(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConfigurationTemplateError {}
 /// Errors returned by UpdateEnvironment
 #[derive(Debug, PartialEq)]
 pub enum UpdateEnvironmentError {
@@ -9482,17 +9368,13 @@ impl UpdateEnvironmentError {
 }
 impl fmt::Display for UpdateEnvironmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEnvironmentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEnvironmentError::InsufficientPrivileges(ref cause) => cause,
-            UpdateEnvironmentError::TooManyBuckets(ref cause) => cause,
+            UpdateEnvironmentError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            UpdateEnvironmentError::TooManyBuckets(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEnvironmentError {}
 /// Errors returned by UpdateTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum UpdateTagsForResourceError {
@@ -9562,20 +9444,18 @@ impl UpdateTagsForResourceError {
 }
 impl fmt::Display for UpdateTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTagsForResourceError::InsufficientPrivileges(ref cause) => cause,
-            UpdateTagsForResourceError::OperationInProgress(ref cause) => cause,
-            UpdateTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            UpdateTagsForResourceError::ResourceTypeNotSupported(ref cause) => cause,
-            UpdateTagsForResourceError::TooManyTags(ref cause) => cause,
+            UpdateTagsForResourceError::InsufficientPrivileges(ref cause) => write!(f, "{}", cause),
+            UpdateTagsForResourceError::OperationInProgress(ref cause) => write!(f, "{}", cause),
+            UpdateTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTagsForResourceError::ResourceTypeNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTagsForResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTagsForResourceError {}
 /// Errors returned by ValidateConfigurationSettings
 #[derive(Debug, PartialEq)]
 pub enum ValidateConfigurationSettingsError {
@@ -9626,17 +9506,15 @@ impl ValidateConfigurationSettingsError {
 }
 impl fmt::Display for ValidateConfigurationSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ValidateConfigurationSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            ValidateConfigurationSettingsError::InsufficientPrivileges(ref cause) => cause,
-            ValidateConfigurationSettingsError::TooManyBuckets(ref cause) => cause,
+            ValidateConfigurationSettingsError::InsufficientPrivileges(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ValidateConfigurationSettingsError::TooManyBuckets(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ValidateConfigurationSettingsError {}
 /// Trait representing the capabilities of the Elastic Beanstalk API. Elastic Beanstalk clients implement this trait.
 pub trait ElasticBeanstalk {
     /// <p>Cancels in-progress environment configuration update or application version deployment.</p>

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -1452,20 +1452,16 @@ impl CancelJobError {
 }
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelJobError {
-    fn description(&self) -> &str {
         match *self {
-            CancelJobError::AccessDenied(ref cause) => cause,
-            CancelJobError::IncompatibleVersion(ref cause) => cause,
-            CancelJobError::InternalService(ref cause) => cause,
-            CancelJobError::ResourceInUse(ref cause) => cause,
-            CancelJobError::ResourceNotFound(ref cause) => cause,
+            CancelJobError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CancelJobError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            CancelJobError::InternalService(ref cause) => write!(f, "{}", cause),
+            CancelJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CancelJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelJobError {}
 /// Errors returned by CreateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateJobError {
@@ -1509,20 +1505,16 @@ impl CreateJobError {
 }
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobError::AccessDenied(ref cause) => cause,
-            CreateJobError::IncompatibleVersion(ref cause) => cause,
-            CreateJobError::InternalService(ref cause) => cause,
-            CreateJobError::LimitExceeded(ref cause) => cause,
-            CreateJobError::ResourceNotFound(ref cause) => cause,
+            CreateJobError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateJobError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobError {}
 /// Errors returned by CreatePipeline
 #[derive(Debug, PartialEq)]
 pub enum CreatePipelineError {
@@ -1566,20 +1558,16 @@ impl CreatePipelineError {
 }
 impl fmt::Display for CreatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePipelineError::AccessDenied(ref cause) => cause,
-            CreatePipelineError::IncompatibleVersion(ref cause) => cause,
-            CreatePipelineError::InternalService(ref cause) => cause,
-            CreatePipelineError::LimitExceeded(ref cause) => cause,
-            CreatePipelineError::ResourceNotFound(ref cause) => cause,
+            CreatePipelineError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePipelineError {}
 /// Errors returned by CreatePreset
 #[derive(Debug, PartialEq)]
 pub enum CreatePresetError {
@@ -1618,19 +1606,15 @@ impl CreatePresetError {
 }
 impl fmt::Display for CreatePresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePresetError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePresetError::AccessDenied(ref cause) => cause,
-            CreatePresetError::IncompatibleVersion(ref cause) => cause,
-            CreatePresetError::InternalService(ref cause) => cause,
-            CreatePresetError::LimitExceeded(ref cause) => cause,
+            CreatePresetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePresetError {}
 /// Errors returned by DeletePipeline
 #[derive(Debug, PartialEq)]
 pub enum DeletePipelineError {
@@ -1674,20 +1658,16 @@ impl DeletePipelineError {
 }
 impl fmt::Display for DeletePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePipelineError::AccessDenied(ref cause) => cause,
-            DeletePipelineError::IncompatibleVersion(ref cause) => cause,
-            DeletePipelineError::InternalService(ref cause) => cause,
-            DeletePipelineError::ResourceInUse(ref cause) => cause,
-            DeletePipelineError::ResourceNotFound(ref cause) => cause,
+            DeletePipelineError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePipelineError {}
 /// Errors returned by DeletePreset
 #[derive(Debug, PartialEq)]
 pub enum DeletePresetError {
@@ -1726,19 +1706,15 @@ impl DeletePresetError {
 }
 impl fmt::Display for DeletePresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePresetError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePresetError::AccessDenied(ref cause) => cause,
-            DeletePresetError::IncompatibleVersion(ref cause) => cause,
-            DeletePresetError::InternalService(ref cause) => cause,
-            DeletePresetError::ResourceNotFound(ref cause) => cause,
+            DeletePresetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePresetError {}
 /// Errors returned by ListJobsByPipeline
 #[derive(Debug, PartialEq)]
 pub enum ListJobsByPipelineError {
@@ -1779,19 +1755,15 @@ impl ListJobsByPipelineError {
 }
 impl fmt::Display for ListJobsByPipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsByPipelineError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsByPipelineError::AccessDenied(ref cause) => cause,
-            ListJobsByPipelineError::IncompatibleVersion(ref cause) => cause,
-            ListJobsByPipelineError::InternalService(ref cause) => cause,
-            ListJobsByPipelineError::ResourceNotFound(ref cause) => cause,
+            ListJobsByPipelineError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListJobsByPipelineError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ListJobsByPipelineError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListJobsByPipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsByPipelineError {}
 /// Errors returned by ListJobsByStatus
 #[derive(Debug, PartialEq)]
 pub enum ListJobsByStatusError {
@@ -1832,19 +1804,15 @@ impl ListJobsByStatusError {
 }
 impl fmt::Display for ListJobsByStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsByStatusError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsByStatusError::AccessDenied(ref cause) => cause,
-            ListJobsByStatusError::IncompatibleVersion(ref cause) => cause,
-            ListJobsByStatusError::InternalService(ref cause) => cause,
-            ListJobsByStatusError::ResourceNotFound(ref cause) => cause,
+            ListJobsByStatusError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListJobsByStatusError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ListJobsByStatusError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListJobsByStatusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsByStatusError {}
 /// Errors returned by ListPipelines
 #[derive(Debug, PartialEq)]
 pub enum ListPipelinesError {
@@ -1878,18 +1846,14 @@ impl ListPipelinesError {
 }
 impl fmt::Display for ListPipelinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPipelinesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPipelinesError::AccessDenied(ref cause) => cause,
-            ListPipelinesError::IncompatibleVersion(ref cause) => cause,
-            ListPipelinesError::InternalService(ref cause) => cause,
+            ListPipelinesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListPipelinesError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ListPipelinesError::InternalService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPipelinesError {}
 /// Errors returned by ListPresets
 #[derive(Debug, PartialEq)]
 pub enum ListPresetsError {
@@ -1923,18 +1887,14 @@ impl ListPresetsError {
 }
 impl fmt::Display for ListPresetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPresetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPresetsError::AccessDenied(ref cause) => cause,
-            ListPresetsError::IncompatibleVersion(ref cause) => cause,
-            ListPresetsError::InternalService(ref cause) => cause,
+            ListPresetsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListPresetsError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ListPresetsError::InternalService(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPresetsError {}
 /// Errors returned by ReadJob
 #[derive(Debug, PartialEq)]
 pub enum ReadJobError {
@@ -1973,19 +1933,15 @@ impl ReadJobError {
 }
 impl fmt::Display for ReadJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReadJobError {
-    fn description(&self) -> &str {
         match *self {
-            ReadJobError::AccessDenied(ref cause) => cause,
-            ReadJobError::IncompatibleVersion(ref cause) => cause,
-            ReadJobError::InternalService(ref cause) => cause,
-            ReadJobError::ResourceNotFound(ref cause) => cause,
+            ReadJobError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ReadJobError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ReadJobError::InternalService(ref cause) => write!(f, "{}", cause),
+            ReadJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReadJobError {}
 /// Errors returned by ReadPipeline
 #[derive(Debug, PartialEq)]
 pub enum ReadPipelineError {
@@ -2024,19 +1980,15 @@ impl ReadPipelineError {
 }
 impl fmt::Display for ReadPipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReadPipelineError {
-    fn description(&self) -> &str {
         match *self {
-            ReadPipelineError::AccessDenied(ref cause) => cause,
-            ReadPipelineError::IncompatibleVersion(ref cause) => cause,
-            ReadPipelineError::InternalService(ref cause) => cause,
-            ReadPipelineError::ResourceNotFound(ref cause) => cause,
+            ReadPipelineError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ReadPipelineError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ReadPipelineError::InternalService(ref cause) => write!(f, "{}", cause),
+            ReadPipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReadPipelineError {}
 /// Errors returned by ReadPreset
 #[derive(Debug, PartialEq)]
 pub enum ReadPresetError {
@@ -2075,19 +2027,15 @@ impl ReadPresetError {
 }
 impl fmt::Display for ReadPresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReadPresetError {
-    fn description(&self) -> &str {
         match *self {
-            ReadPresetError::AccessDenied(ref cause) => cause,
-            ReadPresetError::IncompatibleVersion(ref cause) => cause,
-            ReadPresetError::InternalService(ref cause) => cause,
-            ReadPresetError::ResourceNotFound(ref cause) => cause,
+            ReadPresetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ReadPresetError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ReadPresetError::InternalService(ref cause) => write!(f, "{}", cause),
+            ReadPresetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReadPresetError {}
 /// Errors returned by TestRole
 #[derive(Debug, PartialEq)]
 pub enum TestRoleError {
@@ -2126,19 +2074,15 @@ impl TestRoleError {
 }
 impl fmt::Display for TestRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestRoleError {
-    fn description(&self) -> &str {
         match *self {
-            TestRoleError::AccessDenied(ref cause) => cause,
-            TestRoleError::IncompatibleVersion(ref cause) => cause,
-            TestRoleError::InternalService(ref cause) => cause,
-            TestRoleError::ResourceNotFound(ref cause) => cause,
+            TestRoleError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TestRoleError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            TestRoleError::InternalService(ref cause) => write!(f, "{}", cause),
+            TestRoleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestRoleError {}
 /// Errors returned by UpdatePipeline
 #[derive(Debug, PartialEq)]
 pub enum UpdatePipelineError {
@@ -2182,20 +2126,16 @@ impl UpdatePipelineError {
 }
 impl fmt::Display for UpdatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePipelineError::AccessDenied(ref cause) => cause,
-            UpdatePipelineError::IncompatibleVersion(ref cause) => cause,
-            UpdatePipelineError::InternalService(ref cause) => cause,
-            UpdatePipelineError::ResourceInUse(ref cause) => cause,
-            UpdatePipelineError::ResourceNotFound(ref cause) => cause,
+            UpdatePipelineError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePipelineError {}
 /// Errors returned by UpdatePipelineNotifications
 #[derive(Debug, PartialEq)]
 pub enum UpdatePipelineNotificationsError {
@@ -2251,20 +2191,18 @@ impl UpdatePipelineNotificationsError {
 }
 impl fmt::Display for UpdatePipelineNotificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePipelineNotificationsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePipelineNotificationsError::AccessDenied(ref cause) => cause,
-            UpdatePipelineNotificationsError::IncompatibleVersion(ref cause) => cause,
-            UpdatePipelineNotificationsError::InternalService(ref cause) => cause,
-            UpdatePipelineNotificationsError::ResourceInUse(ref cause) => cause,
-            UpdatePipelineNotificationsError::ResourceNotFound(ref cause) => cause,
+            UpdatePipelineNotificationsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineNotificationsError::IncompatibleVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePipelineNotificationsError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineNotificationsError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineNotificationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePipelineNotificationsError {}
 /// Errors returned by UpdatePipelineStatus
 #[derive(Debug, PartialEq)]
 pub enum UpdatePipelineStatusError {
@@ -2314,20 +2252,16 @@ impl UpdatePipelineStatusError {
 }
 impl fmt::Display for UpdatePipelineStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePipelineStatusError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePipelineStatusError::AccessDenied(ref cause) => cause,
-            UpdatePipelineStatusError::IncompatibleVersion(ref cause) => cause,
-            UpdatePipelineStatusError::InternalService(ref cause) => cause,
-            UpdatePipelineStatusError::ResourceInUse(ref cause) => cause,
-            UpdatePipelineStatusError::ResourceNotFound(ref cause) => cause,
+            UpdatePipelineStatusError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineStatusError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineStatusError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineStatusError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineStatusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePipelineStatusError {}
 /// Trait representing the capabilities of the Amazon Elastic Transcoder API. Amazon Elastic Transcoder clients implement this trait.
 pub trait Ets {
     /// <p><p>The CancelJob operation cancels an unfinished job.</p> <note> <p>You can only cancel a job that has a status of <code>Submitted</code>. To prevent a pipeline from starting to process a job while you&#39;re getting the job identifier, use <a>UpdatePipelineStatus</a> to temporarily pause the pipeline.</p> </note></p>

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -4109,18 +4109,14 @@ impl AddTagsError {
 }
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsError::AccessPointNotFound(ref cause) => cause,
-            AddTagsError::DuplicateTagKeys(ref cause) => cause,
-            AddTagsError::TooManyTags(ref cause) => cause,
+            AddTagsError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
+            AddTagsError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            AddTagsError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsError {}
 /// Errors returned by ApplySecurityGroupsToLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum ApplySecurityGroupsToLoadBalancerError {
@@ -4180,18 +4176,20 @@ impl ApplySecurityGroupsToLoadBalancerError {
 }
 impl fmt::Display for ApplySecurityGroupsToLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApplySecurityGroupsToLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            ApplySecurityGroupsToLoadBalancerError::AccessPointNotFound(ref cause) => cause,
-            ApplySecurityGroupsToLoadBalancerError::InvalidConfigurationRequest(ref cause) => cause,
-            ApplySecurityGroupsToLoadBalancerError::InvalidSecurityGroup(ref cause) => cause,
+            ApplySecurityGroupsToLoadBalancerError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ApplySecurityGroupsToLoadBalancerError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ApplySecurityGroupsToLoadBalancerError::InvalidSecurityGroup(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ApplySecurityGroupsToLoadBalancerError {}
 /// Errors returned by AttachLoadBalancerToSubnets
 #[derive(Debug, PartialEq)]
 pub enum AttachLoadBalancerToSubnetsError {
@@ -4256,19 +4254,19 @@ impl AttachLoadBalancerToSubnetsError {
 }
 impl fmt::Display for AttachLoadBalancerToSubnetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachLoadBalancerToSubnetsError {
-    fn description(&self) -> &str {
         match *self {
-            AttachLoadBalancerToSubnetsError::AccessPointNotFound(ref cause) => cause,
-            AttachLoadBalancerToSubnetsError::InvalidConfigurationRequest(ref cause) => cause,
-            AttachLoadBalancerToSubnetsError::InvalidSubnet(ref cause) => cause,
-            AttachLoadBalancerToSubnetsError::SubnetNotFound(ref cause) => cause,
+            AttachLoadBalancerToSubnetsError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachLoadBalancerToSubnetsError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachLoadBalancerToSubnetsError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            AttachLoadBalancerToSubnetsError::SubnetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachLoadBalancerToSubnetsError {}
 /// Errors returned by ConfigureHealthCheck
 #[derive(Debug, PartialEq)]
 pub enum ConfigureHealthCheckError {
@@ -4306,16 +4304,12 @@ impl ConfigureHealthCheckError {
 }
 impl fmt::Display for ConfigureHealthCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfigureHealthCheckError {
-    fn description(&self) -> &str {
         match *self {
-            ConfigureHealthCheckError::AccessPointNotFound(ref cause) => cause,
+            ConfigureHealthCheckError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConfigureHealthCheckError {}
 /// Errors returned by CreateAppCookieStickinessPolicy
 #[derive(Debug, PartialEq)]
 pub enum CreateAppCookieStickinessPolicyError {
@@ -4384,19 +4378,23 @@ impl CreateAppCookieStickinessPolicyError {
 }
 impl fmt::Display for CreateAppCookieStickinessPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAppCookieStickinessPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAppCookieStickinessPolicyError::AccessPointNotFound(ref cause) => cause,
-            CreateAppCookieStickinessPolicyError::DuplicatePolicyName(ref cause) => cause,
-            CreateAppCookieStickinessPolicyError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateAppCookieStickinessPolicyError::TooManyPolicies(ref cause) => cause,
+            CreateAppCookieStickinessPolicyError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAppCookieStickinessPolicyError::DuplicatePolicyName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAppCookieStickinessPolicyError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAppCookieStickinessPolicyError::TooManyPolicies(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateAppCookieStickinessPolicyError {}
 /// Errors returned by CreateLBCookieStickinessPolicy
 #[derive(Debug, PartialEq)]
 pub enum CreateLBCookieStickinessPolicyError {
@@ -4465,19 +4463,23 @@ impl CreateLBCookieStickinessPolicyError {
 }
 impl fmt::Display for CreateLBCookieStickinessPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLBCookieStickinessPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLBCookieStickinessPolicyError::AccessPointNotFound(ref cause) => cause,
-            CreateLBCookieStickinessPolicyError::DuplicatePolicyName(ref cause) => cause,
-            CreateLBCookieStickinessPolicyError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateLBCookieStickinessPolicyError::TooManyPolicies(ref cause) => cause,
+            CreateLBCookieStickinessPolicyError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLBCookieStickinessPolicyError::DuplicatePolicyName(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLBCookieStickinessPolicyError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLBCookieStickinessPolicyError::TooManyPolicies(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateLBCookieStickinessPolicyError {}
 /// Errors returned by CreateLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum CreateLoadBalancerError {
@@ -4594,27 +4596,25 @@ impl CreateLoadBalancerError {
 }
 impl fmt::Display for CreateLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoadBalancerError::CertificateNotFound(ref cause) => cause,
-            CreateLoadBalancerError::DuplicateAccessPointName(ref cause) => cause,
-            CreateLoadBalancerError::DuplicateTagKeys(ref cause) => cause,
-            CreateLoadBalancerError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateLoadBalancerError::InvalidScheme(ref cause) => cause,
-            CreateLoadBalancerError::InvalidSecurityGroup(ref cause) => cause,
-            CreateLoadBalancerError::InvalidSubnet(ref cause) => cause,
-            CreateLoadBalancerError::OperationNotPermitted(ref cause) => cause,
-            CreateLoadBalancerError::SubnetNotFound(ref cause) => cause,
-            CreateLoadBalancerError::TooManyAccessPoints(ref cause) => cause,
-            CreateLoadBalancerError::TooManyTags(ref cause) => cause,
-            CreateLoadBalancerError::UnsupportedProtocol(ref cause) => cause,
+            CreateLoadBalancerError::CertificateNotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::DuplicateAccessPointName(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerError::InvalidScheme(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::InvalidSecurityGroup(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::SubnetNotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::TooManyAccessPoints(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::TooManyTags(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::UnsupportedProtocol(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLoadBalancerError {}
 /// Errors returned by CreateLoadBalancerListeners
 #[derive(Debug, PartialEq)]
 pub enum CreateLoadBalancerListenersError {
@@ -4692,20 +4692,26 @@ impl CreateLoadBalancerListenersError {
 }
 impl fmt::Display for CreateLoadBalancerListenersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoadBalancerListenersError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoadBalancerListenersError::AccessPointNotFound(ref cause) => cause,
-            CreateLoadBalancerListenersError::CertificateNotFound(ref cause) => cause,
-            CreateLoadBalancerListenersError::DuplicateListener(ref cause) => cause,
-            CreateLoadBalancerListenersError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateLoadBalancerListenersError::UnsupportedProtocol(ref cause) => cause,
+            CreateLoadBalancerListenersError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerListenersError::CertificateNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerListenersError::DuplicateListener(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerListenersError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerListenersError::UnsupportedProtocol(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateLoadBalancerListenersError {}
 /// Errors returned by CreateLoadBalancerPolicy
 #[derive(Debug, PartialEq)]
 pub enum CreateLoadBalancerPolicyError {
@@ -4777,20 +4783,18 @@ impl CreateLoadBalancerPolicyError {
 }
 impl fmt::Display for CreateLoadBalancerPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoadBalancerPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoadBalancerPolicyError::AccessPointNotFound(ref cause) => cause,
-            CreateLoadBalancerPolicyError::DuplicatePolicyName(ref cause) => cause,
-            CreateLoadBalancerPolicyError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateLoadBalancerPolicyError::PolicyTypeNotFound(ref cause) => cause,
-            CreateLoadBalancerPolicyError::TooManyPolicies(ref cause) => cause,
+            CreateLoadBalancerPolicyError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerPolicyError::DuplicatePolicyName(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerPolicyError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerPolicyError::PolicyTypeNotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerPolicyError::TooManyPolicies(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLoadBalancerPolicyError {}
 /// Errors returned by DeleteLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoadBalancerError {}
@@ -4820,14 +4824,10 @@ impl DeleteLoadBalancerError {
 }
 impl fmt::Display for DeleteLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteLoadBalancerError {}
 /// Errors returned by DeleteLoadBalancerListeners
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoadBalancerListenersError {
@@ -4869,16 +4869,14 @@ impl DeleteLoadBalancerListenersError {
 }
 impl fmt::Display for DeleteLoadBalancerListenersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoadBalancerListenersError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoadBalancerListenersError::AccessPointNotFound(ref cause) => cause,
+            DeleteLoadBalancerListenersError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteLoadBalancerListenersError {}
 /// Errors returned by DeleteLoadBalancerPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoadBalancerPolicyError {
@@ -4927,17 +4925,15 @@ impl DeleteLoadBalancerPolicyError {
 }
 impl fmt::Display for DeleteLoadBalancerPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoadBalancerPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoadBalancerPolicyError::AccessPointNotFound(ref cause) => cause,
-            DeleteLoadBalancerPolicyError::InvalidConfigurationRequest(ref cause) => cause,
+            DeleteLoadBalancerPolicyError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerPolicyError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteLoadBalancerPolicyError {}
 /// Errors returned by DeregisterInstancesFromLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum DeregisterInstancesFromLoadBalancerError {
@@ -4988,17 +4984,17 @@ impl DeregisterInstancesFromLoadBalancerError {
 }
 impl fmt::Display for DeregisterInstancesFromLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterInstancesFromLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterInstancesFromLoadBalancerError::AccessPointNotFound(ref cause) => cause,
-            DeregisterInstancesFromLoadBalancerError::InvalidEndPoint(ref cause) => cause,
+            DeregisterInstancesFromLoadBalancerError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterInstancesFromLoadBalancerError::InvalidEndPoint(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterInstancesFromLoadBalancerError {}
 /// Errors returned by DescribeAccountLimits
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountLimitsError {}
@@ -5028,14 +5024,10 @@ impl DescribeAccountLimitsError {
 }
 impl fmt::Display for DescribeAccountLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountLimitsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAccountLimitsError {}
 /// Errors returned by DescribeInstanceHealth
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstanceHealthError {
@@ -5080,17 +5072,13 @@ impl DescribeInstanceHealthError {
 }
 impl fmt::Display for DescribeInstanceHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstanceHealthError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstanceHealthError::AccessPointNotFound(ref cause) => cause,
-            DescribeInstanceHealthError::InvalidEndPoint(ref cause) => cause,
+            DescribeInstanceHealthError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeInstanceHealthError::InvalidEndPoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInstanceHealthError {}
 /// Errors returned by DescribeLoadBalancerAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancerAttributesError {
@@ -5141,17 +5129,17 @@ impl DescribeLoadBalancerAttributesError {
 }
 impl fmt::Display for DescribeLoadBalancerAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancerAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancerAttributesError::AccessPointNotFound(ref cause) => cause,
-            DescribeLoadBalancerAttributesError::LoadBalancerAttributeNotFound(ref cause) => cause,
+            DescribeLoadBalancerAttributesError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeLoadBalancerAttributesError::LoadBalancerAttributeNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLoadBalancerAttributesError {}
 /// Errors returned by DescribeLoadBalancerPolicies
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancerPoliciesError {
@@ -5200,17 +5188,15 @@ impl DescribeLoadBalancerPoliciesError {
 }
 impl fmt::Display for DescribeLoadBalancerPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancerPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancerPoliciesError::AccessPointNotFound(ref cause) => cause,
-            DescribeLoadBalancerPoliciesError::PolicyNotFound(ref cause) => cause,
+            DescribeLoadBalancerPoliciesError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeLoadBalancerPoliciesError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLoadBalancerPoliciesError {}
 /// Errors returned by DescribeLoadBalancerPolicyTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancerPolicyTypesError {
@@ -5252,16 +5238,14 @@ impl DescribeLoadBalancerPolicyTypesError {
 }
 impl fmt::Display for DescribeLoadBalancerPolicyTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancerPolicyTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancerPolicyTypesError::PolicyTypeNotFound(ref cause) => cause,
+            DescribeLoadBalancerPolicyTypesError::PolicyTypeNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLoadBalancerPolicyTypesError {}
 /// Errors returned by DescribeLoadBalancers
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancersError {
@@ -5306,17 +5290,13 @@ impl DescribeLoadBalancersError {
 }
 impl fmt::Display for DescribeLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancersError::AccessPointNotFound(ref cause) => cause,
-            DescribeLoadBalancersError::DependencyThrottle(ref cause) => cause,
+            DescribeLoadBalancersError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeLoadBalancersError::DependencyThrottle(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLoadBalancersError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -5354,16 +5334,12 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::AccessPointNotFound(ref cause) => cause,
+            DescribeTagsError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by DetachLoadBalancerFromSubnets
 #[derive(Debug, PartialEq)]
 pub enum DetachLoadBalancerFromSubnetsError {
@@ -5414,17 +5390,17 @@ impl DetachLoadBalancerFromSubnetsError {
 }
 impl fmt::Display for DetachLoadBalancerFromSubnetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachLoadBalancerFromSubnetsError {
-    fn description(&self) -> &str {
         match *self {
-            DetachLoadBalancerFromSubnetsError::AccessPointNotFound(ref cause) => cause,
-            DetachLoadBalancerFromSubnetsError::InvalidConfigurationRequest(ref cause) => cause,
+            DetachLoadBalancerFromSubnetsError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DetachLoadBalancerFromSubnetsError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DetachLoadBalancerFromSubnetsError {}
 /// Errors returned by DisableAvailabilityZonesForLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum DisableAvailabilityZonesForLoadBalancerError {
@@ -5473,19 +5449,17 @@ impl DisableAvailabilityZonesForLoadBalancerError {
 }
 impl fmt::Display for DisableAvailabilityZonesForLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableAvailabilityZonesForLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            DisableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(ref cause) => cause,
+            DisableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DisableAvailabilityZonesForLoadBalancerError::InvalidConfigurationRequest(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableAvailabilityZonesForLoadBalancerError {}
 /// Errors returned by EnableAvailabilityZonesForLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum EnableAvailabilityZonesForLoadBalancerError {
@@ -5527,16 +5501,14 @@ impl EnableAvailabilityZonesForLoadBalancerError {
 }
 impl fmt::Display for EnableAvailabilityZonesForLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableAvailabilityZonesForLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            EnableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(ref cause) => cause,
+            EnableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for EnableAvailabilityZonesForLoadBalancerError {}
 /// Errors returned by ModifyLoadBalancerAttributes
 #[derive(Debug, PartialEq)]
 pub enum ModifyLoadBalancerAttributesError {
@@ -5596,18 +5568,20 @@ impl ModifyLoadBalancerAttributesError {
 }
 impl fmt::Display for ModifyLoadBalancerAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyLoadBalancerAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyLoadBalancerAttributesError::AccessPointNotFound(ref cause) => cause,
-            ModifyLoadBalancerAttributesError::InvalidConfigurationRequest(ref cause) => cause,
-            ModifyLoadBalancerAttributesError::LoadBalancerAttributeNotFound(ref cause) => cause,
+            ModifyLoadBalancerAttributesError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyLoadBalancerAttributesError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyLoadBalancerAttributesError::LoadBalancerAttributeNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyLoadBalancerAttributesError {}
 /// Errors returned by RegisterInstancesWithLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum RegisterInstancesWithLoadBalancerError {
@@ -5658,17 +5632,17 @@ impl RegisterInstancesWithLoadBalancerError {
 }
 impl fmt::Display for RegisterInstancesWithLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterInstancesWithLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterInstancesWithLoadBalancerError::AccessPointNotFound(ref cause) => cause,
-            RegisterInstancesWithLoadBalancerError::InvalidEndPoint(ref cause) => cause,
+            RegisterInstancesWithLoadBalancerError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterInstancesWithLoadBalancerError::InvalidEndPoint(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterInstancesWithLoadBalancerError {}
 /// Errors returned by RemoveTags
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsError {
@@ -5706,16 +5680,12 @@ impl RemoveTagsError {
 }
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsError::AccessPointNotFound(ref cause) => cause,
+            RemoveTagsError::AccessPointNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsError {}
 /// Errors returned by SetLoadBalancerListenerSSLCertificate
 #[derive(Debug, PartialEq)]
 pub enum SetLoadBalancerListenerSSLCertificateError {
@@ -5793,22 +5763,26 @@ impl SetLoadBalancerListenerSSLCertificateError {
 }
 impl fmt::Display for SetLoadBalancerListenerSSLCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetLoadBalancerListenerSSLCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            SetLoadBalancerListenerSSLCertificateError::AccessPointNotFound(ref cause) => cause,
-            SetLoadBalancerListenerSSLCertificateError::CertificateNotFound(ref cause) => cause,
-            SetLoadBalancerListenerSSLCertificateError::InvalidConfigurationRequest(ref cause) => {
-                cause
+            SetLoadBalancerListenerSSLCertificateError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
             }
-            SetLoadBalancerListenerSSLCertificateError::ListenerNotFound(ref cause) => cause,
-            SetLoadBalancerListenerSSLCertificateError::UnsupportedProtocol(ref cause) => cause,
+            SetLoadBalancerListenerSSLCertificateError::CertificateNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetLoadBalancerListenerSSLCertificateError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetLoadBalancerListenerSSLCertificateError::ListenerNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetLoadBalancerListenerSSLCertificateError::UnsupportedProtocol(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetLoadBalancerListenerSSLCertificateError {}
 /// Errors returned by SetLoadBalancerPoliciesForBackendServer
 #[derive(Debug, PartialEq)]
 pub enum SetLoadBalancerPoliciesForBackendServerError {
@@ -5866,20 +5840,20 @@ impl SetLoadBalancerPoliciesForBackendServerError {
 }
 impl fmt::Display for SetLoadBalancerPoliciesForBackendServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetLoadBalancerPoliciesForBackendServerError {
-    fn description(&self) -> &str {
         match *self {
-            SetLoadBalancerPoliciesForBackendServerError::AccessPointNotFound(ref cause) => cause,
+            SetLoadBalancerPoliciesForBackendServerError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
             SetLoadBalancerPoliciesForBackendServerError::InvalidConfigurationRequest(
                 ref cause,
-            ) => cause,
-            SetLoadBalancerPoliciesForBackendServerError::PolicyNotFound(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            SetLoadBalancerPoliciesForBackendServerError::PolicyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetLoadBalancerPoliciesForBackendServerError {}
 /// Errors returned by SetLoadBalancerPoliciesOfListener
 #[derive(Debug, PartialEq)]
 pub enum SetLoadBalancerPoliciesOfListenerError {
@@ -5948,19 +5922,23 @@ impl SetLoadBalancerPoliciesOfListenerError {
 }
 impl fmt::Display for SetLoadBalancerPoliciesOfListenerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetLoadBalancerPoliciesOfListenerError {
-    fn description(&self) -> &str {
         match *self {
-            SetLoadBalancerPoliciesOfListenerError::AccessPointNotFound(ref cause) => cause,
-            SetLoadBalancerPoliciesOfListenerError::InvalidConfigurationRequest(ref cause) => cause,
-            SetLoadBalancerPoliciesOfListenerError::ListenerNotFound(ref cause) => cause,
-            SetLoadBalancerPoliciesOfListenerError::PolicyNotFound(ref cause) => cause,
+            SetLoadBalancerPoliciesOfListenerError::AccessPointNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetLoadBalancerPoliciesOfListenerError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetLoadBalancerPoliciesOfListenerError::ListenerNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetLoadBalancerPoliciesOfListenerError::PolicyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetLoadBalancerPoliciesOfListenerError {}
 /// Trait representing the capabilities of the Elastic Load Balancing API. Elastic Load Balancing clients implement this trait.
 pub trait Elb {
     /// <p>Adds the specified tags to the specified load balancer. Each load balancer can have a maximum of 10 tags.</p> <p>Each tag consists of a key and an optional value. If a tag with the same key is already associated with the load balancer, <code>AddTags</code> updates its value.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/add-remove-tags.html">Tag Your Classic Load Balancer</a> in the <i>Classic Load Balancers Guide</i>.</p>

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -6314,18 +6314,14 @@ impl AddListenerCertificatesError {
 }
 impl fmt::Display for AddListenerCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddListenerCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            AddListenerCertificatesError::CertificateNotFound(ref cause) => cause,
-            AddListenerCertificatesError::ListenerNotFound(ref cause) => cause,
-            AddListenerCertificatesError::TooManyCertificates(ref cause) => cause,
+            AddListenerCertificatesError::CertificateNotFound(ref cause) => write!(f, "{}", cause),
+            AddListenerCertificatesError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            AddListenerCertificatesError::TooManyCertificates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddListenerCertificatesError {}
 /// Errors returned by AddTags
 #[derive(Debug, PartialEq)]
 pub enum AddTagsError {
@@ -6384,19 +6380,15 @@ impl AddTagsError {
 }
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsError::DuplicateTagKeys(ref cause) => cause,
-            AddTagsError::LoadBalancerNotFound(ref cause) => cause,
-            AddTagsError::TargetGroupNotFound(ref cause) => cause,
-            AddTagsError::TooManyTags(ref cause) => cause,
+            AddTagsError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            AddTagsError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            AddTagsError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
+            AddTagsError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsError {}
 /// Errors returned by CreateListener
 #[derive(Debug, PartialEq)]
 pub enum CreateListenerError {
@@ -6543,31 +6535,31 @@ impl CreateListenerError {
 }
 impl fmt::Display for CreateListenerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateListenerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateListenerError::CertificateNotFound(ref cause) => cause,
-            CreateListenerError::DuplicateListener(ref cause) => cause,
-            CreateListenerError::IncompatibleProtocols(ref cause) => cause,
-            CreateListenerError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateListenerError::InvalidLoadBalancerAction(ref cause) => cause,
-            CreateListenerError::LoadBalancerNotFound(ref cause) => cause,
-            CreateListenerError::SSLPolicyNotFound(ref cause) => cause,
-            CreateListenerError::TargetGroupAssociationLimit(ref cause) => cause,
-            CreateListenerError::TargetGroupNotFound(ref cause) => cause,
-            CreateListenerError::TooManyActions(ref cause) => cause,
-            CreateListenerError::TooManyCertificates(ref cause) => cause,
-            CreateListenerError::TooManyListeners(ref cause) => cause,
-            CreateListenerError::TooManyRegistrationsForTargetId(ref cause) => cause,
-            CreateListenerError::TooManyTargets(ref cause) => cause,
-            CreateListenerError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => cause,
-            CreateListenerError::UnsupportedProtocol(ref cause) => cause,
+            CreateListenerError::CertificateNotFound(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::DuplicateListener(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::IncompatibleProtocols(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::InvalidConfigurationRequest(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::InvalidLoadBalancerAction(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::SSLPolicyNotFound(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::TargetGroupAssociationLimit(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::TooManyActions(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::TooManyCertificates(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::TooManyListeners(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::TooManyRegistrationsForTargetId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateListenerError::TooManyTargets(ref cause) => write!(f, "{}", cause),
+            CreateListenerError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateListenerError::UnsupportedProtocol(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateListenerError {}
 /// Errors returned by CreateLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum CreateLoadBalancerError {
@@ -6695,28 +6687,28 @@ impl CreateLoadBalancerError {
 }
 impl fmt::Display for CreateLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoadBalancerError::AllocationIdNotFound(ref cause) => cause,
-            CreateLoadBalancerError::AvailabilityZoneNotSupported(ref cause) => cause,
-            CreateLoadBalancerError::DuplicateLoadBalancerName(ref cause) => cause,
-            CreateLoadBalancerError::DuplicateTagKeys(ref cause) => cause,
-            CreateLoadBalancerError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateLoadBalancerError::InvalidScheme(ref cause) => cause,
-            CreateLoadBalancerError::InvalidSecurityGroup(ref cause) => cause,
-            CreateLoadBalancerError::InvalidSubnet(ref cause) => cause,
-            CreateLoadBalancerError::OperationNotPermitted(ref cause) => cause,
-            CreateLoadBalancerError::ResourceInUse(ref cause) => cause,
-            CreateLoadBalancerError::SubnetNotFound(ref cause) => cause,
-            CreateLoadBalancerError::TooManyLoadBalancers(ref cause) => cause,
-            CreateLoadBalancerError::TooManyTags(ref cause) => cause,
+            CreateLoadBalancerError::AllocationIdNotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::AvailabilityZoneNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerError::DuplicateLoadBalancerName(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::DuplicateTagKeys(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerError::InvalidScheme(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::InvalidSecurityGroup(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::SubnetNotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::TooManyLoadBalancers(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLoadBalancerError {}
 /// Errors returned by CreateRule
 #[derive(Debug, PartialEq)]
 pub enum CreateRuleError {
@@ -6847,29 +6839,27 @@ impl CreateRuleError {
 }
 impl fmt::Display for CreateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRuleError::IncompatibleProtocols(ref cause) => cause,
-            CreateRuleError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateRuleError::InvalidLoadBalancerAction(ref cause) => cause,
-            CreateRuleError::ListenerNotFound(ref cause) => cause,
-            CreateRuleError::PriorityInUse(ref cause) => cause,
-            CreateRuleError::TargetGroupAssociationLimit(ref cause) => cause,
-            CreateRuleError::TargetGroupNotFound(ref cause) => cause,
-            CreateRuleError::TooManyActions(ref cause) => cause,
-            CreateRuleError::TooManyRegistrationsForTargetId(ref cause) => cause,
-            CreateRuleError::TooManyRules(ref cause) => cause,
-            CreateRuleError::TooManyTargetGroups(ref cause) => cause,
-            CreateRuleError::TooManyTargets(ref cause) => cause,
-            CreateRuleError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => cause,
-            CreateRuleError::UnsupportedProtocol(ref cause) => cause,
+            CreateRuleError::IncompatibleProtocols(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::InvalidConfigurationRequest(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::InvalidLoadBalancerAction(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::PriorityInUse(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TargetGroupAssociationLimit(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TooManyActions(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TooManyRegistrationsForTargetId(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TooManyRules(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TooManyTargetGroups(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TooManyTargets(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRuleError::UnsupportedProtocol(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRuleError {}
 /// Errors returned by CreateTargetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateTargetGroupError {
@@ -6923,18 +6913,16 @@ impl CreateTargetGroupError {
 }
 impl fmt::Display for CreateTargetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTargetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTargetGroupError::DuplicateTargetGroupName(ref cause) => cause,
-            CreateTargetGroupError::InvalidConfigurationRequest(ref cause) => cause,
-            CreateTargetGroupError::TooManyTargetGroups(ref cause) => cause,
+            CreateTargetGroupError::DuplicateTargetGroupName(ref cause) => write!(f, "{}", cause),
+            CreateTargetGroupError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTargetGroupError::TooManyTargetGroups(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTargetGroupError {}
 /// Errors returned by DeleteListener
 #[derive(Debug, PartialEq)]
 pub enum DeleteListenerError {
@@ -6972,16 +6960,12 @@ impl DeleteListenerError {
 }
 impl fmt::Display for DeleteListenerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteListenerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteListenerError::ListenerNotFound(ref cause) => cause,
+            DeleteListenerError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteListenerError {}
 /// Errors returned by DeleteLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoadBalancerError {
@@ -7033,18 +7017,14 @@ impl DeleteLoadBalancerError {
 }
 impl fmt::Display for DeleteLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoadBalancerError::LoadBalancerNotFound(ref cause) => cause,
-            DeleteLoadBalancerError::OperationNotPermitted(ref cause) => cause,
-            DeleteLoadBalancerError::ResourceInUse(ref cause) => cause,
+            DeleteLoadBalancerError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLoadBalancerError {}
 /// Errors returned by DeleteRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteRuleError {
@@ -7089,17 +7069,13 @@ impl DeleteRuleError {
 }
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRuleError::OperationNotPermitted(ref cause) => cause,
-            DeleteRuleError::RuleNotFound(ref cause) => cause,
+            DeleteRuleError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::RuleNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRuleError {}
 /// Errors returned by DeleteTargetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteTargetGroupError {
@@ -7137,16 +7113,12 @@ impl DeleteTargetGroupError {
 }
 impl fmt::Display for DeleteTargetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTargetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTargetGroupError::ResourceInUse(ref cause) => cause,
+            DeleteTargetGroupError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTargetGroupError {}
 /// Errors returned by DeregisterTargets
 #[derive(Debug, PartialEq)]
 pub enum DeregisterTargetsError {
@@ -7191,17 +7163,13 @@ impl DeregisterTargetsError {
 }
 impl fmt::Display for DeregisterTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterTargetsError::InvalidTarget(ref cause) => cause,
-            DeregisterTargetsError::TargetGroupNotFound(ref cause) => cause,
+            DeregisterTargetsError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            DeregisterTargetsError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterTargetsError {}
 /// Errors returned by DescribeAccountLimits
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountLimitsError {}
@@ -7231,14 +7199,10 @@ impl DescribeAccountLimitsError {
 }
 impl fmt::Display for DescribeAccountLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountLimitsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAccountLimitsError {}
 /// Errors returned by DescribeListenerCertificates
 #[derive(Debug, PartialEq)]
 pub enum DescribeListenerCertificatesError {
@@ -7280,16 +7244,14 @@ impl DescribeListenerCertificatesError {
 }
 impl fmt::Display for DescribeListenerCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeListenerCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeListenerCertificatesError::ListenerNotFound(ref cause) => cause,
+            DescribeListenerCertificatesError::ListenerNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeListenerCertificatesError {}
 /// Errors returned by DescribeListeners
 #[derive(Debug, PartialEq)]
 pub enum DescribeListenersError {
@@ -7341,18 +7303,14 @@ impl DescribeListenersError {
 }
 impl fmt::Display for DescribeListenersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeListenersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeListenersError::ListenerNotFound(ref cause) => cause,
-            DescribeListenersError::LoadBalancerNotFound(ref cause) => cause,
-            DescribeListenersError::UnsupportedProtocol(ref cause) => cause,
+            DescribeListenersError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeListenersError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeListenersError::UnsupportedProtocol(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeListenersError {}
 /// Errors returned by DescribeLoadBalancerAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancerAttributesError {
@@ -7394,16 +7352,14 @@ impl DescribeLoadBalancerAttributesError {
 }
 impl fmt::Display for DescribeLoadBalancerAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancerAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancerAttributesError::LoadBalancerNotFound(ref cause) => cause,
+            DescribeLoadBalancerAttributesError::LoadBalancerNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLoadBalancerAttributesError {}
 /// Errors returned by DescribeLoadBalancers
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBalancersError {
@@ -7441,16 +7397,12 @@ impl DescribeLoadBalancersError {
 }
 impl fmt::Display for DescribeLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBalancersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBalancersError::LoadBalancerNotFound(ref cause) => cause,
+            DescribeLoadBalancersError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLoadBalancersError {}
 /// Errors returned by DescribeRules
 #[derive(Debug, PartialEq)]
 pub enum DescribeRulesError {
@@ -7502,18 +7454,14 @@ impl DescribeRulesError {
 }
 impl fmt::Display for DescribeRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRulesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRulesError::ListenerNotFound(ref cause) => cause,
-            DescribeRulesError::RuleNotFound(ref cause) => cause,
-            DescribeRulesError::UnsupportedProtocol(ref cause) => cause,
+            DescribeRulesError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeRulesError::RuleNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeRulesError::UnsupportedProtocol(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRulesError {}
 /// Errors returned by DescribeSSLPolicies
 #[derive(Debug, PartialEq)]
 pub enum DescribeSSLPoliciesError {
@@ -7551,16 +7499,12 @@ impl DescribeSSLPoliciesError {
 }
 impl fmt::Display for DescribeSSLPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSSLPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSSLPoliciesError::SSLPolicyNotFound(ref cause) => cause,
+            DescribeSSLPoliciesError::SSLPolicyNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSSLPoliciesError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -7619,19 +7563,15 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::ListenerNotFound(ref cause) => cause,
-            DescribeTagsError::LoadBalancerNotFound(ref cause) => cause,
-            DescribeTagsError::RuleNotFound(ref cause) => cause,
-            DescribeTagsError::TargetGroupNotFound(ref cause) => cause,
+            DescribeTagsError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::RuleNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by DescribeTargetGroupAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeTargetGroupAttributesError {
@@ -7673,16 +7613,14 @@ impl DescribeTargetGroupAttributesError {
 }
 impl fmt::Display for DescribeTargetGroupAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTargetGroupAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTargetGroupAttributesError::TargetGroupNotFound(ref cause) => cause,
+            DescribeTargetGroupAttributesError::TargetGroupNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTargetGroupAttributesError {}
 /// Errors returned by DescribeTargetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeTargetGroupsError {
@@ -7727,17 +7665,13 @@ impl DescribeTargetGroupsError {
 }
 impl fmt::Display for DescribeTargetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTargetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTargetGroupsError::LoadBalancerNotFound(ref cause) => cause,
-            DescribeTargetGroupsError::TargetGroupNotFound(ref cause) => cause,
+            DescribeTargetGroupsError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTargetGroupsError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTargetGroupsError {}
 /// Errors returned by DescribeTargetHealth
 #[derive(Debug, PartialEq)]
 pub enum DescribeTargetHealthError {
@@ -7789,18 +7723,14 @@ impl DescribeTargetHealthError {
 }
 impl fmt::Display for DescribeTargetHealthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTargetHealthError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTargetHealthError::HealthUnavailable(ref cause) => cause,
-            DescribeTargetHealthError::InvalidTarget(ref cause) => cause,
-            DescribeTargetHealthError::TargetGroupNotFound(ref cause) => cause,
+            DescribeTargetHealthError::HealthUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeTargetHealthError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            DescribeTargetHealthError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTargetHealthError {}
 /// Errors returned by ModifyListener
 #[derive(Debug, PartialEq)]
 pub enum ModifyListenerError {
@@ -7947,31 +7877,31 @@ impl ModifyListenerError {
 }
 impl fmt::Display for ModifyListenerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyListenerError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyListenerError::CertificateNotFound(ref cause) => cause,
-            ModifyListenerError::DuplicateListener(ref cause) => cause,
-            ModifyListenerError::IncompatibleProtocols(ref cause) => cause,
-            ModifyListenerError::InvalidConfigurationRequest(ref cause) => cause,
-            ModifyListenerError::InvalidLoadBalancerAction(ref cause) => cause,
-            ModifyListenerError::ListenerNotFound(ref cause) => cause,
-            ModifyListenerError::SSLPolicyNotFound(ref cause) => cause,
-            ModifyListenerError::TargetGroupAssociationLimit(ref cause) => cause,
-            ModifyListenerError::TargetGroupNotFound(ref cause) => cause,
-            ModifyListenerError::TooManyActions(ref cause) => cause,
-            ModifyListenerError::TooManyCertificates(ref cause) => cause,
-            ModifyListenerError::TooManyListeners(ref cause) => cause,
-            ModifyListenerError::TooManyRegistrationsForTargetId(ref cause) => cause,
-            ModifyListenerError::TooManyTargets(ref cause) => cause,
-            ModifyListenerError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => cause,
-            ModifyListenerError::UnsupportedProtocol(ref cause) => cause,
+            ModifyListenerError::CertificateNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::DuplicateListener(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::IncompatibleProtocols(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::InvalidConfigurationRequest(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::InvalidLoadBalancerAction(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::SSLPolicyNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::TargetGroupAssociationLimit(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::TooManyActions(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::TooManyCertificates(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::TooManyListeners(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::TooManyRegistrationsForTargetId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyListenerError::TooManyTargets(ref cause) => write!(f, "{}", cause),
+            ModifyListenerError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyListenerError::UnsupportedProtocol(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyListenerError {}
 /// Errors returned by ModifyLoadBalancerAttributes
 #[derive(Debug, PartialEq)]
 pub enum ModifyLoadBalancerAttributesError {
@@ -8022,17 +7952,17 @@ impl ModifyLoadBalancerAttributesError {
 }
 impl fmt::Display for ModifyLoadBalancerAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyLoadBalancerAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyLoadBalancerAttributesError::InvalidConfigurationRequest(ref cause) => cause,
-            ModifyLoadBalancerAttributesError::LoadBalancerNotFound(ref cause) => cause,
+            ModifyLoadBalancerAttributesError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyLoadBalancerAttributesError::LoadBalancerNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyLoadBalancerAttributesError {}
 /// Errors returned by ModifyRule
 #[derive(Debug, PartialEq)]
 pub enum ModifyRuleError {
@@ -8142,26 +8072,24 @@ impl ModifyRuleError {
 }
 impl fmt::Display for ModifyRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyRuleError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyRuleError::IncompatibleProtocols(ref cause) => cause,
-            ModifyRuleError::InvalidLoadBalancerAction(ref cause) => cause,
-            ModifyRuleError::OperationNotPermitted(ref cause) => cause,
-            ModifyRuleError::RuleNotFound(ref cause) => cause,
-            ModifyRuleError::TargetGroupAssociationLimit(ref cause) => cause,
-            ModifyRuleError::TargetGroupNotFound(ref cause) => cause,
-            ModifyRuleError::TooManyActions(ref cause) => cause,
-            ModifyRuleError::TooManyRegistrationsForTargetId(ref cause) => cause,
-            ModifyRuleError::TooManyTargets(ref cause) => cause,
-            ModifyRuleError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => cause,
-            ModifyRuleError::UnsupportedProtocol(ref cause) => cause,
+            ModifyRuleError::IncompatibleProtocols(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::InvalidLoadBalancerAction(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::RuleNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::TargetGroupAssociationLimit(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::TooManyActions(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::TooManyRegistrationsForTargetId(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::TooManyTargets(ref cause) => write!(f, "{}", cause),
+            ModifyRuleError::TooManyUniqueTargetGroupsPerLoadBalancer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyRuleError::UnsupportedProtocol(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyRuleError {}
 /// Errors returned by ModifyTargetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyTargetGroupError {
@@ -8208,17 +8136,15 @@ impl ModifyTargetGroupError {
 }
 impl fmt::Display for ModifyTargetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyTargetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyTargetGroupError::InvalidConfigurationRequest(ref cause) => cause,
-            ModifyTargetGroupError::TargetGroupNotFound(ref cause) => cause,
+            ModifyTargetGroupError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyTargetGroupError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyTargetGroupError {}
 /// Errors returned by ModifyTargetGroupAttributes
 #[derive(Debug, PartialEq)]
 pub enum ModifyTargetGroupAttributesError {
@@ -8269,17 +8195,17 @@ impl ModifyTargetGroupAttributesError {
 }
 impl fmt::Display for ModifyTargetGroupAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyTargetGroupAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyTargetGroupAttributesError::InvalidConfigurationRequest(ref cause) => cause,
-            ModifyTargetGroupAttributesError::TargetGroupNotFound(ref cause) => cause,
+            ModifyTargetGroupAttributesError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyTargetGroupAttributesError::TargetGroupNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyTargetGroupAttributesError {}
 /// Errors returned by RegisterTargets
 #[derive(Debug, PartialEq)]
 pub enum RegisterTargetsError {
@@ -8340,19 +8266,17 @@ impl RegisterTargetsError {
 }
 impl fmt::Display for RegisterTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterTargetsError::InvalidTarget(ref cause) => cause,
-            RegisterTargetsError::TargetGroupNotFound(ref cause) => cause,
-            RegisterTargetsError::TooManyRegistrationsForTargetId(ref cause) => cause,
-            RegisterTargetsError::TooManyTargets(ref cause) => cause,
+            RegisterTargetsError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            RegisterTargetsError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
+            RegisterTargetsError::TooManyRegistrationsForTargetId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterTargetsError::TooManyTargets(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterTargetsError {}
 /// Errors returned by RemoveListenerCertificates
 #[derive(Debug, PartialEq)]
 pub enum RemoveListenerCertificatesError {
@@ -8401,17 +8325,15 @@ impl RemoveListenerCertificatesError {
 }
 impl fmt::Display for RemoveListenerCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveListenerCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveListenerCertificatesError::ListenerNotFound(ref cause) => cause,
-            RemoveListenerCertificatesError::OperationNotPermitted(ref cause) => cause,
+            RemoveListenerCertificatesError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveListenerCertificatesError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveListenerCertificatesError {}
 /// Errors returned by RemoveTags
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsError {
@@ -8477,20 +8399,16 @@ impl RemoveTagsError {
 }
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsError::ListenerNotFound(ref cause) => cause,
-            RemoveTagsError::LoadBalancerNotFound(ref cause) => cause,
-            RemoveTagsError::RuleNotFound(ref cause) => cause,
-            RemoveTagsError::TargetGroupNotFound(ref cause) => cause,
-            RemoveTagsError::TooManyTags(ref cause) => cause,
+            RemoveTagsError::ListenerNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::RuleNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::TargetGroupNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsError {}
 /// Errors returned by SetIpAddressType
 #[derive(Debug, PartialEq)]
 pub enum SetIpAddressTypeError {
@@ -8544,18 +8462,14 @@ impl SetIpAddressTypeError {
 }
 impl fmt::Display for SetIpAddressTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIpAddressTypeError {
-    fn description(&self) -> &str {
         match *self {
-            SetIpAddressTypeError::InvalidConfigurationRequest(ref cause) => cause,
-            SetIpAddressTypeError::InvalidSubnet(ref cause) => cause,
-            SetIpAddressTypeError::LoadBalancerNotFound(ref cause) => cause,
+            SetIpAddressTypeError::InvalidConfigurationRequest(ref cause) => write!(f, "{}", cause),
+            SetIpAddressTypeError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            SetIpAddressTypeError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetIpAddressTypeError {}
 /// Errors returned by SetRulePriorities
 #[derive(Debug, PartialEq)]
 pub enum SetRulePrioritiesError {
@@ -8607,18 +8521,14 @@ impl SetRulePrioritiesError {
 }
 impl fmt::Display for SetRulePrioritiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetRulePrioritiesError {
-    fn description(&self) -> &str {
         match *self {
-            SetRulePrioritiesError::OperationNotPermitted(ref cause) => cause,
-            SetRulePrioritiesError::PriorityInUse(ref cause) => cause,
-            SetRulePrioritiesError::RuleNotFound(ref cause) => cause,
+            SetRulePrioritiesError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            SetRulePrioritiesError::PriorityInUse(ref cause) => write!(f, "{}", cause),
+            SetRulePrioritiesError::RuleNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetRulePrioritiesError {}
 /// Errors returned by SetSecurityGroups
 #[derive(Debug, PartialEq)]
 pub enum SetSecurityGroupsError {
@@ -8672,18 +8582,16 @@ impl SetSecurityGroupsError {
 }
 impl fmt::Display for SetSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetSecurityGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            SetSecurityGroupsError::InvalidConfigurationRequest(ref cause) => cause,
-            SetSecurityGroupsError::InvalidSecurityGroup(ref cause) => cause,
-            SetSecurityGroupsError::LoadBalancerNotFound(ref cause) => cause,
+            SetSecurityGroupsError::InvalidConfigurationRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetSecurityGroupsError::InvalidSecurityGroup(ref cause) => write!(f, "{}", cause),
+            SetSecurityGroupsError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetSecurityGroupsError {}
 /// Errors returned by SetSubnets
 #[derive(Debug, PartialEq)]
 pub enum SetSubnetsError {
@@ -8756,21 +8664,17 @@ impl SetSubnetsError {
 }
 impl fmt::Display for SetSubnetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetSubnetsError {
-    fn description(&self) -> &str {
         match *self {
-            SetSubnetsError::AllocationIdNotFound(ref cause) => cause,
-            SetSubnetsError::AvailabilityZoneNotSupported(ref cause) => cause,
-            SetSubnetsError::InvalidConfigurationRequest(ref cause) => cause,
-            SetSubnetsError::InvalidSubnet(ref cause) => cause,
-            SetSubnetsError::LoadBalancerNotFound(ref cause) => cause,
-            SetSubnetsError::SubnetNotFound(ref cause) => cause,
+            SetSubnetsError::AllocationIdNotFound(ref cause) => write!(f, "{}", cause),
+            SetSubnetsError::AvailabilityZoneNotSupported(ref cause) => write!(f, "{}", cause),
+            SetSubnetsError::InvalidConfigurationRequest(ref cause) => write!(f, "{}", cause),
+            SetSubnetsError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            SetSubnetsError::LoadBalancerNotFound(ref cause) => write!(f, "{}", cause),
+            SetSubnetsError::SubnetNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetSubnetsError {}
 /// Trait representing the capabilities of the Elastic Load Balancing v2 API. Elastic Load Balancing v2 clients implement this trait.
 pub trait Elb {
     /// <p>Adds the specified SSL server certificate to the certificate list for the specified HTTPS or TLS listener.</p> <p>If the certificate in already in the certificate list, the call is successful but the certificate is not added again.</p> <p>To get the certificate list for a listener, use <a>DescribeListenerCertificates</a>. To remove certificates from the certificate list for a listener, use <a>RemoveListenerCertificates</a>. To replace the default certificate for a listener, use <a>ModifyListener</a>.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#https-listener-certificates">SSL Certificates</a> in the <i>Application Load Balancers Guide</i>.</p>

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -2533,17 +2533,13 @@ impl AddInstanceFleetError {
 }
 impl fmt::Display for AddInstanceFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddInstanceFleetError {
-    fn description(&self) -> &str {
         match *self {
-            AddInstanceFleetError::InternalServer(ref cause) => cause,
-            AddInstanceFleetError::InvalidRequest(ref cause) => cause,
+            AddInstanceFleetError::InternalServer(ref cause) => write!(f, "{}", cause),
+            AddInstanceFleetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddInstanceFleetError {}
 /// Errors returned by AddInstanceGroups
 #[derive(Debug, PartialEq)]
 pub enum AddInstanceGroupsError {
@@ -2569,16 +2565,12 @@ impl AddInstanceGroupsError {
 }
 impl fmt::Display for AddInstanceGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddInstanceGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            AddInstanceGroupsError::InternalServerError(ref cause) => cause,
+            AddInstanceGroupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddInstanceGroupsError {}
 /// Errors returned by AddJobFlowSteps
 #[derive(Debug, PartialEq)]
 pub enum AddJobFlowStepsError {
@@ -2602,16 +2594,12 @@ impl AddJobFlowStepsError {
 }
 impl fmt::Display for AddJobFlowStepsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddJobFlowStepsError {
-    fn description(&self) -> &str {
         match *self {
-            AddJobFlowStepsError::InternalServerError(ref cause) => cause,
+            AddJobFlowStepsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddJobFlowStepsError {}
 /// Errors returned by AddTags
 #[derive(Debug, PartialEq)]
 pub enum AddTagsError {
@@ -2640,17 +2628,13 @@ impl AddTagsError {
 }
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsError::InternalServer(ref cause) => cause,
-            AddTagsError::InvalidRequest(ref cause) => cause,
+            AddTagsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            AddTagsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsError {}
 /// Errors returned by CancelSteps
 #[derive(Debug, PartialEq)]
 pub enum CancelStepsError {
@@ -2679,17 +2663,13 @@ impl CancelStepsError {
 }
 impl fmt::Display for CancelStepsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelStepsError {
-    fn description(&self) -> &str {
         match *self {
-            CancelStepsError::InternalServerError(ref cause) => cause,
-            CancelStepsError::InvalidRequest(ref cause) => cause,
+            CancelStepsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CancelStepsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelStepsError {}
 /// Errors returned by CreateSecurityConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateSecurityConfigurationError {
@@ -2724,17 +2704,13 @@ impl CreateSecurityConfigurationError {
 }
 impl fmt::Display for CreateSecurityConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSecurityConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSecurityConfigurationError::InternalServer(ref cause) => cause,
-            CreateSecurityConfigurationError::InvalidRequest(ref cause) => cause,
+            CreateSecurityConfigurationError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateSecurityConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSecurityConfigurationError {}
 /// Errors returned by DeleteSecurityConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteSecurityConfigurationError {
@@ -2769,17 +2745,13 @@ impl DeleteSecurityConfigurationError {
 }
 impl fmt::Display for DeleteSecurityConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSecurityConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSecurityConfigurationError::InternalServer(ref cause) => cause,
-            DeleteSecurityConfigurationError::InvalidRequest(ref cause) => cause,
+            DeleteSecurityConfigurationError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteSecurityConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSecurityConfigurationError {}
 /// Errors returned by DescribeCluster
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterError {
@@ -2808,17 +2780,13 @@ impl DescribeClusterError {
 }
 impl fmt::Display for DescribeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterError::InternalServer(ref cause) => cause,
-            DescribeClusterError::InvalidRequest(ref cause) => cause,
+            DescribeClusterError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterError {}
 /// Errors returned by DescribeJobFlows
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobFlowsError {
@@ -2844,16 +2812,12 @@ impl DescribeJobFlowsError {
 }
 impl fmt::Display for DescribeJobFlowsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobFlowsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobFlowsError::InternalServerError(ref cause) => cause,
+            DescribeJobFlowsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobFlowsError {}
 /// Errors returned by DescribeSecurityConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeSecurityConfigurationError {
@@ -2888,17 +2852,13 @@ impl DescribeSecurityConfigurationError {
 }
 impl fmt::Display for DescribeSecurityConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSecurityConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSecurityConfigurationError::InternalServer(ref cause) => cause,
-            DescribeSecurityConfigurationError::InvalidRequest(ref cause) => cause,
+            DescribeSecurityConfigurationError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeSecurityConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSecurityConfigurationError {}
 /// Errors returned by DescribeStep
 #[derive(Debug, PartialEq)]
 pub enum DescribeStepError {
@@ -2927,17 +2887,13 @@ impl DescribeStepError {
 }
 impl fmt::Display for DescribeStepError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStepError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStepError::InternalServer(ref cause) => cause,
-            DescribeStepError::InvalidRequest(ref cause) => cause,
+            DescribeStepError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeStepError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStepError {}
 /// Errors returned by GetBlockPublicAccessConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetBlockPublicAccessConfigurationError {
@@ -2972,17 +2928,17 @@ impl GetBlockPublicAccessConfigurationError {
 }
 impl fmt::Display for GetBlockPublicAccessConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBlockPublicAccessConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetBlockPublicAccessConfigurationError::InternalServer(ref cause) => cause,
-            GetBlockPublicAccessConfigurationError::InvalidRequest(ref cause) => cause,
+            GetBlockPublicAccessConfigurationError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetBlockPublicAccessConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetBlockPublicAccessConfigurationError {}
 /// Errors returned by ListBootstrapActions
 #[derive(Debug, PartialEq)]
 pub enum ListBootstrapActionsError {
@@ -3011,17 +2967,13 @@ impl ListBootstrapActionsError {
 }
 impl fmt::Display for ListBootstrapActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBootstrapActionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBootstrapActionsError::InternalServer(ref cause) => cause,
-            ListBootstrapActionsError::InvalidRequest(ref cause) => cause,
+            ListBootstrapActionsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListBootstrapActionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBootstrapActionsError {}
 /// Errors returned by ListClusters
 #[derive(Debug, PartialEq)]
 pub enum ListClustersError {
@@ -3050,17 +3002,13 @@ impl ListClustersError {
 }
 impl fmt::Display for ListClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClustersError {
-    fn description(&self) -> &str {
         match *self {
-            ListClustersError::InternalServer(ref cause) => cause,
-            ListClustersError::InvalidRequest(ref cause) => cause,
+            ListClustersError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListClustersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListClustersError {}
 /// Errors returned by ListInstanceFleets
 #[derive(Debug, PartialEq)]
 pub enum ListInstanceFleetsError {
@@ -3089,17 +3037,13 @@ impl ListInstanceFleetsError {
 }
 impl fmt::Display for ListInstanceFleetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInstanceFleetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListInstanceFleetsError::InternalServer(ref cause) => cause,
-            ListInstanceFleetsError::InvalidRequest(ref cause) => cause,
+            ListInstanceFleetsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListInstanceFleetsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInstanceFleetsError {}
 /// Errors returned by ListInstanceGroups
 #[derive(Debug, PartialEq)]
 pub enum ListInstanceGroupsError {
@@ -3128,17 +3072,13 @@ impl ListInstanceGroupsError {
 }
 impl fmt::Display for ListInstanceGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInstanceGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListInstanceGroupsError::InternalServer(ref cause) => cause,
-            ListInstanceGroupsError::InvalidRequest(ref cause) => cause,
+            ListInstanceGroupsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListInstanceGroupsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInstanceGroupsError {}
 /// Errors returned by ListInstances
 #[derive(Debug, PartialEq)]
 pub enum ListInstancesError {
@@ -3167,17 +3107,13 @@ impl ListInstancesError {
 }
 impl fmt::Display for ListInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListInstancesError::InternalServer(ref cause) => cause,
-            ListInstancesError::InvalidRequest(ref cause) => cause,
+            ListInstancesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListInstancesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInstancesError {}
 /// Errors returned by ListSecurityConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListSecurityConfigurationsError {
@@ -3212,17 +3148,13 @@ impl ListSecurityConfigurationsError {
 }
 impl fmt::Display for ListSecurityConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSecurityConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSecurityConfigurationsError::InternalServer(ref cause) => cause,
-            ListSecurityConfigurationsError::InvalidRequest(ref cause) => cause,
+            ListSecurityConfigurationsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListSecurityConfigurationsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSecurityConfigurationsError {}
 /// Errors returned by ListSteps
 #[derive(Debug, PartialEq)]
 pub enum ListStepsError {
@@ -3251,17 +3183,13 @@ impl ListStepsError {
 }
 impl fmt::Display for ListStepsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStepsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStepsError::InternalServer(ref cause) => cause,
-            ListStepsError::InvalidRequest(ref cause) => cause,
+            ListStepsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListStepsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStepsError {}
 /// Errors returned by ModifyCluster
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterError {
@@ -3290,17 +3218,13 @@ impl ModifyClusterError {
 }
 impl fmt::Display for ModifyClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterError::InternalServerError(ref cause) => cause,
-            ModifyClusterError::InvalidRequest(ref cause) => cause,
+            ModifyClusterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyClusterError {}
 /// Errors returned by ModifyInstanceFleet
 #[derive(Debug, PartialEq)]
 pub enum ModifyInstanceFleetError {
@@ -3329,17 +3253,13 @@ impl ModifyInstanceFleetError {
 }
 impl fmt::Display for ModifyInstanceFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyInstanceFleetError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyInstanceFleetError::InternalServer(ref cause) => cause,
-            ModifyInstanceFleetError::InvalidRequest(ref cause) => cause,
+            ModifyInstanceFleetError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ModifyInstanceFleetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyInstanceFleetError {}
 /// Errors returned by ModifyInstanceGroups
 #[derive(Debug, PartialEq)]
 pub enum ModifyInstanceGroupsError {
@@ -3365,16 +3285,12 @@ impl ModifyInstanceGroupsError {
 }
 impl fmt::Display for ModifyInstanceGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyInstanceGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyInstanceGroupsError::InternalServerError(ref cause) => cause,
+            ModifyInstanceGroupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyInstanceGroupsError {}
 /// Errors returned by PutAutoScalingPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutAutoScalingPolicyError {}
@@ -3392,14 +3308,10 @@ impl PutAutoScalingPolicyError {
 }
 impl fmt::Display for PutAutoScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAutoScalingPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutAutoScalingPolicyError {}
 /// Errors returned by PutBlockPublicAccessConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutBlockPublicAccessConfigurationError {
@@ -3434,17 +3346,17 @@ impl PutBlockPublicAccessConfigurationError {
 }
 impl fmt::Display for PutBlockPublicAccessConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBlockPublicAccessConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutBlockPublicAccessConfigurationError::InternalServer(ref cause) => cause,
-            PutBlockPublicAccessConfigurationError::InvalidRequest(ref cause) => cause,
+            PutBlockPublicAccessConfigurationError::InternalServer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutBlockPublicAccessConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutBlockPublicAccessConfigurationError {}
 /// Errors returned by RemoveAutoScalingPolicy
 #[derive(Debug, PartialEq)]
 pub enum RemoveAutoScalingPolicyError {}
@@ -3462,14 +3374,10 @@ impl RemoveAutoScalingPolicyError {
 }
 impl fmt::Display for RemoveAutoScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveAutoScalingPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RemoveAutoScalingPolicyError {}
 /// Errors returned by RemoveTags
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsError {
@@ -3498,17 +3406,13 @@ impl RemoveTagsError {
 }
 impl fmt::Display for RemoveTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsError::InternalServer(ref cause) => cause,
-            RemoveTagsError::InvalidRequest(ref cause) => cause,
+            RemoveTagsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            RemoveTagsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsError {}
 /// Errors returned by RunJobFlow
 #[derive(Debug, PartialEq)]
 pub enum RunJobFlowError {
@@ -3532,16 +3436,12 @@ impl RunJobFlowError {
 }
 impl fmt::Display for RunJobFlowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RunJobFlowError {
-    fn description(&self) -> &str {
         match *self {
-            RunJobFlowError::InternalServerError(ref cause) => cause,
+            RunJobFlowError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RunJobFlowError {}
 /// Errors returned by SetTerminationProtection
 #[derive(Debug, PartialEq)]
 pub enum SetTerminationProtectionError {
@@ -3567,16 +3467,12 @@ impl SetTerminationProtectionError {
 }
 impl fmt::Display for SetTerminationProtectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetTerminationProtectionError {
-    fn description(&self) -> &str {
         match *self {
-            SetTerminationProtectionError::InternalServerError(ref cause) => cause,
+            SetTerminationProtectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetTerminationProtectionError {}
 /// Errors returned by SetVisibleToAllUsers
 #[derive(Debug, PartialEq)]
 pub enum SetVisibleToAllUsersError {
@@ -3602,16 +3498,12 @@ impl SetVisibleToAllUsersError {
 }
 impl fmt::Display for SetVisibleToAllUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetVisibleToAllUsersError {
-    fn description(&self) -> &str {
         match *self {
-            SetVisibleToAllUsersError::InternalServerError(ref cause) => cause,
+            SetVisibleToAllUsersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetVisibleToAllUsersError {}
 /// Errors returned by TerminateJobFlows
 #[derive(Debug, PartialEq)]
 pub enum TerminateJobFlowsError {
@@ -3637,16 +3529,12 @@ impl TerminateJobFlowsError {
 }
 impl fmt::Display for TerminateJobFlowsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateJobFlowsError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateJobFlowsError::InternalServerError(ref cause) => cause,
+            TerminateJobFlowsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TerminateJobFlowsError {}
 /// Trait representing the capabilities of the Amazon EMR API. Amazon EMR clients implement this trait.
 pub trait Emr {
     /// <p><p>Adds an instance fleet to a running cluster.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x.</p> </note></p>

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -1208,18 +1208,14 @@ impl ActivateEventSourceError {
 }
 impl fmt::Display for ActivateEventSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ActivateEventSourceError {
-    fn description(&self) -> &str {
         match *self {
-            ActivateEventSourceError::Internal(ref cause) => cause,
-            ActivateEventSourceError::InvalidState(ref cause) => cause,
-            ActivateEventSourceError::ResourceNotFound(ref cause) => cause,
+            ActivateEventSourceError::Internal(ref cause) => write!(f, "{}", cause),
+            ActivateEventSourceError::InvalidState(ref cause) => write!(f, "{}", cause),
+            ActivateEventSourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ActivateEventSourceError {}
 /// Errors returned by CreateEventBus
 #[derive(Debug, PartialEq)]
 pub enum CreateEventBusError {
@@ -1272,21 +1268,17 @@ impl CreateEventBusError {
 }
 impl fmt::Display for CreateEventBusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEventBusError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEventBusError::ConcurrentModification(ref cause) => cause,
-            CreateEventBusError::Internal(ref cause) => cause,
-            CreateEventBusError::InvalidState(ref cause) => cause,
-            CreateEventBusError::LimitExceeded(ref cause) => cause,
-            CreateEventBusError::ResourceAlreadyExists(ref cause) => cause,
-            CreateEventBusError::ResourceNotFound(ref cause) => cause,
+            CreateEventBusError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateEventBusError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateEventBusError::InvalidState(ref cause) => write!(f, "{}", cause),
+            CreateEventBusError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateEventBusError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateEventBusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEventBusError {}
 /// Errors returned by CreatePartnerEventSource
 #[derive(Debug, PartialEq)]
 pub enum CreatePartnerEventSourceError {
@@ -1331,19 +1323,19 @@ impl CreatePartnerEventSourceError {
 }
 impl fmt::Display for CreatePartnerEventSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePartnerEventSourceError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePartnerEventSourceError::ConcurrentModification(ref cause) => cause,
-            CreatePartnerEventSourceError::Internal(ref cause) => cause,
-            CreatePartnerEventSourceError::LimitExceeded(ref cause) => cause,
-            CreatePartnerEventSourceError::ResourceAlreadyExists(ref cause) => cause,
+            CreatePartnerEventSourceError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePartnerEventSourceError::Internal(ref cause) => write!(f, "{}", cause),
+            CreatePartnerEventSourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePartnerEventSourceError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreatePartnerEventSourceError {}
 /// Errors returned by DeactivateEventSource
 #[derive(Debug, PartialEq)]
 pub enum DeactivateEventSourceError {
@@ -1379,18 +1371,14 @@ impl DeactivateEventSourceError {
 }
 impl fmt::Display for DeactivateEventSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeactivateEventSourceError {
-    fn description(&self) -> &str {
         match *self {
-            DeactivateEventSourceError::Internal(ref cause) => cause,
-            DeactivateEventSourceError::InvalidState(ref cause) => cause,
-            DeactivateEventSourceError::ResourceNotFound(ref cause) => cause,
+            DeactivateEventSourceError::Internal(ref cause) => write!(f, "{}", cause),
+            DeactivateEventSourceError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DeactivateEventSourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeactivateEventSourceError {}
 /// Errors returned by DeleteEventBus
 #[derive(Debug, PartialEq)]
 pub enum DeleteEventBusError {
@@ -1414,16 +1402,12 @@ impl DeleteEventBusError {
 }
 impl fmt::Display for DeleteEventBusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEventBusError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEventBusError::Internal(ref cause) => cause,
+            DeleteEventBusError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEventBusError {}
 /// Errors returned by DeletePartnerEventSource
 #[derive(Debug, PartialEq)]
 pub enum DeletePartnerEventSourceError {
@@ -1447,16 +1431,12 @@ impl DeletePartnerEventSourceError {
 }
 impl fmt::Display for DeletePartnerEventSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePartnerEventSourceError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePartnerEventSourceError::Internal(ref cause) => cause,
+            DeletePartnerEventSourceError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePartnerEventSourceError {}
 /// Errors returned by DeleteRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteRuleError {
@@ -1495,19 +1475,15 @@ impl DeleteRuleError {
 }
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRuleError::ConcurrentModification(ref cause) => cause,
-            DeleteRuleError::Internal(ref cause) => cause,
-            DeleteRuleError::ManagedRule(ref cause) => cause,
-            DeleteRuleError::ResourceNotFound(ref cause) => cause,
+            DeleteRuleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRuleError {}
 /// Errors returned by DescribeEventBus
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventBusError {
@@ -1536,17 +1512,13 @@ impl DescribeEventBusError {
 }
 impl fmt::Display for DescribeEventBusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventBusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventBusError::Internal(ref cause) => cause,
-            DescribeEventBusError::ResourceNotFound(ref cause) => cause,
+            DescribeEventBusError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeEventBusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventBusError {}
 /// Errors returned by DescribeEventSource
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventSourceError {
@@ -1577,17 +1549,13 @@ impl DescribeEventSourceError {
 }
 impl fmt::Display for DescribeEventSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventSourceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventSourceError::Internal(ref cause) => cause,
-            DescribeEventSourceError::ResourceNotFound(ref cause) => cause,
+            DescribeEventSourceError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeEventSourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventSourceError {}
 /// Errors returned by DescribePartnerEventSource
 #[derive(Debug, PartialEq)]
 pub enum DescribePartnerEventSourceError {
@@ -1620,17 +1588,13 @@ impl DescribePartnerEventSourceError {
 }
 impl fmt::Display for DescribePartnerEventSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePartnerEventSourceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePartnerEventSourceError::Internal(ref cause) => cause,
-            DescribePartnerEventSourceError::ResourceNotFound(ref cause) => cause,
+            DescribePartnerEventSourceError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribePartnerEventSourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePartnerEventSourceError {}
 /// Errors returned by DescribeRule
 #[derive(Debug, PartialEq)]
 pub enum DescribeRuleError {
@@ -1659,17 +1623,13 @@ impl DescribeRuleError {
 }
 impl fmt::Display for DescribeRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRuleError::Internal(ref cause) => cause,
-            DescribeRuleError::ResourceNotFound(ref cause) => cause,
+            DescribeRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeRuleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRuleError {}
 /// Errors returned by DisableRule
 #[derive(Debug, PartialEq)]
 pub enum DisableRuleError {
@@ -1708,19 +1668,15 @@ impl DisableRuleError {
 }
 impl fmt::Display for DisableRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DisableRuleError::ConcurrentModification(ref cause) => cause,
-            DisableRuleError::Internal(ref cause) => cause,
-            DisableRuleError::ManagedRule(ref cause) => cause,
-            DisableRuleError::ResourceNotFound(ref cause) => cause,
+            DisableRuleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DisableRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            DisableRuleError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            DisableRuleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableRuleError {}
 /// Errors returned by EnableRule
 #[derive(Debug, PartialEq)]
 pub enum EnableRuleError {
@@ -1759,19 +1715,15 @@ impl EnableRuleError {
 }
 impl fmt::Display for EnableRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableRuleError {
-    fn description(&self) -> &str {
         match *self {
-            EnableRuleError::ConcurrentModification(ref cause) => cause,
-            EnableRuleError::Internal(ref cause) => cause,
-            EnableRuleError::ManagedRule(ref cause) => cause,
-            EnableRuleError::ResourceNotFound(ref cause) => cause,
+            EnableRuleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            EnableRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            EnableRuleError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            EnableRuleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableRuleError {}
 /// Errors returned by ListEventBuses
 #[derive(Debug, PartialEq)]
 pub enum ListEventBusesError {
@@ -1795,16 +1747,12 @@ impl ListEventBusesError {
 }
 impl fmt::Display for ListEventBusesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEventBusesError {
-    fn description(&self) -> &str {
         match *self {
-            ListEventBusesError::Internal(ref cause) => cause,
+            ListEventBusesError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEventBusesError {}
 /// Errors returned by ListEventSources
 #[derive(Debug, PartialEq)]
 pub enum ListEventSourcesError {
@@ -1828,16 +1776,12 @@ impl ListEventSourcesError {
 }
 impl fmt::Display for ListEventSourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEventSourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListEventSourcesError::Internal(ref cause) => cause,
+            ListEventSourcesError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEventSourcesError {}
 /// Errors returned by ListPartnerEventSourceAccounts
 #[derive(Debug, PartialEq)]
 pub enum ListPartnerEventSourceAccountsError {
@@ -1872,17 +1816,15 @@ impl ListPartnerEventSourceAccountsError {
 }
 impl fmt::Display for ListPartnerEventSourceAccountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPartnerEventSourceAccountsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPartnerEventSourceAccountsError::Internal(ref cause) => cause,
-            ListPartnerEventSourceAccountsError::ResourceNotFound(ref cause) => cause,
+            ListPartnerEventSourceAccountsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListPartnerEventSourceAccountsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListPartnerEventSourceAccountsError {}
 /// Errors returned by ListPartnerEventSources
 #[derive(Debug, PartialEq)]
 pub enum ListPartnerEventSourcesError {
@@ -1906,16 +1848,12 @@ impl ListPartnerEventSourcesError {
 }
 impl fmt::Display for ListPartnerEventSourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPartnerEventSourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPartnerEventSourcesError::Internal(ref cause) => cause,
+            ListPartnerEventSourcesError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPartnerEventSourcesError {}
 /// Errors returned by ListRuleNamesByTarget
 #[derive(Debug, PartialEq)]
 pub enum ListRuleNamesByTargetError {
@@ -1946,17 +1884,13 @@ impl ListRuleNamesByTargetError {
 }
 impl fmt::Display for ListRuleNamesByTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRuleNamesByTargetError {
-    fn description(&self) -> &str {
         match *self {
-            ListRuleNamesByTargetError::Internal(ref cause) => cause,
-            ListRuleNamesByTargetError::ResourceNotFound(ref cause) => cause,
+            ListRuleNamesByTargetError::Internal(ref cause) => write!(f, "{}", cause),
+            ListRuleNamesByTargetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRuleNamesByTargetError {}
 /// Errors returned by ListRules
 #[derive(Debug, PartialEq)]
 pub enum ListRulesError {
@@ -1985,17 +1919,13 @@ impl ListRulesError {
 }
 impl fmt::Display for ListRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRulesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRulesError::Internal(ref cause) => cause,
-            ListRulesError::ResourceNotFound(ref cause) => cause,
+            ListRulesError::Internal(ref cause) => write!(f, "{}", cause),
+            ListRulesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRulesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2026,17 +1956,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::Internal(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTargetsByRule
 #[derive(Debug, PartialEq)]
 pub enum ListTargetsByRuleError {
@@ -2065,17 +1991,13 @@ impl ListTargetsByRuleError {
 }
 impl fmt::Display for ListTargetsByRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTargetsByRuleError {
-    fn description(&self) -> &str {
         match *self {
-            ListTargetsByRuleError::Internal(ref cause) => cause,
-            ListTargetsByRuleError::ResourceNotFound(ref cause) => cause,
+            ListTargetsByRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            ListTargetsByRuleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTargetsByRuleError {}
 /// Errors returned by PutEvents
 #[derive(Debug, PartialEq)]
 pub enum PutEventsError {
@@ -2099,16 +2021,12 @@ impl PutEventsError {
 }
 impl fmt::Display for PutEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutEventsError {
-    fn description(&self) -> &str {
         match *self {
-            PutEventsError::Internal(ref cause) => cause,
+            PutEventsError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutEventsError {}
 /// Errors returned by PutPartnerEvents
 #[derive(Debug, PartialEq)]
 pub enum PutPartnerEventsError {
@@ -2132,16 +2050,12 @@ impl PutPartnerEventsError {
 }
 impl fmt::Display for PutPartnerEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPartnerEventsError {
-    fn description(&self) -> &str {
         match *self {
-            PutPartnerEventsError::Internal(ref cause) => cause,
+            PutPartnerEventsError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutPartnerEventsError {}
 /// Errors returned by PutPermission
 #[derive(Debug, PartialEq)]
 pub enum PutPermissionError {
@@ -2182,19 +2096,15 @@ impl PutPermissionError {
 }
 impl fmt::Display for PutPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            PutPermissionError::ConcurrentModification(ref cause) => cause,
-            PutPermissionError::Internal(ref cause) => cause,
-            PutPermissionError::PolicyLengthExceeded(ref cause) => cause,
-            PutPermissionError::ResourceNotFound(ref cause) => cause,
+            PutPermissionError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            PutPermissionError::Internal(ref cause) => write!(f, "{}", cause),
+            PutPermissionError::PolicyLengthExceeded(ref cause) => write!(f, "{}", cause),
+            PutPermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutPermissionError {}
 /// Errors returned by PutRule
 #[derive(Debug, PartialEq)]
 pub enum PutRuleError {
@@ -2243,21 +2153,17 @@ impl PutRuleError {
 }
 impl fmt::Display for PutRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRuleError {
-    fn description(&self) -> &str {
         match *self {
-            PutRuleError::ConcurrentModification(ref cause) => cause,
-            PutRuleError::Internal(ref cause) => cause,
-            PutRuleError::InvalidEventPattern(ref cause) => cause,
-            PutRuleError::LimitExceeded(ref cause) => cause,
-            PutRuleError::ManagedRule(ref cause) => cause,
-            PutRuleError::ResourceNotFound(ref cause) => cause,
+            PutRuleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            PutRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            PutRuleError::InvalidEventPattern(ref cause) => write!(f, "{}", cause),
+            PutRuleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutRuleError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            PutRuleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRuleError {}
 /// Errors returned by PutTargets
 #[derive(Debug, PartialEq)]
 pub enum PutTargetsError {
@@ -2301,20 +2207,16 @@ impl PutTargetsError {
 }
 impl fmt::Display for PutTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            PutTargetsError::ConcurrentModification(ref cause) => cause,
-            PutTargetsError::Internal(ref cause) => cause,
-            PutTargetsError::LimitExceeded(ref cause) => cause,
-            PutTargetsError::ManagedRule(ref cause) => cause,
-            PutTargetsError::ResourceNotFound(ref cause) => cause,
+            PutTargetsError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            PutTargetsError::Internal(ref cause) => write!(f, "{}", cause),
+            PutTargetsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutTargetsError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            PutTargetsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutTargetsError {}
 /// Errors returned by RemovePermission
 #[derive(Debug, PartialEq)]
 pub enum RemovePermissionError {
@@ -2350,18 +2252,14 @@ impl RemovePermissionError {
 }
 impl fmt::Display for RemovePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemovePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            RemovePermissionError::ConcurrentModification(ref cause) => cause,
-            RemovePermissionError::Internal(ref cause) => cause,
-            RemovePermissionError::ResourceNotFound(ref cause) => cause,
+            RemovePermissionError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::Internal(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemovePermissionError {}
 /// Errors returned by RemoveTargets
 #[derive(Debug, PartialEq)]
 pub enum RemoveTargetsError {
@@ -2402,19 +2300,15 @@ impl RemoveTargetsError {
 }
 impl fmt::Display for RemoveTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTargetsError::ConcurrentModification(ref cause) => cause,
-            RemoveTargetsError::Internal(ref cause) => cause,
-            RemoveTargetsError::ManagedRule(ref cause) => cause,
-            RemoveTargetsError::ResourceNotFound(ref cause) => cause,
+            RemoveTargetsError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            RemoveTargetsError::Internal(ref cause) => write!(f, "{}", cause),
+            RemoveTargetsError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            RemoveTargetsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTargetsError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2453,19 +2347,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ConcurrentModification(ref cause) => cause,
-            TagResourceError::Internal(ref cause) => cause,
-            TagResourceError::ManagedRule(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TestEventPattern
 #[derive(Debug, PartialEq)]
 pub enum TestEventPatternError {
@@ -2496,17 +2386,13 @@ impl TestEventPatternError {
 }
 impl fmt::Display for TestEventPatternError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestEventPatternError {
-    fn description(&self) -> &str {
         match *self {
-            TestEventPatternError::Internal(ref cause) => cause,
-            TestEventPatternError::InvalidEventPattern(ref cause) => cause,
+            TestEventPatternError::Internal(ref cause) => write!(f, "{}", cause),
+            TestEventPatternError::InvalidEventPattern(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestEventPatternError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2547,19 +2433,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ConcurrentModification(ref cause) => cause,
-            UntagResourceError::Internal(ref cause) => cause,
-            UntagResourceError::ManagedRule(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ManagedRule(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the Amazon EventBridge API. Amazon EventBridge clients implement this trait.
 pub trait EventBridge {
     /// <p><p>Activates a partner event source that has been deactivated. Once activated, your matching event bus will start receiving events from the event source.</p> <note> <p>This operation is performed by AWS customers, not by SaaS partners.</p> </note></p>

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -1545,19 +1545,15 @@ impl CreateDeliveryStreamError {
 }
 impl fmt::Display for CreateDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeliveryStreamError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeliveryStreamError::InvalidArgument(ref cause) => cause,
-            CreateDeliveryStreamError::InvalidKMSResource(ref cause) => cause,
-            CreateDeliveryStreamError::LimitExceeded(ref cause) => cause,
-            CreateDeliveryStreamError::ResourceInUse(ref cause) => cause,
+            CreateDeliveryStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateDeliveryStreamError::InvalidKMSResource(ref cause) => write!(f, "{}", cause),
+            CreateDeliveryStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDeliveryStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeliveryStreamError {}
 /// Errors returned by DeleteDeliveryStream
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeliveryStreamError {
@@ -1588,17 +1584,13 @@ impl DeleteDeliveryStreamError {
 }
 impl fmt::Display for DeleteDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeliveryStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeliveryStreamError::ResourceInUse(ref cause) => cause,
-            DeleteDeliveryStreamError::ResourceNotFound(ref cause) => cause,
+            DeleteDeliveryStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteDeliveryStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeliveryStreamError {}
 /// Errors returned by DescribeDeliveryStream
 #[derive(Debug, PartialEq)]
 pub enum DescribeDeliveryStreamError {
@@ -1624,16 +1616,12 @@ impl DescribeDeliveryStreamError {
 }
 impl fmt::Display for DescribeDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDeliveryStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDeliveryStreamError::ResourceNotFound(ref cause) => cause,
+            DescribeDeliveryStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDeliveryStreamError {}
 /// Errors returned by ListDeliveryStreams
 #[derive(Debug, PartialEq)]
 pub enum ListDeliveryStreamsError {}
@@ -1651,14 +1639,10 @@ impl ListDeliveryStreamsError {
 }
 impl fmt::Display for ListDeliveryStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeliveryStreamsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListDeliveryStreamsError {}
 /// Errors returned by ListTagsForDeliveryStream
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForDeliveryStreamError {
@@ -1698,18 +1682,14 @@ impl ListTagsForDeliveryStreamError {
 }
 impl fmt::Display for ListTagsForDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForDeliveryStreamError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForDeliveryStreamError::InvalidArgument(ref cause) => cause,
-            ListTagsForDeliveryStreamError::LimitExceeded(ref cause) => cause,
-            ListTagsForDeliveryStreamError::ResourceNotFound(ref cause) => cause,
+            ListTagsForDeliveryStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListTagsForDeliveryStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForDeliveryStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForDeliveryStreamError {}
 /// Errors returned by PutRecord
 #[derive(Debug, PartialEq)]
 pub enum PutRecordError {
@@ -1748,19 +1728,15 @@ impl PutRecordError {
 }
 impl fmt::Display for PutRecordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRecordError {
-    fn description(&self) -> &str {
         match *self {
-            PutRecordError::InvalidArgument(ref cause) => cause,
-            PutRecordError::InvalidKMSResource(ref cause) => cause,
-            PutRecordError::ResourceNotFound(ref cause) => cause,
-            PutRecordError::ServiceUnavailable(ref cause) => cause,
+            PutRecordError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            PutRecordError::InvalidKMSResource(ref cause) => write!(f, "{}", cause),
+            PutRecordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutRecordError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRecordError {}
 /// Errors returned by PutRecordBatch
 #[derive(Debug, PartialEq)]
 pub enum PutRecordBatchError {
@@ -1799,19 +1775,15 @@ impl PutRecordBatchError {
 }
 impl fmt::Display for PutRecordBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRecordBatchError {
-    fn description(&self) -> &str {
         match *self {
-            PutRecordBatchError::InvalidArgument(ref cause) => cause,
-            PutRecordBatchError::InvalidKMSResource(ref cause) => cause,
-            PutRecordBatchError::ResourceNotFound(ref cause) => cause,
-            PutRecordBatchError::ServiceUnavailable(ref cause) => cause,
+            PutRecordBatchError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            PutRecordBatchError::InvalidKMSResource(ref cause) => write!(f, "{}", cause),
+            PutRecordBatchError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutRecordBatchError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRecordBatchError {}
 /// Errors returned by StartDeliveryStreamEncryption
 #[derive(Debug, PartialEq)]
 pub enum StartDeliveryStreamEncryptionError {
@@ -1867,20 +1839,22 @@ impl StartDeliveryStreamEncryptionError {
 }
 impl fmt::Display for StartDeliveryStreamEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDeliveryStreamEncryptionError {
-    fn description(&self) -> &str {
         match *self {
-            StartDeliveryStreamEncryptionError::InvalidArgument(ref cause) => cause,
-            StartDeliveryStreamEncryptionError::InvalidKMSResource(ref cause) => cause,
-            StartDeliveryStreamEncryptionError::LimitExceeded(ref cause) => cause,
-            StartDeliveryStreamEncryptionError::ResourceInUse(ref cause) => cause,
-            StartDeliveryStreamEncryptionError::ResourceNotFound(ref cause) => cause,
+            StartDeliveryStreamEncryptionError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDeliveryStreamEncryptionError::InvalidKMSResource(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDeliveryStreamEncryptionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartDeliveryStreamEncryptionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StartDeliveryStreamEncryptionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartDeliveryStreamEncryptionError {}
 /// Errors returned by StopDeliveryStreamEncryption
 #[derive(Debug, PartialEq)]
 pub enum StopDeliveryStreamEncryptionError {
@@ -1929,19 +1903,17 @@ impl StopDeliveryStreamEncryptionError {
 }
 impl fmt::Display for StopDeliveryStreamEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopDeliveryStreamEncryptionError {
-    fn description(&self) -> &str {
         match *self {
-            StopDeliveryStreamEncryptionError::InvalidArgument(ref cause) => cause,
-            StopDeliveryStreamEncryptionError::LimitExceeded(ref cause) => cause,
-            StopDeliveryStreamEncryptionError::ResourceInUse(ref cause) => cause,
-            StopDeliveryStreamEncryptionError::ResourceNotFound(ref cause) => cause,
+            StopDeliveryStreamEncryptionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            StopDeliveryStreamEncryptionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StopDeliveryStreamEncryptionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StopDeliveryStreamEncryptionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StopDeliveryStreamEncryptionError {}
 /// Errors returned by TagDeliveryStream
 #[derive(Debug, PartialEq)]
 pub enum TagDeliveryStreamError {
@@ -1980,19 +1952,15 @@ impl TagDeliveryStreamError {
 }
 impl fmt::Display for TagDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagDeliveryStreamError {
-    fn description(&self) -> &str {
         match *self {
-            TagDeliveryStreamError::InvalidArgument(ref cause) => cause,
-            TagDeliveryStreamError::LimitExceeded(ref cause) => cause,
-            TagDeliveryStreamError::ResourceInUse(ref cause) => cause,
-            TagDeliveryStreamError::ResourceNotFound(ref cause) => cause,
+            TagDeliveryStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            TagDeliveryStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagDeliveryStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            TagDeliveryStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagDeliveryStreamError {}
 /// Errors returned by UntagDeliveryStream
 #[derive(Debug, PartialEq)]
 pub enum UntagDeliveryStreamError {
@@ -2033,19 +2001,15 @@ impl UntagDeliveryStreamError {
 }
 impl fmt::Display for UntagDeliveryStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagDeliveryStreamError {
-    fn description(&self) -> &str {
         match *self {
-            UntagDeliveryStreamError::InvalidArgument(ref cause) => cause,
-            UntagDeliveryStreamError::LimitExceeded(ref cause) => cause,
-            UntagDeliveryStreamError::ResourceInUse(ref cause) => cause,
-            UntagDeliveryStreamError::ResourceNotFound(ref cause) => cause,
+            UntagDeliveryStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UntagDeliveryStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagDeliveryStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UntagDeliveryStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagDeliveryStreamError {}
 /// Errors returned by UpdateDestination
 #[derive(Debug, PartialEq)]
 pub enum UpdateDestinationError {
@@ -2086,19 +2050,15 @@ impl UpdateDestinationError {
 }
 impl fmt::Display for UpdateDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDestinationError::ConcurrentModification(ref cause) => cause,
-            UpdateDestinationError::InvalidArgument(ref cause) => cause,
-            UpdateDestinationError::ResourceInUse(ref cause) => cause,
-            UpdateDestinationError::ResourceNotFound(ref cause) => cause,
+            UpdateDestinationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateDestinationError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateDestinationError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateDestinationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDestinationError {}
 /// Trait representing the capabilities of the Firehose API. Firehose clients implement this trait.
 pub trait KinesisFirehose {
     /// <p>Creates a Kinesis Data Firehose delivery stream.</p> <p>By default, you can create up to 50 delivery streams per AWS Region.</p> <p>This is an asynchronous operation that immediately returns. The initial status of the delivery stream is <code>CREATING</code>. After the delivery stream is created, its status is <code>ACTIVE</code> and it now accepts data. If the delivery stream creation fails, the status transitions to <code>CREATING_FAILED</code>. Attempts to send data to a delivery stream that is not in the <code>ACTIVE</code> state cause an exception. To check the state of a delivery stream, use <a>DescribeDeliveryStream</a>.</p> <p>If the status of a delivery stream is <code>CREATING_FAILED</code>, this status doesn't change, and you can't invoke <code>CreateDeliveryStream</code> again on it. However, you can invoke the <a>DeleteDeliveryStream</a> operation to delete it.</p> <p>A Kinesis Data Firehose delivery stream can be configured to receive records directly from providers using <a>PutRecord</a> or <a>PutRecordBatch</a>, or it can be configured to use an existing Kinesis stream as its source. To specify a Kinesis data stream as input, set the <code>DeliveryStreamType</code> parameter to <code>KinesisStreamAsSource</code>, and provide the Kinesis stream Amazon Resource Name (ARN) and role ARN in the <code>KinesisStreamSourceConfiguration</code> parameter.</p> <p>To create a delivery stream with server-side encryption (SSE) enabled, include <a>DeliveryStreamEncryptionConfigurationInput</a> in your request. This is optional. You can also invoke <a>StartDeliveryStreamEncryption</a> to turn on SSE for an existing delivery stream that doesn't have SSE enabled.</p> <p>A delivery stream is configured with a single destination: Amazon S3, Amazon ES, Amazon Redshift, or Splunk. You must specify only one of the following destination configuration parameters: <code>ExtendedS3DestinationConfiguration</code>, <code>S3DestinationConfiguration</code>, <code>ElasticsearchDestinationConfiguration</code>, <code>RedshiftDestinationConfiguration</code>, or <code>SplunkDestinationConfiguration</code>.</p> <p>When you specify <code>S3DestinationConfiguration</code>, you can also provide the following optional values: BufferingHints, <code>EncryptionConfiguration</code>, and <code>CompressionFormat</code>. By default, if no <code>BufferingHints</code> value is provided, Kinesis Data Firehose buffers data up to 5 MB or for 5 minutes, whichever condition is satisfied first. <code>BufferingHints</code> is a hint, so there are some cases where the service cannot adhere to these conditions strictly. For example, record boundaries might be such that the size is a little over or under the configured buffering size. By default, no encryption is performed. We strongly recommend that you enable encryption to ensure secure data storage in Amazon S3.</p> <p>A few notes about Amazon Redshift as a destination:</p> <ul> <li> <p>An Amazon Redshift destination requires an S3 bucket as intermediate location. Kinesis Data Firehose first delivers data to Amazon S3 and then uses <code>COPY</code> syntax to load data into an Amazon Redshift table. This is specified in the <code>RedshiftDestinationConfiguration.S3Configuration</code> parameter.</p> </li> <li> <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified in <code>RedshiftDestinationConfiguration.S3Configuration</code> because the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these compression formats.</p> </li> <li> <p>We strongly recommend that you use the user name and password you provide exclusively with Kinesis Data Firehose, and that the permissions for the account are restricted for Amazon Redshift <code>INSERT</code> permissions.</p> </li> </ul> <p>Kinesis Data Firehose assumes the IAM role that is configured as part of the destination. The role should allow the Kinesis Data Firehose principal to assume the role, and the role should have permissions that allow the service to deliver the data. For more information, see <a href="https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3">Grant Kinesis Data Firehose Access to an Amazon S3 Destination</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>

--- a/rusoto/services/fms/src/generated.rs
+++ b/rusoto/services/fms/src/generated.rs
@@ -518,19 +518,15 @@ impl AssociateAdminAccountError {
 }
 impl fmt::Display for AssociateAdminAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateAdminAccountError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateAdminAccountError::InternalError(ref cause) => cause,
-            AssociateAdminAccountError::InvalidInput(ref cause) => cause,
-            AssociateAdminAccountError::InvalidOperation(ref cause) => cause,
-            AssociateAdminAccountError::ResourceNotFound(ref cause) => cause,
+            AssociateAdminAccountError::InternalError(ref cause) => write!(f, "{}", cause),
+            AssociateAdminAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AssociateAdminAccountError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            AssociateAdminAccountError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateAdminAccountError {}
 /// Errors returned by DeleteNotificationChannel
 #[derive(Debug, PartialEq)]
 pub enum DeleteNotificationChannelError {
@@ -570,18 +566,14 @@ impl DeleteNotificationChannelError {
 }
 impl fmt::Display for DeleteNotificationChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNotificationChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNotificationChannelError::InternalError(ref cause) => cause,
-            DeleteNotificationChannelError::InvalidOperation(ref cause) => cause,
-            DeleteNotificationChannelError::ResourceNotFound(ref cause) => cause,
+            DeleteNotificationChannelError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteNotificationChannelError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DeleteNotificationChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteNotificationChannelError {}
 /// Errors returned by DeletePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeletePolicyError {
@@ -615,18 +607,14 @@ impl DeletePolicyError {
 }
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePolicyError::InternalError(ref cause) => cause,
-            DeletePolicyError::InvalidOperation(ref cause) => cause,
-            DeletePolicyError::ResourceNotFound(ref cause) => cause,
+            DeletePolicyError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePolicyError {}
 /// Errors returned by DisassociateAdminAccount
 #[derive(Debug, PartialEq)]
 pub enum DisassociateAdminAccountError {
@@ -666,18 +654,14 @@ impl DisassociateAdminAccountError {
 }
 impl fmt::Display for DisassociateAdminAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateAdminAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateAdminAccountError::InternalError(ref cause) => cause,
-            DisassociateAdminAccountError::InvalidOperation(ref cause) => cause,
-            DisassociateAdminAccountError::ResourceNotFound(ref cause) => cause,
+            DisassociateAdminAccountError::InternalError(ref cause) => write!(f, "{}", cause),
+            DisassociateAdminAccountError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DisassociateAdminAccountError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateAdminAccountError {}
 /// Errors returned by GetAdminAccount
 #[derive(Debug, PartialEq)]
 pub enum GetAdminAccountError {
@@ -711,18 +695,14 @@ impl GetAdminAccountError {
 }
 impl fmt::Display for GetAdminAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAdminAccountError {
-    fn description(&self) -> &str {
         match *self {
-            GetAdminAccountError::InternalError(ref cause) => cause,
-            GetAdminAccountError::InvalidOperation(ref cause) => cause,
-            GetAdminAccountError::ResourceNotFound(ref cause) => cause,
+            GetAdminAccountError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetAdminAccountError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            GetAdminAccountError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAdminAccountError {}
 /// Errors returned by GetComplianceDetail
 #[derive(Debug, PartialEq)]
 pub enum GetComplianceDetailError {
@@ -753,17 +733,13 @@ impl GetComplianceDetailError {
 }
 impl fmt::Display for GetComplianceDetailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetComplianceDetailError {
-    fn description(&self) -> &str {
         match *self {
-            GetComplianceDetailError::InternalError(ref cause) => cause,
-            GetComplianceDetailError::ResourceNotFound(ref cause) => cause,
+            GetComplianceDetailError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetComplianceDetailError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetComplianceDetailError {}
 /// Errors returned by GetNotificationChannel
 #[derive(Debug, PartialEq)]
 pub enum GetNotificationChannelError {
@@ -803,18 +779,14 @@ impl GetNotificationChannelError {
 }
 impl fmt::Display for GetNotificationChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetNotificationChannelError {
-    fn description(&self) -> &str {
         match *self {
-            GetNotificationChannelError::InternalError(ref cause) => cause,
-            GetNotificationChannelError::InvalidOperation(ref cause) => cause,
-            GetNotificationChannelError::ResourceNotFound(ref cause) => cause,
+            GetNotificationChannelError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetNotificationChannelError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            GetNotificationChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetNotificationChannelError {}
 /// Errors returned by GetPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetPolicyError {
@@ -853,19 +825,15 @@ impl GetPolicyError {
 }
 impl fmt::Display for GetPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPolicyError::InternalError(ref cause) => cause,
-            GetPolicyError::InvalidOperation(ref cause) => cause,
-            GetPolicyError::InvalidType(ref cause) => cause,
-            GetPolicyError::ResourceNotFound(ref cause) => cause,
+            GetPolicyError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::InvalidType(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPolicyError {}
 /// Errors returned by GetProtectionStatus
 #[derive(Debug, PartialEq)]
 pub enum GetProtectionStatusError {
@@ -901,18 +869,14 @@ impl GetProtectionStatusError {
 }
 impl fmt::Display for GetProtectionStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetProtectionStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetProtectionStatusError::InternalError(ref cause) => cause,
-            GetProtectionStatusError::InvalidInput(ref cause) => cause,
-            GetProtectionStatusError::ResourceNotFound(ref cause) => cause,
+            GetProtectionStatusError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetProtectionStatusError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetProtectionStatusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetProtectionStatusError {}
 /// Errors returned by ListComplianceStatus
 #[derive(Debug, PartialEq)]
 pub enum ListComplianceStatusError {
@@ -943,17 +907,13 @@ impl ListComplianceStatusError {
 }
 impl fmt::Display for ListComplianceStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListComplianceStatusError {
-    fn description(&self) -> &str {
         match *self {
-            ListComplianceStatusError::InternalError(ref cause) => cause,
-            ListComplianceStatusError::ResourceNotFound(ref cause) => cause,
+            ListComplianceStatusError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListComplianceStatusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListComplianceStatusError {}
 /// Errors returned by ListMemberAccounts
 #[derive(Debug, PartialEq)]
 pub enum ListMemberAccountsError {
@@ -982,17 +942,13 @@ impl ListMemberAccountsError {
 }
 impl fmt::Display for ListMemberAccountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMemberAccountsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMemberAccountsError::InternalError(ref cause) => cause,
-            ListMemberAccountsError::ResourceNotFound(ref cause) => cause,
+            ListMemberAccountsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListMemberAccountsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMemberAccountsError {}
 /// Errors returned by ListPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListPoliciesError {
@@ -1031,19 +987,15 @@ impl ListPoliciesError {
 }
 impl fmt::Display for ListPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPoliciesError::InternalError(ref cause) => cause,
-            ListPoliciesError::InvalidOperation(ref cause) => cause,
-            ListPoliciesError::LimitExceeded(ref cause) => cause,
-            ListPoliciesError::ResourceNotFound(ref cause) => cause,
+            ListPoliciesError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPoliciesError {}
 /// Errors returned by PutNotificationChannel
 #[derive(Debug, PartialEq)]
 pub enum PutNotificationChannelError {
@@ -1083,18 +1035,14 @@ impl PutNotificationChannelError {
 }
 impl fmt::Display for PutNotificationChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutNotificationChannelError {
-    fn description(&self) -> &str {
         match *self {
-            PutNotificationChannelError::InternalError(ref cause) => cause,
-            PutNotificationChannelError::InvalidOperation(ref cause) => cause,
-            PutNotificationChannelError::ResourceNotFound(ref cause) => cause,
+            PutNotificationChannelError::InternalError(ref cause) => write!(f, "{}", cause),
+            PutNotificationChannelError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            PutNotificationChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutNotificationChannelError {}
 /// Errors returned by PutPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutPolicyError {
@@ -1143,21 +1091,17 @@ impl PutPolicyError {
 }
 impl fmt::Display for PutPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutPolicyError::InternalError(ref cause) => cause,
-            PutPolicyError::InvalidInput(ref cause) => cause,
-            PutPolicyError::InvalidOperation(ref cause) => cause,
-            PutPolicyError::InvalidType(ref cause) => cause,
-            PutPolicyError::LimitExceeded(ref cause) => cause,
-            PutPolicyError::ResourceNotFound(ref cause) => cause,
+            PutPolicyError::InternalError(ref cause) => write!(f, "{}", cause),
+            PutPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PutPolicyError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            PutPolicyError::InvalidType(ref cause) => write!(f, "{}", cause),
+            PutPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutPolicyError {}
 /// Trait representing the capabilities of the FMS API. FMS clients implement this trait.
 pub trait Fms {
     /// <p>Sets the AWS Firewall Manager administrator account. AWS Firewall Manager must be associated with the master account of your AWS organization or associated with a member account that has the appropriate permissions. If the account ID that you submit is not an AWS Organizations master account, AWS Firewall Manager will set the appropriate permissions for the given member account.</p> <p>The account that you associate with AWS Firewall Manager is called the AWS Firewall Manager administrator account. </p>

--- a/rusoto/services/fsx/src/generated.rs
+++ b/rusoto/services/fsx/src/generated.rs
@@ -843,22 +843,18 @@ impl CreateBackupError {
 }
 impl fmt::Display for CreateBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBackupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBackupError::BackupInProgress(ref cause) => cause,
-            CreateBackupError::BadRequest(ref cause) => cause,
-            CreateBackupError::FileSystemNotFound(ref cause) => cause,
-            CreateBackupError::IncompatibleParameterError(ref cause) => cause,
-            CreateBackupError::InternalServerError(ref cause) => cause,
-            CreateBackupError::ServiceLimitExceeded(ref cause) => cause,
-            CreateBackupError::UnsupportedOperation(ref cause) => cause,
+            CreateBackupError::BackupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::IncompatibleParameterError(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::ServiceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBackupError {}
 /// Errors returned by CreateFileSystem
 #[derive(Debug, PartialEq)]
 pub enum CreateFileSystemError {
@@ -934,24 +930,22 @@ impl CreateFileSystemError {
 }
 impl fmt::Display for CreateFileSystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFileSystemError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFileSystemError::ActiveDirectoryError(ref cause) => cause,
-            CreateFileSystemError::BadRequest(ref cause) => cause,
-            CreateFileSystemError::IncompatibleParameterError(ref cause) => cause,
-            CreateFileSystemError::InternalServerError(ref cause) => cause,
-            CreateFileSystemError::InvalidExportPath(ref cause) => cause,
-            CreateFileSystemError::InvalidImportPath(ref cause) => cause,
-            CreateFileSystemError::InvalidNetworkSettings(ref cause) => cause,
-            CreateFileSystemError::MissingFileSystemConfiguration(ref cause) => cause,
-            CreateFileSystemError::ServiceLimitExceeded(ref cause) => cause,
+            CreateFileSystemError::ActiveDirectoryError(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::IncompatibleParameterError(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::InvalidExportPath(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::InvalidImportPath(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::InvalidNetworkSettings(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemError::MissingFileSystemConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateFileSystemError::ServiceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFileSystemError {}
 /// Errors returned by CreateFileSystemFromBackup
 #[derive(Debug, PartialEq)]
 pub enum CreateFileSystemFromBackupError {
@@ -1028,23 +1022,31 @@ impl CreateFileSystemFromBackupError {
 }
 impl fmt::Display for CreateFileSystemFromBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFileSystemFromBackupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFileSystemFromBackupError::ActiveDirectoryError(ref cause) => cause,
-            CreateFileSystemFromBackupError::BackupNotFound(ref cause) => cause,
-            CreateFileSystemFromBackupError::BadRequest(ref cause) => cause,
-            CreateFileSystemFromBackupError::IncompatibleParameterError(ref cause) => cause,
-            CreateFileSystemFromBackupError::InternalServerError(ref cause) => cause,
-            CreateFileSystemFromBackupError::InvalidNetworkSettings(ref cause) => cause,
-            CreateFileSystemFromBackupError::MissingFileSystemConfiguration(ref cause) => cause,
-            CreateFileSystemFromBackupError::ServiceLimitExceeded(ref cause) => cause,
+            CreateFileSystemFromBackupError::ActiveDirectoryError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateFileSystemFromBackupError::BackupNotFound(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemFromBackupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateFileSystemFromBackupError::IncompatibleParameterError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateFileSystemFromBackupError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateFileSystemFromBackupError::InvalidNetworkSettings(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateFileSystemFromBackupError::MissingFileSystemConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateFileSystemFromBackupError::ServiceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateFileSystemFromBackupError {}
 /// Errors returned by DeleteBackup
 #[derive(Debug, PartialEq)]
 pub enum DeleteBackupError {
@@ -1095,21 +1097,17 @@ impl DeleteBackupError {
 }
 impl fmt::Display for DeleteBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBackupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBackupError::BackupInProgress(ref cause) => cause,
-            DeleteBackupError::BackupNotFound(ref cause) => cause,
-            DeleteBackupError::BackupRestoring(ref cause) => cause,
-            DeleteBackupError::BadRequest(ref cause) => cause,
-            DeleteBackupError::IncompatibleParameterError(ref cause) => cause,
-            DeleteBackupError::InternalServerError(ref cause) => cause,
+            DeleteBackupError::BackupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::BackupNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::BackupRestoring(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::IncompatibleParameterError(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBackupError {}
 /// Errors returned by DeleteFileSystem
 #[derive(Debug, PartialEq)]
 pub enum DeleteFileSystemError {
@@ -1159,20 +1157,16 @@ impl DeleteFileSystemError {
 }
 impl fmt::Display for DeleteFileSystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFileSystemError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFileSystemError::BadRequest(ref cause) => cause,
-            DeleteFileSystemError::FileSystemNotFound(ref cause) => cause,
-            DeleteFileSystemError::IncompatibleParameterError(ref cause) => cause,
-            DeleteFileSystemError::InternalServerError(ref cause) => cause,
-            DeleteFileSystemError::ServiceLimitExceeded(ref cause) => cause,
+            DeleteFileSystemError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteFileSystemError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFileSystemError::IncompatibleParameterError(ref cause) => write!(f, "{}", cause),
+            DeleteFileSystemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteFileSystemError::ServiceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFileSystemError {}
 /// Errors returned by DescribeBackups
 #[derive(Debug, PartialEq)]
 pub enum DescribeBackupsError {
@@ -1211,19 +1205,15 @@ impl DescribeBackupsError {
 }
 impl fmt::Display for DescribeBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBackupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBackupsError::BackupNotFound(ref cause) => cause,
-            DescribeBackupsError::BadRequest(ref cause) => cause,
-            DescribeBackupsError::FileSystemNotFound(ref cause) => cause,
-            DescribeBackupsError::InternalServerError(ref cause) => cause,
+            DescribeBackupsError::BackupNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBackupsError {}
 /// Errors returned by DescribeFileSystems
 #[derive(Debug, PartialEq)]
 pub enum DescribeFileSystemsError {
@@ -1261,18 +1251,14 @@ impl DescribeFileSystemsError {
 }
 impl fmt::Display for DescribeFileSystemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFileSystemsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFileSystemsError::BadRequest(ref cause) => cause,
-            DescribeFileSystemsError::FileSystemNotFound(ref cause) => cause,
-            DescribeFileSystemsError::InternalServerError(ref cause) => cause,
+            DescribeFileSystemsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFileSystemsError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFileSystemsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFileSystemsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1324,20 +1310,18 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
-            ListTagsForResourceError::NotServiceResourceError(ref cause) => cause,
-            ListTagsForResourceError::ResourceDoesNotSupportTagging(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotServiceResourceError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceDoesNotSupportTagging(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1381,20 +1365,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::InternalServerError(ref cause) => cause,
-            TagResourceError::NotServiceResourceError(ref cause) => cause,
-            TagResourceError::ResourceDoesNotSupportTagging(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotServiceResourceError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceDoesNotSupportTagging(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1442,20 +1422,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::InternalServerError(ref cause) => cause,
-            UntagResourceError::NotServiceResourceError(ref cause) => cause,
-            UntagResourceError::ResourceDoesNotSupportTagging(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotServiceResourceError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceDoesNotSupportTagging(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateFileSystem
 #[derive(Debug, PartialEq)]
 pub enum UpdateFileSystemError {
@@ -1512,21 +1488,19 @@ impl UpdateFileSystemError {
 }
 impl fmt::Display for UpdateFileSystemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFileSystemError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFileSystemError::BadRequest(ref cause) => cause,
-            UpdateFileSystemError::FileSystemNotFound(ref cause) => cause,
-            UpdateFileSystemError::IncompatibleParameterError(ref cause) => cause,
-            UpdateFileSystemError::InternalServerError(ref cause) => cause,
-            UpdateFileSystemError::MissingFileSystemConfiguration(ref cause) => cause,
-            UpdateFileSystemError::UnsupportedOperation(ref cause) => cause,
+            UpdateFileSystemError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::FileSystemNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::IncompatibleParameterError(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateFileSystemError::MissingFileSystemConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateFileSystemError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFileSystemError {}
 /// Trait representing the capabilities of the Amazon FSx API. Amazon FSx clients implement this trait.
 pub trait Fsx {
     /// <p><p>Creates a backup of an existing Amazon FSx for Windows File Server file system. Creating regular backups for your file system is a best practice that complements the replication that Amazon FSx for Windows File Server performs for your file system. It also enables you to restore from user modification of data.</p> <p>If a backup with the specified client request token exists, and the parameters match, this operation returns the description of the existing backup. If a backup specified client request token exists, and the parameters don&#39;t match, this operation returns <code>IncompatibleParameterError</code>. If a backup with the specified client request token doesn&#39;t exist, <code>CreateBackup</code> does the following: </p> <ul> <li> <p>Creates a new Amazon FSx backup with an assigned ID, and an initial lifecycle state of <code>CREATING</code>.</p> </li> <li> <p>Returns the description of the backup.</p> </li> </ul> <p>By using the idempotent operation, you can retry a <code>CreateBackup</code> operation without the risk of creating an extra backup. This approach can be useful when an initial call fails in a way that makes it unclear whether a backup was created. If you use the same client request token and the initial call created a backup, the operation returns a successful result because all the parameters are the same.</p> <p>The <code>CreateFileSystem</code> operation returns while the backup&#39;s lifecycle state is still <code>CREATING</code>. You can check the file system creation status by calling the <a>DescribeBackups</a> operation, which returns the backup state along with other information.</p> <note> <p/> </note></p>

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -3193,19 +3193,15 @@ impl AcceptMatchError {
 }
 impl fmt::Display for AcceptMatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptMatchError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptMatchError::InternalService(ref cause) => cause,
-            AcceptMatchError::InvalidRequest(ref cause) => cause,
-            AcceptMatchError::NotFound(ref cause) => cause,
-            AcceptMatchError::UnsupportedRegion(ref cause) => cause,
+            AcceptMatchError::InternalService(ref cause) => write!(f, "{}", cause),
+            AcceptMatchError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AcceptMatchError::NotFound(ref cause) => write!(f, "{}", cause),
+            AcceptMatchError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptMatchError {}
 /// Errors returned by CreateAlias
 #[derive(Debug, PartialEq)]
 pub enum CreateAliasError {
@@ -3249,20 +3245,16 @@ impl CreateAliasError {
 }
 impl fmt::Display for CreateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAliasError::Conflict(ref cause) => cause,
-            CreateAliasError::InternalService(ref cause) => cause,
-            CreateAliasError::InvalidRequest(ref cause) => cause,
-            CreateAliasError::LimitExceeded(ref cause) => cause,
-            CreateAliasError::Unauthorized(ref cause) => cause,
+            CreateAliasError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAliasError {}
 /// Errors returned by CreateBuild
 #[derive(Debug, PartialEq)]
 pub enum CreateBuildError {
@@ -3301,19 +3293,15 @@ impl CreateBuildError {
 }
 impl fmt::Display for CreateBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBuildError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBuildError::Conflict(ref cause) => cause,
-            CreateBuildError::InternalService(ref cause) => cause,
-            CreateBuildError::InvalidRequest(ref cause) => cause,
-            CreateBuildError::Unauthorized(ref cause) => cause,
+            CreateBuildError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateBuildError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateBuildError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateBuildError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBuildError {}
 /// Errors returned by CreateFleet
 #[derive(Debug, PartialEq)]
 pub enum CreateFleetError {
@@ -3362,21 +3350,17 @@ impl CreateFleetError {
 }
 impl fmt::Display for CreateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFleetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFleetError::Conflict(ref cause) => cause,
-            CreateFleetError::InternalService(ref cause) => cause,
-            CreateFleetError::InvalidRequest(ref cause) => cause,
-            CreateFleetError::LimitExceeded(ref cause) => cause,
-            CreateFleetError::NotFound(ref cause) => cause,
-            CreateFleetError::Unauthorized(ref cause) => cause,
+            CreateFleetError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFleetError {}
 /// Errors returned by CreateGameSession
 #[derive(Debug, PartialEq)]
 pub enum CreateGameSessionError {
@@ -3453,25 +3437,23 @@ impl CreateGameSessionError {
 }
 impl fmt::Display for CreateGameSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGameSessionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGameSessionError::Conflict(ref cause) => cause,
-            CreateGameSessionError::FleetCapacityExceeded(ref cause) => cause,
-            CreateGameSessionError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateGameSessionError::InternalService(ref cause) => cause,
-            CreateGameSessionError::InvalidFleetStatus(ref cause) => cause,
-            CreateGameSessionError::InvalidRequest(ref cause) => cause,
-            CreateGameSessionError::LimitExceeded(ref cause) => cause,
-            CreateGameSessionError::NotFound(ref cause) => cause,
-            CreateGameSessionError::TerminalRoutingStrategy(ref cause) => cause,
-            CreateGameSessionError::Unauthorized(ref cause) => cause,
+            CreateGameSessionError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::FleetCapacityExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateGameSessionError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::InvalidFleetStatus(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::TerminalRoutingStrategy(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGameSessionError {}
 /// Errors returned by CreateGameSessionQueue
 #[derive(Debug, PartialEq)]
 pub enum CreateGameSessionQueueError {
@@ -3516,19 +3498,15 @@ impl CreateGameSessionQueueError {
 }
 impl fmt::Display for CreateGameSessionQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGameSessionQueueError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGameSessionQueueError::InternalService(ref cause) => cause,
-            CreateGameSessionQueueError::InvalidRequest(ref cause) => cause,
-            CreateGameSessionQueueError::LimitExceeded(ref cause) => cause,
-            CreateGameSessionQueueError::Unauthorized(ref cause) => cause,
+            CreateGameSessionQueueError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionQueueError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionQueueError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGameSessionQueueError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGameSessionQueueError {}
 /// Errors returned by CreateMatchmakingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateMatchmakingConfigurationError {
@@ -3584,20 +3562,22 @@ impl CreateMatchmakingConfigurationError {
 }
 impl fmt::Display for CreateMatchmakingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMatchmakingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMatchmakingConfigurationError::InternalService(ref cause) => cause,
-            CreateMatchmakingConfigurationError::InvalidRequest(ref cause) => cause,
-            CreateMatchmakingConfigurationError::LimitExceeded(ref cause) => cause,
-            CreateMatchmakingConfigurationError::NotFound(ref cause) => cause,
-            CreateMatchmakingConfigurationError::UnsupportedRegion(ref cause) => cause,
+            CreateMatchmakingConfigurationError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateMatchmakingConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateMatchmakingConfigurationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateMatchmakingConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateMatchmakingConfigurationError::UnsupportedRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateMatchmakingConfigurationError {}
 /// Errors returned by CreateMatchmakingRuleSet
 #[derive(Debug, PartialEq)]
 pub enum CreateMatchmakingRuleSetError {
@@ -3637,18 +3617,14 @@ impl CreateMatchmakingRuleSetError {
 }
 impl fmt::Display for CreateMatchmakingRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMatchmakingRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMatchmakingRuleSetError::InternalService(ref cause) => cause,
-            CreateMatchmakingRuleSetError::InvalidRequest(ref cause) => cause,
-            CreateMatchmakingRuleSetError::UnsupportedRegion(ref cause) => cause,
+            CreateMatchmakingRuleSetError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateMatchmakingRuleSetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateMatchmakingRuleSetError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMatchmakingRuleSetError {}
 /// Errors returned by CreatePlayerSession
 #[derive(Debug, PartialEq)]
 pub enum CreatePlayerSessionError {
@@ -3706,22 +3682,18 @@ impl CreatePlayerSessionError {
 }
 impl fmt::Display for CreatePlayerSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePlayerSessionError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePlayerSessionError::GameSessionFull(ref cause) => cause,
-            CreatePlayerSessionError::InternalService(ref cause) => cause,
-            CreatePlayerSessionError::InvalidGameSessionStatus(ref cause) => cause,
-            CreatePlayerSessionError::InvalidRequest(ref cause) => cause,
-            CreatePlayerSessionError::NotFound(ref cause) => cause,
-            CreatePlayerSessionError::TerminalRoutingStrategy(ref cause) => cause,
-            CreatePlayerSessionError::Unauthorized(ref cause) => cause,
+            CreatePlayerSessionError::GameSessionFull(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionError::InvalidGameSessionStatus(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionError::TerminalRoutingStrategy(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePlayerSessionError {}
 /// Errors returned by CreatePlayerSessions
 #[derive(Debug, PartialEq)]
 pub enum CreatePlayerSessionsError {
@@ -3783,22 +3755,20 @@ impl CreatePlayerSessionsError {
 }
 impl fmt::Display for CreatePlayerSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePlayerSessionsError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePlayerSessionsError::GameSessionFull(ref cause) => cause,
-            CreatePlayerSessionsError::InternalService(ref cause) => cause,
-            CreatePlayerSessionsError::InvalidGameSessionStatus(ref cause) => cause,
-            CreatePlayerSessionsError::InvalidRequest(ref cause) => cause,
-            CreatePlayerSessionsError::NotFound(ref cause) => cause,
-            CreatePlayerSessionsError::TerminalRoutingStrategy(ref cause) => cause,
-            CreatePlayerSessionsError::Unauthorized(ref cause) => cause,
+            CreatePlayerSessionsError::GameSessionFull(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionsError::InvalidGameSessionStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePlayerSessionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionsError::TerminalRoutingStrategy(ref cause) => write!(f, "{}", cause),
+            CreatePlayerSessionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePlayerSessionsError {}
 /// Errors returned by CreateScript
 #[derive(Debug, PartialEq)]
 pub enum CreateScriptError {
@@ -3837,19 +3807,15 @@ impl CreateScriptError {
 }
 impl fmt::Display for CreateScriptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateScriptError {
-    fn description(&self) -> &str {
         match *self {
-            CreateScriptError::Conflict(ref cause) => cause,
-            CreateScriptError::InternalService(ref cause) => cause,
-            CreateScriptError::InvalidRequest(ref cause) => cause,
-            CreateScriptError::Unauthorized(ref cause) => cause,
+            CreateScriptError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateScriptError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateScriptError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateScriptError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateScriptError {}
 /// Errors returned by CreateVpcPeeringAuthorization
 #[derive(Debug, PartialEq)]
 pub enum CreateVpcPeeringAuthorizationError {
@@ -3898,19 +3864,17 @@ impl CreateVpcPeeringAuthorizationError {
 }
 impl fmt::Display for CreateVpcPeeringAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVpcPeeringAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVpcPeeringAuthorizationError::InternalService(ref cause) => cause,
-            CreateVpcPeeringAuthorizationError::InvalidRequest(ref cause) => cause,
-            CreateVpcPeeringAuthorizationError::NotFound(ref cause) => cause,
-            CreateVpcPeeringAuthorizationError::Unauthorized(ref cause) => cause,
+            CreateVpcPeeringAuthorizationError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateVpcPeeringAuthorizationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateVpcPeeringAuthorizationError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateVpcPeeringAuthorizationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVpcPeeringAuthorizationError {}
 /// Errors returned by CreateVpcPeeringConnection
 #[derive(Debug, PartialEq)]
 pub enum CreateVpcPeeringConnectionError {
@@ -3957,19 +3921,15 @@ impl CreateVpcPeeringConnectionError {
 }
 impl fmt::Display for CreateVpcPeeringConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVpcPeeringConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVpcPeeringConnectionError::InternalService(ref cause) => cause,
-            CreateVpcPeeringConnectionError::InvalidRequest(ref cause) => cause,
-            CreateVpcPeeringConnectionError::NotFound(ref cause) => cause,
-            CreateVpcPeeringConnectionError::Unauthorized(ref cause) => cause,
+            CreateVpcPeeringConnectionError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateVpcPeeringConnectionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateVpcPeeringConnectionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateVpcPeeringConnectionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVpcPeeringConnectionError {}
 /// Errors returned by DeleteAlias
 #[derive(Debug, PartialEq)]
 pub enum DeleteAliasError {
@@ -4008,19 +3968,15 @@ impl DeleteAliasError {
 }
 impl fmt::Display for DeleteAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAliasError::InternalService(ref cause) => cause,
-            DeleteAliasError::InvalidRequest(ref cause) => cause,
-            DeleteAliasError::NotFound(ref cause) => cause,
-            DeleteAliasError::Unauthorized(ref cause) => cause,
+            DeleteAliasError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAliasError {}
 /// Errors returned by DeleteBuild
 #[derive(Debug, PartialEq)]
 pub enum DeleteBuildError {
@@ -4059,19 +4015,15 @@ impl DeleteBuildError {
 }
 impl fmt::Display for DeleteBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBuildError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBuildError::InternalService(ref cause) => cause,
-            DeleteBuildError::InvalidRequest(ref cause) => cause,
-            DeleteBuildError::NotFound(ref cause) => cause,
-            DeleteBuildError::Unauthorized(ref cause) => cause,
+            DeleteBuildError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteBuildError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBuildError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBuildError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBuildError {}
 /// Errors returned by DeleteFleet
 #[derive(Debug, PartialEq)]
 pub enum DeleteFleetError {
@@ -4115,20 +4067,16 @@ impl DeleteFleetError {
 }
 impl fmt::Display for DeleteFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFleetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFleetError::InternalService(ref cause) => cause,
-            DeleteFleetError::InvalidFleetStatus(ref cause) => cause,
-            DeleteFleetError::InvalidRequest(ref cause) => cause,
-            DeleteFleetError::NotFound(ref cause) => cause,
-            DeleteFleetError::Unauthorized(ref cause) => cause,
+            DeleteFleetError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::InvalidFleetStatus(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFleetError {}
 /// Errors returned by DeleteGameSessionQueue
 #[derive(Debug, PartialEq)]
 pub enum DeleteGameSessionQueueError {
@@ -4171,19 +4119,15 @@ impl DeleteGameSessionQueueError {
 }
 impl fmt::Display for DeleteGameSessionQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGameSessionQueueError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGameSessionQueueError::InternalService(ref cause) => cause,
-            DeleteGameSessionQueueError::InvalidRequest(ref cause) => cause,
-            DeleteGameSessionQueueError::NotFound(ref cause) => cause,
-            DeleteGameSessionQueueError::Unauthorized(ref cause) => cause,
+            DeleteGameSessionQueueError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteGameSessionQueueError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteGameSessionQueueError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteGameSessionQueueError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGameSessionQueueError {}
 /// Errors returned by DeleteMatchmakingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteMatchmakingConfigurationError {
@@ -4232,19 +4176,21 @@ impl DeleteMatchmakingConfigurationError {
 }
 impl fmt::Display for DeleteMatchmakingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMatchmakingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMatchmakingConfigurationError::InternalService(ref cause) => cause,
-            DeleteMatchmakingConfigurationError::InvalidRequest(ref cause) => cause,
-            DeleteMatchmakingConfigurationError::NotFound(ref cause) => cause,
-            DeleteMatchmakingConfigurationError::UnsupportedRegion(ref cause) => cause,
+            DeleteMatchmakingConfigurationError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteMatchmakingConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteMatchmakingConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMatchmakingConfigurationError::UnsupportedRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteMatchmakingConfigurationError {}
 /// Errors returned by DeleteMatchmakingRuleSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteMatchmakingRuleSetError {
@@ -4289,19 +4235,15 @@ impl DeleteMatchmakingRuleSetError {
 }
 impl fmt::Display for DeleteMatchmakingRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMatchmakingRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMatchmakingRuleSetError::InternalService(ref cause) => cause,
-            DeleteMatchmakingRuleSetError::InvalidRequest(ref cause) => cause,
-            DeleteMatchmakingRuleSetError::NotFound(ref cause) => cause,
-            DeleteMatchmakingRuleSetError::UnsupportedRegion(ref cause) => cause,
+            DeleteMatchmakingRuleSetError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteMatchmakingRuleSetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMatchmakingRuleSetError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMatchmakingRuleSetError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMatchmakingRuleSetError {}
 /// Errors returned by DeleteScalingPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteScalingPolicyError {
@@ -4340,19 +4282,15 @@ impl DeleteScalingPolicyError {
 }
 impl fmt::Display for DeleteScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScalingPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScalingPolicyError::InternalService(ref cause) => cause,
-            DeleteScalingPolicyError::InvalidRequest(ref cause) => cause,
-            DeleteScalingPolicyError::NotFound(ref cause) => cause,
-            DeleteScalingPolicyError::Unauthorized(ref cause) => cause,
+            DeleteScalingPolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteScalingPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteScalingPolicyError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteScalingPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScalingPolicyError {}
 /// Errors returned by DeleteScript
 #[derive(Debug, PartialEq)]
 pub enum DeleteScriptError {
@@ -4391,19 +4329,15 @@ impl DeleteScriptError {
 }
 impl fmt::Display for DeleteScriptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScriptError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScriptError::InternalService(ref cause) => cause,
-            DeleteScriptError::InvalidRequest(ref cause) => cause,
-            DeleteScriptError::NotFound(ref cause) => cause,
-            DeleteScriptError::Unauthorized(ref cause) => cause,
+            DeleteScriptError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteScriptError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteScriptError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteScriptError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScriptError {}
 /// Errors returned by DeleteVpcPeeringAuthorization
 #[derive(Debug, PartialEq)]
 pub enum DeleteVpcPeeringAuthorizationError {
@@ -4452,19 +4386,17 @@ impl DeleteVpcPeeringAuthorizationError {
 }
 impl fmt::Display for DeleteVpcPeeringAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVpcPeeringAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVpcPeeringAuthorizationError::InternalService(ref cause) => cause,
-            DeleteVpcPeeringAuthorizationError::InvalidRequest(ref cause) => cause,
-            DeleteVpcPeeringAuthorizationError::NotFound(ref cause) => cause,
-            DeleteVpcPeeringAuthorizationError::Unauthorized(ref cause) => cause,
+            DeleteVpcPeeringAuthorizationError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVpcPeeringAuthorizationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVpcPeeringAuthorizationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVpcPeeringAuthorizationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVpcPeeringAuthorizationError {}
 /// Errors returned by DeleteVpcPeeringConnection
 #[derive(Debug, PartialEq)]
 pub enum DeleteVpcPeeringConnectionError {
@@ -4511,19 +4443,15 @@ impl DeleteVpcPeeringConnectionError {
 }
 impl fmt::Display for DeleteVpcPeeringConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVpcPeeringConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVpcPeeringConnectionError::InternalService(ref cause) => cause,
-            DeleteVpcPeeringConnectionError::InvalidRequest(ref cause) => cause,
-            DeleteVpcPeeringConnectionError::NotFound(ref cause) => cause,
-            DeleteVpcPeeringConnectionError::Unauthorized(ref cause) => cause,
+            DeleteVpcPeeringConnectionError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteVpcPeeringConnectionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVpcPeeringConnectionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVpcPeeringConnectionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVpcPeeringConnectionError {}
 /// Errors returned by DescribeAlias
 #[derive(Debug, PartialEq)]
 pub enum DescribeAliasError {
@@ -4562,19 +4490,15 @@ impl DescribeAliasError {
 }
 impl fmt::Display for DescribeAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAliasError::InternalService(ref cause) => cause,
-            DescribeAliasError::InvalidRequest(ref cause) => cause,
-            DescribeAliasError::NotFound(ref cause) => cause,
-            DescribeAliasError::Unauthorized(ref cause) => cause,
+            DescribeAliasError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeAliasError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAliasError {}
 /// Errors returned by DescribeBuild
 #[derive(Debug, PartialEq)]
 pub enum DescribeBuildError {
@@ -4613,19 +4537,15 @@ impl DescribeBuildError {
 }
 impl fmt::Display for DescribeBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBuildError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBuildError::InternalService(ref cause) => cause,
-            DescribeBuildError::InvalidRequest(ref cause) => cause,
-            DescribeBuildError::NotFound(ref cause) => cause,
-            DescribeBuildError::Unauthorized(ref cause) => cause,
+            DescribeBuildError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeBuildError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBuildError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeBuildError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBuildError {}
 /// Errors returned by DescribeEC2InstanceLimits
 #[derive(Debug, PartialEq)]
 pub enum DescribeEC2InstanceLimitsError {
@@ -4665,18 +4585,14 @@ impl DescribeEC2InstanceLimitsError {
 }
 impl fmt::Display for DescribeEC2InstanceLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEC2InstanceLimitsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEC2InstanceLimitsError::InternalService(ref cause) => cause,
-            DescribeEC2InstanceLimitsError::InvalidRequest(ref cause) => cause,
-            DescribeEC2InstanceLimitsError::Unauthorized(ref cause) => cause,
+            DescribeEC2InstanceLimitsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeEC2InstanceLimitsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEC2InstanceLimitsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEC2InstanceLimitsError {}
 /// Errors returned by DescribeFleetAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeFleetAttributesError {
@@ -4721,19 +4637,15 @@ impl DescribeFleetAttributesError {
 }
 impl fmt::Display for DescribeFleetAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFleetAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFleetAttributesError::InternalService(ref cause) => cause,
-            DescribeFleetAttributesError::InvalidRequest(ref cause) => cause,
-            DescribeFleetAttributesError::NotFound(ref cause) => cause,
-            DescribeFleetAttributesError::Unauthorized(ref cause) => cause,
+            DescribeFleetAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeFleetAttributesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFleetAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFleetAttributesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFleetAttributesError {}
 /// Errors returned by DescribeFleetCapacity
 #[derive(Debug, PartialEq)]
 pub enum DescribeFleetCapacityError {
@@ -4776,19 +4688,15 @@ impl DescribeFleetCapacityError {
 }
 impl fmt::Display for DescribeFleetCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFleetCapacityError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFleetCapacityError::InternalService(ref cause) => cause,
-            DescribeFleetCapacityError::InvalidRequest(ref cause) => cause,
-            DescribeFleetCapacityError::NotFound(ref cause) => cause,
-            DescribeFleetCapacityError::Unauthorized(ref cause) => cause,
+            DescribeFleetCapacityError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeFleetCapacityError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFleetCapacityError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFleetCapacityError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFleetCapacityError {}
 /// Errors returned by DescribeFleetEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeFleetEventsError {
@@ -4827,19 +4735,15 @@ impl DescribeFleetEventsError {
 }
 impl fmt::Display for DescribeFleetEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFleetEventsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFleetEventsError::InternalService(ref cause) => cause,
-            DescribeFleetEventsError::InvalidRequest(ref cause) => cause,
-            DescribeFleetEventsError::NotFound(ref cause) => cause,
-            DescribeFleetEventsError::Unauthorized(ref cause) => cause,
+            DescribeFleetEventsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeFleetEventsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFleetEventsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFleetEventsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFleetEventsError {}
 /// Errors returned by DescribeFleetPortSettings
 #[derive(Debug, PartialEq)]
 pub enum DescribeFleetPortSettingsError {
@@ -4884,19 +4788,15 @@ impl DescribeFleetPortSettingsError {
 }
 impl fmt::Display for DescribeFleetPortSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFleetPortSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFleetPortSettingsError::InternalService(ref cause) => cause,
-            DescribeFleetPortSettingsError::InvalidRequest(ref cause) => cause,
-            DescribeFleetPortSettingsError::NotFound(ref cause) => cause,
-            DescribeFleetPortSettingsError::Unauthorized(ref cause) => cause,
+            DescribeFleetPortSettingsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeFleetPortSettingsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFleetPortSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFleetPortSettingsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFleetPortSettingsError {}
 /// Errors returned by DescribeFleetUtilization
 #[derive(Debug, PartialEq)]
 pub enum DescribeFleetUtilizationError {
@@ -4941,19 +4841,15 @@ impl DescribeFleetUtilizationError {
 }
 impl fmt::Display for DescribeFleetUtilizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFleetUtilizationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFleetUtilizationError::InternalService(ref cause) => cause,
-            DescribeFleetUtilizationError::InvalidRequest(ref cause) => cause,
-            DescribeFleetUtilizationError::NotFound(ref cause) => cause,
-            DescribeFleetUtilizationError::Unauthorized(ref cause) => cause,
+            DescribeFleetUtilizationError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeFleetUtilizationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFleetUtilizationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFleetUtilizationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFleetUtilizationError {}
 /// Errors returned by DescribeGameSessionDetails
 #[derive(Debug, PartialEq)]
 pub enum DescribeGameSessionDetailsError {
@@ -5007,20 +4903,18 @@ impl DescribeGameSessionDetailsError {
 }
 impl fmt::Display for DescribeGameSessionDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGameSessionDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGameSessionDetailsError::InternalService(ref cause) => cause,
-            DescribeGameSessionDetailsError::InvalidRequest(ref cause) => cause,
-            DescribeGameSessionDetailsError::NotFound(ref cause) => cause,
-            DescribeGameSessionDetailsError::TerminalRoutingStrategy(ref cause) => cause,
-            DescribeGameSessionDetailsError::Unauthorized(ref cause) => cause,
+            DescribeGameSessionDetailsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionDetailsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionDetailsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionDetailsError::TerminalRoutingStrategy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeGameSessionDetailsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeGameSessionDetailsError {}
 /// Errors returned by DescribeGameSessionPlacement
 #[derive(Debug, PartialEq)]
 pub enum DescribeGameSessionPlacementError {
@@ -5069,19 +4963,15 @@ impl DescribeGameSessionPlacementError {
 }
 impl fmt::Display for DescribeGameSessionPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGameSessionPlacementError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGameSessionPlacementError::InternalService(ref cause) => cause,
-            DescribeGameSessionPlacementError::InvalidRequest(ref cause) => cause,
-            DescribeGameSessionPlacementError::NotFound(ref cause) => cause,
-            DescribeGameSessionPlacementError::Unauthorized(ref cause) => cause,
+            DescribeGameSessionPlacementError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionPlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionPlacementError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionPlacementError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeGameSessionPlacementError {}
 /// Errors returned by DescribeGameSessionQueues
 #[derive(Debug, PartialEq)]
 pub enum DescribeGameSessionQueuesError {
@@ -5126,19 +5016,15 @@ impl DescribeGameSessionQueuesError {
 }
 impl fmt::Display for DescribeGameSessionQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGameSessionQueuesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGameSessionQueuesError::InternalService(ref cause) => cause,
-            DescribeGameSessionQueuesError::InvalidRequest(ref cause) => cause,
-            DescribeGameSessionQueuesError::NotFound(ref cause) => cause,
-            DescribeGameSessionQueuesError::Unauthorized(ref cause) => cause,
+            DescribeGameSessionQueuesError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionQueuesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionQueuesError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionQueuesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeGameSessionQueuesError {}
 /// Errors returned by DescribeGameSessions
 #[derive(Debug, PartialEq)]
 pub enum DescribeGameSessionsError {
@@ -5186,20 +5072,16 @@ impl DescribeGameSessionsError {
 }
 impl fmt::Display for DescribeGameSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGameSessionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGameSessionsError::InternalService(ref cause) => cause,
-            DescribeGameSessionsError::InvalidRequest(ref cause) => cause,
-            DescribeGameSessionsError::NotFound(ref cause) => cause,
-            DescribeGameSessionsError::TerminalRoutingStrategy(ref cause) => cause,
-            DescribeGameSessionsError::Unauthorized(ref cause) => cause,
+            DescribeGameSessionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionsError::TerminalRoutingStrategy(ref cause) => write!(f, "{}", cause),
+            DescribeGameSessionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeGameSessionsError {}
 /// Errors returned by DescribeInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstancesError {
@@ -5238,19 +5120,15 @@ impl DescribeInstancesError {
 }
 impl fmt::Display for DescribeInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstancesError::InternalService(ref cause) => cause,
-            DescribeInstancesError::InvalidRequest(ref cause) => cause,
-            DescribeInstancesError::NotFound(ref cause) => cause,
-            DescribeInstancesError::Unauthorized(ref cause) => cause,
+            DescribeInstancesError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeInstancesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeInstancesError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeInstancesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInstancesError {}
 /// Errors returned by DescribeMatchmaking
 #[derive(Debug, PartialEq)]
 pub enum DescribeMatchmakingError {
@@ -5286,18 +5164,14 @@ impl DescribeMatchmakingError {
 }
 impl fmt::Display for DescribeMatchmakingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMatchmakingError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMatchmakingError::InternalService(ref cause) => cause,
-            DescribeMatchmakingError::InvalidRequest(ref cause) => cause,
-            DescribeMatchmakingError::UnsupportedRegion(ref cause) => cause,
+            DescribeMatchmakingError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeMatchmakingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMatchmakingError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMatchmakingError {}
 /// Errors returned by DescribeMatchmakingConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeMatchmakingConfigurationsError {
@@ -5339,18 +5213,20 @@ impl DescribeMatchmakingConfigurationsError {
 }
 impl fmt::Display for DescribeMatchmakingConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMatchmakingConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMatchmakingConfigurationsError::InternalService(ref cause) => cause,
-            DescribeMatchmakingConfigurationsError::InvalidRequest(ref cause) => cause,
-            DescribeMatchmakingConfigurationsError::UnsupportedRegion(ref cause) => cause,
+            DescribeMatchmakingConfigurationsError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMatchmakingConfigurationsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMatchmakingConfigurationsError::UnsupportedRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMatchmakingConfigurationsError {}
 /// Errors returned by DescribeMatchmakingRuleSets
 #[derive(Debug, PartialEq)]
 pub enum DescribeMatchmakingRuleSetsError {
@@ -5399,19 +5275,17 @@ impl DescribeMatchmakingRuleSetsError {
 }
 impl fmt::Display for DescribeMatchmakingRuleSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMatchmakingRuleSetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMatchmakingRuleSetsError::InternalService(ref cause) => cause,
-            DescribeMatchmakingRuleSetsError::InvalidRequest(ref cause) => cause,
-            DescribeMatchmakingRuleSetsError::NotFound(ref cause) => cause,
-            DescribeMatchmakingRuleSetsError::UnsupportedRegion(ref cause) => cause,
+            DescribeMatchmakingRuleSetsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeMatchmakingRuleSetsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMatchmakingRuleSetsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMatchmakingRuleSetsError::UnsupportedRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMatchmakingRuleSetsError {}
 /// Errors returned by DescribePlayerSessions
 #[derive(Debug, PartialEq)]
 pub enum DescribePlayerSessionsError {
@@ -5454,19 +5328,15 @@ impl DescribePlayerSessionsError {
 }
 impl fmt::Display for DescribePlayerSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePlayerSessionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePlayerSessionsError::InternalService(ref cause) => cause,
-            DescribePlayerSessionsError::InvalidRequest(ref cause) => cause,
-            DescribePlayerSessionsError::NotFound(ref cause) => cause,
-            DescribePlayerSessionsError::Unauthorized(ref cause) => cause,
+            DescribePlayerSessionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribePlayerSessionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribePlayerSessionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribePlayerSessionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePlayerSessionsError {}
 /// Errors returned by DescribeRuntimeConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeRuntimeConfigurationError {
@@ -5515,19 +5385,15 @@ impl DescribeRuntimeConfigurationError {
 }
 impl fmt::Display for DescribeRuntimeConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRuntimeConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRuntimeConfigurationError::InternalService(ref cause) => cause,
-            DescribeRuntimeConfigurationError::InvalidRequest(ref cause) => cause,
-            DescribeRuntimeConfigurationError::NotFound(ref cause) => cause,
-            DescribeRuntimeConfigurationError::Unauthorized(ref cause) => cause,
+            DescribeRuntimeConfigurationError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeRuntimeConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeRuntimeConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeRuntimeConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRuntimeConfigurationError {}
 /// Errors returned by DescribeScalingPolicies
 #[derive(Debug, PartialEq)]
 pub enum DescribeScalingPoliciesError {
@@ -5572,19 +5438,15 @@ impl DescribeScalingPoliciesError {
 }
 impl fmt::Display for DescribeScalingPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScalingPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScalingPoliciesError::InternalService(ref cause) => cause,
-            DescribeScalingPoliciesError::InvalidRequest(ref cause) => cause,
-            DescribeScalingPoliciesError::NotFound(ref cause) => cause,
-            DescribeScalingPoliciesError::Unauthorized(ref cause) => cause,
+            DescribeScalingPoliciesError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPoliciesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPoliciesError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeScalingPoliciesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScalingPoliciesError {}
 /// Errors returned by DescribeScript
 #[derive(Debug, PartialEq)]
 pub enum DescribeScriptError {
@@ -5623,19 +5485,15 @@ impl DescribeScriptError {
 }
 impl fmt::Display for DescribeScriptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScriptError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScriptError::InternalService(ref cause) => cause,
-            DescribeScriptError::InvalidRequest(ref cause) => cause,
-            DescribeScriptError::NotFound(ref cause) => cause,
-            DescribeScriptError::Unauthorized(ref cause) => cause,
+            DescribeScriptError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeScriptError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeScriptError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeScriptError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScriptError {}
 /// Errors returned by DescribeVpcPeeringAuthorizations
 #[derive(Debug, PartialEq)]
 pub enum DescribeVpcPeeringAuthorizationsError {
@@ -5677,18 +5535,20 @@ impl DescribeVpcPeeringAuthorizationsError {
 }
 impl fmt::Display for DescribeVpcPeeringAuthorizationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVpcPeeringAuthorizationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVpcPeeringAuthorizationsError::InternalService(ref cause) => cause,
-            DescribeVpcPeeringAuthorizationsError::InvalidRequest(ref cause) => cause,
-            DescribeVpcPeeringAuthorizationsError::Unauthorized(ref cause) => cause,
+            DescribeVpcPeeringAuthorizationsError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeVpcPeeringAuthorizationsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeVpcPeeringAuthorizationsError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeVpcPeeringAuthorizationsError {}
 /// Errors returned by DescribeVpcPeeringConnections
 #[derive(Debug, PartialEq)]
 pub enum DescribeVpcPeeringConnectionsError {
@@ -5737,19 +5597,17 @@ impl DescribeVpcPeeringConnectionsError {
 }
 impl fmt::Display for DescribeVpcPeeringConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVpcPeeringConnectionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVpcPeeringConnectionsError::InternalService(ref cause) => cause,
-            DescribeVpcPeeringConnectionsError::InvalidRequest(ref cause) => cause,
-            DescribeVpcPeeringConnectionsError::NotFound(ref cause) => cause,
-            DescribeVpcPeeringConnectionsError::Unauthorized(ref cause) => cause,
+            DescribeVpcPeeringConnectionsError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeVpcPeeringConnectionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeVpcPeeringConnectionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeVpcPeeringConnectionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVpcPeeringConnectionsError {}
 /// Errors returned by GetGameSessionLogUrl
 #[derive(Debug, PartialEq)]
 pub enum GetGameSessionLogUrlError {
@@ -5790,19 +5648,15 @@ impl GetGameSessionLogUrlError {
 }
 impl fmt::Display for GetGameSessionLogUrlError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGameSessionLogUrlError {
-    fn description(&self) -> &str {
         match *self {
-            GetGameSessionLogUrlError::InternalService(ref cause) => cause,
-            GetGameSessionLogUrlError::InvalidRequest(ref cause) => cause,
-            GetGameSessionLogUrlError::NotFound(ref cause) => cause,
-            GetGameSessionLogUrlError::Unauthorized(ref cause) => cause,
+            GetGameSessionLogUrlError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetGameSessionLogUrlError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetGameSessionLogUrlError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetGameSessionLogUrlError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGameSessionLogUrlError {}
 /// Errors returned by GetInstanceAccess
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceAccessError {
@@ -5841,19 +5695,15 @@ impl GetInstanceAccessError {
 }
 impl fmt::Display for GetInstanceAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceAccessError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceAccessError::InternalService(ref cause) => cause,
-            GetInstanceAccessError::InvalidRequest(ref cause) => cause,
-            GetInstanceAccessError::NotFound(ref cause) => cause,
-            GetInstanceAccessError::Unauthorized(ref cause) => cause,
+            GetInstanceAccessError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceAccessError {}
 /// Errors returned by ListAliases
 #[derive(Debug, PartialEq)]
 pub enum ListAliasesError {
@@ -5887,18 +5737,14 @@ impl ListAliasesError {
 }
 impl fmt::Display for ListAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAliasesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAliasesError::InternalService(ref cause) => cause,
-            ListAliasesError::InvalidRequest(ref cause) => cause,
-            ListAliasesError::Unauthorized(ref cause) => cause,
+            ListAliasesError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAliasesError {}
 /// Errors returned by ListBuilds
 #[derive(Debug, PartialEq)]
 pub enum ListBuildsError {
@@ -5932,18 +5778,14 @@ impl ListBuildsError {
 }
 impl fmt::Display for ListBuildsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBuildsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBuildsError::InternalService(ref cause) => cause,
-            ListBuildsError::InvalidRequest(ref cause) => cause,
-            ListBuildsError::Unauthorized(ref cause) => cause,
+            ListBuildsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListBuildsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListBuildsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBuildsError {}
 /// Errors returned by ListFleets
 #[derive(Debug, PartialEq)]
 pub enum ListFleetsError {
@@ -5982,19 +5824,15 @@ impl ListFleetsError {
 }
 impl fmt::Display for ListFleetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFleetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFleetsError::InternalService(ref cause) => cause,
-            ListFleetsError::InvalidRequest(ref cause) => cause,
-            ListFleetsError::NotFound(ref cause) => cause,
-            ListFleetsError::Unauthorized(ref cause) => cause,
+            ListFleetsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListFleetsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListFleetsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListFleetsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFleetsError {}
 /// Errors returned by ListScripts
 #[derive(Debug, PartialEq)]
 pub enum ListScriptsError {
@@ -6028,18 +5866,14 @@ impl ListScriptsError {
 }
 impl fmt::Display for ListScriptsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListScriptsError {
-    fn description(&self) -> &str {
         match *self {
-            ListScriptsError::InternalService(ref cause) => cause,
-            ListScriptsError::InvalidRequest(ref cause) => cause,
-            ListScriptsError::Unauthorized(ref cause) => cause,
+            ListScriptsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListScriptsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListScriptsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListScriptsError {}
 /// Errors returned by PutScalingPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutScalingPolicyError {
@@ -6078,19 +5912,15 @@ impl PutScalingPolicyError {
 }
 impl fmt::Display for PutScalingPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutScalingPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutScalingPolicyError::InternalService(ref cause) => cause,
-            PutScalingPolicyError::InvalidRequest(ref cause) => cause,
-            PutScalingPolicyError::NotFound(ref cause) => cause,
-            PutScalingPolicyError::Unauthorized(ref cause) => cause,
+            PutScalingPolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutScalingPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutScalingPolicyError {}
 /// Errors returned by RequestUploadCredentials
 #[derive(Debug, PartialEq)]
 pub enum RequestUploadCredentialsError {
@@ -6135,19 +5965,15 @@ impl RequestUploadCredentialsError {
 }
 impl fmt::Display for RequestUploadCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RequestUploadCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            RequestUploadCredentialsError::InternalService(ref cause) => cause,
-            RequestUploadCredentialsError::InvalidRequest(ref cause) => cause,
-            RequestUploadCredentialsError::NotFound(ref cause) => cause,
-            RequestUploadCredentialsError::Unauthorized(ref cause) => cause,
+            RequestUploadCredentialsError::InternalService(ref cause) => write!(f, "{}", cause),
+            RequestUploadCredentialsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RequestUploadCredentialsError::NotFound(ref cause) => write!(f, "{}", cause),
+            RequestUploadCredentialsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RequestUploadCredentialsError {}
 /// Errors returned by ResolveAlias
 #[derive(Debug, PartialEq)]
 pub enum ResolveAliasError {
@@ -6193,20 +6019,16 @@ impl ResolveAliasError {
 }
 impl fmt::Display for ResolveAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResolveAliasError {
-    fn description(&self) -> &str {
         match *self {
-            ResolveAliasError::InternalService(ref cause) => cause,
-            ResolveAliasError::InvalidRequest(ref cause) => cause,
-            ResolveAliasError::NotFound(ref cause) => cause,
-            ResolveAliasError::TerminalRoutingStrategy(ref cause) => cause,
-            ResolveAliasError::Unauthorized(ref cause) => cause,
+            ResolveAliasError::InternalService(ref cause) => write!(f, "{}", cause),
+            ResolveAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ResolveAliasError::NotFound(ref cause) => write!(f, "{}", cause),
+            ResolveAliasError::TerminalRoutingStrategy(ref cause) => write!(f, "{}", cause),
+            ResolveAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResolveAliasError {}
 /// Errors returned by SearchGameSessions
 #[derive(Debug, PartialEq)]
 pub enum SearchGameSessionsError {
@@ -6252,20 +6074,16 @@ impl SearchGameSessionsError {
 }
 impl fmt::Display for SearchGameSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchGameSessionsError {
-    fn description(&self) -> &str {
         match *self {
-            SearchGameSessionsError::InternalService(ref cause) => cause,
-            SearchGameSessionsError::InvalidRequest(ref cause) => cause,
-            SearchGameSessionsError::NotFound(ref cause) => cause,
-            SearchGameSessionsError::TerminalRoutingStrategy(ref cause) => cause,
-            SearchGameSessionsError::Unauthorized(ref cause) => cause,
+            SearchGameSessionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            SearchGameSessionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SearchGameSessionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            SearchGameSessionsError::TerminalRoutingStrategy(ref cause) => write!(f, "{}", cause),
+            SearchGameSessionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchGameSessionsError {}
 /// Errors returned by StartFleetActions
 #[derive(Debug, PartialEq)]
 pub enum StartFleetActionsError {
@@ -6304,19 +6122,15 @@ impl StartFleetActionsError {
 }
 impl fmt::Display for StartFleetActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartFleetActionsError {
-    fn description(&self) -> &str {
         match *self {
-            StartFleetActionsError::InternalService(ref cause) => cause,
-            StartFleetActionsError::InvalidRequest(ref cause) => cause,
-            StartFleetActionsError::NotFound(ref cause) => cause,
-            StartFleetActionsError::Unauthorized(ref cause) => cause,
+            StartFleetActionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartFleetActionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartFleetActionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartFleetActionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartFleetActionsError {}
 /// Errors returned by StartGameSessionPlacement
 #[derive(Debug, PartialEq)]
 pub enum StartGameSessionPlacementError {
@@ -6361,19 +6175,15 @@ impl StartGameSessionPlacementError {
 }
 impl fmt::Display for StartGameSessionPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartGameSessionPlacementError {
-    fn description(&self) -> &str {
         match *self {
-            StartGameSessionPlacementError::InternalService(ref cause) => cause,
-            StartGameSessionPlacementError::InvalidRequest(ref cause) => cause,
-            StartGameSessionPlacementError::NotFound(ref cause) => cause,
-            StartGameSessionPlacementError::Unauthorized(ref cause) => cause,
+            StartGameSessionPlacementError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartGameSessionPlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartGameSessionPlacementError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartGameSessionPlacementError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartGameSessionPlacementError {}
 /// Errors returned by StartMatchBackfill
 #[derive(Debug, PartialEq)]
 pub enum StartMatchBackfillError {
@@ -6414,19 +6224,15 @@ impl StartMatchBackfillError {
 }
 impl fmt::Display for StartMatchBackfillError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMatchBackfillError {
-    fn description(&self) -> &str {
         match *self {
-            StartMatchBackfillError::InternalService(ref cause) => cause,
-            StartMatchBackfillError::InvalidRequest(ref cause) => cause,
-            StartMatchBackfillError::NotFound(ref cause) => cause,
-            StartMatchBackfillError::UnsupportedRegion(ref cause) => cause,
+            StartMatchBackfillError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartMatchBackfillError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartMatchBackfillError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartMatchBackfillError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMatchBackfillError {}
 /// Errors returned by StartMatchmaking
 #[derive(Debug, PartialEq)]
 pub enum StartMatchmakingError {
@@ -6465,19 +6271,15 @@ impl StartMatchmakingError {
 }
 impl fmt::Display for StartMatchmakingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMatchmakingError {
-    fn description(&self) -> &str {
         match *self {
-            StartMatchmakingError::InternalService(ref cause) => cause,
-            StartMatchmakingError::InvalidRequest(ref cause) => cause,
-            StartMatchmakingError::NotFound(ref cause) => cause,
-            StartMatchmakingError::UnsupportedRegion(ref cause) => cause,
+            StartMatchmakingError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartMatchmakingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartMatchmakingError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartMatchmakingError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMatchmakingError {}
 /// Errors returned by StopFleetActions
 #[derive(Debug, PartialEq)]
 pub enum StopFleetActionsError {
@@ -6516,19 +6318,15 @@ impl StopFleetActionsError {
 }
 impl fmt::Display for StopFleetActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopFleetActionsError {
-    fn description(&self) -> &str {
         match *self {
-            StopFleetActionsError::InternalService(ref cause) => cause,
-            StopFleetActionsError::InvalidRequest(ref cause) => cause,
-            StopFleetActionsError::NotFound(ref cause) => cause,
-            StopFleetActionsError::Unauthorized(ref cause) => cause,
+            StopFleetActionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            StopFleetActionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopFleetActionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopFleetActionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopFleetActionsError {}
 /// Errors returned by StopGameSessionPlacement
 #[derive(Debug, PartialEq)]
 pub enum StopGameSessionPlacementError {
@@ -6573,19 +6371,15 @@ impl StopGameSessionPlacementError {
 }
 impl fmt::Display for StopGameSessionPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopGameSessionPlacementError {
-    fn description(&self) -> &str {
         match *self {
-            StopGameSessionPlacementError::InternalService(ref cause) => cause,
-            StopGameSessionPlacementError::InvalidRequest(ref cause) => cause,
-            StopGameSessionPlacementError::NotFound(ref cause) => cause,
-            StopGameSessionPlacementError::Unauthorized(ref cause) => cause,
+            StopGameSessionPlacementError::InternalService(ref cause) => write!(f, "{}", cause),
+            StopGameSessionPlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopGameSessionPlacementError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopGameSessionPlacementError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopGameSessionPlacementError {}
 /// Errors returned by StopMatchmaking
 #[derive(Debug, PartialEq)]
 pub enum StopMatchmakingError {
@@ -6624,19 +6418,15 @@ impl StopMatchmakingError {
 }
 impl fmt::Display for StopMatchmakingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopMatchmakingError {
-    fn description(&self) -> &str {
         match *self {
-            StopMatchmakingError::InternalService(ref cause) => cause,
-            StopMatchmakingError::InvalidRequest(ref cause) => cause,
-            StopMatchmakingError::NotFound(ref cause) => cause,
-            StopMatchmakingError::UnsupportedRegion(ref cause) => cause,
+            StopMatchmakingError::InternalService(ref cause) => write!(f, "{}", cause),
+            StopMatchmakingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopMatchmakingError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopMatchmakingError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopMatchmakingError {}
 /// Errors returned by UpdateAlias
 #[derive(Debug, PartialEq)]
 pub enum UpdateAliasError {
@@ -6675,19 +6465,15 @@ impl UpdateAliasError {
 }
 impl fmt::Display for UpdateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAliasError::InternalService(ref cause) => cause,
-            UpdateAliasError::InvalidRequest(ref cause) => cause,
-            UpdateAliasError::NotFound(ref cause) => cause,
-            UpdateAliasError::Unauthorized(ref cause) => cause,
+            UpdateAliasError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAliasError {}
 /// Errors returned by UpdateBuild
 #[derive(Debug, PartialEq)]
 pub enum UpdateBuildError {
@@ -6726,19 +6512,15 @@ impl UpdateBuildError {
 }
 impl fmt::Display for UpdateBuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBuildError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBuildError::InternalService(ref cause) => cause,
-            UpdateBuildError::InvalidRequest(ref cause) => cause,
-            UpdateBuildError::NotFound(ref cause) => cause,
-            UpdateBuildError::Unauthorized(ref cause) => cause,
+            UpdateBuildError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateBuildError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBuildError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateBuildError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBuildError {}
 /// Errors returned by UpdateFleetAttributes
 #[derive(Debug, PartialEq)]
 pub enum UpdateFleetAttributesError {
@@ -6798,22 +6580,18 @@ impl UpdateFleetAttributesError {
 }
 impl fmt::Display for UpdateFleetAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFleetAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFleetAttributesError::Conflict(ref cause) => cause,
-            UpdateFleetAttributesError::InternalService(ref cause) => cause,
-            UpdateFleetAttributesError::InvalidFleetStatus(ref cause) => cause,
-            UpdateFleetAttributesError::InvalidRequest(ref cause) => cause,
-            UpdateFleetAttributesError::LimitExceeded(ref cause) => cause,
-            UpdateFleetAttributesError::NotFound(ref cause) => cause,
-            UpdateFleetAttributesError::Unauthorized(ref cause) => cause,
+            UpdateFleetAttributesError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateFleetAttributesError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateFleetAttributesError::InvalidFleetStatus(ref cause) => write!(f, "{}", cause),
+            UpdateFleetAttributesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFleetAttributesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFleetAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFleetAttributesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFleetAttributesError {}
 /// Errors returned by UpdateFleetCapacity
 #[derive(Debug, PartialEq)]
 pub enum UpdateFleetCapacityError {
@@ -6869,22 +6647,18 @@ impl UpdateFleetCapacityError {
 }
 impl fmt::Display for UpdateFleetCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFleetCapacityError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFleetCapacityError::Conflict(ref cause) => cause,
-            UpdateFleetCapacityError::InternalService(ref cause) => cause,
-            UpdateFleetCapacityError::InvalidFleetStatus(ref cause) => cause,
-            UpdateFleetCapacityError::InvalidRequest(ref cause) => cause,
-            UpdateFleetCapacityError::LimitExceeded(ref cause) => cause,
-            UpdateFleetCapacityError::NotFound(ref cause) => cause,
-            UpdateFleetCapacityError::Unauthorized(ref cause) => cause,
+            UpdateFleetCapacityError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateFleetCapacityError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateFleetCapacityError::InvalidFleetStatus(ref cause) => write!(f, "{}", cause),
+            UpdateFleetCapacityError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFleetCapacityError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFleetCapacityError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFleetCapacityError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFleetCapacityError {}
 /// Errors returned by UpdateFleetPortSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateFleetPortSettingsError {
@@ -6948,22 +6722,18 @@ impl UpdateFleetPortSettingsError {
 }
 impl fmt::Display for UpdateFleetPortSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFleetPortSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFleetPortSettingsError::Conflict(ref cause) => cause,
-            UpdateFleetPortSettingsError::InternalService(ref cause) => cause,
-            UpdateFleetPortSettingsError::InvalidFleetStatus(ref cause) => cause,
-            UpdateFleetPortSettingsError::InvalidRequest(ref cause) => cause,
-            UpdateFleetPortSettingsError::LimitExceeded(ref cause) => cause,
-            UpdateFleetPortSettingsError::NotFound(ref cause) => cause,
-            UpdateFleetPortSettingsError::Unauthorized(ref cause) => cause,
+            UpdateFleetPortSettingsError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateFleetPortSettingsError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateFleetPortSettingsError::InvalidFleetStatus(ref cause) => write!(f, "{}", cause),
+            UpdateFleetPortSettingsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFleetPortSettingsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFleetPortSettingsError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFleetPortSettingsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFleetPortSettingsError {}
 /// Errors returned by UpdateGameSession
 #[derive(Debug, PartialEq)]
 pub enum UpdateGameSessionError {
@@ -7014,21 +6784,17 @@ impl UpdateGameSessionError {
 }
 impl fmt::Display for UpdateGameSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGameSessionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGameSessionError::Conflict(ref cause) => cause,
-            UpdateGameSessionError::InternalService(ref cause) => cause,
-            UpdateGameSessionError::InvalidGameSessionStatus(ref cause) => cause,
-            UpdateGameSessionError::InvalidRequest(ref cause) => cause,
-            UpdateGameSessionError::NotFound(ref cause) => cause,
-            UpdateGameSessionError::Unauthorized(ref cause) => cause,
+            UpdateGameSessionError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionError::InvalidGameSessionStatus(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGameSessionError {}
 /// Errors returned by UpdateGameSessionQueue
 #[derive(Debug, PartialEq)]
 pub enum UpdateGameSessionQueueError {
@@ -7071,19 +6837,15 @@ impl UpdateGameSessionQueueError {
 }
 impl fmt::Display for UpdateGameSessionQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGameSessionQueueError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGameSessionQueueError::InternalService(ref cause) => cause,
-            UpdateGameSessionQueueError::InvalidRequest(ref cause) => cause,
-            UpdateGameSessionQueueError::NotFound(ref cause) => cause,
-            UpdateGameSessionQueueError::Unauthorized(ref cause) => cause,
+            UpdateGameSessionQueueError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionQueueError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionQueueError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGameSessionQueueError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGameSessionQueueError {}
 /// Errors returned by UpdateMatchmakingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateMatchmakingConfigurationError {
@@ -7132,19 +6894,21 @@ impl UpdateMatchmakingConfigurationError {
 }
 impl fmt::Display for UpdateMatchmakingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMatchmakingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMatchmakingConfigurationError::InternalService(ref cause) => cause,
-            UpdateMatchmakingConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateMatchmakingConfigurationError::NotFound(ref cause) => cause,
-            UpdateMatchmakingConfigurationError::UnsupportedRegion(ref cause) => cause,
+            UpdateMatchmakingConfigurationError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateMatchmakingConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateMatchmakingConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMatchmakingConfigurationError::UnsupportedRegion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateMatchmakingConfigurationError {}
 /// Errors returned by UpdateRuntimeConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateRuntimeConfigurationError {
@@ -7198,20 +6962,18 @@ impl UpdateRuntimeConfigurationError {
 }
 impl fmt::Display for UpdateRuntimeConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRuntimeConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRuntimeConfigurationError::InternalService(ref cause) => cause,
-            UpdateRuntimeConfigurationError::InvalidFleetStatus(ref cause) => cause,
-            UpdateRuntimeConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateRuntimeConfigurationError::NotFound(ref cause) => cause,
-            UpdateRuntimeConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateRuntimeConfigurationError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateRuntimeConfigurationError::InvalidFleetStatus(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRuntimeConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRuntimeConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRuntimeConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRuntimeConfigurationError {}
 /// Errors returned by UpdateScript
 #[derive(Debug, PartialEq)]
 pub enum UpdateScriptError {
@@ -7250,19 +7012,15 @@ impl UpdateScriptError {
 }
 impl fmt::Display for UpdateScriptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateScriptError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateScriptError::InternalService(ref cause) => cause,
-            UpdateScriptError::InvalidRequest(ref cause) => cause,
-            UpdateScriptError::NotFound(ref cause) => cause,
-            UpdateScriptError::Unauthorized(ref cause) => cause,
+            UpdateScriptError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateScriptError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateScriptError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateScriptError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateScriptError {}
 /// Errors returned by ValidateMatchmakingRuleSet
 #[derive(Debug, PartialEq)]
 pub enum ValidateMatchmakingRuleSetError {
@@ -7304,18 +7062,14 @@ impl ValidateMatchmakingRuleSetError {
 }
 impl fmt::Display for ValidateMatchmakingRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ValidateMatchmakingRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            ValidateMatchmakingRuleSetError::InternalService(ref cause) => cause,
-            ValidateMatchmakingRuleSetError::InvalidRequest(ref cause) => cause,
-            ValidateMatchmakingRuleSetError::UnsupportedRegion(ref cause) => cause,
+            ValidateMatchmakingRuleSetError::InternalService(ref cause) => write!(f, "{}", cause),
+            ValidateMatchmakingRuleSetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ValidateMatchmakingRuleSetError::UnsupportedRegion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ValidateMatchmakingRuleSetError {}
 /// Trait representing the capabilities of the Amazon GameLift API. Amazon GameLift clients implement this trait.
 pub trait GameLift {
     /// <p><p>Registers a player&#39;s acceptance or rejection of a proposed FlexMatch match. A matchmaking configuration may require player acceptance; if so, then matches built with that configuration cannot be completed unless all players accept the proposed match within a specified time limit. </p> <p>When FlexMatch builds a match, all the matchmaking tickets involved in the proposed match are placed into status <code>REQUIRES_ACCEPTANCE</code>. This is a trigger for your game to get acceptance from all players in the ticket. Acceptances are only valid for tickets when they are in this status; all other acceptances result in an error.</p> <p>To register acceptance, specify the ticket ID, a response, and one or more players. Once all players have registered acceptance, the matchmaking tickets advance to status <code>PLACING</code>, where a new game session is created for the match. </p> <p>If any player rejects the match, or if acceptances are not received before a specified timeout, the proposed match is dropped. The matchmaking tickets are then handled in one of two ways: For tickets where one or more players rejected the match, the ticket status is returned to <code>SEARCHING</code> to find a new match. For tickets where one or more players failed to respond, the ticket status is set to <code>CANCELLED</code>, and processing is terminated. A new matchmaking request for these players can be submitted as needed. </p> <p> <b>Learn more</b> </p> <p> <a href="https://docs.aws.amazon.com/gamelift/latest/developerguide/match-client.html"> Add FlexMatch to a Game Client</a> </p> <p> <a href="https://docs.aws.amazon.com/gamelift/latest/developerguide/match-events.html"> FlexMatch Events Reference</a> </p> <p> <b>Related operations</b> </p> <ul> <li> <p> <a>StartMatchmaking</a> </p> </li> <li> <p> <a>DescribeMatchmaking</a> </p> </li> <li> <p> <a>StopMatchmaking</a> </p> </li> <li> <p> <a>AcceptMatch</a> </p> </li> <li> <p> <a>StartMatchBackfill</a> </p> </li> </ul></p>

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -1333,19 +1333,15 @@ impl AbortMultipartUploadError {
 }
 impl fmt::Display for AbortMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AbortMultipartUploadError {
-    fn description(&self) -> &str {
         match *self {
-            AbortMultipartUploadError::InvalidParameterValue(ref cause) => cause,
-            AbortMultipartUploadError::MissingParameterValue(ref cause) => cause,
-            AbortMultipartUploadError::ResourceNotFound(ref cause) => cause,
-            AbortMultipartUploadError::ServiceUnavailable(ref cause) => cause,
+            AbortMultipartUploadError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            AbortMultipartUploadError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            AbortMultipartUploadError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AbortMultipartUploadError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AbortMultipartUploadError {}
 /// Errors returned by AbortVaultLock
 #[derive(Debug, PartialEq)]
 pub enum AbortVaultLockError {
@@ -1388,19 +1384,15 @@ impl AbortVaultLockError {
 }
 impl fmt::Display for AbortVaultLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AbortVaultLockError {
-    fn description(&self) -> &str {
         match *self {
-            AbortVaultLockError::InvalidParameterValue(ref cause) => cause,
-            AbortVaultLockError::MissingParameterValue(ref cause) => cause,
-            AbortVaultLockError::ResourceNotFound(ref cause) => cause,
-            AbortVaultLockError::ServiceUnavailable(ref cause) => cause,
+            AbortVaultLockError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            AbortVaultLockError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            AbortVaultLockError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AbortVaultLockError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AbortVaultLockError {}
 /// Errors returned by AddTagsToVault
 #[derive(Debug, PartialEq)]
 pub enum AddTagsToVaultError {
@@ -1448,20 +1440,16 @@ impl AddTagsToVaultError {
 }
 impl fmt::Display for AddTagsToVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToVaultError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToVaultError::InvalidParameterValue(ref cause) => cause,
-            AddTagsToVaultError::LimitExceeded(ref cause) => cause,
-            AddTagsToVaultError::MissingParameterValue(ref cause) => cause,
-            AddTagsToVaultError::ResourceNotFound(ref cause) => cause,
-            AddTagsToVaultError::ServiceUnavailable(ref cause) => cause,
+            AddTagsToVaultError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            AddTagsToVaultError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddTagsToVaultError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            AddTagsToVaultError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddTagsToVaultError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToVaultError {}
 /// Errors returned by CompleteMultipartUpload
 #[derive(Debug, PartialEq)]
 pub enum CompleteMultipartUploadError {
@@ -1508,19 +1496,19 @@ impl CompleteMultipartUploadError {
 }
 impl fmt::Display for CompleteMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CompleteMultipartUploadError {
-    fn description(&self) -> &str {
         match *self {
-            CompleteMultipartUploadError::InvalidParameterValue(ref cause) => cause,
-            CompleteMultipartUploadError::MissingParameterValue(ref cause) => cause,
-            CompleteMultipartUploadError::ResourceNotFound(ref cause) => cause,
-            CompleteMultipartUploadError::ServiceUnavailable(ref cause) => cause,
+            CompleteMultipartUploadError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CompleteMultipartUploadError::MissingParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CompleteMultipartUploadError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CompleteMultipartUploadError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CompleteMultipartUploadError {}
 /// Errors returned by CompleteVaultLock
 #[derive(Debug, PartialEq)]
 pub enum CompleteVaultLockError {
@@ -1565,19 +1553,15 @@ impl CompleteVaultLockError {
 }
 impl fmt::Display for CompleteVaultLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CompleteVaultLockError {
-    fn description(&self) -> &str {
         match *self {
-            CompleteVaultLockError::InvalidParameterValue(ref cause) => cause,
-            CompleteVaultLockError::MissingParameterValue(ref cause) => cause,
-            CompleteVaultLockError::ResourceNotFound(ref cause) => cause,
-            CompleteVaultLockError::ServiceUnavailable(ref cause) => cause,
+            CompleteVaultLockError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CompleteVaultLockError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            CompleteVaultLockError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CompleteVaultLockError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CompleteVaultLockError {}
 /// Errors returned by CreateVault
 #[derive(Debug, PartialEq)]
 pub enum CreateVaultError {
@@ -1616,19 +1600,15 @@ impl CreateVaultError {
 }
 impl fmt::Display for CreateVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVaultError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVaultError::InvalidParameterValue(ref cause) => cause,
-            CreateVaultError::LimitExceeded(ref cause) => cause,
-            CreateVaultError::MissingParameterValue(ref cause) => cause,
-            CreateVaultError::ServiceUnavailable(ref cause) => cause,
+            CreateVaultError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateVaultError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateVaultError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateVaultError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVaultError {}
 /// Errors returned by DeleteArchive
 #[derive(Debug, PartialEq)]
 pub enum DeleteArchiveError {
@@ -1667,19 +1647,15 @@ impl DeleteArchiveError {
 }
 impl fmt::Display for DeleteArchiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteArchiveError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteArchiveError::InvalidParameterValue(ref cause) => cause,
-            DeleteArchiveError::MissingParameterValue(ref cause) => cause,
-            DeleteArchiveError::ResourceNotFound(ref cause) => cause,
-            DeleteArchiveError::ServiceUnavailable(ref cause) => cause,
+            DeleteArchiveError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteArchiveError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteArchiveError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteArchiveError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteArchiveError {}
 /// Errors returned by DeleteVault
 #[derive(Debug, PartialEq)]
 pub enum DeleteVaultError {
@@ -1718,19 +1694,15 @@ impl DeleteVaultError {
 }
 impl fmt::Display for DeleteVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVaultError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVaultError::InvalidParameterValue(ref cause) => cause,
-            DeleteVaultError::MissingParameterValue(ref cause) => cause,
-            DeleteVaultError::ResourceNotFound(ref cause) => cause,
-            DeleteVaultError::ServiceUnavailable(ref cause) => cause,
+            DeleteVaultError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteVaultError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteVaultError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVaultError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVaultError {}
 /// Errors returned by DeleteVaultAccessPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteVaultAccessPolicyError {
@@ -1777,19 +1749,19 @@ impl DeleteVaultAccessPolicyError {
 }
 impl fmt::Display for DeleteVaultAccessPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVaultAccessPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVaultAccessPolicyError::InvalidParameterValue(ref cause) => cause,
-            DeleteVaultAccessPolicyError::MissingParameterValue(ref cause) => cause,
-            DeleteVaultAccessPolicyError::ResourceNotFound(ref cause) => cause,
-            DeleteVaultAccessPolicyError::ServiceUnavailable(ref cause) => cause,
+            DeleteVaultAccessPolicyError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVaultAccessPolicyError::MissingParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVaultAccessPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVaultAccessPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVaultAccessPolicyError {}
 /// Errors returned by DeleteVaultNotifications
 #[derive(Debug, PartialEq)]
 pub enum DeleteVaultNotificationsError {
@@ -1836,19 +1808,19 @@ impl DeleteVaultNotificationsError {
 }
 impl fmt::Display for DeleteVaultNotificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVaultNotificationsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVaultNotificationsError::InvalidParameterValue(ref cause) => cause,
-            DeleteVaultNotificationsError::MissingParameterValue(ref cause) => cause,
-            DeleteVaultNotificationsError::ResourceNotFound(ref cause) => cause,
-            DeleteVaultNotificationsError::ServiceUnavailable(ref cause) => cause,
+            DeleteVaultNotificationsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVaultNotificationsError::MissingParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVaultNotificationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteVaultNotificationsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVaultNotificationsError {}
 /// Errors returned by DescribeJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobError {
@@ -1887,19 +1859,15 @@ impl DescribeJobError {
 }
 impl fmt::Display for DescribeJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobError::InvalidParameterValue(ref cause) => cause,
-            DescribeJobError::MissingParameterValue(ref cause) => cause,
-            DescribeJobError::ResourceNotFound(ref cause) => cause,
-            DescribeJobError::ServiceUnavailable(ref cause) => cause,
+            DescribeJobError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeJobError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobError {}
 /// Errors returned by DescribeVault
 #[derive(Debug, PartialEq)]
 pub enum DescribeVaultError {
@@ -1938,19 +1906,15 @@ impl DescribeVaultError {
 }
 impl fmt::Display for DescribeVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVaultError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVaultError::InvalidParameterValue(ref cause) => cause,
-            DescribeVaultError::MissingParameterValue(ref cause) => cause,
-            DescribeVaultError::ResourceNotFound(ref cause) => cause,
-            DescribeVaultError::ServiceUnavailable(ref cause) => cause,
+            DescribeVaultError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeVaultError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            DescribeVaultError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeVaultError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVaultError {}
 /// Errors returned by GetDataRetrievalPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetDataRetrievalPolicyError {
@@ -1990,18 +1954,14 @@ impl GetDataRetrievalPolicyError {
 }
 impl fmt::Display for GetDataRetrievalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDataRetrievalPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetDataRetrievalPolicyError::InvalidParameterValue(ref cause) => cause,
-            GetDataRetrievalPolicyError::MissingParameterValue(ref cause) => cause,
-            GetDataRetrievalPolicyError::ServiceUnavailable(ref cause) => cause,
+            GetDataRetrievalPolicyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetDataRetrievalPolicyError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            GetDataRetrievalPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDataRetrievalPolicyError {}
 /// Errors returned by GetJobOutput
 #[derive(Debug, PartialEq)]
 pub enum GetJobOutputError {
@@ -2040,19 +2000,15 @@ impl GetJobOutputError {
 }
 impl fmt::Display for GetJobOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobOutputError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobOutputError::InvalidParameterValue(ref cause) => cause,
-            GetJobOutputError::MissingParameterValue(ref cause) => cause,
-            GetJobOutputError::ResourceNotFound(ref cause) => cause,
-            GetJobOutputError::ServiceUnavailable(ref cause) => cause,
+            GetJobOutputError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetJobOutputError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            GetJobOutputError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetJobOutputError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobOutputError {}
 /// Errors returned by GetVaultAccessPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetVaultAccessPolicyError {
@@ -2099,19 +2055,15 @@ impl GetVaultAccessPolicyError {
 }
 impl fmt::Display for GetVaultAccessPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVaultAccessPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetVaultAccessPolicyError::InvalidParameterValue(ref cause) => cause,
-            GetVaultAccessPolicyError::MissingParameterValue(ref cause) => cause,
-            GetVaultAccessPolicyError::ResourceNotFound(ref cause) => cause,
-            GetVaultAccessPolicyError::ServiceUnavailable(ref cause) => cause,
+            GetVaultAccessPolicyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetVaultAccessPolicyError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            GetVaultAccessPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetVaultAccessPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVaultAccessPolicyError {}
 /// Errors returned by GetVaultLock
 #[derive(Debug, PartialEq)]
 pub enum GetVaultLockError {
@@ -2150,19 +2102,15 @@ impl GetVaultLockError {
 }
 impl fmt::Display for GetVaultLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVaultLockError {
-    fn description(&self) -> &str {
         match *self {
-            GetVaultLockError::InvalidParameterValue(ref cause) => cause,
-            GetVaultLockError::MissingParameterValue(ref cause) => cause,
-            GetVaultLockError::ResourceNotFound(ref cause) => cause,
-            GetVaultLockError::ServiceUnavailable(ref cause) => cause,
+            GetVaultLockError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetVaultLockError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            GetVaultLockError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetVaultLockError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVaultLockError {}
 /// Errors returned by GetVaultNotifications
 #[derive(Debug, PartialEq)]
 pub enum GetVaultNotificationsError {
@@ -2209,19 +2157,15 @@ impl GetVaultNotificationsError {
 }
 impl fmt::Display for GetVaultNotificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVaultNotificationsError {
-    fn description(&self) -> &str {
         match *self {
-            GetVaultNotificationsError::InvalidParameterValue(ref cause) => cause,
-            GetVaultNotificationsError::MissingParameterValue(ref cause) => cause,
-            GetVaultNotificationsError::ResourceNotFound(ref cause) => cause,
-            GetVaultNotificationsError::ServiceUnavailable(ref cause) => cause,
+            GetVaultNotificationsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetVaultNotificationsError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            GetVaultNotificationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetVaultNotificationsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVaultNotificationsError {}
 /// Errors returned by InitiateJob
 #[derive(Debug, PartialEq)]
 pub enum InitiateJobError {
@@ -2270,21 +2214,17 @@ impl InitiateJobError {
 }
 impl fmt::Display for InitiateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitiateJobError {
-    fn description(&self) -> &str {
         match *self {
-            InitiateJobError::InsufficientCapacity(ref cause) => cause,
-            InitiateJobError::InvalidParameterValue(ref cause) => cause,
-            InitiateJobError::MissingParameterValue(ref cause) => cause,
-            InitiateJobError::PolicyEnforced(ref cause) => cause,
-            InitiateJobError::ResourceNotFound(ref cause) => cause,
-            InitiateJobError::ServiceUnavailable(ref cause) => cause,
+            InitiateJobError::InsufficientCapacity(ref cause) => write!(f, "{}", cause),
+            InitiateJobError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            InitiateJobError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            InitiateJobError::PolicyEnforced(ref cause) => write!(f, "{}", cause),
+            InitiateJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            InitiateJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InitiateJobError {}
 /// Errors returned by InitiateMultipartUpload
 #[derive(Debug, PartialEq)]
 pub enum InitiateMultipartUploadError {
@@ -2331,19 +2271,19 @@ impl InitiateMultipartUploadError {
 }
 impl fmt::Display for InitiateMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitiateMultipartUploadError {
-    fn description(&self) -> &str {
         match *self {
-            InitiateMultipartUploadError::InvalidParameterValue(ref cause) => cause,
-            InitiateMultipartUploadError::MissingParameterValue(ref cause) => cause,
-            InitiateMultipartUploadError::ResourceNotFound(ref cause) => cause,
-            InitiateMultipartUploadError::ServiceUnavailable(ref cause) => cause,
+            InitiateMultipartUploadError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateMultipartUploadError::MissingParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateMultipartUploadError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            InitiateMultipartUploadError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InitiateMultipartUploadError {}
 /// Errors returned by InitiateVaultLock
 #[derive(Debug, PartialEq)]
 pub enum InitiateVaultLockError {
@@ -2388,19 +2328,15 @@ impl InitiateVaultLockError {
 }
 impl fmt::Display for InitiateVaultLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitiateVaultLockError {
-    fn description(&self) -> &str {
         match *self {
-            InitiateVaultLockError::InvalidParameterValue(ref cause) => cause,
-            InitiateVaultLockError::MissingParameterValue(ref cause) => cause,
-            InitiateVaultLockError::ResourceNotFound(ref cause) => cause,
-            InitiateVaultLockError::ServiceUnavailable(ref cause) => cause,
+            InitiateVaultLockError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            InitiateVaultLockError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            InitiateVaultLockError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            InitiateVaultLockError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InitiateVaultLockError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -2439,19 +2375,15 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::InvalidParameterValue(ref cause) => cause,
-            ListJobsError::MissingParameterValue(ref cause) => cause,
-            ListJobsError::ResourceNotFound(ref cause) => cause,
-            ListJobsError::ServiceUnavailable(ref cause) => cause,
+            ListJobsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListJobsError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            ListJobsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListJobsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by ListMultipartUploads
 #[derive(Debug, PartialEq)]
 pub enum ListMultipartUploadsError {
@@ -2498,19 +2430,15 @@ impl ListMultipartUploadsError {
 }
 impl fmt::Display for ListMultipartUploadsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMultipartUploadsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMultipartUploadsError::InvalidParameterValue(ref cause) => cause,
-            ListMultipartUploadsError::MissingParameterValue(ref cause) => cause,
-            ListMultipartUploadsError::ResourceNotFound(ref cause) => cause,
-            ListMultipartUploadsError::ServiceUnavailable(ref cause) => cause,
+            ListMultipartUploadsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListMultipartUploadsError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            ListMultipartUploadsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListMultipartUploadsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMultipartUploadsError {}
 /// Errors returned by ListParts
 #[derive(Debug, PartialEq)]
 pub enum ListPartsError {
@@ -2549,19 +2477,15 @@ impl ListPartsError {
 }
 impl fmt::Display for ListPartsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPartsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPartsError::InvalidParameterValue(ref cause) => cause,
-            ListPartsError::MissingParameterValue(ref cause) => cause,
-            ListPartsError::ResourceNotFound(ref cause) => cause,
-            ListPartsError::ServiceUnavailable(ref cause) => cause,
+            ListPartsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListPartsError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            ListPartsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPartsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPartsError {}
 /// Errors returned by ListProvisionedCapacity
 #[derive(Debug, PartialEq)]
 pub enum ListProvisionedCapacityError {
@@ -2601,18 +2525,18 @@ impl ListProvisionedCapacityError {
 }
 impl fmt::Display for ListProvisionedCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProvisionedCapacityError {
-    fn description(&self) -> &str {
         match *self {
-            ListProvisionedCapacityError::InvalidParameterValue(ref cause) => cause,
-            ListProvisionedCapacityError::MissingParameterValue(ref cause) => cause,
-            ListProvisionedCapacityError::ServiceUnavailable(ref cause) => cause,
+            ListProvisionedCapacityError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisionedCapacityError::MissingParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisionedCapacityError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProvisionedCapacityError {}
 /// Errors returned by ListTagsForVault
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForVaultError {
@@ -2655,19 +2579,15 @@ impl ListTagsForVaultError {
 }
 impl fmt::Display for ListTagsForVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForVaultError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForVaultError::InvalidParameterValue(ref cause) => cause,
-            ListTagsForVaultError::MissingParameterValue(ref cause) => cause,
-            ListTagsForVaultError::ResourceNotFound(ref cause) => cause,
-            ListTagsForVaultError::ServiceUnavailable(ref cause) => cause,
+            ListTagsForVaultError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListTagsForVaultError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            ListTagsForVaultError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForVaultError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForVaultError {}
 /// Errors returned by ListVaults
 #[derive(Debug, PartialEq)]
 pub enum ListVaultsError {
@@ -2706,19 +2626,15 @@ impl ListVaultsError {
 }
 impl fmt::Display for ListVaultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVaultsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVaultsError::InvalidParameterValue(ref cause) => cause,
-            ListVaultsError::MissingParameterValue(ref cause) => cause,
-            ListVaultsError::ResourceNotFound(ref cause) => cause,
-            ListVaultsError::ServiceUnavailable(ref cause) => cause,
+            ListVaultsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListVaultsError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            ListVaultsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListVaultsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVaultsError {}
 /// Errors returned by PurchaseProvisionedCapacity
 #[derive(Debug, PartialEq)]
 pub enum PurchaseProvisionedCapacityError {
@@ -2767,19 +2683,21 @@ impl PurchaseProvisionedCapacityError {
 }
 impl fmt::Display for PurchaseProvisionedCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PurchaseProvisionedCapacityError {
-    fn description(&self) -> &str {
         match *self {
-            PurchaseProvisionedCapacityError::InvalidParameterValue(ref cause) => cause,
-            PurchaseProvisionedCapacityError::LimitExceeded(ref cause) => cause,
-            PurchaseProvisionedCapacityError::MissingParameterValue(ref cause) => cause,
-            PurchaseProvisionedCapacityError::ServiceUnavailable(ref cause) => cause,
+            PurchaseProvisionedCapacityError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PurchaseProvisionedCapacityError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PurchaseProvisionedCapacityError::MissingParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PurchaseProvisionedCapacityError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PurchaseProvisionedCapacityError {}
 /// Errors returned by RemoveTagsFromVault
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromVaultError {
@@ -2826,19 +2744,15 @@ impl RemoveTagsFromVaultError {
 }
 impl fmt::Display for RemoveTagsFromVaultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromVaultError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromVaultError::InvalidParameterValue(ref cause) => cause,
-            RemoveTagsFromVaultError::MissingParameterValue(ref cause) => cause,
-            RemoveTagsFromVaultError::ResourceNotFound(ref cause) => cause,
-            RemoveTagsFromVaultError::ServiceUnavailable(ref cause) => cause,
+            RemoveTagsFromVaultError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromVaultError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromVaultError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromVaultError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromVaultError {}
 /// Errors returned by SetDataRetrievalPolicy
 #[derive(Debug, PartialEq)]
 pub enum SetDataRetrievalPolicyError {
@@ -2878,18 +2792,14 @@ impl SetDataRetrievalPolicyError {
 }
 impl fmt::Display for SetDataRetrievalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetDataRetrievalPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            SetDataRetrievalPolicyError::InvalidParameterValue(ref cause) => cause,
-            SetDataRetrievalPolicyError::MissingParameterValue(ref cause) => cause,
-            SetDataRetrievalPolicyError::ServiceUnavailable(ref cause) => cause,
+            SetDataRetrievalPolicyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            SetDataRetrievalPolicyError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            SetDataRetrievalPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetDataRetrievalPolicyError {}
 /// Errors returned by SetVaultAccessPolicy
 #[derive(Debug, PartialEq)]
 pub enum SetVaultAccessPolicyError {
@@ -2936,19 +2846,15 @@ impl SetVaultAccessPolicyError {
 }
 impl fmt::Display for SetVaultAccessPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetVaultAccessPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            SetVaultAccessPolicyError::InvalidParameterValue(ref cause) => cause,
-            SetVaultAccessPolicyError::MissingParameterValue(ref cause) => cause,
-            SetVaultAccessPolicyError::ResourceNotFound(ref cause) => cause,
-            SetVaultAccessPolicyError::ServiceUnavailable(ref cause) => cause,
+            SetVaultAccessPolicyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            SetVaultAccessPolicyError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            SetVaultAccessPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetVaultAccessPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetVaultAccessPolicyError {}
 /// Errors returned by SetVaultNotifications
 #[derive(Debug, PartialEq)]
 pub enum SetVaultNotificationsError {
@@ -2995,19 +2901,15 @@ impl SetVaultNotificationsError {
 }
 impl fmt::Display for SetVaultNotificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetVaultNotificationsError {
-    fn description(&self) -> &str {
         match *self {
-            SetVaultNotificationsError::InvalidParameterValue(ref cause) => cause,
-            SetVaultNotificationsError::MissingParameterValue(ref cause) => cause,
-            SetVaultNotificationsError::ResourceNotFound(ref cause) => cause,
-            SetVaultNotificationsError::ServiceUnavailable(ref cause) => cause,
+            SetVaultNotificationsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            SetVaultNotificationsError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            SetVaultNotificationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetVaultNotificationsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetVaultNotificationsError {}
 /// Errors returned by UploadArchive
 #[derive(Debug, PartialEq)]
 pub enum UploadArchiveError {
@@ -3051,20 +2953,16 @@ impl UploadArchiveError {
 }
 impl fmt::Display for UploadArchiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadArchiveError {
-    fn description(&self) -> &str {
         match *self {
-            UploadArchiveError::InvalidParameterValue(ref cause) => cause,
-            UploadArchiveError::MissingParameterValue(ref cause) => cause,
-            UploadArchiveError::RequestTimeout(ref cause) => cause,
-            UploadArchiveError::ResourceNotFound(ref cause) => cause,
-            UploadArchiveError::ServiceUnavailable(ref cause) => cause,
+            UploadArchiveError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UploadArchiveError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            UploadArchiveError::RequestTimeout(ref cause) => write!(f, "{}", cause),
+            UploadArchiveError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UploadArchiveError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UploadArchiveError {}
 /// Errors returned by UploadMultipartPart
 #[derive(Debug, PartialEq)]
 pub enum UploadMultipartPartError {
@@ -3116,20 +3014,16 @@ impl UploadMultipartPartError {
 }
 impl fmt::Display for UploadMultipartPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadMultipartPartError {
-    fn description(&self) -> &str {
         match *self {
-            UploadMultipartPartError::InvalidParameterValue(ref cause) => cause,
-            UploadMultipartPartError::MissingParameterValue(ref cause) => cause,
-            UploadMultipartPartError::RequestTimeout(ref cause) => cause,
-            UploadMultipartPartError::ResourceNotFound(ref cause) => cause,
-            UploadMultipartPartError::ServiceUnavailable(ref cause) => cause,
+            UploadMultipartPartError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UploadMultipartPartError::MissingParameterValue(ref cause) => write!(f, "{}", cause),
+            UploadMultipartPartError::RequestTimeout(ref cause) => write!(f, "{}", cause),
+            UploadMultipartPartError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UploadMultipartPartError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UploadMultipartPartError {}
 /// Trait representing the capabilities of the Amazon Glacier API. Amazon Glacier clients implement this trait.
 pub trait Glacier {
     /// <p>This operation aborts a multipart upload identified by the upload ID.</p> <p>After the Abort Multipart Upload request succeeds, you cannot upload any more parts to the multipart upload or complete the multipart upload. Aborting a completed upload fails. However, aborting an already-aborted upload will succeed, for a short time. For more information about uploading a part and completing a multipart upload, see <a>UploadMultipartPart</a> and <a>CompleteMultipartUpload</a>.</p> <p>This operation is idempotent.</p> <p>An AWS account has full permission to perform all operations (actions). However, AWS Identity and Access Management (IAM) users don't have any permissions by default. You must grant them explicit permission to perform specific actions. For more information, see <a href="https://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html">Access Control Using AWS Identity and Access Management (IAM)</a>.</p> <p> For conceptual information and underlying REST API, see <a href="https://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html">Working with Archives in Amazon S3 Glacier</a> and <a href="https://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html">Abort Multipart Upload</a> in the <i>Amazon Glacier Developer Guide</i>. </p>

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -5905,22 +5905,20 @@ impl BatchCreatePartitionError {
 }
 impl fmt::Display for BatchCreatePartitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchCreatePartitionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchCreatePartitionError::AlreadyExists(ref cause) => cause,
-            BatchCreatePartitionError::EntityNotFound(ref cause) => cause,
-            BatchCreatePartitionError::GlueEncryption(ref cause) => cause,
-            BatchCreatePartitionError::InternalService(ref cause) => cause,
-            BatchCreatePartitionError::InvalidInput(ref cause) => cause,
-            BatchCreatePartitionError::OperationTimeout(ref cause) => cause,
-            BatchCreatePartitionError::ResourceNumberLimitExceeded(ref cause) => cause,
+            BatchCreatePartitionError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            BatchCreatePartitionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            BatchCreatePartitionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            BatchCreatePartitionError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchCreatePartitionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchCreatePartitionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            BatchCreatePartitionError::ResourceNumberLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchCreatePartitionError {}
 /// Errors returned by BatchDeleteConnection
 #[derive(Debug, PartialEq)]
 pub enum BatchDeleteConnectionError {
@@ -5953,17 +5951,13 @@ impl BatchDeleteConnectionError {
 }
 impl fmt::Display for BatchDeleteConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeleteConnectionError::InternalService(ref cause) => cause,
-            BatchDeleteConnectionError::OperationTimeout(ref cause) => cause,
+            BatchDeleteConnectionError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchDeleteConnectionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeleteConnectionError {}
 /// Errors returned by BatchDeletePartition
 #[derive(Debug, PartialEq)]
 pub enum BatchDeletePartitionError {
@@ -6006,19 +6000,15 @@ impl BatchDeletePartitionError {
 }
 impl fmt::Display for BatchDeletePartitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeletePartitionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeletePartitionError::EntityNotFound(ref cause) => cause,
-            BatchDeletePartitionError::InternalService(ref cause) => cause,
-            BatchDeletePartitionError::InvalidInput(ref cause) => cause,
-            BatchDeletePartitionError::OperationTimeout(ref cause) => cause,
+            BatchDeletePartitionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            BatchDeletePartitionError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchDeletePartitionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchDeletePartitionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeletePartitionError {}
 /// Errors returned by BatchDeleteTable
 #[derive(Debug, PartialEq)]
 pub enum BatchDeleteTableError {
@@ -6057,19 +6047,15 @@ impl BatchDeleteTableError {
 }
 impl fmt::Display for BatchDeleteTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteTableError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeleteTableError::EntityNotFound(ref cause) => cause,
-            BatchDeleteTableError::InternalService(ref cause) => cause,
-            BatchDeleteTableError::InvalidInput(ref cause) => cause,
-            BatchDeleteTableError::OperationTimeout(ref cause) => cause,
+            BatchDeleteTableError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            BatchDeleteTableError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchDeleteTableError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchDeleteTableError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeleteTableError {}
 /// Errors returned by BatchDeleteTableVersion
 #[derive(Debug, PartialEq)]
 pub enum BatchDeleteTableVersionError {
@@ -6116,19 +6102,15 @@ impl BatchDeleteTableVersionError {
 }
 impl fmt::Display for BatchDeleteTableVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteTableVersionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDeleteTableVersionError::EntityNotFound(ref cause) => cause,
-            BatchDeleteTableVersionError::InternalService(ref cause) => cause,
-            BatchDeleteTableVersionError::InvalidInput(ref cause) => cause,
-            BatchDeleteTableVersionError::OperationTimeout(ref cause) => cause,
+            BatchDeleteTableVersionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            BatchDeleteTableVersionError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchDeleteTableVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchDeleteTableVersionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDeleteTableVersionError {}
 /// Errors returned by BatchGetCrawlers
 #[derive(Debug, PartialEq)]
 pub enum BatchGetCrawlersError {
@@ -6157,17 +6139,13 @@ impl BatchGetCrawlersError {
 }
 impl fmt::Display for BatchGetCrawlersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetCrawlersError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetCrawlersError::InvalidInput(ref cause) => cause,
-            BatchGetCrawlersError::OperationTimeout(ref cause) => cause,
+            BatchGetCrawlersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchGetCrawlersError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetCrawlersError {}
 /// Errors returned by BatchGetDevEndpoints
 #[derive(Debug, PartialEq)]
 pub enum BatchGetDevEndpointsError {
@@ -6210,19 +6188,15 @@ impl BatchGetDevEndpointsError {
 }
 impl fmt::Display for BatchGetDevEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetDevEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetDevEndpointsError::AccessDenied(ref cause) => cause,
-            BatchGetDevEndpointsError::InternalService(ref cause) => cause,
-            BatchGetDevEndpointsError::InvalidInput(ref cause) => cause,
-            BatchGetDevEndpointsError::OperationTimeout(ref cause) => cause,
+            BatchGetDevEndpointsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            BatchGetDevEndpointsError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchGetDevEndpointsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchGetDevEndpointsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetDevEndpointsError {}
 /// Errors returned by BatchGetJobs
 #[derive(Debug, PartialEq)]
 pub enum BatchGetJobsError {
@@ -6256,18 +6230,14 @@ impl BatchGetJobsError {
 }
 impl fmt::Display for BatchGetJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetJobsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetJobsError::InternalService(ref cause) => cause,
-            BatchGetJobsError::InvalidInput(ref cause) => cause,
-            BatchGetJobsError::OperationTimeout(ref cause) => cause,
+            BatchGetJobsError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchGetJobsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchGetJobsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetJobsError {}
 /// Errors returned by BatchGetPartition
 #[derive(Debug, PartialEq)]
 pub enum BatchGetPartitionError {
@@ -6311,20 +6281,16 @@ impl BatchGetPartitionError {
 }
 impl fmt::Display for BatchGetPartitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetPartitionError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetPartitionError::EntityNotFound(ref cause) => cause,
-            BatchGetPartitionError::GlueEncryption(ref cause) => cause,
-            BatchGetPartitionError::InternalService(ref cause) => cause,
-            BatchGetPartitionError::InvalidInput(ref cause) => cause,
-            BatchGetPartitionError::OperationTimeout(ref cause) => cause,
+            BatchGetPartitionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            BatchGetPartitionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            BatchGetPartitionError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchGetPartitionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchGetPartitionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetPartitionError {}
 /// Errors returned by BatchGetTriggers
 #[derive(Debug, PartialEq)]
 pub enum BatchGetTriggersError {
@@ -6358,18 +6324,14 @@ impl BatchGetTriggersError {
 }
 impl fmt::Display for BatchGetTriggersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetTriggersError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetTriggersError::InternalService(ref cause) => cause,
-            BatchGetTriggersError::InvalidInput(ref cause) => cause,
-            BatchGetTriggersError::OperationTimeout(ref cause) => cause,
+            BatchGetTriggersError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchGetTriggersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchGetTriggersError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetTriggersError {}
 /// Errors returned by BatchGetWorkflows
 #[derive(Debug, PartialEq)]
 pub enum BatchGetWorkflowsError {
@@ -6403,18 +6365,14 @@ impl BatchGetWorkflowsError {
 }
 impl fmt::Display for BatchGetWorkflowsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetWorkflowsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetWorkflowsError::InternalService(ref cause) => cause,
-            BatchGetWorkflowsError::InvalidInput(ref cause) => cause,
-            BatchGetWorkflowsError::OperationTimeout(ref cause) => cause,
+            BatchGetWorkflowsError::InternalService(ref cause) => write!(f, "{}", cause),
+            BatchGetWorkflowsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchGetWorkflowsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetWorkflowsError {}
 /// Errors returned by BatchStopJobRun
 #[derive(Debug, PartialEq)]
 pub enum GlueBatchStopJobRunError {
@@ -6450,18 +6408,14 @@ impl GlueBatchStopJobRunError {
 }
 impl fmt::Display for GlueBatchStopJobRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GlueBatchStopJobRunError {
-    fn description(&self) -> &str {
         match *self {
-            GlueBatchStopJobRunError::InternalService(ref cause) => cause,
-            GlueBatchStopJobRunError::InvalidInput(ref cause) => cause,
-            GlueBatchStopJobRunError::OperationTimeout(ref cause) => cause,
+            GlueBatchStopJobRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            GlueBatchStopJobRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GlueBatchStopJobRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GlueBatchStopJobRunError {}
 /// Errors returned by CancelMLTaskRun
 #[derive(Debug, PartialEq)]
 pub enum CancelMLTaskRunError {
@@ -6500,19 +6454,15 @@ impl CancelMLTaskRunError {
 }
 impl fmt::Display for CancelMLTaskRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelMLTaskRunError {
-    fn description(&self) -> &str {
         match *self {
-            CancelMLTaskRunError::EntityNotFound(ref cause) => cause,
-            CancelMLTaskRunError::InternalService(ref cause) => cause,
-            CancelMLTaskRunError::InvalidInput(ref cause) => cause,
-            CancelMLTaskRunError::OperationTimeout(ref cause) => cause,
+            CancelMLTaskRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            CancelMLTaskRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            CancelMLTaskRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CancelMLTaskRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelMLTaskRunError {}
 /// Errors returned by CreateClassifier
 #[derive(Debug, PartialEq)]
 pub enum CreateClassifierError {
@@ -6546,18 +6496,14 @@ impl CreateClassifierError {
 }
 impl fmt::Display for CreateClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClassifierError::AlreadyExists(ref cause) => cause,
-            CreateClassifierError::InvalidInput(ref cause) => cause,
-            CreateClassifierError::OperationTimeout(ref cause) => cause,
+            CreateClassifierError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateClassifierError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateClassifierError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClassifierError {}
 /// Errors returned by CreateConnection
 #[derive(Debug, PartialEq)]
 pub enum CreateConnectionError {
@@ -6603,20 +6549,16 @@ impl CreateConnectionError {
 }
 impl fmt::Display for CreateConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConnectionError::AlreadyExists(ref cause) => cause,
-            CreateConnectionError::GlueEncryption(ref cause) => cause,
-            CreateConnectionError::InvalidInput(ref cause) => cause,
-            CreateConnectionError::OperationTimeout(ref cause) => cause,
-            CreateConnectionError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateConnectionError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateConnectionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            CreateConnectionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateConnectionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateConnectionError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConnectionError {}
 /// Errors returned by CreateCrawler
 #[derive(Debug, PartialEq)]
 pub enum CreateCrawlerError {
@@ -6657,19 +6599,15 @@ impl CreateCrawlerError {
 }
 impl fmt::Display for CreateCrawlerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCrawlerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCrawlerError::AlreadyExists(ref cause) => cause,
-            CreateCrawlerError::InvalidInput(ref cause) => cause,
-            CreateCrawlerError::OperationTimeout(ref cause) => cause,
-            CreateCrawlerError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateCrawlerError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateCrawlerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateCrawlerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateCrawlerError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCrawlerError {}
 /// Errors returned by CreateDatabase
 #[derive(Debug, PartialEq)]
 pub enum CreateDatabaseError {
@@ -6720,21 +6658,17 @@ impl CreateDatabaseError {
 }
 impl fmt::Display for CreateDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDatabaseError::AlreadyExists(ref cause) => cause,
-            CreateDatabaseError::GlueEncryption(ref cause) => cause,
-            CreateDatabaseError::InternalService(ref cause) => cause,
-            CreateDatabaseError::InvalidInput(ref cause) => cause,
-            CreateDatabaseError::OperationTimeout(ref cause) => cause,
-            CreateDatabaseError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateDatabaseError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateDatabaseError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            CreateDatabaseError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDatabaseError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateDatabaseError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDatabaseError {}
 /// Errors returned by CreateDevEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateDevEndpointError {
@@ -6792,22 +6726,22 @@ impl CreateDevEndpointError {
 }
 impl fmt::Display for CreateDevEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDevEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDevEndpointError::AccessDenied(ref cause) => cause,
-            CreateDevEndpointError::AlreadyExists(ref cause) => cause,
-            CreateDevEndpointError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateDevEndpointError::InternalService(ref cause) => cause,
-            CreateDevEndpointError::InvalidInput(ref cause) => cause,
-            CreateDevEndpointError::OperationTimeout(ref cause) => cause,
-            CreateDevEndpointError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateDevEndpointError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDevEndpointError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateDevEndpointError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDevEndpointError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateDevEndpointError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDevEndpointError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateDevEndpointError::ResourceNumberLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDevEndpointError {}
 /// Errors returned by CreateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateJobError {
@@ -6865,22 +6799,18 @@ impl CreateJobError {
 }
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobError::AlreadyExists(ref cause) => cause,
-            CreateJobError::ConcurrentModification(ref cause) => cause,
-            CreateJobError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateJobError::InternalService(ref cause) => cause,
-            CreateJobError::InvalidInput(ref cause) => cause,
-            CreateJobError::OperationTimeout(ref cause) => cause,
-            CreateJobError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateJobError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateJobError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateJobError::IdempotentParameterMismatch(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateJobError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateJobError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobError {}
 /// Errors returned by CreateMLTransform
 #[derive(Debug, PartialEq)]
 pub enum CreateMLTransformError {
@@ -6938,22 +6868,22 @@ impl CreateMLTransformError {
 }
 impl fmt::Display for CreateMLTransformError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMLTransformError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMLTransformError::AccessDenied(ref cause) => cause,
-            CreateMLTransformError::AlreadyExists(ref cause) => cause,
-            CreateMLTransformError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateMLTransformError::InternalService(ref cause) => cause,
-            CreateMLTransformError::InvalidInput(ref cause) => cause,
-            CreateMLTransformError::OperationTimeout(ref cause) => cause,
-            CreateMLTransformError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateMLTransformError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateMLTransformError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateMLTransformError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateMLTransformError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateMLTransformError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateMLTransformError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateMLTransformError::ResourceNumberLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateMLTransformError {}
 /// Errors returned by CreatePartition
 #[derive(Debug, PartialEq)]
 pub enum CreatePartitionError {
@@ -7009,22 +6939,18 @@ impl CreatePartitionError {
 }
 impl fmt::Display for CreatePartitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePartitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePartitionError::AlreadyExists(ref cause) => cause,
-            CreatePartitionError::EntityNotFound(ref cause) => cause,
-            CreatePartitionError::GlueEncryption(ref cause) => cause,
-            CreatePartitionError::InternalService(ref cause) => cause,
-            CreatePartitionError::InvalidInput(ref cause) => cause,
-            CreatePartitionError::OperationTimeout(ref cause) => cause,
-            CreatePartitionError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreatePartitionError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreatePartitionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            CreatePartitionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            CreatePartitionError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreatePartitionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreatePartitionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreatePartitionError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePartitionError {}
 /// Errors returned by CreateScript
 #[derive(Debug, PartialEq)]
 pub enum CreateScriptError {
@@ -7058,18 +6984,14 @@ impl CreateScriptError {
 }
 impl fmt::Display for CreateScriptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateScriptError {
-    fn description(&self) -> &str {
         match *self {
-            CreateScriptError::InternalService(ref cause) => cause,
-            CreateScriptError::InvalidInput(ref cause) => cause,
-            CreateScriptError::OperationTimeout(ref cause) => cause,
+            CreateScriptError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateScriptError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateScriptError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateScriptError {}
 /// Errors returned by CreateSecurityConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateSecurityConfigurationError {
@@ -7125,20 +7047,18 @@ impl CreateSecurityConfigurationError {
 }
 impl fmt::Display for CreateSecurityConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSecurityConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSecurityConfigurationError::AlreadyExists(ref cause) => cause,
-            CreateSecurityConfigurationError::InternalService(ref cause) => cause,
-            CreateSecurityConfigurationError::InvalidInput(ref cause) => cause,
-            CreateSecurityConfigurationError::OperationTimeout(ref cause) => cause,
-            CreateSecurityConfigurationError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateSecurityConfigurationError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateSecurityConfigurationError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateSecurityConfigurationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateSecurityConfigurationError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateSecurityConfigurationError::ResourceNumberLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateSecurityConfigurationError {}
 /// Errors returned by CreateTable
 #[derive(Debug, PartialEq)]
 pub enum CreateTableError {
@@ -7194,22 +7114,18 @@ impl CreateTableError {
 }
 impl fmt::Display for CreateTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTableError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTableError::AlreadyExists(ref cause) => cause,
-            CreateTableError::EntityNotFound(ref cause) => cause,
-            CreateTableError::GlueEncryption(ref cause) => cause,
-            CreateTableError::InternalService(ref cause) => cause,
-            CreateTableError::InvalidInput(ref cause) => cause,
-            CreateTableError::OperationTimeout(ref cause) => cause,
-            CreateTableError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateTableError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateTableError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTableError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            CreateTableError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateTableError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateTableError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateTableError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTableError {}
 /// Errors returned by CreateTrigger
 #[derive(Debug, PartialEq)]
 pub enum CreateTriggerError {
@@ -7274,23 +7190,19 @@ impl CreateTriggerError {
 }
 impl fmt::Display for CreateTriggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTriggerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTriggerError::AlreadyExists(ref cause) => cause,
-            CreateTriggerError::ConcurrentModification(ref cause) => cause,
-            CreateTriggerError::EntityNotFound(ref cause) => cause,
-            CreateTriggerError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateTriggerError::InternalService(ref cause) => cause,
-            CreateTriggerError::InvalidInput(ref cause) => cause,
-            CreateTriggerError::OperationTimeout(ref cause) => cause,
-            CreateTriggerError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateTriggerError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateTriggerError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateTriggerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            CreateTriggerError::IdempotentParameterMismatch(ref cause) => write!(f, "{}", cause),
+            CreateTriggerError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateTriggerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateTriggerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateTriggerError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTriggerError {}
 /// Errors returned by CreateUserDefinedFunction
 #[derive(Debug, PartialEq)]
 pub enum CreateUserDefinedFunctionError {
@@ -7358,22 +7270,20 @@ impl CreateUserDefinedFunctionError {
 }
 impl fmt::Display for CreateUserDefinedFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserDefinedFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserDefinedFunctionError::AlreadyExists(ref cause) => cause,
-            CreateUserDefinedFunctionError::EntityNotFound(ref cause) => cause,
-            CreateUserDefinedFunctionError::GlueEncryption(ref cause) => cause,
-            CreateUserDefinedFunctionError::InternalService(ref cause) => cause,
-            CreateUserDefinedFunctionError::InvalidInput(ref cause) => cause,
-            CreateUserDefinedFunctionError::OperationTimeout(ref cause) => cause,
-            CreateUserDefinedFunctionError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateUserDefinedFunctionError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateUserDefinedFunctionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            CreateUserDefinedFunctionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            CreateUserDefinedFunctionError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateUserDefinedFunctionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateUserDefinedFunctionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateUserDefinedFunctionError::ResourceNumberLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateUserDefinedFunctionError {}
 /// Errors returned by CreateWorkflow
 #[derive(Debug, PartialEq)]
 pub enum CreateWorkflowError {
@@ -7426,21 +7336,17 @@ impl CreateWorkflowError {
 }
 impl fmt::Display for CreateWorkflowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWorkflowError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWorkflowError::AlreadyExists(ref cause) => cause,
-            CreateWorkflowError::ConcurrentModification(ref cause) => cause,
-            CreateWorkflowError::InternalService(ref cause) => cause,
-            CreateWorkflowError::InvalidInput(ref cause) => cause,
-            CreateWorkflowError::OperationTimeout(ref cause) => cause,
-            CreateWorkflowError::ResourceNumberLimitExceeded(ref cause) => cause,
+            CreateWorkflowError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateWorkflowError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateWorkflowError::InternalService(ref cause) => write!(f, "{}", cause),
+            CreateWorkflowError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateWorkflowError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            CreateWorkflowError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWorkflowError {}
 /// Errors returned by DeleteClassifier
 #[derive(Debug, PartialEq)]
 pub enum DeleteClassifierError {
@@ -7469,17 +7375,13 @@ impl DeleteClassifierError {
 }
 impl fmt::Display for DeleteClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClassifierError::EntityNotFound(ref cause) => cause,
-            DeleteClassifierError::OperationTimeout(ref cause) => cause,
+            DeleteClassifierError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteClassifierError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClassifierError {}
 /// Errors returned by DeleteConnection
 #[derive(Debug, PartialEq)]
 pub enum DeleteConnectionError {
@@ -7508,17 +7410,13 @@ impl DeleteConnectionError {
 }
 impl fmt::Display for DeleteConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConnectionError::EntityNotFound(ref cause) => cause,
-            DeleteConnectionError::OperationTimeout(ref cause) => cause,
+            DeleteConnectionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteConnectionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConnectionError {}
 /// Errors returned by DeleteCrawler
 #[derive(Debug, PartialEq)]
 pub enum DeleteCrawlerError {
@@ -7559,19 +7457,15 @@ impl DeleteCrawlerError {
 }
 impl fmt::Display for DeleteCrawlerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCrawlerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCrawlerError::CrawlerRunning(ref cause) => cause,
-            DeleteCrawlerError::EntityNotFound(ref cause) => cause,
-            DeleteCrawlerError::OperationTimeout(ref cause) => cause,
-            DeleteCrawlerError::SchedulerTransitioning(ref cause) => cause,
+            DeleteCrawlerError::CrawlerRunning(ref cause) => write!(f, "{}", cause),
+            DeleteCrawlerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCrawlerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteCrawlerError::SchedulerTransitioning(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCrawlerError {}
 /// Errors returned by DeleteDatabase
 #[derive(Debug, PartialEq)]
 pub enum DeleteDatabaseError {
@@ -7610,19 +7504,15 @@ impl DeleteDatabaseError {
 }
 impl fmt::Display for DeleteDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDatabaseError::EntityNotFound(ref cause) => cause,
-            DeleteDatabaseError::InternalService(ref cause) => cause,
-            DeleteDatabaseError::InvalidInput(ref cause) => cause,
-            DeleteDatabaseError::OperationTimeout(ref cause) => cause,
+            DeleteDatabaseError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDatabaseError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteDatabaseError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDatabaseError {}
 /// Errors returned by DeleteDevEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteDevEndpointError {
@@ -7661,19 +7551,15 @@ impl DeleteDevEndpointError {
 }
 impl fmt::Display for DeleteDevEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDevEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDevEndpointError::EntityNotFound(ref cause) => cause,
-            DeleteDevEndpointError::InternalService(ref cause) => cause,
-            DeleteDevEndpointError::InvalidInput(ref cause) => cause,
-            DeleteDevEndpointError::OperationTimeout(ref cause) => cause,
+            DeleteDevEndpointError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDevEndpointError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteDevEndpointError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteDevEndpointError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDevEndpointError {}
 /// Errors returned by DeleteJob
 #[derive(Debug, PartialEq)]
 pub enum DeleteJobError {
@@ -7707,18 +7593,14 @@ impl DeleteJobError {
 }
 impl fmt::Display for DeleteJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteJobError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteJobError::InternalService(ref cause) => cause,
-            DeleteJobError::InvalidInput(ref cause) => cause,
-            DeleteJobError::OperationTimeout(ref cause) => cause,
+            DeleteJobError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteJobError {}
 /// Errors returned by DeleteMLTransform
 #[derive(Debug, PartialEq)]
 pub enum DeleteMLTransformError {
@@ -7757,19 +7639,15 @@ impl DeleteMLTransformError {
 }
 impl fmt::Display for DeleteMLTransformError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMLTransformError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMLTransformError::EntityNotFound(ref cause) => cause,
-            DeleteMLTransformError::InternalService(ref cause) => cause,
-            DeleteMLTransformError::InvalidInput(ref cause) => cause,
-            DeleteMLTransformError::OperationTimeout(ref cause) => cause,
+            DeleteMLTransformError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMLTransformError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteMLTransformError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteMLTransformError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMLTransformError {}
 /// Errors returned by DeletePartition
 #[derive(Debug, PartialEq)]
 pub enum DeletePartitionError {
@@ -7808,19 +7686,15 @@ impl DeletePartitionError {
 }
 impl fmt::Display for DeletePartitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePartitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePartitionError::EntityNotFound(ref cause) => cause,
-            DeletePartitionError::InternalService(ref cause) => cause,
-            DeletePartitionError::InvalidInput(ref cause) => cause,
-            DeletePartitionError::OperationTimeout(ref cause) => cause,
+            DeletePartitionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeletePartitionError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeletePartitionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeletePartitionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePartitionError {}
 /// Errors returned by DeleteResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourcePolicyError {
@@ -7870,20 +7744,16 @@ impl DeleteResourcePolicyError {
 }
 impl fmt::Display for DeleteResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourcePolicyError::ConditionCheckFailure(ref cause) => cause,
-            DeleteResourcePolicyError::EntityNotFound(ref cause) => cause,
-            DeleteResourcePolicyError::InternalService(ref cause) => cause,
-            DeleteResourcePolicyError::InvalidInput(ref cause) => cause,
-            DeleteResourcePolicyError::OperationTimeout(ref cause) => cause,
+            DeleteResourcePolicyError::ConditionCheckFailure(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourcePolicyError {}
 /// Errors returned by DeleteSecurityConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteSecurityConfigurationError {
@@ -7932,19 +7802,15 @@ impl DeleteSecurityConfigurationError {
 }
 impl fmt::Display for DeleteSecurityConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSecurityConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSecurityConfigurationError::EntityNotFound(ref cause) => cause,
-            DeleteSecurityConfigurationError::InternalService(ref cause) => cause,
-            DeleteSecurityConfigurationError::InvalidInput(ref cause) => cause,
-            DeleteSecurityConfigurationError::OperationTimeout(ref cause) => cause,
+            DeleteSecurityConfigurationError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteSecurityConfigurationError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteSecurityConfigurationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteSecurityConfigurationError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSecurityConfigurationError {}
 /// Errors returned by DeleteTable
 #[derive(Debug, PartialEq)]
 pub enum DeleteTableError {
@@ -7983,19 +7849,15 @@ impl DeleteTableError {
 }
 impl fmt::Display for DeleteTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTableError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTableError::EntityNotFound(ref cause) => cause,
-            DeleteTableError::InternalService(ref cause) => cause,
-            DeleteTableError::InvalidInput(ref cause) => cause,
-            DeleteTableError::OperationTimeout(ref cause) => cause,
+            DeleteTableError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTableError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteTableError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteTableError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTableError {}
 /// Errors returned by DeleteTableVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteTableVersionError {
@@ -8034,19 +7896,15 @@ impl DeleteTableVersionError {
 }
 impl fmt::Display for DeleteTableVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTableVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTableVersionError::EntityNotFound(ref cause) => cause,
-            DeleteTableVersionError::InternalService(ref cause) => cause,
-            DeleteTableVersionError::InvalidInput(ref cause) => cause,
-            DeleteTableVersionError::OperationTimeout(ref cause) => cause,
+            DeleteTableVersionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTableVersionError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteTableVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteTableVersionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTableVersionError {}
 /// Errors returned by DeleteTrigger
 #[derive(Debug, PartialEq)]
 pub enum DeleteTriggerError {
@@ -8087,19 +7945,15 @@ impl DeleteTriggerError {
 }
 impl fmt::Display for DeleteTriggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTriggerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTriggerError::ConcurrentModification(ref cause) => cause,
-            DeleteTriggerError::InternalService(ref cause) => cause,
-            DeleteTriggerError::InvalidInput(ref cause) => cause,
-            DeleteTriggerError::OperationTimeout(ref cause) => cause,
+            DeleteTriggerError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteTriggerError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteTriggerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteTriggerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTriggerError {}
 /// Errors returned by DeleteUserDefinedFunction
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserDefinedFunctionError {
@@ -8146,19 +8000,15 @@ impl DeleteUserDefinedFunctionError {
 }
 impl fmt::Display for DeleteUserDefinedFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserDefinedFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserDefinedFunctionError::EntityNotFound(ref cause) => cause,
-            DeleteUserDefinedFunctionError::InternalService(ref cause) => cause,
-            DeleteUserDefinedFunctionError::InvalidInput(ref cause) => cause,
-            DeleteUserDefinedFunctionError::OperationTimeout(ref cause) => cause,
+            DeleteUserDefinedFunctionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserDefinedFunctionError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteUserDefinedFunctionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteUserDefinedFunctionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserDefinedFunctionError {}
 /// Errors returned by DeleteWorkflow
 #[derive(Debug, PartialEq)]
 pub enum DeleteWorkflowError {
@@ -8199,19 +8049,15 @@ impl DeleteWorkflowError {
 }
 impl fmt::Display for DeleteWorkflowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWorkflowError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWorkflowError::ConcurrentModification(ref cause) => cause,
-            DeleteWorkflowError::InternalService(ref cause) => cause,
-            DeleteWorkflowError::InvalidInput(ref cause) => cause,
-            DeleteWorkflowError::OperationTimeout(ref cause) => cause,
+            DeleteWorkflowError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteWorkflowError::InternalService(ref cause) => write!(f, "{}", cause),
+            DeleteWorkflowError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteWorkflowError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWorkflowError {}
 /// Errors returned by GetCatalogImportStatus
 #[derive(Debug, PartialEq)]
 pub enum GetCatalogImportStatusError {
@@ -8244,17 +8090,13 @@ impl GetCatalogImportStatusError {
 }
 impl fmt::Display for GetCatalogImportStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCatalogImportStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetCatalogImportStatusError::InternalService(ref cause) => cause,
-            GetCatalogImportStatusError::OperationTimeout(ref cause) => cause,
+            GetCatalogImportStatusError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetCatalogImportStatusError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCatalogImportStatusError {}
 /// Errors returned by GetClassifier
 #[derive(Debug, PartialEq)]
 pub enum GetClassifierError {
@@ -8283,17 +8125,13 @@ impl GetClassifierError {
 }
 impl fmt::Display for GetClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            GetClassifierError::EntityNotFound(ref cause) => cause,
-            GetClassifierError::OperationTimeout(ref cause) => cause,
+            GetClassifierError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetClassifierError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetClassifierError {}
 /// Errors returned by GetClassifiers
 #[derive(Debug, PartialEq)]
 pub enum GetClassifiersError {
@@ -8317,16 +8155,12 @@ impl GetClassifiersError {
 }
 impl fmt::Display for GetClassifiersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetClassifiersError {
-    fn description(&self) -> &str {
         match *self {
-            GetClassifiersError::OperationTimeout(ref cause) => cause,
+            GetClassifiersError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetClassifiersError {}
 /// Errors returned by GetConnection
 #[derive(Debug, PartialEq)]
 pub enum GetConnectionError {
@@ -8365,19 +8199,15 @@ impl GetConnectionError {
 }
 impl fmt::Display for GetConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectionError::EntityNotFound(ref cause) => cause,
-            GetConnectionError::GlueEncryption(ref cause) => cause,
-            GetConnectionError::InvalidInput(ref cause) => cause,
-            GetConnectionError::OperationTimeout(ref cause) => cause,
+            GetConnectionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetConnectionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetConnectionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetConnectionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectionError {}
 /// Errors returned by GetConnections
 #[derive(Debug, PartialEq)]
 pub enum GetConnectionsError {
@@ -8416,19 +8246,15 @@ impl GetConnectionsError {
 }
 impl fmt::Display for GetConnectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectionsError::EntityNotFound(ref cause) => cause,
-            GetConnectionsError::GlueEncryption(ref cause) => cause,
-            GetConnectionsError::InvalidInput(ref cause) => cause,
-            GetConnectionsError::OperationTimeout(ref cause) => cause,
+            GetConnectionsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetConnectionsError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetConnectionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetConnectionsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectionsError {}
 /// Errors returned by GetCrawler
 #[derive(Debug, PartialEq)]
 pub enum GetCrawlerError {
@@ -8457,17 +8283,13 @@ impl GetCrawlerError {
 }
 impl fmt::Display for GetCrawlerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCrawlerError {
-    fn description(&self) -> &str {
         match *self {
-            GetCrawlerError::EntityNotFound(ref cause) => cause,
-            GetCrawlerError::OperationTimeout(ref cause) => cause,
+            GetCrawlerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetCrawlerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCrawlerError {}
 /// Errors returned by GetCrawlerMetrics
 #[derive(Debug, PartialEq)]
 pub enum GetCrawlerMetricsError {
@@ -8491,16 +8313,12 @@ impl GetCrawlerMetricsError {
 }
 impl fmt::Display for GetCrawlerMetricsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCrawlerMetricsError {
-    fn description(&self) -> &str {
         match *self {
-            GetCrawlerMetricsError::OperationTimeout(ref cause) => cause,
+            GetCrawlerMetricsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCrawlerMetricsError {}
 /// Errors returned by GetCrawlers
 #[derive(Debug, PartialEq)]
 pub enum GetCrawlersError {
@@ -8524,16 +8342,12 @@ impl GetCrawlersError {
 }
 impl fmt::Display for GetCrawlersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCrawlersError {
-    fn description(&self) -> &str {
         match *self {
-            GetCrawlersError::OperationTimeout(ref cause) => cause,
+            GetCrawlersError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCrawlersError {}
 /// Errors returned by GetDataCatalogEncryptionSettings
 #[derive(Debug, PartialEq)]
 pub enum GetDataCatalogEncryptionSettingsError {
@@ -8575,18 +8389,20 @@ impl GetDataCatalogEncryptionSettingsError {
 }
 impl fmt::Display for GetDataCatalogEncryptionSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDataCatalogEncryptionSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDataCatalogEncryptionSettingsError::InternalService(ref cause) => cause,
-            GetDataCatalogEncryptionSettingsError::InvalidInput(ref cause) => cause,
-            GetDataCatalogEncryptionSettingsError::OperationTimeout(ref cause) => cause,
+            GetDataCatalogEncryptionSettingsError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDataCatalogEncryptionSettingsError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDataCatalogEncryptionSettingsError::OperationTimeout(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetDataCatalogEncryptionSettingsError {}
 /// Errors returned by GetDatabase
 #[derive(Debug, PartialEq)]
 pub enum GetDatabaseError {
@@ -8630,20 +8446,16 @@ impl GetDatabaseError {
 }
 impl fmt::Display for GetDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            GetDatabaseError::EntityNotFound(ref cause) => cause,
-            GetDatabaseError::GlueEncryption(ref cause) => cause,
-            GetDatabaseError::InternalService(ref cause) => cause,
-            GetDatabaseError::InvalidInput(ref cause) => cause,
-            GetDatabaseError::OperationTimeout(ref cause) => cause,
+            GetDatabaseError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetDatabaseError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetDatabaseError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDatabaseError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDatabaseError {}
 /// Errors returned by GetDatabases
 #[derive(Debug, PartialEq)]
 pub enum GetDatabasesError {
@@ -8682,19 +8494,15 @@ impl GetDatabasesError {
 }
 impl fmt::Display for GetDatabasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDatabasesError {
-    fn description(&self) -> &str {
         match *self {
-            GetDatabasesError::GlueEncryption(ref cause) => cause,
-            GetDatabasesError::InternalService(ref cause) => cause,
-            GetDatabasesError::InvalidInput(ref cause) => cause,
-            GetDatabasesError::OperationTimeout(ref cause) => cause,
+            GetDatabasesError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetDatabasesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetDatabasesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDatabasesError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDatabasesError {}
 /// Errors returned by GetDataflowGraph
 #[derive(Debug, PartialEq)]
 pub enum GetDataflowGraphError {
@@ -8728,18 +8536,14 @@ impl GetDataflowGraphError {
 }
 impl fmt::Display for GetDataflowGraphError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDataflowGraphError {
-    fn description(&self) -> &str {
         match *self {
-            GetDataflowGraphError::InternalService(ref cause) => cause,
-            GetDataflowGraphError::InvalidInput(ref cause) => cause,
-            GetDataflowGraphError::OperationTimeout(ref cause) => cause,
+            GetDataflowGraphError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetDataflowGraphError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDataflowGraphError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDataflowGraphError {}
 /// Errors returned by GetDevEndpoint
 #[derive(Debug, PartialEq)]
 pub enum GetDevEndpointError {
@@ -8778,19 +8582,15 @@ impl GetDevEndpointError {
 }
 impl fmt::Display for GetDevEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDevEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            GetDevEndpointError::EntityNotFound(ref cause) => cause,
-            GetDevEndpointError::InternalService(ref cause) => cause,
-            GetDevEndpointError::InvalidInput(ref cause) => cause,
-            GetDevEndpointError::OperationTimeout(ref cause) => cause,
+            GetDevEndpointError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetDevEndpointError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetDevEndpointError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDevEndpointError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDevEndpointError {}
 /// Errors returned by GetDevEndpoints
 #[derive(Debug, PartialEq)]
 pub enum GetDevEndpointsError {
@@ -8829,19 +8629,15 @@ impl GetDevEndpointsError {
 }
 impl fmt::Display for GetDevEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDevEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDevEndpointsError::EntityNotFound(ref cause) => cause,
-            GetDevEndpointsError::InternalService(ref cause) => cause,
-            GetDevEndpointsError::InvalidInput(ref cause) => cause,
-            GetDevEndpointsError::OperationTimeout(ref cause) => cause,
+            GetDevEndpointsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetDevEndpointsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetDevEndpointsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDevEndpointsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDevEndpointsError {}
 /// Errors returned by GetJob
 #[derive(Debug, PartialEq)]
 pub enum GetJobError {
@@ -8880,19 +8676,15 @@ impl GetJobError {
 }
 impl fmt::Display for GetJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobError::EntityNotFound(ref cause) => cause,
-            GetJobError::InternalService(ref cause) => cause,
-            GetJobError::InvalidInput(ref cause) => cause,
-            GetJobError::OperationTimeout(ref cause) => cause,
+            GetJobError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetJobError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetJobError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetJobError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobError {}
 /// Errors returned by GetJobBookmark
 #[derive(Debug, PartialEq)]
 pub enum GetJobBookmarkError {
@@ -8931,19 +8723,15 @@ impl GetJobBookmarkError {
 }
 impl fmt::Display for GetJobBookmarkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobBookmarkError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobBookmarkError::EntityNotFound(ref cause) => cause,
-            GetJobBookmarkError::InternalService(ref cause) => cause,
-            GetJobBookmarkError::InvalidInput(ref cause) => cause,
-            GetJobBookmarkError::OperationTimeout(ref cause) => cause,
+            GetJobBookmarkError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetJobBookmarkError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetJobBookmarkError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetJobBookmarkError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobBookmarkError {}
 /// Errors returned by GetJobRun
 #[derive(Debug, PartialEq)]
 pub enum GetJobRunError {
@@ -8982,19 +8770,15 @@ impl GetJobRunError {
 }
 impl fmt::Display for GetJobRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobRunError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobRunError::EntityNotFound(ref cause) => cause,
-            GetJobRunError::InternalService(ref cause) => cause,
-            GetJobRunError::InvalidInput(ref cause) => cause,
-            GetJobRunError::OperationTimeout(ref cause) => cause,
+            GetJobRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetJobRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetJobRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetJobRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobRunError {}
 /// Errors returned by GetJobRuns
 #[derive(Debug, PartialEq)]
 pub enum GetJobRunsError {
@@ -9033,19 +8817,15 @@ impl GetJobRunsError {
 }
 impl fmt::Display for GetJobRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobRunsError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobRunsError::EntityNotFound(ref cause) => cause,
-            GetJobRunsError::InternalService(ref cause) => cause,
-            GetJobRunsError::InvalidInput(ref cause) => cause,
-            GetJobRunsError::OperationTimeout(ref cause) => cause,
+            GetJobRunsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetJobRunsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetJobRunsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetJobRunsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobRunsError {}
 /// Errors returned by GetJobs
 #[derive(Debug, PartialEq)]
 pub enum GetJobsError {
@@ -9084,19 +8864,15 @@ impl GetJobsError {
 }
 impl fmt::Display for GetJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobsError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobsError::EntityNotFound(ref cause) => cause,
-            GetJobsError::InternalService(ref cause) => cause,
-            GetJobsError::InvalidInput(ref cause) => cause,
-            GetJobsError::OperationTimeout(ref cause) => cause,
+            GetJobsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetJobsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetJobsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetJobsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobsError {}
 /// Errors returned by GetMLTaskRun
 #[derive(Debug, PartialEq)]
 pub enum GetMLTaskRunError {
@@ -9135,19 +8911,15 @@ impl GetMLTaskRunError {
 }
 impl fmt::Display for GetMLTaskRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMLTaskRunError {
-    fn description(&self) -> &str {
         match *self {
-            GetMLTaskRunError::EntityNotFound(ref cause) => cause,
-            GetMLTaskRunError::InternalService(ref cause) => cause,
-            GetMLTaskRunError::InvalidInput(ref cause) => cause,
-            GetMLTaskRunError::OperationTimeout(ref cause) => cause,
+            GetMLTaskRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetMLTaskRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetMLTaskRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMLTaskRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMLTaskRunError {}
 /// Errors returned by GetMLTaskRuns
 #[derive(Debug, PartialEq)]
 pub enum GetMLTaskRunsError {
@@ -9186,19 +8958,15 @@ impl GetMLTaskRunsError {
 }
 impl fmt::Display for GetMLTaskRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMLTaskRunsError {
-    fn description(&self) -> &str {
         match *self {
-            GetMLTaskRunsError::EntityNotFound(ref cause) => cause,
-            GetMLTaskRunsError::InternalService(ref cause) => cause,
-            GetMLTaskRunsError::InvalidInput(ref cause) => cause,
-            GetMLTaskRunsError::OperationTimeout(ref cause) => cause,
+            GetMLTaskRunsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetMLTaskRunsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetMLTaskRunsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMLTaskRunsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMLTaskRunsError {}
 /// Errors returned by GetMLTransform
 #[derive(Debug, PartialEq)]
 pub enum GetMLTransformError {
@@ -9237,19 +9005,15 @@ impl GetMLTransformError {
 }
 impl fmt::Display for GetMLTransformError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMLTransformError {
-    fn description(&self) -> &str {
         match *self {
-            GetMLTransformError::EntityNotFound(ref cause) => cause,
-            GetMLTransformError::InternalService(ref cause) => cause,
-            GetMLTransformError::InvalidInput(ref cause) => cause,
-            GetMLTransformError::OperationTimeout(ref cause) => cause,
+            GetMLTransformError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetMLTransformError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetMLTransformError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMLTransformError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMLTransformError {}
 /// Errors returned by GetMLTransforms
 #[derive(Debug, PartialEq)]
 pub enum GetMLTransformsError {
@@ -9288,19 +9052,15 @@ impl GetMLTransformsError {
 }
 impl fmt::Display for GetMLTransformsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMLTransformsError {
-    fn description(&self) -> &str {
         match *self {
-            GetMLTransformsError::EntityNotFound(ref cause) => cause,
-            GetMLTransformsError::InternalService(ref cause) => cause,
-            GetMLTransformsError::InvalidInput(ref cause) => cause,
-            GetMLTransformsError::OperationTimeout(ref cause) => cause,
+            GetMLTransformsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetMLTransformsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetMLTransformsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMLTransformsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMLTransformsError {}
 /// Errors returned by GetMapping
 #[derive(Debug, PartialEq)]
 pub enum GetMappingError {
@@ -9339,19 +9099,15 @@ impl GetMappingError {
 }
 impl fmt::Display for GetMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMappingError {
-    fn description(&self) -> &str {
         match *self {
-            GetMappingError::EntityNotFound(ref cause) => cause,
-            GetMappingError::InternalService(ref cause) => cause,
-            GetMappingError::InvalidInput(ref cause) => cause,
-            GetMappingError::OperationTimeout(ref cause) => cause,
+            GetMappingError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetMappingError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetMappingError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMappingError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMappingError {}
 /// Errors returned by GetPartition
 #[derive(Debug, PartialEq)]
 pub enum GetPartitionError {
@@ -9395,20 +9151,16 @@ impl GetPartitionError {
 }
 impl fmt::Display for GetPartitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPartitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetPartitionError::EntityNotFound(ref cause) => cause,
-            GetPartitionError::GlueEncryption(ref cause) => cause,
-            GetPartitionError::InternalService(ref cause) => cause,
-            GetPartitionError::InvalidInput(ref cause) => cause,
-            GetPartitionError::OperationTimeout(ref cause) => cause,
+            GetPartitionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetPartitionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetPartitionError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetPartitionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetPartitionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPartitionError {}
 /// Errors returned by GetPartitions
 #[derive(Debug, PartialEq)]
 pub enum GetPartitionsError {
@@ -9452,20 +9204,16 @@ impl GetPartitionsError {
 }
 impl fmt::Display for GetPartitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPartitionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetPartitionsError::EntityNotFound(ref cause) => cause,
-            GetPartitionsError::GlueEncryption(ref cause) => cause,
-            GetPartitionsError::InternalService(ref cause) => cause,
-            GetPartitionsError::InvalidInput(ref cause) => cause,
-            GetPartitionsError::OperationTimeout(ref cause) => cause,
+            GetPartitionsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetPartitionsError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetPartitionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetPartitionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetPartitionsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPartitionsError {}
 /// Errors returned by GetPlan
 #[derive(Debug, PartialEq)]
 pub enum GetPlanError {
@@ -9499,18 +9247,14 @@ impl GetPlanError {
 }
 impl fmt::Display for GetPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPlanError {
-    fn description(&self) -> &str {
         match *self {
-            GetPlanError::InternalService(ref cause) => cause,
-            GetPlanError::InvalidInput(ref cause) => cause,
-            GetPlanError::OperationTimeout(ref cause) => cause,
+            GetPlanError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetPlanError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetPlanError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPlanError {}
 /// Errors returned by GetResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum GetResourcePolicyError {
@@ -9549,19 +9293,15 @@ impl GetResourcePolicyError {
 }
 impl fmt::Display for GetResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourcePolicyError::EntityNotFound(ref cause) => cause,
-            GetResourcePolicyError::InternalService(ref cause) => cause,
-            GetResourcePolicyError::InvalidInput(ref cause) => cause,
-            GetResourcePolicyError::OperationTimeout(ref cause) => cause,
+            GetResourcePolicyError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetResourcePolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetResourcePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetResourcePolicyError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourcePolicyError {}
 /// Errors returned by GetSecurityConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetSecurityConfigurationError {
@@ -9608,19 +9348,15 @@ impl GetSecurityConfigurationError {
 }
 impl fmt::Display for GetSecurityConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSecurityConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetSecurityConfigurationError::EntityNotFound(ref cause) => cause,
-            GetSecurityConfigurationError::InternalService(ref cause) => cause,
-            GetSecurityConfigurationError::InvalidInput(ref cause) => cause,
-            GetSecurityConfigurationError::OperationTimeout(ref cause) => cause,
+            GetSecurityConfigurationError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetSecurityConfigurationError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetSecurityConfigurationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetSecurityConfigurationError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSecurityConfigurationError {}
 /// Errors returned by GetSecurityConfigurations
 #[derive(Debug, PartialEq)]
 pub enum GetSecurityConfigurationsError {
@@ -9667,19 +9403,15 @@ impl GetSecurityConfigurationsError {
 }
 impl fmt::Display for GetSecurityConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSecurityConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            GetSecurityConfigurationsError::EntityNotFound(ref cause) => cause,
-            GetSecurityConfigurationsError::InternalService(ref cause) => cause,
-            GetSecurityConfigurationsError::InvalidInput(ref cause) => cause,
-            GetSecurityConfigurationsError::OperationTimeout(ref cause) => cause,
+            GetSecurityConfigurationsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetSecurityConfigurationsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetSecurityConfigurationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetSecurityConfigurationsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSecurityConfigurationsError {}
 /// Errors returned by GetTable
 #[derive(Debug, PartialEq)]
 pub enum GetTableError {
@@ -9723,20 +9455,16 @@ impl GetTableError {
 }
 impl fmt::Display for GetTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTableError {
-    fn description(&self) -> &str {
         match *self {
-            GetTableError::EntityNotFound(ref cause) => cause,
-            GetTableError::GlueEncryption(ref cause) => cause,
-            GetTableError::InternalService(ref cause) => cause,
-            GetTableError::InvalidInput(ref cause) => cause,
-            GetTableError::OperationTimeout(ref cause) => cause,
+            GetTableError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetTableError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetTableError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTableError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTableError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTableError {}
 /// Errors returned by GetTableVersion
 #[derive(Debug, PartialEq)]
 pub enum GetTableVersionError {
@@ -9780,20 +9508,16 @@ impl GetTableVersionError {
 }
 impl fmt::Display for GetTableVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTableVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetTableVersionError::EntityNotFound(ref cause) => cause,
-            GetTableVersionError::GlueEncryption(ref cause) => cause,
-            GetTableVersionError::InternalService(ref cause) => cause,
-            GetTableVersionError::InvalidInput(ref cause) => cause,
-            GetTableVersionError::OperationTimeout(ref cause) => cause,
+            GetTableVersionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetTableVersionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetTableVersionError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTableVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTableVersionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTableVersionError {}
 /// Errors returned by GetTableVersions
 #[derive(Debug, PartialEq)]
 pub enum GetTableVersionsError {
@@ -9837,20 +9561,16 @@ impl GetTableVersionsError {
 }
 impl fmt::Display for GetTableVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTableVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetTableVersionsError::EntityNotFound(ref cause) => cause,
-            GetTableVersionsError::GlueEncryption(ref cause) => cause,
-            GetTableVersionsError::InternalService(ref cause) => cause,
-            GetTableVersionsError::InvalidInput(ref cause) => cause,
-            GetTableVersionsError::OperationTimeout(ref cause) => cause,
+            GetTableVersionsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetTableVersionsError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetTableVersionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTableVersionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTableVersionsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTableVersionsError {}
 /// Errors returned by GetTables
 #[derive(Debug, PartialEq)]
 pub enum GetTablesError {
@@ -9894,20 +9614,16 @@ impl GetTablesError {
 }
 impl fmt::Display for GetTablesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTablesError {
-    fn description(&self) -> &str {
         match *self {
-            GetTablesError::EntityNotFound(ref cause) => cause,
-            GetTablesError::GlueEncryption(ref cause) => cause,
-            GetTablesError::InternalService(ref cause) => cause,
-            GetTablesError::InvalidInput(ref cause) => cause,
-            GetTablesError::OperationTimeout(ref cause) => cause,
+            GetTablesError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetTablesError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetTablesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTablesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTablesError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTablesError {}
 /// Errors returned by GetTags
 #[derive(Debug, PartialEq)]
 pub enum GetTagsError {
@@ -9946,19 +9662,15 @@ impl GetTagsError {
 }
 impl fmt::Display for GetTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTagsError {
-    fn description(&self) -> &str {
         match *self {
-            GetTagsError::EntityNotFound(ref cause) => cause,
-            GetTagsError::InternalService(ref cause) => cause,
-            GetTagsError::InvalidInput(ref cause) => cause,
-            GetTagsError::OperationTimeout(ref cause) => cause,
+            GetTagsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetTagsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTagsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTagsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTagsError {}
 /// Errors returned by GetTrigger
 #[derive(Debug, PartialEq)]
 pub enum GetTriggerError {
@@ -9997,19 +9709,15 @@ impl GetTriggerError {
 }
 impl fmt::Display for GetTriggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTriggerError {
-    fn description(&self) -> &str {
         match *self {
-            GetTriggerError::EntityNotFound(ref cause) => cause,
-            GetTriggerError::InternalService(ref cause) => cause,
-            GetTriggerError::InvalidInput(ref cause) => cause,
-            GetTriggerError::OperationTimeout(ref cause) => cause,
+            GetTriggerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetTriggerError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTriggerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTriggerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTriggerError {}
 /// Errors returned by GetTriggers
 #[derive(Debug, PartialEq)]
 pub enum GetTriggersError {
@@ -10048,19 +9756,15 @@ impl GetTriggersError {
 }
 impl fmt::Display for GetTriggersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTriggersError {
-    fn description(&self) -> &str {
         match *self {
-            GetTriggersError::EntityNotFound(ref cause) => cause,
-            GetTriggersError::InternalService(ref cause) => cause,
-            GetTriggersError::InvalidInput(ref cause) => cause,
-            GetTriggersError::OperationTimeout(ref cause) => cause,
+            GetTriggersError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetTriggersError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTriggersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTriggersError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTriggersError {}
 /// Errors returned by GetUserDefinedFunction
 #[derive(Debug, PartialEq)]
 pub enum GetUserDefinedFunctionError {
@@ -10112,20 +9816,16 @@ impl GetUserDefinedFunctionError {
 }
 impl fmt::Display for GetUserDefinedFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserDefinedFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserDefinedFunctionError::EntityNotFound(ref cause) => cause,
-            GetUserDefinedFunctionError::GlueEncryption(ref cause) => cause,
-            GetUserDefinedFunctionError::InternalService(ref cause) => cause,
-            GetUserDefinedFunctionError::InvalidInput(ref cause) => cause,
-            GetUserDefinedFunctionError::OperationTimeout(ref cause) => cause,
+            GetUserDefinedFunctionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserDefinedFunctionError {}
 /// Errors returned by GetUserDefinedFunctions
 #[derive(Debug, PartialEq)]
 pub enum GetUserDefinedFunctionsError {
@@ -10179,20 +9879,16 @@ impl GetUserDefinedFunctionsError {
 }
 impl fmt::Display for GetUserDefinedFunctionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserDefinedFunctionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserDefinedFunctionsError::EntityNotFound(ref cause) => cause,
-            GetUserDefinedFunctionsError::GlueEncryption(ref cause) => cause,
-            GetUserDefinedFunctionsError::InternalService(ref cause) => cause,
-            GetUserDefinedFunctionsError::InvalidInput(ref cause) => cause,
-            GetUserDefinedFunctionsError::OperationTimeout(ref cause) => cause,
+            GetUserDefinedFunctionsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionsError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetUserDefinedFunctionsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserDefinedFunctionsError {}
 /// Errors returned by GetWorkflow
 #[derive(Debug, PartialEq)]
 pub enum GetWorkflowError {
@@ -10231,19 +9927,15 @@ impl GetWorkflowError {
 }
 impl fmt::Display for GetWorkflowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWorkflowError {
-    fn description(&self) -> &str {
         match *self {
-            GetWorkflowError::EntityNotFound(ref cause) => cause,
-            GetWorkflowError::InternalService(ref cause) => cause,
-            GetWorkflowError::InvalidInput(ref cause) => cause,
-            GetWorkflowError::OperationTimeout(ref cause) => cause,
+            GetWorkflowError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetWorkflowError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetWorkflowError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetWorkflowError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWorkflowError {}
 /// Errors returned by GetWorkflowRun
 #[derive(Debug, PartialEq)]
 pub enum GetWorkflowRunError {
@@ -10282,19 +9974,15 @@ impl GetWorkflowRunError {
 }
 impl fmt::Display for GetWorkflowRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWorkflowRunError {
-    fn description(&self) -> &str {
         match *self {
-            GetWorkflowRunError::EntityNotFound(ref cause) => cause,
-            GetWorkflowRunError::InternalService(ref cause) => cause,
-            GetWorkflowRunError::InvalidInput(ref cause) => cause,
-            GetWorkflowRunError::OperationTimeout(ref cause) => cause,
+            GetWorkflowRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWorkflowRunError {}
 /// Errors returned by GetWorkflowRunProperties
 #[derive(Debug, PartialEq)]
 pub enum GetWorkflowRunPropertiesError {
@@ -10341,19 +10029,15 @@ impl GetWorkflowRunPropertiesError {
 }
 impl fmt::Display for GetWorkflowRunPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWorkflowRunPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            GetWorkflowRunPropertiesError::EntityNotFound(ref cause) => cause,
-            GetWorkflowRunPropertiesError::InternalService(ref cause) => cause,
-            GetWorkflowRunPropertiesError::InvalidInput(ref cause) => cause,
-            GetWorkflowRunPropertiesError::OperationTimeout(ref cause) => cause,
+            GetWorkflowRunPropertiesError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunPropertiesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunPropertiesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunPropertiesError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWorkflowRunPropertiesError {}
 /// Errors returned by GetWorkflowRuns
 #[derive(Debug, PartialEq)]
 pub enum GetWorkflowRunsError {
@@ -10392,19 +10076,15 @@ impl GetWorkflowRunsError {
 }
 impl fmt::Display for GetWorkflowRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWorkflowRunsError {
-    fn description(&self) -> &str {
         match *self {
-            GetWorkflowRunsError::EntityNotFound(ref cause) => cause,
-            GetWorkflowRunsError::InternalService(ref cause) => cause,
-            GetWorkflowRunsError::InvalidInput(ref cause) => cause,
-            GetWorkflowRunsError::OperationTimeout(ref cause) => cause,
+            GetWorkflowRunsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunsError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetWorkflowRunsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWorkflowRunsError {}
 /// Errors returned by ImportCatalogToGlue
 #[derive(Debug, PartialEq)]
 pub enum ImportCatalogToGlueError {
@@ -10435,17 +10115,13 @@ impl ImportCatalogToGlueError {
 }
 impl fmt::Display for ImportCatalogToGlueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportCatalogToGlueError {
-    fn description(&self) -> &str {
         match *self {
-            ImportCatalogToGlueError::InternalService(ref cause) => cause,
-            ImportCatalogToGlueError::OperationTimeout(ref cause) => cause,
+            ImportCatalogToGlueError::InternalService(ref cause) => write!(f, "{}", cause),
+            ImportCatalogToGlueError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportCatalogToGlueError {}
 /// Errors returned by ListCrawlers
 #[derive(Debug, PartialEq)]
 pub enum ListCrawlersError {
@@ -10469,16 +10145,12 @@ impl ListCrawlersError {
 }
 impl fmt::Display for ListCrawlersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCrawlersError {
-    fn description(&self) -> &str {
         match *self {
-            ListCrawlersError::OperationTimeout(ref cause) => cause,
+            ListCrawlersError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCrawlersError {}
 /// Errors returned by ListDevEndpoints
 #[derive(Debug, PartialEq)]
 pub enum ListDevEndpointsError {
@@ -10517,19 +10189,15 @@ impl ListDevEndpointsError {
 }
 impl fmt::Display for ListDevEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDevEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDevEndpointsError::EntityNotFound(ref cause) => cause,
-            ListDevEndpointsError::InternalService(ref cause) => cause,
-            ListDevEndpointsError::InvalidInput(ref cause) => cause,
-            ListDevEndpointsError::OperationTimeout(ref cause) => cause,
+            ListDevEndpointsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListDevEndpointsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListDevEndpointsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListDevEndpointsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDevEndpointsError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -10568,19 +10236,15 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::EntityNotFound(ref cause) => cause,
-            ListJobsError::InternalService(ref cause) => cause,
-            ListJobsError::InvalidInput(ref cause) => cause,
-            ListJobsError::OperationTimeout(ref cause) => cause,
+            ListJobsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListJobsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListJobsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListJobsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by ListTriggers
 #[derive(Debug, PartialEq)]
 pub enum ListTriggersError {
@@ -10619,19 +10283,15 @@ impl ListTriggersError {
 }
 impl fmt::Display for ListTriggersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTriggersError {
-    fn description(&self) -> &str {
         match *self {
-            ListTriggersError::EntityNotFound(ref cause) => cause,
-            ListTriggersError::InternalService(ref cause) => cause,
-            ListTriggersError::InvalidInput(ref cause) => cause,
-            ListTriggersError::OperationTimeout(ref cause) => cause,
+            ListTriggersError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListTriggersError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListTriggersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTriggersError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTriggersError {}
 /// Errors returned by ListWorkflows
 #[derive(Debug, PartialEq)]
 pub enum ListWorkflowsError {
@@ -10665,18 +10325,14 @@ impl ListWorkflowsError {
 }
 impl fmt::Display for ListWorkflowsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWorkflowsError {
-    fn description(&self) -> &str {
         match *self {
-            ListWorkflowsError::InternalService(ref cause) => cause,
-            ListWorkflowsError::InvalidInput(ref cause) => cause,
-            ListWorkflowsError::OperationTimeout(ref cause) => cause,
+            ListWorkflowsError::InternalService(ref cause) => write!(f, "{}", cause),
+            ListWorkflowsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListWorkflowsError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWorkflowsError {}
 /// Errors returned by PutDataCatalogEncryptionSettings
 #[derive(Debug, PartialEq)]
 pub enum PutDataCatalogEncryptionSettingsError {
@@ -10718,18 +10374,20 @@ impl PutDataCatalogEncryptionSettingsError {
 }
 impl fmt::Display for PutDataCatalogEncryptionSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutDataCatalogEncryptionSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            PutDataCatalogEncryptionSettingsError::InternalService(ref cause) => cause,
-            PutDataCatalogEncryptionSettingsError::InvalidInput(ref cause) => cause,
-            PutDataCatalogEncryptionSettingsError::OperationTimeout(ref cause) => cause,
+            PutDataCatalogEncryptionSettingsError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutDataCatalogEncryptionSettingsError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutDataCatalogEncryptionSettingsError::OperationTimeout(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutDataCatalogEncryptionSettingsError {}
 /// Errors returned by PutResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum PutResourcePolicyError {
@@ -10775,20 +10433,16 @@ impl PutResourcePolicyError {
 }
 impl fmt::Display for PutResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutResourcePolicyError::ConditionCheckFailure(ref cause) => cause,
-            PutResourcePolicyError::EntityNotFound(ref cause) => cause,
-            PutResourcePolicyError::InternalService(ref cause) => cause,
-            PutResourcePolicyError::InvalidInput(ref cause) => cause,
-            PutResourcePolicyError::OperationTimeout(ref cause) => cause,
+            PutResourcePolicyError::ConditionCheckFailure(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::InternalService(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutResourcePolicyError {}
 /// Errors returned by PutWorkflowRunProperties
 #[derive(Debug, PartialEq)]
 pub enum PutWorkflowRunPropertiesError {
@@ -10856,22 +10510,22 @@ impl PutWorkflowRunPropertiesError {
 }
 impl fmt::Display for PutWorkflowRunPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutWorkflowRunPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            PutWorkflowRunPropertiesError::AlreadyExists(ref cause) => cause,
-            PutWorkflowRunPropertiesError::ConcurrentModification(ref cause) => cause,
-            PutWorkflowRunPropertiesError::EntityNotFound(ref cause) => cause,
-            PutWorkflowRunPropertiesError::InternalService(ref cause) => cause,
-            PutWorkflowRunPropertiesError::InvalidInput(ref cause) => cause,
-            PutWorkflowRunPropertiesError::OperationTimeout(ref cause) => cause,
-            PutWorkflowRunPropertiesError::ResourceNumberLimitExceeded(ref cause) => cause,
+            PutWorkflowRunPropertiesError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            PutWorkflowRunPropertiesError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutWorkflowRunPropertiesError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            PutWorkflowRunPropertiesError::InternalService(ref cause) => write!(f, "{}", cause),
+            PutWorkflowRunPropertiesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PutWorkflowRunPropertiesError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            PutWorkflowRunPropertiesError::ResourceNumberLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutWorkflowRunPropertiesError {}
 /// Errors returned by ResetJobBookmark
 #[derive(Debug, PartialEq)]
 pub enum ResetJobBookmarkError {
@@ -10910,19 +10564,15 @@ impl ResetJobBookmarkError {
 }
 impl fmt::Display for ResetJobBookmarkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetJobBookmarkError {
-    fn description(&self) -> &str {
         match *self {
-            ResetJobBookmarkError::EntityNotFound(ref cause) => cause,
-            ResetJobBookmarkError::InternalService(ref cause) => cause,
-            ResetJobBookmarkError::InvalidInput(ref cause) => cause,
-            ResetJobBookmarkError::OperationTimeout(ref cause) => cause,
+            ResetJobBookmarkError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ResetJobBookmarkError::InternalService(ref cause) => write!(f, "{}", cause),
+            ResetJobBookmarkError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ResetJobBookmarkError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetJobBookmarkError {}
 /// Errors returned by SearchTables
 #[derive(Debug, PartialEq)]
 pub enum SearchTablesError {
@@ -10956,18 +10606,14 @@ impl SearchTablesError {
 }
 impl fmt::Display for SearchTablesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchTablesError {
-    fn description(&self) -> &str {
         match *self {
-            SearchTablesError::InternalService(ref cause) => cause,
-            SearchTablesError::InvalidInput(ref cause) => cause,
-            SearchTablesError::OperationTimeout(ref cause) => cause,
+            SearchTablesError::InternalService(ref cause) => write!(f, "{}", cause),
+            SearchTablesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            SearchTablesError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchTablesError {}
 /// Errors returned by StartCrawler
 #[derive(Debug, PartialEq)]
 pub enum StartCrawlerError {
@@ -11001,18 +10647,14 @@ impl StartCrawlerError {
 }
 impl fmt::Display for StartCrawlerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartCrawlerError {
-    fn description(&self) -> &str {
         match *self {
-            StartCrawlerError::CrawlerRunning(ref cause) => cause,
-            StartCrawlerError::EntityNotFound(ref cause) => cause,
-            StartCrawlerError::OperationTimeout(ref cause) => cause,
+            StartCrawlerError::CrawlerRunning(ref cause) => write!(f, "{}", cause),
+            StartCrawlerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartCrawlerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartCrawlerError {}
 /// Errors returned by StartCrawlerSchedule
 #[derive(Debug, PartialEq)]
 pub enum StartCrawlerScheduleError {
@@ -11062,20 +10704,16 @@ impl StartCrawlerScheduleError {
 }
 impl fmt::Display for StartCrawlerScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartCrawlerScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            StartCrawlerScheduleError::EntityNotFound(ref cause) => cause,
-            StartCrawlerScheduleError::NoSchedule(ref cause) => cause,
-            StartCrawlerScheduleError::OperationTimeout(ref cause) => cause,
-            StartCrawlerScheduleError::SchedulerRunning(ref cause) => cause,
-            StartCrawlerScheduleError::SchedulerTransitioning(ref cause) => cause,
+            StartCrawlerScheduleError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartCrawlerScheduleError::NoSchedule(ref cause) => write!(f, "{}", cause),
+            StartCrawlerScheduleError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            StartCrawlerScheduleError::SchedulerRunning(ref cause) => write!(f, "{}", cause),
+            StartCrawlerScheduleError::SchedulerTransitioning(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartCrawlerScheduleError {}
 /// Errors returned by StartExportLabelsTaskRun
 #[derive(Debug, PartialEq)]
 pub enum StartExportLabelsTaskRunError {
@@ -11122,19 +10760,15 @@ impl StartExportLabelsTaskRunError {
 }
 impl fmt::Display for StartExportLabelsTaskRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartExportLabelsTaskRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartExportLabelsTaskRunError::EntityNotFound(ref cause) => cause,
-            StartExportLabelsTaskRunError::InternalService(ref cause) => cause,
-            StartExportLabelsTaskRunError::InvalidInput(ref cause) => cause,
-            StartExportLabelsTaskRunError::OperationTimeout(ref cause) => cause,
+            StartExportLabelsTaskRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartExportLabelsTaskRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartExportLabelsTaskRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartExportLabelsTaskRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartExportLabelsTaskRunError {}
 /// Errors returned by StartImportLabelsTaskRun
 #[derive(Debug, PartialEq)]
 pub enum StartImportLabelsTaskRunError {
@@ -11188,20 +10822,18 @@ impl StartImportLabelsTaskRunError {
 }
 impl fmt::Display for StartImportLabelsTaskRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartImportLabelsTaskRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartImportLabelsTaskRunError::EntityNotFound(ref cause) => cause,
-            StartImportLabelsTaskRunError::InternalService(ref cause) => cause,
-            StartImportLabelsTaskRunError::InvalidInput(ref cause) => cause,
-            StartImportLabelsTaskRunError::OperationTimeout(ref cause) => cause,
-            StartImportLabelsTaskRunError::ResourceNumberLimitExceeded(ref cause) => cause,
+            StartImportLabelsTaskRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartImportLabelsTaskRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartImportLabelsTaskRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartImportLabelsTaskRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            StartImportLabelsTaskRunError::ResourceNumberLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartImportLabelsTaskRunError {}
 /// Errors returned by StartJobRun
 #[derive(Debug, PartialEq)]
 pub enum StartJobRunError {
@@ -11252,21 +10884,17 @@ impl StartJobRunError {
 }
 impl fmt::Display for StartJobRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartJobRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartJobRunError::ConcurrentRunsExceeded(ref cause) => cause,
-            StartJobRunError::EntityNotFound(ref cause) => cause,
-            StartJobRunError::InternalService(ref cause) => cause,
-            StartJobRunError::InvalidInput(ref cause) => cause,
-            StartJobRunError::OperationTimeout(ref cause) => cause,
-            StartJobRunError::ResourceNumberLimitExceeded(ref cause) => cause,
+            StartJobRunError::ConcurrentRunsExceeded(ref cause) => write!(f, "{}", cause),
+            StartJobRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartJobRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartJobRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartJobRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            StartJobRunError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartJobRunError {}
 /// Errors returned by StartMLEvaluationTaskRun
 #[derive(Debug, PartialEq)]
 pub enum StartMLEvaluationTaskRunError {
@@ -11327,21 +10955,19 @@ impl StartMLEvaluationTaskRunError {
 }
 impl fmt::Display for StartMLEvaluationTaskRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMLEvaluationTaskRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartMLEvaluationTaskRunError::ConcurrentRunsExceeded(ref cause) => cause,
-            StartMLEvaluationTaskRunError::EntityNotFound(ref cause) => cause,
-            StartMLEvaluationTaskRunError::InternalService(ref cause) => cause,
-            StartMLEvaluationTaskRunError::InvalidInput(ref cause) => cause,
-            StartMLEvaluationTaskRunError::MLTransformNotReady(ref cause) => cause,
-            StartMLEvaluationTaskRunError::OperationTimeout(ref cause) => cause,
+            StartMLEvaluationTaskRunError::ConcurrentRunsExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartMLEvaluationTaskRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartMLEvaluationTaskRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartMLEvaluationTaskRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartMLEvaluationTaskRunError::MLTransformNotReady(ref cause) => write!(f, "{}", cause),
+            StartMLEvaluationTaskRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMLEvaluationTaskRunError {}
 /// Errors returned by StartMLLabelingSetGenerationTaskRun
 #[derive(Debug, PartialEq)]
 pub enum StartMLLabelingSetGenerationTaskRunError {
@@ -11397,20 +11023,26 @@ impl StartMLLabelingSetGenerationTaskRunError {
 }
 impl fmt::Display for StartMLLabelingSetGenerationTaskRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMLLabelingSetGenerationTaskRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartMLLabelingSetGenerationTaskRunError::ConcurrentRunsExceeded(ref cause) => cause,
-            StartMLLabelingSetGenerationTaskRunError::EntityNotFound(ref cause) => cause,
-            StartMLLabelingSetGenerationTaskRunError::InternalService(ref cause) => cause,
-            StartMLLabelingSetGenerationTaskRunError::InvalidInput(ref cause) => cause,
-            StartMLLabelingSetGenerationTaskRunError::OperationTimeout(ref cause) => cause,
+            StartMLLabelingSetGenerationTaskRunError::ConcurrentRunsExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartMLLabelingSetGenerationTaskRunError::EntityNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartMLLabelingSetGenerationTaskRunError::InternalService(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartMLLabelingSetGenerationTaskRunError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartMLLabelingSetGenerationTaskRunError::OperationTimeout(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartMLLabelingSetGenerationTaskRunError {}
 /// Errors returned by StartTrigger
 #[derive(Debug, PartialEq)]
 pub enum StartTriggerError {
@@ -11461,21 +11093,17 @@ impl StartTriggerError {
 }
 impl fmt::Display for StartTriggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartTriggerError {
-    fn description(&self) -> &str {
         match *self {
-            StartTriggerError::ConcurrentRunsExceeded(ref cause) => cause,
-            StartTriggerError::EntityNotFound(ref cause) => cause,
-            StartTriggerError::InternalService(ref cause) => cause,
-            StartTriggerError::InvalidInput(ref cause) => cause,
-            StartTriggerError::OperationTimeout(ref cause) => cause,
-            StartTriggerError::ResourceNumberLimitExceeded(ref cause) => cause,
+            StartTriggerError::ConcurrentRunsExceeded(ref cause) => write!(f, "{}", cause),
+            StartTriggerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartTriggerError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartTriggerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartTriggerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            StartTriggerError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartTriggerError {}
 /// Errors returned by StartWorkflowRun
 #[derive(Debug, PartialEq)]
 pub enum StartWorkflowRunError {
@@ -11528,21 +11156,17 @@ impl StartWorkflowRunError {
 }
 impl fmt::Display for StartWorkflowRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartWorkflowRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartWorkflowRunError::ConcurrentRunsExceeded(ref cause) => cause,
-            StartWorkflowRunError::EntityNotFound(ref cause) => cause,
-            StartWorkflowRunError::InternalService(ref cause) => cause,
-            StartWorkflowRunError::InvalidInput(ref cause) => cause,
-            StartWorkflowRunError::OperationTimeout(ref cause) => cause,
-            StartWorkflowRunError::ResourceNumberLimitExceeded(ref cause) => cause,
+            StartWorkflowRunError::ConcurrentRunsExceeded(ref cause) => write!(f, "{}", cause),
+            StartWorkflowRunError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StartWorkflowRunError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartWorkflowRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartWorkflowRunError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            StartWorkflowRunError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartWorkflowRunError {}
 /// Errors returned by StopCrawler
 #[derive(Debug, PartialEq)]
 pub enum StopCrawlerError {
@@ -11581,19 +11205,15 @@ impl StopCrawlerError {
 }
 impl fmt::Display for StopCrawlerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopCrawlerError {
-    fn description(&self) -> &str {
         match *self {
-            StopCrawlerError::CrawlerNotRunning(ref cause) => cause,
-            StopCrawlerError::CrawlerStopping(ref cause) => cause,
-            StopCrawlerError::EntityNotFound(ref cause) => cause,
-            StopCrawlerError::OperationTimeout(ref cause) => cause,
+            StopCrawlerError::CrawlerNotRunning(ref cause) => write!(f, "{}", cause),
+            StopCrawlerError::CrawlerStopping(ref cause) => write!(f, "{}", cause),
+            StopCrawlerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StopCrawlerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopCrawlerError {}
 /// Errors returned by StopCrawlerSchedule
 #[derive(Debug, PartialEq)]
 pub enum StopCrawlerScheduleError {
@@ -11638,19 +11258,15 @@ impl StopCrawlerScheduleError {
 }
 impl fmt::Display for StopCrawlerScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopCrawlerScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            StopCrawlerScheduleError::EntityNotFound(ref cause) => cause,
-            StopCrawlerScheduleError::OperationTimeout(ref cause) => cause,
-            StopCrawlerScheduleError::SchedulerNotRunning(ref cause) => cause,
-            StopCrawlerScheduleError::SchedulerTransitioning(ref cause) => cause,
+            StopCrawlerScheduleError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StopCrawlerScheduleError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            StopCrawlerScheduleError::SchedulerNotRunning(ref cause) => write!(f, "{}", cause),
+            StopCrawlerScheduleError::SchedulerTransitioning(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopCrawlerScheduleError {}
 /// Errors returned by StopTrigger
 #[derive(Debug, PartialEq)]
 pub enum StopTriggerError {
@@ -11694,20 +11310,16 @@ impl StopTriggerError {
 }
 impl fmt::Display for StopTriggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopTriggerError {
-    fn description(&self) -> &str {
         match *self {
-            StopTriggerError::ConcurrentModification(ref cause) => cause,
-            StopTriggerError::EntityNotFound(ref cause) => cause,
-            StopTriggerError::InternalService(ref cause) => cause,
-            StopTriggerError::InvalidInput(ref cause) => cause,
-            StopTriggerError::OperationTimeout(ref cause) => cause,
+            StopTriggerError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            StopTriggerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            StopTriggerError::InternalService(ref cause) => write!(f, "{}", cause),
+            StopTriggerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StopTriggerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopTriggerError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -11746,19 +11358,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::EntityNotFound(ref cause) => cause,
-            TagResourceError::InternalService(ref cause) => cause,
-            TagResourceError::InvalidInput(ref cause) => cause,
-            TagResourceError::OperationTimeout(ref cause) => cause,
+            TagResourceError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TagResourceError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -11797,19 +11405,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::EntityNotFound(ref cause) => cause,
-            UntagResourceError::InternalService(ref cause) => cause,
-            UntagResourceError::InvalidInput(ref cause) => cause,
-            UntagResourceError::OperationTimeout(ref cause) => cause,
+            UntagResourceError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalService(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateClassifier
 #[derive(Debug, PartialEq)]
 pub enum UpdateClassifierError {
@@ -11848,19 +11452,15 @@ impl UpdateClassifierError {
 }
 impl fmt::Display for UpdateClassifierError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClassifierError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClassifierError::EntityNotFound(ref cause) => cause,
-            UpdateClassifierError::InvalidInput(ref cause) => cause,
-            UpdateClassifierError::OperationTimeout(ref cause) => cause,
-            UpdateClassifierError::VersionMismatch(ref cause) => cause,
+            UpdateClassifierError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateClassifierError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateClassifierError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateClassifierError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClassifierError {}
 /// Errors returned by UpdateConnection
 #[derive(Debug, PartialEq)]
 pub enum UpdateConnectionError {
@@ -11899,19 +11499,15 @@ impl UpdateConnectionError {
 }
 impl fmt::Display for UpdateConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConnectionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConnectionError::EntityNotFound(ref cause) => cause,
-            UpdateConnectionError::GlueEncryption(ref cause) => cause,
-            UpdateConnectionError::InvalidInput(ref cause) => cause,
-            UpdateConnectionError::OperationTimeout(ref cause) => cause,
+            UpdateConnectionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateConnectionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            UpdateConnectionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateConnectionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConnectionError {}
 /// Errors returned by UpdateCrawler
 #[derive(Debug, PartialEq)]
 pub enum UpdateCrawlerError {
@@ -11955,20 +11551,16 @@ impl UpdateCrawlerError {
 }
 impl fmt::Display for UpdateCrawlerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCrawlerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCrawlerError::CrawlerRunning(ref cause) => cause,
-            UpdateCrawlerError::EntityNotFound(ref cause) => cause,
-            UpdateCrawlerError::InvalidInput(ref cause) => cause,
-            UpdateCrawlerError::OperationTimeout(ref cause) => cause,
-            UpdateCrawlerError::VersionMismatch(ref cause) => cause,
+            UpdateCrawlerError::CrawlerRunning(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCrawlerError {}
 /// Errors returned by UpdateCrawlerSchedule
 #[derive(Debug, PartialEq)]
 pub enum UpdateCrawlerScheduleError {
@@ -12020,20 +11612,16 @@ impl UpdateCrawlerScheduleError {
 }
 impl fmt::Display for UpdateCrawlerScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCrawlerScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCrawlerScheduleError::EntityNotFound(ref cause) => cause,
-            UpdateCrawlerScheduleError::InvalidInput(ref cause) => cause,
-            UpdateCrawlerScheduleError::OperationTimeout(ref cause) => cause,
-            UpdateCrawlerScheduleError::SchedulerTransitioning(ref cause) => cause,
-            UpdateCrawlerScheduleError::VersionMismatch(ref cause) => cause,
+            UpdateCrawlerScheduleError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerScheduleError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerScheduleError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerScheduleError::SchedulerTransitioning(ref cause) => write!(f, "{}", cause),
+            UpdateCrawlerScheduleError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCrawlerScheduleError {}
 /// Errors returned by UpdateDatabase
 #[derive(Debug, PartialEq)]
 pub enum UpdateDatabaseError {
@@ -12077,20 +11665,16 @@ impl UpdateDatabaseError {
 }
 impl fmt::Display for UpdateDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDatabaseError::EntityNotFound(ref cause) => cause,
-            UpdateDatabaseError::GlueEncryption(ref cause) => cause,
-            UpdateDatabaseError::InternalService(ref cause) => cause,
-            UpdateDatabaseError::InvalidInput(ref cause) => cause,
-            UpdateDatabaseError::OperationTimeout(ref cause) => cause,
+            UpdateDatabaseError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDatabaseError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            UpdateDatabaseError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDatabaseError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDatabaseError {}
 /// Errors returned by UpdateDevEndpoint
 #[derive(Debug, PartialEq)]
 pub enum UpdateDevEndpointError {
@@ -12129,19 +11713,15 @@ impl UpdateDevEndpointError {
 }
 impl fmt::Display for UpdateDevEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDevEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDevEndpointError::EntityNotFound(ref cause) => cause,
-            UpdateDevEndpointError::InternalService(ref cause) => cause,
-            UpdateDevEndpointError::InvalidInput(ref cause) => cause,
-            UpdateDevEndpointError::OperationTimeout(ref cause) => cause,
+            UpdateDevEndpointError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDevEndpointError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateDevEndpointError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDevEndpointError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDevEndpointError {}
 /// Errors returned by UpdateJob
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobError {
@@ -12185,20 +11765,16 @@ impl UpdateJobError {
 }
 impl fmt::Display for UpdateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateJobError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateJobError::ConcurrentModification(ref cause) => cause,
-            UpdateJobError::EntityNotFound(ref cause) => cause,
-            UpdateJobError::InternalService(ref cause) => cause,
-            UpdateJobError::InvalidInput(ref cause) => cause,
-            UpdateJobError::OperationTimeout(ref cause) => cause,
+            UpdateJobError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateJobError {}
 /// Errors returned by UpdateMLTransform
 #[derive(Debug, PartialEq)]
 pub enum UpdateMLTransformError {
@@ -12242,20 +11818,16 @@ impl UpdateMLTransformError {
 }
 impl fmt::Display for UpdateMLTransformError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMLTransformError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMLTransformError::AccessDenied(ref cause) => cause,
-            UpdateMLTransformError::EntityNotFound(ref cause) => cause,
-            UpdateMLTransformError::InternalService(ref cause) => cause,
-            UpdateMLTransformError::InvalidInput(ref cause) => cause,
-            UpdateMLTransformError::OperationTimeout(ref cause) => cause,
+            UpdateMLTransformError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateMLTransformError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMLTransformError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateMLTransformError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateMLTransformError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMLTransformError {}
 /// Errors returned by UpdatePartition
 #[derive(Debug, PartialEq)]
 pub enum UpdatePartitionError {
@@ -12299,20 +11871,16 @@ impl UpdatePartitionError {
 }
 impl fmt::Display for UpdatePartitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePartitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePartitionError::EntityNotFound(ref cause) => cause,
-            UpdatePartitionError::GlueEncryption(ref cause) => cause,
-            UpdatePartitionError::InternalService(ref cause) => cause,
-            UpdatePartitionError::InvalidInput(ref cause) => cause,
-            UpdatePartitionError::OperationTimeout(ref cause) => cause,
+            UpdatePartitionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePartitionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            UpdatePartitionError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdatePartitionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdatePartitionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePartitionError {}
 /// Errors returned by UpdateTable
 #[derive(Debug, PartialEq)]
 pub enum UpdateTableError {
@@ -12368,22 +11936,18 @@ impl UpdateTableError {
 }
 impl fmt::Display for UpdateTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTableError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTableError::ConcurrentModification(ref cause) => cause,
-            UpdateTableError::EntityNotFound(ref cause) => cause,
-            UpdateTableError::GlueEncryption(ref cause) => cause,
-            UpdateTableError::InternalService(ref cause) => cause,
-            UpdateTableError::InvalidInput(ref cause) => cause,
-            UpdateTableError::OperationTimeout(ref cause) => cause,
-            UpdateTableError::ResourceNumberLimitExceeded(ref cause) => cause,
+            UpdateTableError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::OperationTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateTableError::ResourceNumberLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTableError {}
 /// Errors returned by UpdateTrigger
 #[derive(Debug, PartialEq)]
 pub enum UpdateTriggerError {
@@ -12429,20 +11993,16 @@ impl UpdateTriggerError {
 }
 impl fmt::Display for UpdateTriggerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTriggerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTriggerError::ConcurrentModification(ref cause) => cause,
-            UpdateTriggerError::EntityNotFound(ref cause) => cause,
-            UpdateTriggerError::InternalService(ref cause) => cause,
-            UpdateTriggerError::InvalidInput(ref cause) => cause,
-            UpdateTriggerError::OperationTimeout(ref cause) => cause,
+            UpdateTriggerError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateTriggerError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTriggerError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateTriggerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateTriggerError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTriggerError {}
 /// Errors returned by UpdateUserDefinedFunction
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserDefinedFunctionError {
@@ -12496,20 +12056,16 @@ impl UpdateUserDefinedFunctionError {
 }
 impl fmt::Display for UpdateUserDefinedFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserDefinedFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserDefinedFunctionError::EntityNotFound(ref cause) => cause,
-            UpdateUserDefinedFunctionError::GlueEncryption(ref cause) => cause,
-            UpdateUserDefinedFunctionError::InternalService(ref cause) => cause,
-            UpdateUserDefinedFunctionError::InvalidInput(ref cause) => cause,
-            UpdateUserDefinedFunctionError::OperationTimeout(ref cause) => cause,
+            UpdateUserDefinedFunctionError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserDefinedFunctionError::GlueEncryption(ref cause) => write!(f, "{}", cause),
+            UpdateUserDefinedFunctionError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateUserDefinedFunctionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateUserDefinedFunctionError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserDefinedFunctionError {}
 /// Errors returned by UpdateWorkflow
 #[derive(Debug, PartialEq)]
 pub enum UpdateWorkflowError {
@@ -12555,20 +12111,16 @@ impl UpdateWorkflowError {
 }
 impl fmt::Display for UpdateWorkflowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateWorkflowError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateWorkflowError::ConcurrentModification(ref cause) => cause,
-            UpdateWorkflowError::EntityNotFound(ref cause) => cause,
-            UpdateWorkflowError::InternalService(ref cause) => cause,
-            UpdateWorkflowError::InvalidInput(ref cause) => cause,
-            UpdateWorkflowError::OperationTimeout(ref cause) => cause,
+            UpdateWorkflowError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateWorkflowError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateWorkflowError::InternalService(ref cause) => write!(f, "{}", cause),
+            UpdateWorkflowError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateWorkflowError::OperationTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateWorkflowError {}
 /// Trait representing the capabilities of the AWS Glue API. AWS Glue clients implement this trait.
 pub trait Glue {
     /// <p>Creates one or more partitions in a batch operation.</p>

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -3387,17 +3387,13 @@ impl AssociateRoleToGroupError {
 }
 impl fmt::Display for AssociateRoleToGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateRoleToGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateRoleToGroupError::BadRequest(ref cause) => cause,
-            AssociateRoleToGroupError::InternalServerError(ref cause) => cause,
+            AssociateRoleToGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            AssociateRoleToGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateRoleToGroupError {}
 /// Errors returned by AssociateServiceRoleToAccount
 #[derive(Debug, PartialEq)]
 pub enum AssociateServiceRoleToAccountError {
@@ -3432,17 +3428,15 @@ impl AssociateServiceRoleToAccountError {
 }
 impl fmt::Display for AssociateServiceRoleToAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateServiceRoleToAccountError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateServiceRoleToAccountError::BadRequest(ref cause) => cause,
-            AssociateServiceRoleToAccountError::InternalServerError(ref cause) => cause,
+            AssociateServiceRoleToAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            AssociateServiceRoleToAccountError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateServiceRoleToAccountError {}
 /// Errors returned by CreateConnectorDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateConnectorDefinitionError {
@@ -3468,16 +3462,12 @@ impl CreateConnectorDefinitionError {
 }
 impl fmt::Display for CreateConnectorDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConnectorDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConnectorDefinitionError::BadRequest(ref cause) => cause,
+            CreateConnectorDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConnectorDefinitionError {}
 /// Errors returned by CreateConnectorDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateConnectorDefinitionVersionError {
@@ -3505,16 +3495,12 @@ impl CreateConnectorDefinitionVersionError {
 }
 impl fmt::Display for CreateConnectorDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConnectorDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConnectorDefinitionVersionError::BadRequest(ref cause) => cause,
+            CreateConnectorDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConnectorDefinitionVersionError {}
 /// Errors returned by CreateCoreDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateCoreDefinitionError {
@@ -3538,16 +3524,12 @@ impl CreateCoreDefinitionError {
 }
 impl fmt::Display for CreateCoreDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCoreDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCoreDefinitionError::BadRequest(ref cause) => cause,
+            CreateCoreDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCoreDefinitionError {}
 /// Errors returned by CreateCoreDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateCoreDefinitionVersionError {
@@ -3575,16 +3557,12 @@ impl CreateCoreDefinitionVersionError {
 }
 impl fmt::Display for CreateCoreDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCoreDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCoreDefinitionVersionError::BadRequest(ref cause) => cause,
+            CreateCoreDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCoreDefinitionVersionError {}
 /// Errors returned by CreateDeployment
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentError {
@@ -3608,16 +3586,12 @@ impl CreateDeploymentError {
 }
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentError::BadRequest(ref cause) => cause,
+            CreateDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeploymentError {}
 /// Errors returned by CreateDeviceDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateDeviceDefinitionError {
@@ -3641,16 +3615,12 @@ impl CreateDeviceDefinitionError {
 }
 impl fmt::Display for CreateDeviceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeviceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeviceDefinitionError::BadRequest(ref cause) => cause,
+            CreateDeviceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeviceDefinitionError {}
 /// Errors returned by CreateDeviceDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateDeviceDefinitionVersionError {
@@ -3678,16 +3648,12 @@ impl CreateDeviceDefinitionVersionError {
 }
 impl fmt::Display for CreateDeviceDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeviceDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeviceDefinitionVersionError::BadRequest(ref cause) => cause,
+            CreateDeviceDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeviceDefinitionVersionError {}
 /// Errors returned by CreateFunctionDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateFunctionDefinitionError {
@@ -3711,16 +3677,12 @@ impl CreateFunctionDefinitionError {
 }
 impl fmt::Display for CreateFunctionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFunctionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFunctionDefinitionError::BadRequest(ref cause) => cause,
+            CreateFunctionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFunctionDefinitionError {}
 /// Errors returned by CreateFunctionDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateFunctionDefinitionVersionError {
@@ -3748,16 +3710,12 @@ impl CreateFunctionDefinitionVersionError {
 }
 impl fmt::Display for CreateFunctionDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFunctionDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFunctionDefinitionVersionError::BadRequest(ref cause) => cause,
+            CreateFunctionDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFunctionDefinitionVersionError {}
 /// Errors returned by CreateGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupError {
@@ -3781,16 +3739,12 @@ impl CreateGroupError {
 }
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupError::BadRequest(ref cause) => cause,
+            CreateGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGroupError {}
 /// Errors returned by CreateGroupCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupCertificateAuthorityError {
@@ -3825,17 +3779,15 @@ impl CreateGroupCertificateAuthorityError {
 }
 impl fmt::Display for CreateGroupCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupCertificateAuthorityError::BadRequest(ref cause) => cause,
-            CreateGroupCertificateAuthorityError::InternalServerError(ref cause) => cause,
+            CreateGroupCertificateAuthorityError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateGroupCertificateAuthorityError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateGroupCertificateAuthorityError {}
 /// Errors returned by CreateGroupVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupVersionError {
@@ -3859,16 +3811,12 @@ impl CreateGroupVersionError {
 }
 impl fmt::Display for CreateGroupVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupVersionError::BadRequest(ref cause) => cause,
+            CreateGroupVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGroupVersionError {}
 /// Errors returned by CreateLoggerDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateLoggerDefinitionError {
@@ -3892,16 +3840,12 @@ impl CreateLoggerDefinitionError {
 }
 impl fmt::Display for CreateLoggerDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoggerDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoggerDefinitionError::BadRequest(ref cause) => cause,
+            CreateLoggerDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLoggerDefinitionError {}
 /// Errors returned by CreateLoggerDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateLoggerDefinitionVersionError {
@@ -3929,16 +3873,12 @@ impl CreateLoggerDefinitionVersionError {
 }
 impl fmt::Display for CreateLoggerDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoggerDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoggerDefinitionVersionError::BadRequest(ref cause) => cause,
+            CreateLoggerDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLoggerDefinitionVersionError {}
 /// Errors returned by CreateResourceDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceDefinitionError {
@@ -3962,16 +3902,12 @@ impl CreateResourceDefinitionError {
 }
 impl fmt::Display for CreateResourceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceDefinitionError::BadRequest(ref cause) => cause,
+            CreateResourceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateResourceDefinitionError {}
 /// Errors returned by CreateResourceDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceDefinitionVersionError {
@@ -3999,16 +3935,12 @@ impl CreateResourceDefinitionVersionError {
 }
 impl fmt::Display for CreateResourceDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceDefinitionVersionError::BadRequest(ref cause) => cause,
+            CreateResourceDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateResourceDefinitionVersionError {}
 /// Errors returned by CreateSoftwareUpdateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateSoftwareUpdateJobError {
@@ -4039,17 +3971,13 @@ impl CreateSoftwareUpdateJobError {
 }
 impl fmt::Display for CreateSoftwareUpdateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSoftwareUpdateJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSoftwareUpdateJobError::BadRequest(ref cause) => cause,
-            CreateSoftwareUpdateJobError::InternalServerError(ref cause) => cause,
+            CreateSoftwareUpdateJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateSoftwareUpdateJobError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSoftwareUpdateJobError {}
 /// Errors returned by CreateSubscriptionDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateSubscriptionDefinitionError {
@@ -4077,16 +4005,12 @@ impl CreateSubscriptionDefinitionError {
 }
 impl fmt::Display for CreateSubscriptionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSubscriptionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSubscriptionDefinitionError::BadRequest(ref cause) => cause,
+            CreateSubscriptionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSubscriptionDefinitionError {}
 /// Errors returned by CreateSubscriptionDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateSubscriptionDefinitionVersionError {
@@ -4114,16 +4038,14 @@ impl CreateSubscriptionDefinitionVersionError {
 }
 impl fmt::Display for CreateSubscriptionDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSubscriptionDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSubscriptionDefinitionVersionError::BadRequest(ref cause) => cause,
+            CreateSubscriptionDefinitionVersionError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateSubscriptionDefinitionVersionError {}
 /// Errors returned by DeleteConnectorDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteConnectorDefinitionError {
@@ -4149,16 +4071,12 @@ impl DeleteConnectorDefinitionError {
 }
 impl fmt::Display for DeleteConnectorDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConnectorDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConnectorDefinitionError::BadRequest(ref cause) => cause,
+            DeleteConnectorDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConnectorDefinitionError {}
 /// Errors returned by DeleteCoreDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteCoreDefinitionError {
@@ -4182,16 +4100,12 @@ impl DeleteCoreDefinitionError {
 }
 impl fmt::Display for DeleteCoreDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCoreDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCoreDefinitionError::BadRequest(ref cause) => cause,
+            DeleteCoreDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCoreDefinitionError {}
 /// Errors returned by DeleteDeviceDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteDeviceDefinitionError {
@@ -4215,16 +4129,12 @@ impl DeleteDeviceDefinitionError {
 }
 impl fmt::Display for DeleteDeviceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDeviceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDeviceDefinitionError::BadRequest(ref cause) => cause,
+            DeleteDeviceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDeviceDefinitionError {}
 /// Errors returned by DeleteFunctionDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteFunctionDefinitionError {
@@ -4248,16 +4158,12 @@ impl DeleteFunctionDefinitionError {
 }
 impl fmt::Display for DeleteFunctionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFunctionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFunctionDefinitionError::BadRequest(ref cause) => cause,
+            DeleteFunctionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFunctionDefinitionError {}
 /// Errors returned by DeleteGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteGroupError {
@@ -4281,16 +4187,12 @@ impl DeleteGroupError {
 }
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGroupError::BadRequest(ref cause) => cause,
+            DeleteGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGroupError {}
 /// Errors returned by DeleteLoggerDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoggerDefinitionError {
@@ -4314,16 +4216,12 @@ impl DeleteLoggerDefinitionError {
 }
 impl fmt::Display for DeleteLoggerDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoggerDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoggerDefinitionError::BadRequest(ref cause) => cause,
+            DeleteLoggerDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLoggerDefinitionError {}
 /// Errors returned by DeleteResourceDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourceDefinitionError {
@@ -4347,16 +4245,12 @@ impl DeleteResourceDefinitionError {
 }
 impl fmt::Display for DeleteResourceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourceDefinitionError::BadRequest(ref cause) => cause,
+            DeleteResourceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourceDefinitionError {}
 /// Errors returned by DeleteSubscriptionDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteSubscriptionDefinitionError {
@@ -4384,16 +4278,12 @@ impl DeleteSubscriptionDefinitionError {
 }
 impl fmt::Display for DeleteSubscriptionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSubscriptionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSubscriptionDefinitionError::BadRequest(ref cause) => cause,
+            DeleteSubscriptionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSubscriptionDefinitionError {}
 /// Errors returned by DisassociateRoleFromGroup
 #[derive(Debug, PartialEq)]
 pub enum DisassociateRoleFromGroupError {
@@ -4426,17 +4316,15 @@ impl DisassociateRoleFromGroupError {
 }
 impl fmt::Display for DisassociateRoleFromGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateRoleFromGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateRoleFromGroupError::BadRequest(ref cause) => cause,
-            DisassociateRoleFromGroupError::InternalServerError(ref cause) => cause,
+            DisassociateRoleFromGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DisassociateRoleFromGroupError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateRoleFromGroupError {}
 /// Errors returned by DisassociateServiceRoleFromAccount
 #[derive(Debug, PartialEq)]
 pub enum DisassociateServiceRoleFromAccountError {
@@ -4464,16 +4352,14 @@ impl DisassociateServiceRoleFromAccountError {
 }
 impl fmt::Display for DisassociateServiceRoleFromAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateServiceRoleFromAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateServiceRoleFromAccountError::InternalServerError(ref cause) => cause,
+            DisassociateServiceRoleFromAccountError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateServiceRoleFromAccountError {}
 /// Errors returned by GetAssociatedRole
 #[derive(Debug, PartialEq)]
 pub enum GetAssociatedRoleError {
@@ -4504,17 +4390,13 @@ impl GetAssociatedRoleError {
 }
 impl fmt::Display for GetAssociatedRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAssociatedRoleError {
-    fn description(&self) -> &str {
         match *self {
-            GetAssociatedRoleError::BadRequest(ref cause) => cause,
-            GetAssociatedRoleError::InternalServerError(ref cause) => cause,
+            GetAssociatedRoleError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetAssociatedRoleError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAssociatedRoleError {}
 /// Errors returned by GetBulkDeploymentStatus
 #[derive(Debug, PartialEq)]
 pub enum GetBulkDeploymentStatusError {
@@ -4538,16 +4420,12 @@ impl GetBulkDeploymentStatusError {
 }
 impl fmt::Display for GetBulkDeploymentStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBulkDeploymentStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetBulkDeploymentStatusError::BadRequest(ref cause) => cause,
+            GetBulkDeploymentStatusError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBulkDeploymentStatusError {}
 /// Errors returned by GetConnectivityInfo
 #[derive(Debug, PartialEq)]
 pub enum GetConnectivityInfoError {
@@ -4578,17 +4456,13 @@ impl GetConnectivityInfoError {
 }
 impl fmt::Display for GetConnectivityInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectivityInfoError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectivityInfoError::BadRequest(ref cause) => cause,
-            GetConnectivityInfoError::InternalServerError(ref cause) => cause,
+            GetConnectivityInfoError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetConnectivityInfoError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectivityInfoError {}
 /// Errors returned by GetConnectorDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetConnectorDefinitionError {
@@ -4612,16 +4486,12 @@ impl GetConnectorDefinitionError {
 }
 impl fmt::Display for GetConnectorDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectorDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectorDefinitionError::BadRequest(ref cause) => cause,
+            GetConnectorDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectorDefinitionError {}
 /// Errors returned by GetConnectorDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum GetConnectorDefinitionVersionError {
@@ -4649,16 +4519,12 @@ impl GetConnectorDefinitionVersionError {
 }
 impl fmt::Display for GetConnectorDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectorDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectorDefinitionVersionError::BadRequest(ref cause) => cause,
+            GetConnectorDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectorDefinitionVersionError {}
 /// Errors returned by GetCoreDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetCoreDefinitionError {
@@ -4682,16 +4548,12 @@ impl GetCoreDefinitionError {
 }
 impl fmt::Display for GetCoreDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCoreDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetCoreDefinitionError::BadRequest(ref cause) => cause,
+            GetCoreDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCoreDefinitionError {}
 /// Errors returned by GetCoreDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum GetCoreDefinitionVersionError {
@@ -4715,16 +4577,12 @@ impl GetCoreDefinitionVersionError {
 }
 impl fmt::Display for GetCoreDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCoreDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetCoreDefinitionVersionError::BadRequest(ref cause) => cause,
+            GetCoreDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCoreDefinitionVersionError {}
 /// Errors returned by GetDeploymentStatus
 #[derive(Debug, PartialEq)]
 pub enum GetDeploymentStatusError {
@@ -4748,16 +4606,12 @@ impl GetDeploymentStatusError {
 }
 impl fmt::Display for GetDeploymentStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeploymentStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeploymentStatusError::BadRequest(ref cause) => cause,
+            GetDeploymentStatusError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeploymentStatusError {}
 /// Errors returned by GetDeviceDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetDeviceDefinitionError {
@@ -4781,16 +4635,12 @@ impl GetDeviceDefinitionError {
 }
 impl fmt::Display for GetDeviceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeviceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeviceDefinitionError::BadRequest(ref cause) => cause,
+            GetDeviceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeviceDefinitionError {}
 /// Errors returned by GetDeviceDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum GetDeviceDefinitionVersionError {
@@ -4818,16 +4668,12 @@ impl GetDeviceDefinitionVersionError {
 }
 impl fmt::Display for GetDeviceDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeviceDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeviceDefinitionVersionError::BadRequest(ref cause) => cause,
+            GetDeviceDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeviceDefinitionVersionError {}
 /// Errors returned by GetFunctionDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetFunctionDefinitionError {
@@ -4851,16 +4697,12 @@ impl GetFunctionDefinitionError {
 }
 impl fmt::Display for GetFunctionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFunctionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetFunctionDefinitionError::BadRequest(ref cause) => cause,
+            GetFunctionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFunctionDefinitionError {}
 /// Errors returned by GetFunctionDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum GetFunctionDefinitionVersionError {
@@ -4888,16 +4730,12 @@ impl GetFunctionDefinitionVersionError {
 }
 impl fmt::Display for GetFunctionDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFunctionDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetFunctionDefinitionVersionError::BadRequest(ref cause) => cause,
+            GetFunctionDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFunctionDefinitionVersionError {}
 /// Errors returned by GetGroup
 #[derive(Debug, PartialEq)]
 pub enum GetGroupError {
@@ -4921,16 +4759,12 @@ impl GetGroupError {
 }
 impl fmt::Display for GetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupError::BadRequest(ref cause) => cause,
+            GetGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupError {}
 /// Errors returned by GetGroupCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum GetGroupCertificateAuthorityError {
@@ -4965,17 +4799,15 @@ impl GetGroupCertificateAuthorityError {
 }
 impl fmt::Display for GetGroupCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupCertificateAuthorityError::BadRequest(ref cause) => cause,
-            GetGroupCertificateAuthorityError::InternalServerError(ref cause) => cause,
+            GetGroupCertificateAuthorityError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetGroupCertificateAuthorityError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetGroupCertificateAuthorityError {}
 /// Errors returned by GetGroupCertificateConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetGroupCertificateConfigurationError {
@@ -5010,17 +4842,15 @@ impl GetGroupCertificateConfigurationError {
 }
 impl fmt::Display for GetGroupCertificateConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupCertificateConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupCertificateConfigurationError::BadRequest(ref cause) => cause,
-            GetGroupCertificateConfigurationError::InternalServerError(ref cause) => cause,
+            GetGroupCertificateConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetGroupCertificateConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetGroupCertificateConfigurationError {}
 /// Errors returned by GetGroupVersion
 #[derive(Debug, PartialEq)]
 pub enum GetGroupVersionError {
@@ -5044,16 +4874,12 @@ impl GetGroupVersionError {
 }
 impl fmt::Display for GetGroupVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupVersionError::BadRequest(ref cause) => cause,
+            GetGroupVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupVersionError {}
 /// Errors returned by GetLoggerDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetLoggerDefinitionError {
@@ -5077,16 +4903,12 @@ impl GetLoggerDefinitionError {
 }
 impl fmt::Display for GetLoggerDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoggerDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoggerDefinitionError::BadRequest(ref cause) => cause,
+            GetLoggerDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoggerDefinitionError {}
 /// Errors returned by GetLoggerDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum GetLoggerDefinitionVersionError {
@@ -5114,16 +4936,12 @@ impl GetLoggerDefinitionVersionError {
 }
 impl fmt::Display for GetLoggerDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoggerDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoggerDefinitionVersionError::BadRequest(ref cause) => cause,
+            GetLoggerDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoggerDefinitionVersionError {}
 /// Errors returned by GetResourceDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetResourceDefinitionError {
@@ -5147,16 +4965,12 @@ impl GetResourceDefinitionError {
 }
 impl fmt::Display for GetResourceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceDefinitionError::BadRequest(ref cause) => cause,
+            GetResourceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourceDefinitionError {}
 /// Errors returned by GetResourceDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum GetResourceDefinitionVersionError {
@@ -5184,16 +4998,12 @@ impl GetResourceDefinitionVersionError {
 }
 impl fmt::Display for GetResourceDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceDefinitionVersionError::BadRequest(ref cause) => cause,
+            GetResourceDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourceDefinitionVersionError {}
 /// Errors returned by GetServiceRoleForAccount
 #[derive(Debug, PartialEq)]
 pub enum GetServiceRoleForAccountError {
@@ -5219,16 +5029,12 @@ impl GetServiceRoleForAccountError {
 }
 impl fmt::Display for GetServiceRoleForAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceRoleForAccountError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceRoleForAccountError::InternalServerError(ref cause) => cause,
+            GetServiceRoleForAccountError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServiceRoleForAccountError {}
 /// Errors returned by GetSubscriptionDefinition
 #[derive(Debug, PartialEq)]
 pub enum GetSubscriptionDefinitionError {
@@ -5254,16 +5060,12 @@ impl GetSubscriptionDefinitionError {
 }
 impl fmt::Display for GetSubscriptionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSubscriptionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetSubscriptionDefinitionError::BadRequest(ref cause) => cause,
+            GetSubscriptionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSubscriptionDefinitionError {}
 /// Errors returned by GetSubscriptionDefinitionVersion
 #[derive(Debug, PartialEq)]
 pub enum GetSubscriptionDefinitionVersionError {
@@ -5291,16 +5093,12 @@ impl GetSubscriptionDefinitionVersionError {
 }
 impl fmt::Display for GetSubscriptionDefinitionVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSubscriptionDefinitionVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetSubscriptionDefinitionVersionError::BadRequest(ref cause) => cause,
+            GetSubscriptionDefinitionVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSubscriptionDefinitionVersionError {}
 /// Errors returned by ListBulkDeploymentDetailedReports
 #[derive(Debug, PartialEq)]
 pub enum ListBulkDeploymentDetailedReportsError {
@@ -5328,16 +5126,12 @@ impl ListBulkDeploymentDetailedReportsError {
 }
 impl fmt::Display for ListBulkDeploymentDetailedReportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBulkDeploymentDetailedReportsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBulkDeploymentDetailedReportsError::BadRequest(ref cause) => cause,
+            ListBulkDeploymentDetailedReportsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBulkDeploymentDetailedReportsError {}
 /// Errors returned by ListBulkDeployments
 #[derive(Debug, PartialEq)]
 pub enum ListBulkDeploymentsError {
@@ -5361,16 +5155,12 @@ impl ListBulkDeploymentsError {
 }
 impl fmt::Display for ListBulkDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBulkDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBulkDeploymentsError::BadRequest(ref cause) => cause,
+            ListBulkDeploymentsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBulkDeploymentsError {}
 /// Errors returned by ListConnectorDefinitionVersions
 #[derive(Debug, PartialEq)]
 pub enum ListConnectorDefinitionVersionsError {
@@ -5398,16 +5188,12 @@ impl ListConnectorDefinitionVersionsError {
 }
 impl fmt::Display for ListConnectorDefinitionVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConnectorDefinitionVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListConnectorDefinitionVersionsError::BadRequest(ref cause) => cause,
+            ListConnectorDefinitionVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListConnectorDefinitionVersionsError {}
 /// Errors returned by ListConnectorDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListConnectorDefinitionsError {}
@@ -5425,14 +5211,10 @@ impl ListConnectorDefinitionsError {
 }
 impl fmt::Display for ListConnectorDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConnectorDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListConnectorDefinitionsError {}
 /// Errors returned by ListCoreDefinitionVersions
 #[derive(Debug, PartialEq)]
 pub enum ListCoreDefinitionVersionsError {
@@ -5460,16 +5242,12 @@ impl ListCoreDefinitionVersionsError {
 }
 impl fmt::Display for ListCoreDefinitionVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCoreDefinitionVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListCoreDefinitionVersionsError::BadRequest(ref cause) => cause,
+            ListCoreDefinitionVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCoreDefinitionVersionsError {}
 /// Errors returned by ListCoreDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListCoreDefinitionsError {}
@@ -5487,14 +5265,10 @@ impl ListCoreDefinitionsError {
 }
 impl fmt::Display for ListCoreDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCoreDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListCoreDefinitionsError {}
 /// Errors returned by ListDeployments
 #[derive(Debug, PartialEq)]
 pub enum ListDeploymentsError {
@@ -5518,16 +5292,12 @@ impl ListDeploymentsError {
 }
 impl fmt::Display for ListDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeploymentsError::BadRequest(ref cause) => cause,
+            ListDeploymentsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeploymentsError {}
 /// Errors returned by ListDeviceDefinitionVersions
 #[derive(Debug, PartialEq)]
 pub enum ListDeviceDefinitionVersionsError {
@@ -5555,16 +5325,12 @@ impl ListDeviceDefinitionVersionsError {
 }
 impl fmt::Display for ListDeviceDefinitionVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeviceDefinitionVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeviceDefinitionVersionsError::BadRequest(ref cause) => cause,
+            ListDeviceDefinitionVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeviceDefinitionVersionsError {}
 /// Errors returned by ListDeviceDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListDeviceDefinitionsError {}
@@ -5582,14 +5348,10 @@ impl ListDeviceDefinitionsError {
 }
 impl fmt::Display for ListDeviceDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeviceDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListDeviceDefinitionsError {}
 /// Errors returned by ListFunctionDefinitionVersions
 #[derive(Debug, PartialEq)]
 pub enum ListFunctionDefinitionVersionsError {
@@ -5617,16 +5379,12 @@ impl ListFunctionDefinitionVersionsError {
 }
 impl fmt::Display for ListFunctionDefinitionVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFunctionDefinitionVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFunctionDefinitionVersionsError::BadRequest(ref cause) => cause,
+            ListFunctionDefinitionVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFunctionDefinitionVersionsError {}
 /// Errors returned by ListFunctionDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListFunctionDefinitionsError {}
@@ -5644,14 +5402,10 @@ impl ListFunctionDefinitionsError {
 }
 impl fmt::Display for ListFunctionDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFunctionDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListFunctionDefinitionsError {}
 /// Errors returned by ListGroupCertificateAuthorities
 #[derive(Debug, PartialEq)]
 pub enum ListGroupCertificateAuthoritiesError {
@@ -5686,17 +5440,15 @@ impl ListGroupCertificateAuthoritiesError {
 }
 impl fmt::Display for ListGroupCertificateAuthoritiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupCertificateAuthoritiesError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupCertificateAuthoritiesError::BadRequest(ref cause) => cause,
-            ListGroupCertificateAuthoritiesError::InternalServerError(ref cause) => cause,
+            ListGroupCertificateAuthoritiesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListGroupCertificateAuthoritiesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListGroupCertificateAuthoritiesError {}
 /// Errors returned by ListGroupVersions
 #[derive(Debug, PartialEq)]
 pub enum ListGroupVersionsError {
@@ -5720,16 +5472,12 @@ impl ListGroupVersionsError {
 }
 impl fmt::Display for ListGroupVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupVersionsError::BadRequest(ref cause) => cause,
+            ListGroupVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupVersionsError {}
 /// Errors returned by ListGroups
 #[derive(Debug, PartialEq)]
 pub enum ListGroupsError {}
@@ -5747,14 +5495,10 @@ impl ListGroupsError {
 }
 impl fmt::Display for ListGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListGroupsError {}
 /// Errors returned by ListLoggerDefinitionVersions
 #[derive(Debug, PartialEq)]
 pub enum ListLoggerDefinitionVersionsError {
@@ -5782,16 +5526,12 @@ impl ListLoggerDefinitionVersionsError {
 }
 impl fmt::Display for ListLoggerDefinitionVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLoggerDefinitionVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLoggerDefinitionVersionsError::BadRequest(ref cause) => cause,
+            ListLoggerDefinitionVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLoggerDefinitionVersionsError {}
 /// Errors returned by ListLoggerDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListLoggerDefinitionsError {}
@@ -5809,14 +5549,10 @@ impl ListLoggerDefinitionsError {
 }
 impl fmt::Display for ListLoggerDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLoggerDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListLoggerDefinitionsError {}
 /// Errors returned by ListResourceDefinitionVersions
 #[derive(Debug, PartialEq)]
 pub enum ListResourceDefinitionVersionsError {
@@ -5844,16 +5580,12 @@ impl ListResourceDefinitionVersionsError {
 }
 impl fmt::Display for ListResourceDefinitionVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceDefinitionVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceDefinitionVersionsError::BadRequest(ref cause) => cause,
+            ListResourceDefinitionVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourceDefinitionVersionsError {}
 /// Errors returned by ListResourceDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListResourceDefinitionsError {}
@@ -5871,14 +5603,10 @@ impl ListResourceDefinitionsError {
 }
 impl fmt::Display for ListResourceDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListResourceDefinitionsError {}
 /// Errors returned by ListSubscriptionDefinitionVersions
 #[derive(Debug, PartialEq)]
 pub enum ListSubscriptionDefinitionVersionsError {
@@ -5906,16 +5634,14 @@ impl ListSubscriptionDefinitionVersionsError {
 }
 impl fmt::Display for ListSubscriptionDefinitionVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSubscriptionDefinitionVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSubscriptionDefinitionVersionsError::BadRequest(ref cause) => cause,
+            ListSubscriptionDefinitionVersionsError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListSubscriptionDefinitionVersionsError {}
 /// Errors returned by ListSubscriptionDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListSubscriptionDefinitionsError {}
@@ -5935,14 +5661,10 @@ impl ListSubscriptionDefinitionsError {
 }
 impl fmt::Display for ListSubscriptionDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSubscriptionDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListSubscriptionDefinitionsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -5966,16 +5688,12 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ResetDeployments
 #[derive(Debug, PartialEq)]
 pub enum ResetDeploymentsError {
@@ -5999,16 +5717,12 @@ impl ResetDeploymentsError {
 }
 impl fmt::Display for ResetDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            ResetDeploymentsError::BadRequest(ref cause) => cause,
+            ResetDeploymentsError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetDeploymentsError {}
 /// Errors returned by StartBulkDeployment
 #[derive(Debug, PartialEq)]
 pub enum StartBulkDeploymentError {
@@ -6032,16 +5746,12 @@ impl StartBulkDeploymentError {
 }
 impl fmt::Display for StartBulkDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartBulkDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            StartBulkDeploymentError::BadRequest(ref cause) => cause,
+            StartBulkDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartBulkDeploymentError {}
 /// Errors returned by StopBulkDeployment
 #[derive(Debug, PartialEq)]
 pub enum StopBulkDeploymentError {
@@ -6065,16 +5775,12 @@ impl StopBulkDeploymentError {
 }
 impl fmt::Display for StopBulkDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopBulkDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            StopBulkDeploymentError::BadRequest(ref cause) => cause,
+            StopBulkDeploymentError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopBulkDeploymentError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -6098,16 +5804,12 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -6131,16 +5833,12 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateConnectivityInfo
 #[derive(Debug, PartialEq)]
 pub enum UpdateConnectivityInfoError {
@@ -6171,17 +5869,13 @@ impl UpdateConnectivityInfoError {
 }
 impl fmt::Display for UpdateConnectivityInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConnectivityInfoError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConnectivityInfoError::BadRequest(ref cause) => cause,
-            UpdateConnectivityInfoError::InternalServerError(ref cause) => cause,
+            UpdateConnectivityInfoError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateConnectivityInfoError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConnectivityInfoError {}
 /// Errors returned by UpdateConnectorDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateConnectorDefinitionError {
@@ -6207,16 +5901,12 @@ impl UpdateConnectorDefinitionError {
 }
 impl fmt::Display for UpdateConnectorDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConnectorDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConnectorDefinitionError::BadRequest(ref cause) => cause,
+            UpdateConnectorDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConnectorDefinitionError {}
 /// Errors returned by UpdateCoreDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateCoreDefinitionError {
@@ -6240,16 +5930,12 @@ impl UpdateCoreDefinitionError {
 }
 impl fmt::Display for UpdateCoreDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCoreDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCoreDefinitionError::BadRequest(ref cause) => cause,
+            UpdateCoreDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCoreDefinitionError {}
 /// Errors returned by UpdateDeviceDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeviceDefinitionError {
@@ -6273,16 +5959,12 @@ impl UpdateDeviceDefinitionError {
 }
 impl fmt::Display for UpdateDeviceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeviceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeviceDefinitionError::BadRequest(ref cause) => cause,
+            UpdateDeviceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDeviceDefinitionError {}
 /// Errors returned by UpdateFunctionDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateFunctionDefinitionError {
@@ -6306,16 +5988,12 @@ impl UpdateFunctionDefinitionError {
 }
 impl fmt::Display for UpdateFunctionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFunctionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFunctionDefinitionError::BadRequest(ref cause) => cause,
+            UpdateFunctionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFunctionDefinitionError {}
 /// Errors returned by UpdateGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateGroupError {
@@ -6339,16 +6017,12 @@ impl UpdateGroupError {
 }
 impl fmt::Display for UpdateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGroupError::BadRequest(ref cause) => cause,
+            UpdateGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGroupError {}
 /// Errors returned by UpdateGroupCertificateConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateGroupCertificateConfigurationError {
@@ -6383,17 +6057,17 @@ impl UpdateGroupCertificateConfigurationError {
 }
 impl fmt::Display for UpdateGroupCertificateConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGroupCertificateConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGroupCertificateConfigurationError::BadRequest(ref cause) => cause,
-            UpdateGroupCertificateConfigurationError::InternalServerError(ref cause) => cause,
+            UpdateGroupCertificateConfigurationError::BadRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateGroupCertificateConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateGroupCertificateConfigurationError {}
 /// Errors returned by UpdateLoggerDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateLoggerDefinitionError {
@@ -6417,16 +6091,12 @@ impl UpdateLoggerDefinitionError {
 }
 impl fmt::Display for UpdateLoggerDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLoggerDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLoggerDefinitionError::BadRequest(ref cause) => cause,
+            UpdateLoggerDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLoggerDefinitionError {}
 /// Errors returned by UpdateResourceDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateResourceDefinitionError {
@@ -6450,16 +6120,12 @@ impl UpdateResourceDefinitionError {
 }
 impl fmt::Display for UpdateResourceDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateResourceDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateResourceDefinitionError::BadRequest(ref cause) => cause,
+            UpdateResourceDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateResourceDefinitionError {}
 /// Errors returned by UpdateSubscriptionDefinition
 #[derive(Debug, PartialEq)]
 pub enum UpdateSubscriptionDefinitionError {
@@ -6487,16 +6153,12 @@ impl UpdateSubscriptionDefinitionError {
 }
 impl fmt::Display for UpdateSubscriptionDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSubscriptionDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSubscriptionDefinitionError::BadRequest(ref cause) => cause,
+            UpdateSubscriptionDefinitionError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSubscriptionDefinitionError {}
 /// Trait representing the capabilities of the AWS Greengrass API. AWS Greengrass clients implement this trait.
 pub trait GreenGrass {
     /// <p>Associates a role with a group. Your Greengrass core will use the role to access AWS cloud services. The role&#39;s permissions should allow Greengrass core Lambda functions to perform actions against the cloud.</p>

--- a/rusoto/services/guardduty/src/generated.rs
+++ b/rusoto/services/guardduty/src/generated.rs
@@ -1931,17 +1931,13 @@ impl AcceptInvitationError {
 }
 impl fmt::Display for AcceptInvitationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptInvitationError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptInvitationError::BadRequest(ref cause) => cause,
-            AcceptInvitationError::InternalServerError(ref cause) => cause,
+            AcceptInvitationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            AcceptInvitationError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptInvitationError {}
 /// Errors returned by ArchiveFindings
 #[derive(Debug, PartialEq)]
 pub enum ArchiveFindingsError {
@@ -1970,17 +1966,13 @@ impl ArchiveFindingsError {
 }
 impl fmt::Display for ArchiveFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ArchiveFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            ArchiveFindingsError::BadRequest(ref cause) => cause,
-            ArchiveFindingsError::InternalServerError(ref cause) => cause,
+            ArchiveFindingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ArchiveFindingsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ArchiveFindingsError {}
 /// Errors returned by CreateDetector
 #[derive(Debug, PartialEq)]
 pub enum CreateDetectorError {
@@ -2009,17 +2001,13 @@ impl CreateDetectorError {
 }
 impl fmt::Display for CreateDetectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDetectorError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDetectorError::BadRequest(ref cause) => cause,
-            CreateDetectorError::InternalServerError(ref cause) => cause,
+            CreateDetectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateDetectorError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDetectorError {}
 /// Errors returned by CreateFilter
 #[derive(Debug, PartialEq)]
 pub enum CreateFilterError {
@@ -2048,17 +2036,13 @@ impl CreateFilterError {
 }
 impl fmt::Display for CreateFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFilterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFilterError::BadRequest(ref cause) => cause,
-            CreateFilterError::InternalServerError(ref cause) => cause,
+            CreateFilterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateFilterError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFilterError {}
 /// Errors returned by CreateIPSet
 #[derive(Debug, PartialEq)]
 pub enum CreateIPSetError {
@@ -2087,17 +2071,13 @@ impl CreateIPSetError {
 }
 impl fmt::Display for CreateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIPSetError::BadRequest(ref cause) => cause,
-            CreateIPSetError::InternalServerError(ref cause) => cause,
+            CreateIPSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIPSetError {}
 /// Errors returned by CreateMembers
 #[derive(Debug, PartialEq)]
 pub enum CreateMembersError {
@@ -2126,17 +2106,13 @@ impl CreateMembersError {
 }
 impl fmt::Display for CreateMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMembersError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMembersError::BadRequest(ref cause) => cause,
-            CreateMembersError::InternalServerError(ref cause) => cause,
+            CreateMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMembersError {}
 /// Errors returned by CreatePublishingDestination
 #[derive(Debug, PartialEq)]
 pub enum CreatePublishingDestinationError {
@@ -2171,17 +2147,15 @@ impl CreatePublishingDestinationError {
 }
 impl fmt::Display for CreatePublishingDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePublishingDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePublishingDestinationError::BadRequest(ref cause) => cause,
-            CreatePublishingDestinationError::InternalServerError(ref cause) => cause,
+            CreatePublishingDestinationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreatePublishingDestinationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreatePublishingDestinationError {}
 /// Errors returned by CreateSampleFindings
 #[derive(Debug, PartialEq)]
 pub enum CreateSampleFindingsError {
@@ -2212,17 +2186,13 @@ impl CreateSampleFindingsError {
 }
 impl fmt::Display for CreateSampleFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSampleFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSampleFindingsError::BadRequest(ref cause) => cause,
-            CreateSampleFindingsError::InternalServerError(ref cause) => cause,
+            CreateSampleFindingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateSampleFindingsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSampleFindingsError {}
 /// Errors returned by CreateThreatIntelSet
 #[derive(Debug, PartialEq)]
 pub enum CreateThreatIntelSetError {
@@ -2253,17 +2223,13 @@ impl CreateThreatIntelSetError {
 }
 impl fmt::Display for CreateThreatIntelSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateThreatIntelSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateThreatIntelSetError::BadRequest(ref cause) => cause,
-            CreateThreatIntelSetError::InternalServerError(ref cause) => cause,
+            CreateThreatIntelSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateThreatIntelSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateThreatIntelSetError {}
 /// Errors returned by DeclineInvitations
 #[derive(Debug, PartialEq)]
 pub enum DeclineInvitationsError {
@@ -2294,17 +2260,13 @@ impl DeclineInvitationsError {
 }
 impl fmt::Display for DeclineInvitationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeclineInvitationsError {
-    fn description(&self) -> &str {
         match *self {
-            DeclineInvitationsError::BadRequest(ref cause) => cause,
-            DeclineInvitationsError::InternalServerError(ref cause) => cause,
+            DeclineInvitationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeclineInvitationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeclineInvitationsError {}
 /// Errors returned by DeleteDetector
 #[derive(Debug, PartialEq)]
 pub enum DeleteDetectorError {
@@ -2333,17 +2295,13 @@ impl DeleteDetectorError {
 }
 impl fmt::Display for DeleteDetectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDetectorError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDetectorError::BadRequest(ref cause) => cause,
-            DeleteDetectorError::InternalServerError(ref cause) => cause,
+            DeleteDetectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDetectorError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDetectorError {}
 /// Errors returned by DeleteFilter
 #[derive(Debug, PartialEq)]
 pub enum DeleteFilterError {
@@ -2372,17 +2330,13 @@ impl DeleteFilterError {
 }
 impl fmt::Display for DeleteFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFilterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFilterError::BadRequest(ref cause) => cause,
-            DeleteFilterError::InternalServerError(ref cause) => cause,
+            DeleteFilterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteFilterError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFilterError {}
 /// Errors returned by DeleteIPSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteIPSetError {
@@ -2411,17 +2365,13 @@ impl DeleteIPSetError {
 }
 impl fmt::Display for DeleteIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIPSetError::BadRequest(ref cause) => cause,
-            DeleteIPSetError::InternalServerError(ref cause) => cause,
+            DeleteIPSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIPSetError {}
 /// Errors returned by DeleteInvitations
 #[derive(Debug, PartialEq)]
 pub enum DeleteInvitationsError {
@@ -2452,17 +2402,13 @@ impl DeleteInvitationsError {
 }
 impl fmt::Display for DeleteInvitationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInvitationsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInvitationsError::BadRequest(ref cause) => cause,
-            DeleteInvitationsError::InternalServerError(ref cause) => cause,
+            DeleteInvitationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteInvitationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInvitationsError {}
 /// Errors returned by DeleteMembers
 #[derive(Debug, PartialEq)]
 pub enum DeleteMembersError {
@@ -2491,17 +2437,13 @@ impl DeleteMembersError {
 }
 impl fmt::Display for DeleteMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMembersError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMembersError::BadRequest(ref cause) => cause,
-            DeleteMembersError::InternalServerError(ref cause) => cause,
+            DeleteMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMembersError {}
 /// Errors returned by DeletePublishingDestination
 #[derive(Debug, PartialEq)]
 pub enum DeletePublishingDestinationError {
@@ -2536,17 +2478,15 @@ impl DeletePublishingDestinationError {
 }
 impl fmt::Display for DeletePublishingDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePublishingDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePublishingDestinationError::BadRequest(ref cause) => cause,
-            DeletePublishingDestinationError::InternalServerError(ref cause) => cause,
+            DeletePublishingDestinationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeletePublishingDestinationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeletePublishingDestinationError {}
 /// Errors returned by DeleteThreatIntelSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteThreatIntelSetError {
@@ -2577,17 +2517,13 @@ impl DeleteThreatIntelSetError {
 }
 impl fmt::Display for DeleteThreatIntelSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteThreatIntelSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteThreatIntelSetError::BadRequest(ref cause) => cause,
-            DeleteThreatIntelSetError::InternalServerError(ref cause) => cause,
+            DeleteThreatIntelSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteThreatIntelSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteThreatIntelSetError {}
 /// Errors returned by DescribePublishingDestination
 #[derive(Debug, PartialEq)]
 pub enum DescribePublishingDestinationError {
@@ -2622,17 +2558,15 @@ impl DescribePublishingDestinationError {
 }
 impl fmt::Display for DescribePublishingDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePublishingDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePublishingDestinationError::BadRequest(ref cause) => cause,
-            DescribePublishingDestinationError::InternalServerError(ref cause) => cause,
+            DescribePublishingDestinationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribePublishingDestinationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePublishingDestinationError {}
 /// Errors returned by DisassociateFromMasterAccount
 #[derive(Debug, PartialEq)]
 pub enum DisassociateFromMasterAccountError {
@@ -2667,17 +2601,15 @@ impl DisassociateFromMasterAccountError {
 }
 impl fmt::Display for DisassociateFromMasterAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateFromMasterAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateFromMasterAccountError::BadRequest(ref cause) => cause,
-            DisassociateFromMasterAccountError::InternalServerError(ref cause) => cause,
+            DisassociateFromMasterAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DisassociateFromMasterAccountError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateFromMasterAccountError {}
 /// Errors returned by DisassociateMembers
 #[derive(Debug, PartialEq)]
 pub enum DisassociateMembersError {
@@ -2708,17 +2640,13 @@ impl DisassociateMembersError {
 }
 impl fmt::Display for DisassociateMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateMembersError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateMembersError::BadRequest(ref cause) => cause,
-            DisassociateMembersError::InternalServerError(ref cause) => cause,
+            DisassociateMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DisassociateMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateMembersError {}
 /// Errors returned by GetDetector
 #[derive(Debug, PartialEq)]
 pub enum GetDetectorError {
@@ -2747,17 +2675,13 @@ impl GetDetectorError {
 }
 impl fmt::Display for GetDetectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDetectorError {
-    fn description(&self) -> &str {
         match *self {
-            GetDetectorError::BadRequest(ref cause) => cause,
-            GetDetectorError::InternalServerError(ref cause) => cause,
+            GetDetectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetDetectorError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDetectorError {}
 /// Errors returned by GetFilter
 #[derive(Debug, PartialEq)]
 pub enum GetFilterError {
@@ -2786,17 +2710,13 @@ impl GetFilterError {
 }
 impl fmt::Display for GetFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFilterError {
-    fn description(&self) -> &str {
         match *self {
-            GetFilterError::BadRequest(ref cause) => cause,
-            GetFilterError::InternalServerError(ref cause) => cause,
+            GetFilterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetFilterError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFilterError {}
 /// Errors returned by GetFindings
 #[derive(Debug, PartialEq)]
 pub enum GetFindingsError {
@@ -2825,17 +2745,13 @@ impl GetFindingsError {
 }
 impl fmt::Display for GetFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetFindingsError::BadRequest(ref cause) => cause,
-            GetFindingsError::InternalServerError(ref cause) => cause,
+            GetFindingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetFindingsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFindingsError {}
 /// Errors returned by GetFindingsStatistics
 #[derive(Debug, PartialEq)]
 pub enum GetFindingsStatisticsError {
@@ -2866,17 +2782,13 @@ impl GetFindingsStatisticsError {
 }
 impl fmt::Display for GetFindingsStatisticsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFindingsStatisticsError {
-    fn description(&self) -> &str {
         match *self {
-            GetFindingsStatisticsError::BadRequest(ref cause) => cause,
-            GetFindingsStatisticsError::InternalServerError(ref cause) => cause,
+            GetFindingsStatisticsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetFindingsStatisticsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFindingsStatisticsError {}
 /// Errors returned by GetIPSet
 #[derive(Debug, PartialEq)]
 pub enum GetIPSetError {
@@ -2905,17 +2817,13 @@ impl GetIPSetError {
 }
 impl fmt::Display for GetIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetIPSetError::BadRequest(ref cause) => cause,
-            GetIPSetError::InternalServerError(ref cause) => cause,
+            GetIPSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetIPSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIPSetError {}
 /// Errors returned by GetInvitationsCount
 #[derive(Debug, PartialEq)]
 pub enum GetInvitationsCountError {
@@ -2946,17 +2854,13 @@ impl GetInvitationsCountError {
 }
 impl fmt::Display for GetInvitationsCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInvitationsCountError {
-    fn description(&self) -> &str {
         match *self {
-            GetInvitationsCountError::BadRequest(ref cause) => cause,
-            GetInvitationsCountError::InternalServerError(ref cause) => cause,
+            GetInvitationsCountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetInvitationsCountError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInvitationsCountError {}
 /// Errors returned by GetMasterAccount
 #[derive(Debug, PartialEq)]
 pub enum GetMasterAccountError {
@@ -2987,17 +2891,13 @@ impl GetMasterAccountError {
 }
 impl fmt::Display for GetMasterAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMasterAccountError {
-    fn description(&self) -> &str {
         match *self {
-            GetMasterAccountError::BadRequest(ref cause) => cause,
-            GetMasterAccountError::InternalServerError(ref cause) => cause,
+            GetMasterAccountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetMasterAccountError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMasterAccountError {}
 /// Errors returned by GetMembers
 #[derive(Debug, PartialEq)]
 pub enum GetMembersError {
@@ -3026,17 +2926,13 @@ impl GetMembersError {
 }
 impl fmt::Display for GetMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMembersError {
-    fn description(&self) -> &str {
         match *self {
-            GetMembersError::BadRequest(ref cause) => cause,
-            GetMembersError::InternalServerError(ref cause) => cause,
+            GetMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMembersError {}
 /// Errors returned by GetThreatIntelSet
 #[derive(Debug, PartialEq)]
 pub enum GetThreatIntelSetError {
@@ -3067,17 +2963,13 @@ impl GetThreatIntelSetError {
 }
 impl fmt::Display for GetThreatIntelSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetThreatIntelSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetThreatIntelSetError::BadRequest(ref cause) => cause,
-            GetThreatIntelSetError::InternalServerError(ref cause) => cause,
+            GetThreatIntelSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetThreatIntelSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetThreatIntelSetError {}
 /// Errors returned by InviteMembers
 #[derive(Debug, PartialEq)]
 pub enum InviteMembersError {
@@ -3106,17 +2998,13 @@ impl InviteMembersError {
 }
 impl fmt::Display for InviteMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InviteMembersError {
-    fn description(&self) -> &str {
         match *self {
-            InviteMembersError::BadRequest(ref cause) => cause,
-            InviteMembersError::InternalServerError(ref cause) => cause,
+            InviteMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            InviteMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InviteMembersError {}
 /// Errors returned by ListDetectors
 #[derive(Debug, PartialEq)]
 pub enum ListDetectorsError {
@@ -3145,17 +3033,13 @@ impl ListDetectorsError {
 }
 impl fmt::Display for ListDetectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDetectorsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDetectorsError::BadRequest(ref cause) => cause,
-            ListDetectorsError::InternalServerError(ref cause) => cause,
+            ListDetectorsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListDetectorsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDetectorsError {}
 /// Errors returned by ListFilters
 #[derive(Debug, PartialEq)]
 pub enum ListFiltersError {
@@ -3184,17 +3068,13 @@ impl ListFiltersError {
 }
 impl fmt::Display for ListFiltersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFiltersError {
-    fn description(&self) -> &str {
         match *self {
-            ListFiltersError::BadRequest(ref cause) => cause,
-            ListFiltersError::InternalServerError(ref cause) => cause,
+            ListFiltersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListFiltersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFiltersError {}
 /// Errors returned by ListFindings
 #[derive(Debug, PartialEq)]
 pub enum ListFindingsError {
@@ -3223,17 +3103,13 @@ impl ListFindingsError {
 }
 impl fmt::Display for ListFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFindingsError::BadRequest(ref cause) => cause,
-            ListFindingsError::InternalServerError(ref cause) => cause,
+            ListFindingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListFindingsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFindingsError {}
 /// Errors returned by ListIPSets
 #[derive(Debug, PartialEq)]
 pub enum ListIPSetsError {
@@ -3262,17 +3138,13 @@ impl ListIPSetsError {
 }
 impl fmt::Display for ListIPSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIPSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListIPSetsError::BadRequest(ref cause) => cause,
-            ListIPSetsError::InternalServerError(ref cause) => cause,
+            ListIPSetsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListIPSetsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIPSetsError {}
 /// Errors returned by ListInvitations
 #[derive(Debug, PartialEq)]
 pub enum ListInvitationsError {
@@ -3301,17 +3173,13 @@ impl ListInvitationsError {
 }
 impl fmt::Display for ListInvitationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInvitationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListInvitationsError::BadRequest(ref cause) => cause,
-            ListInvitationsError::InternalServerError(ref cause) => cause,
+            ListInvitationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListInvitationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInvitationsError {}
 /// Errors returned by ListMembers
 #[derive(Debug, PartialEq)]
 pub enum ListMembersError {
@@ -3340,17 +3208,13 @@ impl ListMembersError {
 }
 impl fmt::Display for ListMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMembersError {
-    fn description(&self) -> &str {
         match *self {
-            ListMembersError::BadRequest(ref cause) => cause,
-            ListMembersError::InternalServerError(ref cause) => cause,
+            ListMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMembersError {}
 /// Errors returned by ListPublishingDestinations
 #[derive(Debug, PartialEq)]
 pub enum ListPublishingDestinationsError {
@@ -3385,17 +3249,15 @@ impl ListPublishingDestinationsError {
 }
 impl fmt::Display for ListPublishingDestinationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPublishingDestinationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPublishingDestinationsError::BadRequest(ref cause) => cause,
-            ListPublishingDestinationsError::InternalServerError(ref cause) => cause,
+            ListPublishingDestinationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListPublishingDestinationsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListPublishingDestinationsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3426,17 +3288,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListThreatIntelSets
 #[derive(Debug, PartialEq)]
 pub enum ListThreatIntelSetsError {
@@ -3467,17 +3325,13 @@ impl ListThreatIntelSetsError {
 }
 impl fmt::Display for ListThreatIntelSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThreatIntelSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListThreatIntelSetsError::BadRequest(ref cause) => cause,
-            ListThreatIntelSetsError::InternalServerError(ref cause) => cause,
+            ListThreatIntelSetsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListThreatIntelSetsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThreatIntelSetsError {}
 /// Errors returned by StartMonitoringMembers
 #[derive(Debug, PartialEq)]
 pub enum StartMonitoringMembersError {
@@ -3508,17 +3362,13 @@ impl StartMonitoringMembersError {
 }
 impl fmt::Display for StartMonitoringMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMonitoringMembersError {
-    fn description(&self) -> &str {
         match *self {
-            StartMonitoringMembersError::BadRequest(ref cause) => cause,
-            StartMonitoringMembersError::InternalServerError(ref cause) => cause,
+            StartMonitoringMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartMonitoringMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMonitoringMembersError {}
 /// Errors returned by StopMonitoringMembers
 #[derive(Debug, PartialEq)]
 pub enum StopMonitoringMembersError {
@@ -3549,17 +3399,13 @@ impl StopMonitoringMembersError {
 }
 impl fmt::Display for StopMonitoringMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopMonitoringMembersError {
-    fn description(&self) -> &str {
         match *self {
-            StopMonitoringMembersError::BadRequest(ref cause) => cause,
-            StopMonitoringMembersError::InternalServerError(ref cause) => cause,
+            StopMonitoringMembersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StopMonitoringMembersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopMonitoringMembersError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3588,17 +3434,13 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::InternalServerError(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UnarchiveFindings
 #[derive(Debug, PartialEq)]
 pub enum UnarchiveFindingsError {
@@ -3629,17 +3471,13 @@ impl UnarchiveFindingsError {
 }
 impl fmt::Display for UnarchiveFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnarchiveFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            UnarchiveFindingsError::BadRequest(ref cause) => cause,
-            UnarchiveFindingsError::InternalServerError(ref cause) => cause,
+            UnarchiveFindingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UnarchiveFindingsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnarchiveFindingsError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3668,17 +3506,13 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::InternalServerError(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateDetector
 #[derive(Debug, PartialEq)]
 pub enum UpdateDetectorError {
@@ -3707,17 +3541,13 @@ impl UpdateDetectorError {
 }
 impl fmt::Display for UpdateDetectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDetectorError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDetectorError::BadRequest(ref cause) => cause,
-            UpdateDetectorError::InternalServerError(ref cause) => cause,
+            UpdateDetectorError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDetectorError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDetectorError {}
 /// Errors returned by UpdateFilter
 #[derive(Debug, PartialEq)]
 pub enum UpdateFilterError {
@@ -3746,17 +3576,13 @@ impl UpdateFilterError {
 }
 impl fmt::Display for UpdateFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFilterError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFilterError::BadRequest(ref cause) => cause,
-            UpdateFilterError::InternalServerError(ref cause) => cause,
+            UpdateFilterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFilterError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFilterError {}
 /// Errors returned by UpdateFindingsFeedback
 #[derive(Debug, PartialEq)]
 pub enum UpdateFindingsFeedbackError {
@@ -3787,17 +3613,13 @@ impl UpdateFindingsFeedbackError {
 }
 impl fmt::Display for UpdateFindingsFeedbackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFindingsFeedbackError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFindingsFeedbackError::BadRequest(ref cause) => cause,
-            UpdateFindingsFeedbackError::InternalServerError(ref cause) => cause,
+            UpdateFindingsFeedbackError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFindingsFeedbackError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFindingsFeedbackError {}
 /// Errors returned by UpdateIPSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateIPSetError {
@@ -3826,17 +3648,13 @@ impl UpdateIPSetError {
 }
 impl fmt::Display for UpdateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIPSetError::BadRequest(ref cause) => cause,
-            UpdateIPSetError::InternalServerError(ref cause) => cause,
+            UpdateIPSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIPSetError {}
 /// Errors returned by UpdatePublishingDestination
 #[derive(Debug, PartialEq)]
 pub enum UpdatePublishingDestinationError {
@@ -3871,17 +3689,15 @@ impl UpdatePublishingDestinationError {
 }
 impl fmt::Display for UpdatePublishingDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePublishingDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePublishingDestinationError::BadRequest(ref cause) => cause,
-            UpdatePublishingDestinationError::InternalServerError(ref cause) => cause,
+            UpdatePublishingDestinationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdatePublishingDestinationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdatePublishingDestinationError {}
 /// Errors returned by UpdateThreatIntelSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateThreatIntelSetError {
@@ -3912,17 +3728,13 @@ impl UpdateThreatIntelSetError {
 }
 impl fmt::Display for UpdateThreatIntelSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateThreatIntelSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateThreatIntelSetError::BadRequest(ref cause) => cause,
-            UpdateThreatIntelSetError::InternalServerError(ref cause) => cause,
+            UpdateThreatIntelSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateThreatIntelSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateThreatIntelSetError {}
 /// Trait representing the capabilities of the Amazon GuardDuty API. Amazon GuardDuty clients implement this trait.
 pub trait GuardDuty {
     /// <p>Accepts the invitation to be monitored by a master GuardDuty account.</p>

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -488,17 +488,15 @@ impl DescribeAffectedEntitiesError {
 }
 impl fmt::Display for DescribeAffectedEntitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAffectedEntitiesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAffectedEntitiesError::InvalidPaginationToken(ref cause) => cause,
-            DescribeAffectedEntitiesError::UnsupportedLocale(ref cause) => cause,
+            DescribeAffectedEntitiesError::InvalidPaginationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAffectedEntitiesError::UnsupportedLocale(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAffectedEntitiesError {}
 /// Errors returned by DescribeEntityAggregates
 #[derive(Debug, PartialEq)]
 pub enum DescribeEntityAggregatesError {}
@@ -516,14 +514,10 @@ impl DescribeEntityAggregatesError {
 }
 impl fmt::Display for DescribeEntityAggregatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEntityAggregatesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEntityAggregatesError {}
 /// Errors returned by DescribeEventAggregates
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventAggregatesError {
@@ -549,16 +543,14 @@ impl DescribeEventAggregatesError {
 }
 impl fmt::Display for DescribeEventAggregatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventAggregatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventAggregatesError::InvalidPaginationToken(ref cause) => cause,
+            DescribeEventAggregatesError::InvalidPaginationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEventAggregatesError {}
 /// Errors returned by DescribeEventDetails
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventDetailsError {
@@ -584,16 +576,12 @@ impl DescribeEventDetailsError {
 }
 impl fmt::Display for DescribeEventDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventDetailsError::UnsupportedLocale(ref cause) => cause,
+            DescribeEventDetailsError::UnsupportedLocale(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventDetailsError {}
 /// Errors returned by DescribeEventTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventTypesError {
@@ -626,17 +614,13 @@ impl DescribeEventTypesError {
 }
 impl fmt::Display for DescribeEventTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventTypesError::InvalidPaginationToken(ref cause) => cause,
-            DescribeEventTypesError::UnsupportedLocale(ref cause) => cause,
+            DescribeEventTypesError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            DescribeEventTypesError::UnsupportedLocale(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventTypesError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {
@@ -667,17 +651,13 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventsError::InvalidPaginationToken(ref cause) => cause,
-            DescribeEventsError::UnsupportedLocale(ref cause) => cause,
+            DescribeEventsError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            DescribeEventsError::UnsupportedLocale(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventsError {}
 /// Trait representing the capabilities of the AWSHealth API. AWSHealth clients implement this trait.
 pub trait AWSHealth {
     /// <p>Returns a list of entities that have been affected by the specified events, based on the specified filter criteria. Entities can refer to individual customer resources, groups of customer resources, or any other construct, depending on the AWS service. Events that have impact beyond that of the affected entities, or where the extent of impact is unknown, include at least one entity indicating this.</p> <p>At least one event ARN is required. Results are sorted by the <code>lastUpdatedTime</code> of the entity, starting with the most recent.</p>

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -11001,19 +11001,23 @@ impl AddClientIDToOpenIDConnectProviderError {
 }
 impl fmt::Display for AddClientIDToOpenIDConnectProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddClientIDToOpenIDConnectProviderError {
-    fn description(&self) -> &str {
         match *self {
-            AddClientIDToOpenIDConnectProviderError::InvalidInput(ref cause) => cause,
-            AddClientIDToOpenIDConnectProviderError::LimitExceeded(ref cause) => cause,
-            AddClientIDToOpenIDConnectProviderError::NoSuchEntity(ref cause) => cause,
-            AddClientIDToOpenIDConnectProviderError::ServiceFailure(ref cause) => cause,
+            AddClientIDToOpenIDConnectProviderError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddClientIDToOpenIDConnectProviderError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddClientIDToOpenIDConnectProviderError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddClientIDToOpenIDConnectProviderError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddClientIDToOpenIDConnectProviderError {}
 /// Errors returned by AddRoleToInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum AddRoleToInstanceProfileError {
@@ -11081,20 +11085,16 @@ impl AddRoleToInstanceProfileError {
 }
 impl fmt::Display for AddRoleToInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddRoleToInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            AddRoleToInstanceProfileError::EntityAlreadyExists(ref cause) => cause,
-            AddRoleToInstanceProfileError::LimitExceeded(ref cause) => cause,
-            AddRoleToInstanceProfileError::NoSuchEntity(ref cause) => cause,
-            AddRoleToInstanceProfileError::ServiceFailure(ref cause) => cause,
-            AddRoleToInstanceProfileError::UnmodifiableEntity(ref cause) => cause,
+            AddRoleToInstanceProfileError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            AddRoleToInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddRoleToInstanceProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            AddRoleToInstanceProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            AddRoleToInstanceProfileError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddRoleToInstanceProfileError {}
 /// Errors returned by AddUserToGroup
 #[derive(Debug, PartialEq)]
 pub enum AddUserToGroupError {
@@ -11146,18 +11146,14 @@ impl AddUserToGroupError {
 }
 impl fmt::Display for AddUserToGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddUserToGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AddUserToGroupError::LimitExceeded(ref cause) => cause,
-            AddUserToGroupError::NoSuchEntity(ref cause) => cause,
-            AddUserToGroupError::ServiceFailure(ref cause) => cause,
+            AddUserToGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddUserToGroupError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            AddUserToGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddUserToGroupError {}
 /// Errors returned by AttachGroupPolicy
 #[derive(Debug, PartialEq)]
 pub enum AttachGroupPolicyError {
@@ -11223,20 +11219,16 @@ impl AttachGroupPolicyError {
 }
 impl fmt::Display for AttachGroupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachGroupPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            AttachGroupPolicyError::InvalidInput(ref cause) => cause,
-            AttachGroupPolicyError::LimitExceeded(ref cause) => cause,
-            AttachGroupPolicyError::NoSuchEntity(ref cause) => cause,
-            AttachGroupPolicyError::PolicyNotAttachable(ref cause) => cause,
-            AttachGroupPolicyError::ServiceFailure(ref cause) => cause,
+            AttachGroupPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AttachGroupPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachGroupPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            AttachGroupPolicyError::PolicyNotAttachable(ref cause) => write!(f, "{}", cause),
+            AttachGroupPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachGroupPolicyError {}
 /// Errors returned by AttachRolePolicy
 #[derive(Debug, PartialEq)]
 pub enum AttachRolePolicyError {
@@ -11309,21 +11301,17 @@ impl AttachRolePolicyError {
 }
 impl fmt::Display for AttachRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachRolePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            AttachRolePolicyError::InvalidInput(ref cause) => cause,
-            AttachRolePolicyError::LimitExceeded(ref cause) => cause,
-            AttachRolePolicyError::NoSuchEntity(ref cause) => cause,
-            AttachRolePolicyError::PolicyNotAttachable(ref cause) => cause,
-            AttachRolePolicyError::ServiceFailure(ref cause) => cause,
-            AttachRolePolicyError::UnmodifiableEntity(ref cause) => cause,
+            AttachRolePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AttachRolePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachRolePolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            AttachRolePolicyError::PolicyNotAttachable(ref cause) => write!(f, "{}", cause),
+            AttachRolePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            AttachRolePolicyError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachRolePolicyError {}
 /// Errors returned by AttachUserPolicy
 #[derive(Debug, PartialEq)]
 pub enum AttachUserPolicyError {
@@ -11389,20 +11377,16 @@ impl AttachUserPolicyError {
 }
 impl fmt::Display for AttachUserPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachUserPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            AttachUserPolicyError::InvalidInput(ref cause) => cause,
-            AttachUserPolicyError::LimitExceeded(ref cause) => cause,
-            AttachUserPolicyError::NoSuchEntity(ref cause) => cause,
-            AttachUserPolicyError::PolicyNotAttachable(ref cause) => cause,
-            AttachUserPolicyError::ServiceFailure(ref cause) => cause,
+            AttachUserPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AttachUserPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachUserPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            AttachUserPolicyError::PolicyNotAttachable(ref cause) => write!(f, "{}", cause),
+            AttachUserPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachUserPolicyError {}
 /// Errors returned by ChangePassword
 #[derive(Debug, PartialEq)]
 pub enum ChangePasswordError {
@@ -11477,21 +11461,17 @@ impl ChangePasswordError {
 }
 impl fmt::Display for ChangePasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ChangePasswordError {
-    fn description(&self) -> &str {
         match *self {
-            ChangePasswordError::EntityTemporarilyUnmodifiable(ref cause) => cause,
-            ChangePasswordError::InvalidUserType(ref cause) => cause,
-            ChangePasswordError::LimitExceeded(ref cause) => cause,
-            ChangePasswordError::NoSuchEntity(ref cause) => cause,
-            ChangePasswordError::PasswordPolicyViolation(ref cause) => cause,
-            ChangePasswordError::ServiceFailure(ref cause) => cause,
+            ChangePasswordError::EntityTemporarilyUnmodifiable(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::InvalidUserType(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::PasswordPolicyViolation(ref cause) => write!(f, "{}", cause),
+            ChangePasswordError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ChangePasswordError {}
 /// Errors returned by CreateAccessKey
 #[derive(Debug, PartialEq)]
 pub enum CreateAccessKeyError {
@@ -11543,18 +11523,14 @@ impl CreateAccessKeyError {
 }
 impl fmt::Display for CreateAccessKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAccessKeyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAccessKeyError::LimitExceeded(ref cause) => cause,
-            CreateAccessKeyError::NoSuchEntity(ref cause) => cause,
-            CreateAccessKeyError::ServiceFailure(ref cause) => cause,
+            CreateAccessKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAccessKeyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateAccessKeyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAccessKeyError {}
 /// Errors returned by CreateAccountAlias
 #[derive(Debug, PartialEq)]
 pub enum CreateAccountAliasError {
@@ -11606,18 +11582,14 @@ impl CreateAccountAliasError {
 }
 impl fmt::Display for CreateAccountAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAccountAliasError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAccountAliasError::EntityAlreadyExists(ref cause) => cause,
-            CreateAccountAliasError::LimitExceeded(ref cause) => cause,
-            CreateAccountAliasError::ServiceFailure(ref cause) => cause,
+            CreateAccountAliasError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateAccountAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAccountAliasError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAccountAliasError {}
 /// Errors returned by CreateGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupError {
@@ -11676,19 +11648,15 @@ impl CreateGroupError {
 }
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupError::EntityAlreadyExists(ref cause) => cause,
-            CreateGroupError::LimitExceeded(ref cause) => cause,
-            CreateGroupError::NoSuchEntity(ref cause) => cause,
-            CreateGroupError::ServiceFailure(ref cause) => cause,
+            CreateGroupError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGroupError {}
 /// Errors returned by CreateInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateInstanceProfileError {
@@ -11740,18 +11708,14 @@ impl CreateInstanceProfileError {
 }
 impl fmt::Display for CreateInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInstanceProfileError::EntityAlreadyExists(ref cause) => cause,
-            CreateInstanceProfileError::LimitExceeded(ref cause) => cause,
-            CreateInstanceProfileError::ServiceFailure(ref cause) => cause,
+            CreateInstanceProfileError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateInstanceProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInstanceProfileError {}
 /// Errors returned by CreateLoginProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateLoginProfileError {
@@ -11817,20 +11781,16 @@ impl CreateLoginProfileError {
 }
 impl fmt::Display for CreateLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoginProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoginProfileError::EntityAlreadyExists(ref cause) => cause,
-            CreateLoginProfileError::LimitExceeded(ref cause) => cause,
-            CreateLoginProfileError::NoSuchEntity(ref cause) => cause,
-            CreateLoginProfileError::PasswordPolicyViolation(ref cause) => cause,
-            CreateLoginProfileError::ServiceFailure(ref cause) => cause,
+            CreateLoginProfileError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateLoginProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateLoginProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateLoginProfileError::PasswordPolicyViolation(ref cause) => write!(f, "{}", cause),
+            CreateLoginProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLoginProfileError {}
 /// Errors returned by CreateOpenIDConnectProvider
 #[derive(Debug, PartialEq)]
 pub enum CreateOpenIDConnectProviderError {
@@ -11893,19 +11853,17 @@ impl CreateOpenIDConnectProviderError {
 }
 impl fmt::Display for CreateOpenIDConnectProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOpenIDConnectProviderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOpenIDConnectProviderError::EntityAlreadyExists(ref cause) => cause,
-            CreateOpenIDConnectProviderError::InvalidInput(ref cause) => cause,
-            CreateOpenIDConnectProviderError::LimitExceeded(ref cause) => cause,
-            CreateOpenIDConnectProviderError::ServiceFailure(ref cause) => cause,
+            CreateOpenIDConnectProviderError::EntityAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateOpenIDConnectProviderError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateOpenIDConnectProviderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateOpenIDConnectProviderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateOpenIDConnectProviderError {}
 /// Errors returned by CreatePolicy
 #[derive(Debug, PartialEq)]
 pub enum CreatePolicyError {
@@ -11971,20 +11929,16 @@ impl CreatePolicyError {
 }
 impl fmt::Display for CreatePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePolicyError::EntityAlreadyExists(ref cause) => cause,
-            CreatePolicyError::InvalidInput(ref cause) => cause,
-            CreatePolicyError::LimitExceeded(ref cause) => cause,
-            CreatePolicyError::MalformedPolicyDocument(ref cause) => cause,
-            CreatePolicyError::ServiceFailure(ref cause) => cause,
+            CreatePolicyError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePolicyError {}
 /// Errors returned by CreatePolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum CreatePolicyVersionError {
@@ -12050,20 +12004,16 @@ impl CreatePolicyVersionError {
 }
 impl fmt::Display for CreatePolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePolicyVersionError::InvalidInput(ref cause) => cause,
-            CreatePolicyVersionError::LimitExceeded(ref cause) => cause,
-            CreatePolicyVersionError::MalformedPolicyDocument(ref cause) => cause,
-            CreatePolicyVersionError::NoSuchEntity(ref cause) => cause,
-            CreatePolicyVersionError::ServiceFailure(ref cause) => cause,
+            CreatePolicyVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePolicyVersionError {}
 /// Errors returned by CreateRole
 #[derive(Debug, PartialEq)]
 pub enum CreateRoleError {
@@ -12136,21 +12086,17 @@ impl CreateRoleError {
 }
 impl fmt::Display for CreateRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRoleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRoleError::ConcurrentModification(ref cause) => cause,
-            CreateRoleError::EntityAlreadyExists(ref cause) => cause,
-            CreateRoleError::InvalidInput(ref cause) => cause,
-            CreateRoleError::LimitExceeded(ref cause) => cause,
-            CreateRoleError::MalformedPolicyDocument(ref cause) => cause,
-            CreateRoleError::ServiceFailure(ref cause) => cause,
+            CreateRoleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateRoleError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateRoleError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateRoleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRoleError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            CreateRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRoleError {}
 /// Errors returned by CreateSAMLProvider
 #[derive(Debug, PartialEq)]
 pub enum CreateSAMLProviderError {
@@ -12209,19 +12155,15 @@ impl CreateSAMLProviderError {
 }
 impl fmt::Display for CreateSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSAMLProviderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSAMLProviderError::EntityAlreadyExists(ref cause) => cause,
-            CreateSAMLProviderError::InvalidInput(ref cause) => cause,
-            CreateSAMLProviderError::LimitExceeded(ref cause) => cause,
-            CreateSAMLProviderError::ServiceFailure(ref cause) => cause,
+            CreateSAMLProviderError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateSAMLProviderError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateSAMLProviderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSAMLProviderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSAMLProviderError {}
 /// Errors returned by CreateServiceLinkedRole
 #[derive(Debug, PartialEq)]
 pub enum CreateServiceLinkedRoleError {
@@ -12280,19 +12222,15 @@ impl CreateServiceLinkedRoleError {
 }
 impl fmt::Display for CreateServiceLinkedRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateServiceLinkedRoleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateServiceLinkedRoleError::InvalidInput(ref cause) => cause,
-            CreateServiceLinkedRoleError::LimitExceeded(ref cause) => cause,
-            CreateServiceLinkedRoleError::NoSuchEntity(ref cause) => cause,
-            CreateServiceLinkedRoleError::ServiceFailure(ref cause) => cause,
+            CreateServiceLinkedRoleError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateServiceLinkedRoleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateServiceLinkedRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateServiceLinkedRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateServiceLinkedRoleError {}
 /// Errors returned by CreateServiceSpecificCredential
 #[derive(Debug, PartialEq)]
 pub enum CreateServiceSpecificCredentialError {
@@ -12352,18 +12290,18 @@ impl CreateServiceSpecificCredentialError {
 }
 impl fmt::Display for CreateServiceSpecificCredentialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateServiceSpecificCredentialError {
-    fn description(&self) -> &str {
         match *self {
-            CreateServiceSpecificCredentialError::LimitExceeded(ref cause) => cause,
-            CreateServiceSpecificCredentialError::NoSuchEntity(ref cause) => cause,
-            CreateServiceSpecificCredentialError::ServiceNotSupported(ref cause) => cause,
+            CreateServiceSpecificCredentialError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateServiceSpecificCredentialError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateServiceSpecificCredentialError::ServiceNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateServiceSpecificCredentialError {}
 /// Errors returned by CreateUser
 #[derive(Debug, PartialEq)]
 pub enum CreateUserError {
@@ -12436,21 +12374,17 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::ConcurrentModification(ref cause) => cause,
-            CreateUserError::EntityAlreadyExists(ref cause) => cause,
-            CreateUserError::InvalidInput(ref cause) => cause,
-            CreateUserError::LimitExceeded(ref cause) => cause,
-            CreateUserError::NoSuchEntity(ref cause) => cause,
-            CreateUserError::ServiceFailure(ref cause) => cause,
+            CreateUserError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateUserError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateUserError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateUserError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by CreateVirtualMFADevice
 #[derive(Debug, PartialEq)]
 pub enum CreateVirtualMFADeviceError {
@@ -12502,18 +12436,14 @@ impl CreateVirtualMFADeviceError {
 }
 impl fmt::Display for CreateVirtualMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVirtualMFADeviceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVirtualMFADeviceError::EntityAlreadyExists(ref cause) => cause,
-            CreateVirtualMFADeviceError::LimitExceeded(ref cause) => cause,
-            CreateVirtualMFADeviceError::ServiceFailure(ref cause) => cause,
+            CreateVirtualMFADeviceError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateVirtualMFADeviceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateVirtualMFADeviceError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVirtualMFADeviceError {}
 /// Errors returned by DeactivateMFADevice
 #[derive(Debug, PartialEq)]
 pub enum DeactivateMFADeviceError {
@@ -12574,19 +12504,17 @@ impl DeactivateMFADeviceError {
 }
 impl fmt::Display for DeactivateMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeactivateMFADeviceError {
-    fn description(&self) -> &str {
         match *self {
-            DeactivateMFADeviceError::EntityTemporarilyUnmodifiable(ref cause) => cause,
-            DeactivateMFADeviceError::LimitExceeded(ref cause) => cause,
-            DeactivateMFADeviceError::NoSuchEntity(ref cause) => cause,
-            DeactivateMFADeviceError::ServiceFailure(ref cause) => cause,
+            DeactivateMFADeviceError::EntityTemporarilyUnmodifiable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeactivateMFADeviceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeactivateMFADeviceError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeactivateMFADeviceError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeactivateMFADeviceError {}
 /// Errors returned by DeleteAccessKey
 #[derive(Debug, PartialEq)]
 pub enum DeleteAccessKeyError {
@@ -12638,18 +12566,14 @@ impl DeleteAccessKeyError {
 }
 impl fmt::Display for DeleteAccessKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAccessKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAccessKeyError::LimitExceeded(ref cause) => cause,
-            DeleteAccessKeyError::NoSuchEntity(ref cause) => cause,
-            DeleteAccessKeyError::ServiceFailure(ref cause) => cause,
+            DeleteAccessKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteAccessKeyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteAccessKeyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAccessKeyError {}
 /// Errors returned by DeleteAccountAlias
 #[derive(Debug, PartialEq)]
 pub enum DeleteAccountAliasError {
@@ -12701,18 +12625,14 @@ impl DeleteAccountAliasError {
 }
 impl fmt::Display for DeleteAccountAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAccountAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAccountAliasError::LimitExceeded(ref cause) => cause,
-            DeleteAccountAliasError::NoSuchEntity(ref cause) => cause,
-            DeleteAccountAliasError::ServiceFailure(ref cause) => cause,
+            DeleteAccountAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteAccountAliasError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteAccountAliasError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAccountAliasError {}
 /// Errors returned by DeleteAccountPasswordPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteAccountPasswordPolicyError {
@@ -12766,18 +12686,14 @@ impl DeleteAccountPasswordPolicyError {
 }
 impl fmt::Display for DeleteAccountPasswordPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAccountPasswordPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAccountPasswordPolicyError::LimitExceeded(ref cause) => cause,
-            DeleteAccountPasswordPolicyError::NoSuchEntity(ref cause) => cause,
-            DeleteAccountPasswordPolicyError::ServiceFailure(ref cause) => cause,
+            DeleteAccountPasswordPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteAccountPasswordPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteAccountPasswordPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAccountPasswordPolicyError {}
 /// Errors returned by DeleteGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteGroupError {
@@ -12836,19 +12752,15 @@ impl DeleteGroupError {
 }
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGroupError::DeleteConflict(ref cause) => cause,
-            DeleteGroupError::LimitExceeded(ref cause) => cause,
-            DeleteGroupError::NoSuchEntity(ref cause) => cause,
-            DeleteGroupError::ServiceFailure(ref cause) => cause,
+            DeleteGroupError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGroupError {}
 /// Errors returned by DeleteGroupPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteGroupPolicyError {
@@ -12900,18 +12812,14 @@ impl DeleteGroupPolicyError {
 }
 impl fmt::Display for DeleteGroupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGroupPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGroupPolicyError::LimitExceeded(ref cause) => cause,
-            DeleteGroupPolicyError::NoSuchEntity(ref cause) => cause,
-            DeleteGroupPolicyError::ServiceFailure(ref cause) => cause,
+            DeleteGroupPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteGroupPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteGroupPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGroupPolicyError {}
 /// Errors returned by DeleteInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteInstanceProfileError {
@@ -12970,19 +12878,15 @@ impl DeleteInstanceProfileError {
 }
 impl fmt::Display for DeleteInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInstanceProfileError::DeleteConflict(ref cause) => cause,
-            DeleteInstanceProfileError::LimitExceeded(ref cause) => cause,
-            DeleteInstanceProfileError::NoSuchEntity(ref cause) => cause,
-            DeleteInstanceProfileError::ServiceFailure(ref cause) => cause,
+            DeleteInstanceProfileError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInstanceProfileError {}
 /// Errors returned by DeleteLoginProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoginProfileError {
@@ -13043,19 +12947,17 @@ impl DeleteLoginProfileError {
 }
 impl fmt::Display for DeleteLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoginProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoginProfileError::EntityTemporarilyUnmodifiable(ref cause) => cause,
-            DeleteLoginProfileError::LimitExceeded(ref cause) => cause,
-            DeleteLoginProfileError::NoSuchEntity(ref cause) => cause,
-            DeleteLoginProfileError::ServiceFailure(ref cause) => cause,
+            DeleteLoginProfileError::EntityTemporarilyUnmodifiable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLoginProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteLoginProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteLoginProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLoginProfileError {}
 /// Errors returned by DeleteOpenIDConnectProvider
 #[derive(Debug, PartialEq)]
 pub enum DeleteOpenIDConnectProviderError {
@@ -13109,18 +13011,14 @@ impl DeleteOpenIDConnectProviderError {
 }
 impl fmt::Display for DeleteOpenIDConnectProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOpenIDConnectProviderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteOpenIDConnectProviderError::InvalidInput(ref cause) => cause,
-            DeleteOpenIDConnectProviderError::NoSuchEntity(ref cause) => cause,
-            DeleteOpenIDConnectProviderError::ServiceFailure(ref cause) => cause,
+            DeleteOpenIDConnectProviderError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteOpenIDConnectProviderError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteOpenIDConnectProviderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteOpenIDConnectProviderError {}
 /// Errors returned by DeletePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeletePolicyError {
@@ -13186,20 +13084,16 @@ impl DeletePolicyError {
 }
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePolicyError::DeleteConflict(ref cause) => cause,
-            DeletePolicyError::InvalidInput(ref cause) => cause,
-            DeletePolicyError::LimitExceeded(ref cause) => cause,
-            DeletePolicyError::NoSuchEntity(ref cause) => cause,
-            DeletePolicyError::ServiceFailure(ref cause) => cause,
+            DeletePolicyError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePolicyError {}
 /// Errors returned by DeletePolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum DeletePolicyVersionError {
@@ -13265,20 +13159,16 @@ impl DeletePolicyVersionError {
 }
 impl fmt::Display for DeletePolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePolicyVersionError::DeleteConflict(ref cause) => cause,
-            DeletePolicyVersionError::InvalidInput(ref cause) => cause,
-            DeletePolicyVersionError::LimitExceeded(ref cause) => cause,
-            DeletePolicyVersionError::NoSuchEntity(ref cause) => cause,
-            DeletePolicyVersionError::ServiceFailure(ref cause) => cause,
+            DeletePolicyVersionError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePolicyVersionError {}
 /// Errors returned by DeleteRole
 #[derive(Debug, PartialEq)]
 pub enum DeleteRoleError {
@@ -13351,21 +13241,17 @@ impl DeleteRoleError {
 }
 impl fmt::Display for DeleteRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRoleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRoleError::ConcurrentModification(ref cause) => cause,
-            DeleteRoleError::DeleteConflict(ref cause) => cause,
-            DeleteRoleError::LimitExceeded(ref cause) => cause,
-            DeleteRoleError::NoSuchEntity(ref cause) => cause,
-            DeleteRoleError::ServiceFailure(ref cause) => cause,
-            DeleteRoleError::UnmodifiableEntity(ref cause) => cause,
+            DeleteRoleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteRoleError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteRoleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRoleError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRoleError {}
 /// Errors returned by DeleteRolePermissionsBoundary
 #[derive(Debug, PartialEq)]
 pub enum DeleteRolePermissionsBoundaryError {
@@ -13423,18 +13309,16 @@ impl DeleteRolePermissionsBoundaryError {
 }
 impl fmt::Display for DeleteRolePermissionsBoundaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRolePermissionsBoundaryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRolePermissionsBoundaryError::NoSuchEntity(ref cause) => cause,
-            DeleteRolePermissionsBoundaryError::ServiceFailure(ref cause) => cause,
-            DeleteRolePermissionsBoundaryError::UnmodifiableEntity(ref cause) => cause,
+            DeleteRolePermissionsBoundaryError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRolePermissionsBoundaryError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRolePermissionsBoundaryError::UnmodifiableEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRolePermissionsBoundaryError {}
 /// Errors returned by DeleteRolePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteRolePolicyError {
@@ -13493,19 +13377,15 @@ impl DeleteRolePolicyError {
 }
 impl fmt::Display for DeleteRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRolePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRolePolicyError::LimitExceeded(ref cause) => cause,
-            DeleteRolePolicyError::NoSuchEntity(ref cause) => cause,
-            DeleteRolePolicyError::ServiceFailure(ref cause) => cause,
-            DeleteRolePolicyError::UnmodifiableEntity(ref cause) => cause,
+            DeleteRolePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteRolePolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRolePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRolePolicyError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRolePolicyError {}
 /// Errors returned by DeleteSAMLProvider
 #[derive(Debug, PartialEq)]
 pub enum DeleteSAMLProviderError {
@@ -13564,19 +13444,15 @@ impl DeleteSAMLProviderError {
 }
 impl fmt::Display for DeleteSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSAMLProviderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSAMLProviderError::InvalidInput(ref cause) => cause,
-            DeleteSAMLProviderError::LimitExceeded(ref cause) => cause,
-            DeleteSAMLProviderError::NoSuchEntity(ref cause) => cause,
-            DeleteSAMLProviderError::ServiceFailure(ref cause) => cause,
+            DeleteSAMLProviderError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteSAMLProviderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteSAMLProviderError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteSAMLProviderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSAMLProviderError {}
 /// Errors returned by DeleteSSHPublicKey
 #[derive(Debug, PartialEq)]
 pub enum DeleteSSHPublicKeyError {
@@ -13614,16 +13490,12 @@ impl DeleteSSHPublicKeyError {
 }
 impl fmt::Display for DeleteSSHPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSSHPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSSHPublicKeyError::NoSuchEntity(ref cause) => cause,
+            DeleteSSHPublicKeyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSSHPublicKeyError {}
 /// Errors returned by DeleteServerCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteServerCertificateError {
@@ -13682,19 +13554,15 @@ impl DeleteServerCertificateError {
 }
 impl fmt::Display for DeleteServerCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServerCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServerCertificateError::DeleteConflict(ref cause) => cause,
-            DeleteServerCertificateError::LimitExceeded(ref cause) => cause,
-            DeleteServerCertificateError::NoSuchEntity(ref cause) => cause,
-            DeleteServerCertificateError::ServiceFailure(ref cause) => cause,
+            DeleteServerCertificateError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteServerCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteServerCertificateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteServerCertificateError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServerCertificateError {}
 /// Errors returned by DeleteServiceLinkedRole
 #[derive(Debug, PartialEq)]
 pub enum DeleteServiceLinkedRoleError {
@@ -13746,18 +13614,14 @@ impl DeleteServiceLinkedRoleError {
 }
 impl fmt::Display for DeleteServiceLinkedRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServiceLinkedRoleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServiceLinkedRoleError::LimitExceeded(ref cause) => cause,
-            DeleteServiceLinkedRoleError::NoSuchEntity(ref cause) => cause,
-            DeleteServiceLinkedRoleError::ServiceFailure(ref cause) => cause,
+            DeleteServiceLinkedRoleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteServiceLinkedRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteServiceLinkedRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServiceLinkedRoleError {}
 /// Errors returned by DeleteServiceSpecificCredential
 #[derive(Debug, PartialEq)]
 pub enum DeleteServiceSpecificCredentialError {
@@ -13799,16 +13663,12 @@ impl DeleteServiceSpecificCredentialError {
 }
 impl fmt::Display for DeleteServiceSpecificCredentialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServiceSpecificCredentialError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServiceSpecificCredentialError::NoSuchEntity(ref cause) => cause,
+            DeleteServiceSpecificCredentialError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServiceSpecificCredentialError {}
 /// Errors returned by DeleteSigningCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteSigningCertificateError {
@@ -13860,18 +13720,14 @@ impl DeleteSigningCertificateError {
 }
 impl fmt::Display for DeleteSigningCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSigningCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSigningCertificateError::LimitExceeded(ref cause) => cause,
-            DeleteSigningCertificateError::NoSuchEntity(ref cause) => cause,
-            DeleteSigningCertificateError::ServiceFailure(ref cause) => cause,
+            DeleteSigningCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteSigningCertificateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteSigningCertificateError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSigningCertificateError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -13937,20 +13793,16 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::ConcurrentModification(ref cause) => cause,
-            DeleteUserError::DeleteConflict(ref cause) => cause,
-            DeleteUserError::LimitExceeded(ref cause) => cause,
-            DeleteUserError::NoSuchEntity(ref cause) => cause,
-            DeleteUserError::ServiceFailure(ref cause) => cause,
+            DeleteUserError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DeleteUserPermissionsBoundary
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserPermissionsBoundaryError {
@@ -13999,17 +13851,13 @@ impl DeleteUserPermissionsBoundaryError {
 }
 impl fmt::Display for DeleteUserPermissionsBoundaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserPermissionsBoundaryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserPermissionsBoundaryError::NoSuchEntity(ref cause) => cause,
-            DeleteUserPermissionsBoundaryError::ServiceFailure(ref cause) => cause,
+            DeleteUserPermissionsBoundaryError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteUserPermissionsBoundaryError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserPermissionsBoundaryError {}
 /// Errors returned by DeleteUserPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserPolicyError {
@@ -14061,18 +13909,14 @@ impl DeleteUserPolicyError {
 }
 impl fmt::Display for DeleteUserPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserPolicyError::LimitExceeded(ref cause) => cause,
-            DeleteUserPolicyError::NoSuchEntity(ref cause) => cause,
-            DeleteUserPolicyError::ServiceFailure(ref cause) => cause,
+            DeleteUserPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteUserPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteUserPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserPolicyError {}
 /// Errors returned by DeleteVirtualMFADevice
 #[derive(Debug, PartialEq)]
 pub enum DeleteVirtualMFADeviceError {
@@ -14131,19 +13975,15 @@ impl DeleteVirtualMFADeviceError {
 }
 impl fmt::Display for DeleteVirtualMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVirtualMFADeviceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVirtualMFADeviceError::DeleteConflict(ref cause) => cause,
-            DeleteVirtualMFADeviceError::LimitExceeded(ref cause) => cause,
-            DeleteVirtualMFADeviceError::NoSuchEntity(ref cause) => cause,
-            DeleteVirtualMFADeviceError::ServiceFailure(ref cause) => cause,
+            DeleteVirtualMFADeviceError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualMFADeviceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualMFADeviceError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteVirtualMFADeviceError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVirtualMFADeviceError {}
 /// Errors returned by DetachGroupPolicy
 #[derive(Debug, PartialEq)]
 pub enum DetachGroupPolicyError {
@@ -14202,19 +14042,15 @@ impl DetachGroupPolicyError {
 }
 impl fmt::Display for DetachGroupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachGroupPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DetachGroupPolicyError::InvalidInput(ref cause) => cause,
-            DetachGroupPolicyError::LimitExceeded(ref cause) => cause,
-            DetachGroupPolicyError::NoSuchEntity(ref cause) => cause,
-            DetachGroupPolicyError::ServiceFailure(ref cause) => cause,
+            DetachGroupPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DetachGroupPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachGroupPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DetachGroupPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachGroupPolicyError {}
 /// Errors returned by DetachRolePolicy
 #[derive(Debug, PartialEq)]
 pub enum DetachRolePolicyError {
@@ -14280,20 +14116,16 @@ impl DetachRolePolicyError {
 }
 impl fmt::Display for DetachRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachRolePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DetachRolePolicyError::InvalidInput(ref cause) => cause,
-            DetachRolePolicyError::LimitExceeded(ref cause) => cause,
-            DetachRolePolicyError::NoSuchEntity(ref cause) => cause,
-            DetachRolePolicyError::ServiceFailure(ref cause) => cause,
-            DetachRolePolicyError::UnmodifiableEntity(ref cause) => cause,
+            DetachRolePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DetachRolePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachRolePolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DetachRolePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            DetachRolePolicyError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachRolePolicyError {}
 /// Errors returned by DetachUserPolicy
 #[derive(Debug, PartialEq)]
 pub enum DetachUserPolicyError {
@@ -14352,19 +14184,15 @@ impl DetachUserPolicyError {
 }
 impl fmt::Display for DetachUserPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachUserPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DetachUserPolicyError::InvalidInput(ref cause) => cause,
-            DetachUserPolicyError::LimitExceeded(ref cause) => cause,
-            DetachUserPolicyError::NoSuchEntity(ref cause) => cause,
-            DetachUserPolicyError::ServiceFailure(ref cause) => cause,
+            DetachUserPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DetachUserPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachUserPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DetachUserPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachUserPolicyError {}
 /// Errors returned by EnableMFADevice
 #[derive(Debug, PartialEq)]
 pub enum EnableMFADeviceError {
@@ -14439,21 +14267,19 @@ impl EnableMFADeviceError {
 }
 impl fmt::Display for EnableMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableMFADeviceError {
-    fn description(&self) -> &str {
         match *self {
-            EnableMFADeviceError::EntityAlreadyExists(ref cause) => cause,
-            EnableMFADeviceError::EntityTemporarilyUnmodifiable(ref cause) => cause,
-            EnableMFADeviceError::InvalidAuthenticationCode(ref cause) => cause,
-            EnableMFADeviceError::LimitExceeded(ref cause) => cause,
-            EnableMFADeviceError::NoSuchEntity(ref cause) => cause,
-            EnableMFADeviceError::ServiceFailure(ref cause) => cause,
+            EnableMFADeviceError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            EnableMFADeviceError::EntityTemporarilyUnmodifiable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableMFADeviceError::InvalidAuthenticationCode(ref cause) => write!(f, "{}", cause),
+            EnableMFADeviceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            EnableMFADeviceError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            EnableMFADeviceError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableMFADeviceError {}
 /// Errors returned by GenerateCredentialReport
 #[derive(Debug, PartialEq)]
 pub enum GenerateCredentialReportError {
@@ -14498,17 +14324,13 @@ impl GenerateCredentialReportError {
 }
 impl fmt::Display for GenerateCredentialReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateCredentialReportError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateCredentialReportError::LimitExceeded(ref cause) => cause,
-            GenerateCredentialReportError::ServiceFailure(ref cause) => cause,
+            GenerateCredentialReportError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GenerateCredentialReportError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateCredentialReportError {}
 /// Errors returned by GenerateOrganizationsAccessReport
 #[derive(Debug, PartialEq)]
 pub enum GenerateOrganizationsAccessReportError {
@@ -14550,18 +14372,14 @@ impl GenerateOrganizationsAccessReportError {
 }
 impl fmt::Display for GenerateOrganizationsAccessReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateOrganizationsAccessReportError {
-    fn description(&self) -> &str {
         match *self {
             GenerateOrganizationsAccessReportError::ReportGenerationLimitExceeded(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GenerateOrganizationsAccessReportError {}
 /// Errors returned by GenerateServiceLastAccessedDetails
 #[derive(Debug, PartialEq)]
 pub enum GenerateServiceLastAccessedDetailsError {
@@ -14612,17 +14430,17 @@ impl GenerateServiceLastAccessedDetailsError {
 }
 impl fmt::Display for GenerateServiceLastAccessedDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateServiceLastAccessedDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateServiceLastAccessedDetailsError::InvalidInput(ref cause) => cause,
-            GenerateServiceLastAccessedDetailsError::NoSuchEntity(ref cause) => cause,
+            GenerateServiceLastAccessedDetailsError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateServiceLastAccessedDetailsError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GenerateServiceLastAccessedDetailsError {}
 /// Errors returned by GetAccessKeyLastUsed
 #[derive(Debug, PartialEq)]
 pub enum GetAccessKeyLastUsedError {}
@@ -14652,14 +14470,10 @@ impl GetAccessKeyLastUsedError {
 }
 impl fmt::Display for GetAccessKeyLastUsedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccessKeyLastUsedError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetAccessKeyLastUsedError {}
 /// Errors returned by GetAccountAuthorizationDetails
 #[derive(Debug, PartialEq)]
 pub enum GetAccountAuthorizationDetailsError {
@@ -14701,16 +14515,14 @@ impl GetAccountAuthorizationDetailsError {
 }
 impl fmt::Display for GetAccountAuthorizationDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountAuthorizationDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountAuthorizationDetailsError::ServiceFailure(ref cause) => cause,
+            GetAccountAuthorizationDetailsError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetAccountAuthorizationDetailsError {}
 /// Errors returned by GetAccountPasswordPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetAccountPasswordPolicyError {
@@ -14755,17 +14567,13 @@ impl GetAccountPasswordPolicyError {
 }
 impl fmt::Display for GetAccountPasswordPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountPasswordPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountPasswordPolicyError::NoSuchEntity(ref cause) => cause,
-            GetAccountPasswordPolicyError::ServiceFailure(ref cause) => cause,
+            GetAccountPasswordPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetAccountPasswordPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountPasswordPolicyError {}
 /// Errors returned by GetAccountSummary
 #[derive(Debug, PartialEq)]
 pub enum GetAccountSummaryError {
@@ -14803,16 +14611,12 @@ impl GetAccountSummaryError {
 }
 impl fmt::Display for GetAccountSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountSummaryError::ServiceFailure(ref cause) => cause,
+            GetAccountSummaryError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountSummaryError {}
 /// Errors returned by GetContextKeysForCustomPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetContextKeysForCustomPolicyError {
@@ -14852,16 +14656,12 @@ impl GetContextKeysForCustomPolicyError {
 }
 impl fmt::Display for GetContextKeysForCustomPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetContextKeysForCustomPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetContextKeysForCustomPolicyError::InvalidInput(ref cause) => cause,
+            GetContextKeysForCustomPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetContextKeysForCustomPolicyError {}
 /// Errors returned by GetContextKeysForPrincipalPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetContextKeysForPrincipalPolicyError {
@@ -14912,17 +14712,17 @@ impl GetContextKeysForPrincipalPolicyError {
 }
 impl fmt::Display for GetContextKeysForPrincipalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetContextKeysForPrincipalPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetContextKeysForPrincipalPolicyError::InvalidInput(ref cause) => cause,
-            GetContextKeysForPrincipalPolicyError::NoSuchEntity(ref cause) => cause,
+            GetContextKeysForPrincipalPolicyError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetContextKeysForPrincipalPolicyError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetContextKeysForPrincipalPolicyError {}
 /// Errors returned by GetCredentialReport
 #[derive(Debug, PartialEq)]
 pub enum GetCredentialReportError {
@@ -14985,19 +14785,17 @@ impl GetCredentialReportError {
 }
 impl fmt::Display for GetCredentialReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCredentialReportError {
-    fn description(&self) -> &str {
         match *self {
-            GetCredentialReportError::CredentialReportExpired(ref cause) => cause,
-            GetCredentialReportError::CredentialReportNotPresent(ref cause) => cause,
-            GetCredentialReportError::CredentialReportNotReady(ref cause) => cause,
-            GetCredentialReportError::ServiceFailure(ref cause) => cause,
+            GetCredentialReportError::CredentialReportExpired(ref cause) => write!(f, "{}", cause),
+            GetCredentialReportError::CredentialReportNotPresent(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCredentialReportError::CredentialReportNotReady(ref cause) => write!(f, "{}", cause),
+            GetCredentialReportError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCredentialReportError {}
 /// Errors returned by GetGroup
 #[derive(Debug, PartialEq)]
 pub enum GetGroupError {
@@ -15042,17 +14840,13 @@ impl GetGroupError {
 }
 impl fmt::Display for GetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupError::NoSuchEntity(ref cause) => cause,
-            GetGroupError::ServiceFailure(ref cause) => cause,
+            GetGroupError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupError {}
 /// Errors returned by GetGroupPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetGroupPolicyError {
@@ -15097,17 +14891,13 @@ impl GetGroupPolicyError {
 }
 impl fmt::Display for GetGroupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupPolicyError::NoSuchEntity(ref cause) => cause,
-            GetGroupPolicyError::ServiceFailure(ref cause) => cause,
+            GetGroupPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetGroupPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupPolicyError {}
 /// Errors returned by GetInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceProfileError {
@@ -15152,17 +14942,13 @@ impl GetInstanceProfileError {
 }
 impl fmt::Display for GetInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceProfileError::NoSuchEntity(ref cause) => cause,
-            GetInstanceProfileError::ServiceFailure(ref cause) => cause,
+            GetInstanceProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetInstanceProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceProfileError {}
 /// Errors returned by GetLoginProfile
 #[derive(Debug, PartialEq)]
 pub enum GetLoginProfileError {
@@ -15207,17 +14993,13 @@ impl GetLoginProfileError {
 }
 impl fmt::Display for GetLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoginProfileError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoginProfileError::NoSuchEntity(ref cause) => cause,
-            GetLoginProfileError::ServiceFailure(ref cause) => cause,
+            GetLoginProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetLoginProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoginProfileError {}
 /// Errors returned by GetOpenIDConnectProvider
 #[derive(Debug, PartialEq)]
 pub enum GetOpenIDConnectProviderError {
@@ -15269,18 +15051,14 @@ impl GetOpenIDConnectProviderError {
 }
 impl fmt::Display for GetOpenIDConnectProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOpenIDConnectProviderError {
-    fn description(&self) -> &str {
         match *self {
-            GetOpenIDConnectProviderError::InvalidInput(ref cause) => cause,
-            GetOpenIDConnectProviderError::NoSuchEntity(ref cause) => cause,
-            GetOpenIDConnectProviderError::ServiceFailure(ref cause) => cause,
+            GetOpenIDConnectProviderError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetOpenIDConnectProviderError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetOpenIDConnectProviderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOpenIDConnectProviderError {}
 /// Errors returned by GetOrganizationsAccessReport
 #[derive(Debug, PartialEq)]
 pub enum GetOrganizationsAccessReportError {
@@ -15320,16 +15098,12 @@ impl GetOrganizationsAccessReportError {
 }
 impl fmt::Display for GetOrganizationsAccessReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOrganizationsAccessReportError {
-    fn description(&self) -> &str {
         match *self {
-            GetOrganizationsAccessReportError::NoSuchEntity(ref cause) => cause,
+            GetOrganizationsAccessReportError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOrganizationsAccessReportError {}
 /// Errors returned by GetPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetPolicyError {
@@ -15381,18 +15155,14 @@ impl GetPolicyError {
 }
 impl fmt::Display for GetPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPolicyError::InvalidInput(ref cause) => cause,
-            GetPolicyError::NoSuchEntity(ref cause) => cause,
-            GetPolicyError::ServiceFailure(ref cause) => cause,
+            GetPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPolicyError {}
 /// Errors returned by GetPolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum GetPolicyVersionError {
@@ -15444,18 +15214,14 @@ impl GetPolicyVersionError {
 }
 impl fmt::Display for GetPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetPolicyVersionError::InvalidInput(ref cause) => cause,
-            GetPolicyVersionError::NoSuchEntity(ref cause) => cause,
-            GetPolicyVersionError::ServiceFailure(ref cause) => cause,
+            GetPolicyVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetPolicyVersionError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetPolicyVersionError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPolicyVersionError {}
 /// Errors returned by GetRole
 #[derive(Debug, PartialEq)]
 pub enum GetRoleError {
@@ -15500,17 +15266,13 @@ impl GetRoleError {
 }
 impl fmt::Display for GetRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRoleError {
-    fn description(&self) -> &str {
         match *self {
-            GetRoleError::NoSuchEntity(ref cause) => cause,
-            GetRoleError::ServiceFailure(ref cause) => cause,
+            GetRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRoleError {}
 /// Errors returned by GetRolePolicy
 #[derive(Debug, PartialEq)]
 pub enum GetRolePolicyError {
@@ -15555,17 +15317,13 @@ impl GetRolePolicyError {
 }
 impl fmt::Display for GetRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRolePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetRolePolicyError::NoSuchEntity(ref cause) => cause,
-            GetRolePolicyError::ServiceFailure(ref cause) => cause,
+            GetRolePolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetRolePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRolePolicyError {}
 /// Errors returned by GetSAMLProvider
 #[derive(Debug, PartialEq)]
 pub enum GetSAMLProviderError {
@@ -15617,18 +15375,14 @@ impl GetSAMLProviderError {
 }
 impl fmt::Display for GetSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSAMLProviderError {
-    fn description(&self) -> &str {
         match *self {
-            GetSAMLProviderError::InvalidInput(ref cause) => cause,
-            GetSAMLProviderError::NoSuchEntity(ref cause) => cause,
-            GetSAMLProviderError::ServiceFailure(ref cause) => cause,
+            GetSAMLProviderError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetSAMLProviderError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetSAMLProviderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSAMLProviderError {}
 /// Errors returned by GetSSHPublicKey
 #[derive(Debug, PartialEq)]
 pub enum GetSSHPublicKeyError {
@@ -15675,17 +15429,15 @@ impl GetSSHPublicKeyError {
 }
 impl fmt::Display for GetSSHPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSSHPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            GetSSHPublicKeyError::NoSuchEntity(ref cause) => cause,
-            GetSSHPublicKeyError::UnrecognizedPublicKeyEncoding(ref cause) => cause,
+            GetSSHPublicKeyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetSSHPublicKeyError::UnrecognizedPublicKeyEncoding(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetSSHPublicKeyError {}
 /// Errors returned by GetServerCertificate
 #[derive(Debug, PartialEq)]
 pub enum GetServerCertificateError {
@@ -15730,17 +15482,13 @@ impl GetServerCertificateError {
 }
 impl fmt::Display for GetServerCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServerCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            GetServerCertificateError::NoSuchEntity(ref cause) => cause,
-            GetServerCertificateError::ServiceFailure(ref cause) => cause,
+            GetServerCertificateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetServerCertificateError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServerCertificateError {}
 /// Errors returned by GetServiceLastAccessedDetails
 #[derive(Debug, PartialEq)]
 pub enum GetServiceLastAccessedDetailsError {
@@ -15787,17 +15535,13 @@ impl GetServiceLastAccessedDetailsError {
 }
 impl fmt::Display for GetServiceLastAccessedDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceLastAccessedDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceLastAccessedDetailsError::InvalidInput(ref cause) => cause,
-            GetServiceLastAccessedDetailsError::NoSuchEntity(ref cause) => cause,
+            GetServiceLastAccessedDetailsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetServiceLastAccessedDetailsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServiceLastAccessedDetailsError {}
 /// Errors returned by GetServiceLastAccessedDetailsWithEntities
 #[derive(Debug, PartialEq)]
 pub enum GetServiceLastAccessedDetailsWithEntitiesError {
@@ -15848,17 +15592,17 @@ impl GetServiceLastAccessedDetailsWithEntitiesError {
 }
 impl fmt::Display for GetServiceLastAccessedDetailsWithEntitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceLastAccessedDetailsWithEntitiesError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceLastAccessedDetailsWithEntitiesError::InvalidInput(ref cause) => cause,
-            GetServiceLastAccessedDetailsWithEntitiesError::NoSuchEntity(ref cause) => cause,
+            GetServiceLastAccessedDetailsWithEntitiesError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetServiceLastAccessedDetailsWithEntitiesError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetServiceLastAccessedDetailsWithEntitiesError {}
 /// Errors returned by GetServiceLinkedRoleDeletionStatus
 #[derive(Debug, PartialEq)]
 pub enum GetServiceLinkedRoleDeletionStatusError {
@@ -15918,18 +15662,20 @@ impl GetServiceLinkedRoleDeletionStatusError {
 }
 impl fmt::Display for GetServiceLinkedRoleDeletionStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceLinkedRoleDeletionStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceLinkedRoleDeletionStatusError::InvalidInput(ref cause) => cause,
-            GetServiceLinkedRoleDeletionStatusError::NoSuchEntity(ref cause) => cause,
-            GetServiceLinkedRoleDeletionStatusError::ServiceFailure(ref cause) => cause,
+            GetServiceLinkedRoleDeletionStatusError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetServiceLinkedRoleDeletionStatusError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetServiceLinkedRoleDeletionStatusError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetServiceLinkedRoleDeletionStatusError {}
 /// Errors returned by GetUser
 #[derive(Debug, PartialEq)]
 pub enum GetUserError {
@@ -15974,17 +15720,13 @@ impl GetUserError {
 }
 impl fmt::Display for GetUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserError::NoSuchEntity(ref cause) => cause,
-            GetUserError::ServiceFailure(ref cause) => cause,
+            GetUserError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserError {}
 /// Errors returned by GetUserPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetUserPolicyError {
@@ -16029,17 +15771,13 @@ impl GetUserPolicyError {
 }
 impl fmt::Display for GetUserPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUserPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetUserPolicyError::NoSuchEntity(ref cause) => cause,
-            GetUserPolicyError::ServiceFailure(ref cause) => cause,
+            GetUserPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetUserPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUserPolicyError {}
 /// Errors returned by ListAccessKeys
 #[derive(Debug, PartialEq)]
 pub enum ListAccessKeysError {
@@ -16084,17 +15822,13 @@ impl ListAccessKeysError {
 }
 impl fmt::Display for ListAccessKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAccessKeysError {
-    fn description(&self) -> &str {
         match *self {
-            ListAccessKeysError::NoSuchEntity(ref cause) => cause,
-            ListAccessKeysError::ServiceFailure(ref cause) => cause,
+            ListAccessKeysError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListAccessKeysError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAccessKeysError {}
 /// Errors returned by ListAccountAliases
 #[derive(Debug, PartialEq)]
 pub enum ListAccountAliasesError {
@@ -16132,16 +15866,12 @@ impl ListAccountAliasesError {
 }
 impl fmt::Display for ListAccountAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAccountAliasesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAccountAliasesError::ServiceFailure(ref cause) => cause,
+            ListAccountAliasesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAccountAliasesError {}
 /// Errors returned by ListAttachedGroupPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListAttachedGroupPoliciesError {
@@ -16193,18 +15923,14 @@ impl ListAttachedGroupPoliciesError {
 }
 impl fmt::Display for ListAttachedGroupPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttachedGroupPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttachedGroupPoliciesError::InvalidInput(ref cause) => cause,
-            ListAttachedGroupPoliciesError::NoSuchEntity(ref cause) => cause,
-            ListAttachedGroupPoliciesError::ServiceFailure(ref cause) => cause,
+            ListAttachedGroupPoliciesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAttachedGroupPoliciesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListAttachedGroupPoliciesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttachedGroupPoliciesError {}
 /// Errors returned by ListAttachedRolePolicies
 #[derive(Debug, PartialEq)]
 pub enum ListAttachedRolePoliciesError {
@@ -16256,18 +15982,14 @@ impl ListAttachedRolePoliciesError {
 }
 impl fmt::Display for ListAttachedRolePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttachedRolePoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttachedRolePoliciesError::InvalidInput(ref cause) => cause,
-            ListAttachedRolePoliciesError::NoSuchEntity(ref cause) => cause,
-            ListAttachedRolePoliciesError::ServiceFailure(ref cause) => cause,
+            ListAttachedRolePoliciesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAttachedRolePoliciesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListAttachedRolePoliciesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttachedRolePoliciesError {}
 /// Errors returned by ListAttachedUserPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListAttachedUserPoliciesError {
@@ -16319,18 +16041,14 @@ impl ListAttachedUserPoliciesError {
 }
 impl fmt::Display for ListAttachedUserPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttachedUserPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttachedUserPoliciesError::InvalidInput(ref cause) => cause,
-            ListAttachedUserPoliciesError::NoSuchEntity(ref cause) => cause,
-            ListAttachedUserPoliciesError::ServiceFailure(ref cause) => cause,
+            ListAttachedUserPoliciesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAttachedUserPoliciesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListAttachedUserPoliciesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttachedUserPoliciesError {}
 /// Errors returned by ListEntitiesForPolicy
 #[derive(Debug, PartialEq)]
 pub enum ListEntitiesForPolicyError {
@@ -16382,18 +16100,14 @@ impl ListEntitiesForPolicyError {
 }
 impl fmt::Display for ListEntitiesForPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEntitiesForPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            ListEntitiesForPolicyError::InvalidInput(ref cause) => cause,
-            ListEntitiesForPolicyError::NoSuchEntity(ref cause) => cause,
-            ListEntitiesForPolicyError::ServiceFailure(ref cause) => cause,
+            ListEntitiesForPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListEntitiesForPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListEntitiesForPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEntitiesForPolicyError {}
 /// Errors returned by ListGroupPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListGroupPoliciesError {
@@ -16438,17 +16152,13 @@ impl ListGroupPoliciesError {
 }
 impl fmt::Display for ListGroupPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupPoliciesError::NoSuchEntity(ref cause) => cause,
-            ListGroupPoliciesError::ServiceFailure(ref cause) => cause,
+            ListGroupPoliciesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListGroupPoliciesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupPoliciesError {}
 /// Errors returned by ListGroups
 #[derive(Debug, PartialEq)]
 pub enum ListGroupsError {
@@ -16486,16 +16196,12 @@ impl ListGroupsError {
 }
 impl fmt::Display for ListGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupsError::ServiceFailure(ref cause) => cause,
+            ListGroupsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupsError {}
 /// Errors returned by ListGroupsForUser
 #[derive(Debug, PartialEq)]
 pub enum ListGroupsForUserError {
@@ -16540,17 +16246,13 @@ impl ListGroupsForUserError {
 }
 impl fmt::Display for ListGroupsForUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupsForUserError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupsForUserError::NoSuchEntity(ref cause) => cause,
-            ListGroupsForUserError::ServiceFailure(ref cause) => cause,
+            ListGroupsForUserError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListGroupsForUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupsForUserError {}
 /// Errors returned by ListInstanceProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListInstanceProfilesError {
@@ -16588,16 +16290,12 @@ impl ListInstanceProfilesError {
 }
 impl fmt::Display for ListInstanceProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInstanceProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListInstanceProfilesError::ServiceFailure(ref cause) => cause,
+            ListInstanceProfilesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInstanceProfilesError {}
 /// Errors returned by ListInstanceProfilesForRole
 #[derive(Debug, PartialEq)]
 pub enum ListInstanceProfilesForRoleError {
@@ -16644,17 +16342,13 @@ impl ListInstanceProfilesForRoleError {
 }
 impl fmt::Display for ListInstanceProfilesForRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInstanceProfilesForRoleError {
-    fn description(&self) -> &str {
         match *self {
-            ListInstanceProfilesForRoleError::NoSuchEntity(ref cause) => cause,
-            ListInstanceProfilesForRoleError::ServiceFailure(ref cause) => cause,
+            ListInstanceProfilesForRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListInstanceProfilesForRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInstanceProfilesForRoleError {}
 /// Errors returned by ListMFADevices
 #[derive(Debug, PartialEq)]
 pub enum ListMFADevicesError {
@@ -16699,17 +16393,13 @@ impl ListMFADevicesError {
 }
 impl fmt::Display for ListMFADevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMFADevicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListMFADevicesError::NoSuchEntity(ref cause) => cause,
-            ListMFADevicesError::ServiceFailure(ref cause) => cause,
+            ListMFADevicesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListMFADevicesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMFADevicesError {}
 /// Errors returned by ListOpenIDConnectProviders
 #[derive(Debug, PartialEq)]
 pub enum ListOpenIDConnectProvidersError {
@@ -16749,16 +16439,12 @@ impl ListOpenIDConnectProvidersError {
 }
 impl fmt::Display for ListOpenIDConnectProvidersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOpenIDConnectProvidersError {
-    fn description(&self) -> &str {
         match *self {
-            ListOpenIDConnectProvidersError::ServiceFailure(ref cause) => cause,
+            ListOpenIDConnectProvidersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOpenIDConnectProvidersError {}
 /// Errors returned by ListPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListPoliciesError {
@@ -16796,16 +16482,12 @@ impl ListPoliciesError {
 }
 impl fmt::Display for ListPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPoliciesError::ServiceFailure(ref cause) => cause,
+            ListPoliciesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPoliciesError {}
 /// Errors returned by ListPoliciesGrantingServiceAccess
 #[derive(Debug, PartialEq)]
 pub enum ListPoliciesGrantingServiceAccessError {
@@ -16856,17 +16538,17 @@ impl ListPoliciesGrantingServiceAccessError {
 }
 impl fmt::Display for ListPoliciesGrantingServiceAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPoliciesGrantingServiceAccessError {
-    fn description(&self) -> &str {
         match *self {
-            ListPoliciesGrantingServiceAccessError::InvalidInput(ref cause) => cause,
-            ListPoliciesGrantingServiceAccessError::NoSuchEntity(ref cause) => cause,
+            ListPoliciesGrantingServiceAccessError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListPoliciesGrantingServiceAccessError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListPoliciesGrantingServiceAccessError {}
 /// Errors returned by ListPolicyVersions
 #[derive(Debug, PartialEq)]
 pub enum ListPolicyVersionsError {
@@ -16918,18 +16600,14 @@ impl ListPolicyVersionsError {
 }
 impl fmt::Display for ListPolicyVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPolicyVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPolicyVersionsError::InvalidInput(ref cause) => cause,
-            ListPolicyVersionsError::NoSuchEntity(ref cause) => cause,
-            ListPolicyVersionsError::ServiceFailure(ref cause) => cause,
+            ListPolicyVersionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListPolicyVersionsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListPolicyVersionsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPolicyVersionsError {}
 /// Errors returned by ListRolePolicies
 #[derive(Debug, PartialEq)]
 pub enum ListRolePoliciesError {
@@ -16974,17 +16652,13 @@ impl ListRolePoliciesError {
 }
 impl fmt::Display for ListRolePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRolePoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRolePoliciesError::NoSuchEntity(ref cause) => cause,
-            ListRolePoliciesError::ServiceFailure(ref cause) => cause,
+            ListRolePoliciesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListRolePoliciesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRolePoliciesError {}
 /// Errors returned by ListRoleTags
 #[derive(Debug, PartialEq)]
 pub enum ListRoleTagsError {
@@ -17029,17 +16703,13 @@ impl ListRoleTagsError {
 }
 impl fmt::Display for ListRoleTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRoleTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRoleTagsError::NoSuchEntity(ref cause) => cause,
-            ListRoleTagsError::ServiceFailure(ref cause) => cause,
+            ListRoleTagsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListRoleTagsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRoleTagsError {}
 /// Errors returned by ListRoles
 #[derive(Debug, PartialEq)]
 pub enum ListRolesError {
@@ -17077,16 +16747,12 @@ impl ListRolesError {
 }
 impl fmt::Display for ListRolesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRolesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRolesError::ServiceFailure(ref cause) => cause,
+            ListRolesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRolesError {}
 /// Errors returned by ListSAMLProviders
 #[derive(Debug, PartialEq)]
 pub enum ListSAMLProvidersError {
@@ -17124,16 +16790,12 @@ impl ListSAMLProvidersError {
 }
 impl fmt::Display for ListSAMLProvidersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSAMLProvidersError {
-    fn description(&self) -> &str {
         match *self {
-            ListSAMLProvidersError::ServiceFailure(ref cause) => cause,
+            ListSAMLProvidersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSAMLProvidersError {}
 /// Errors returned by ListSSHPublicKeys
 #[derive(Debug, PartialEq)]
 pub enum ListSSHPublicKeysError {
@@ -17171,16 +16833,12 @@ impl ListSSHPublicKeysError {
 }
 impl fmt::Display for ListSSHPublicKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSSHPublicKeysError {
-    fn description(&self) -> &str {
         match *self {
-            ListSSHPublicKeysError::NoSuchEntity(ref cause) => cause,
+            ListSSHPublicKeysError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSSHPublicKeysError {}
 /// Errors returned by ListServerCertificates
 #[derive(Debug, PartialEq)]
 pub enum ListServerCertificatesError {
@@ -17218,16 +16876,12 @@ impl ListServerCertificatesError {
 }
 impl fmt::Display for ListServerCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServerCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListServerCertificatesError::ServiceFailure(ref cause) => cause,
+            ListServerCertificatesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListServerCertificatesError {}
 /// Errors returned by ListServiceSpecificCredentials
 #[derive(Debug, PartialEq)]
 pub enum ListServiceSpecificCredentialsError {
@@ -17276,17 +16930,15 @@ impl ListServiceSpecificCredentialsError {
 }
 impl fmt::Display for ListServiceSpecificCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServiceSpecificCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            ListServiceSpecificCredentialsError::NoSuchEntity(ref cause) => cause,
-            ListServiceSpecificCredentialsError::ServiceNotSupported(ref cause) => cause,
+            ListServiceSpecificCredentialsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListServiceSpecificCredentialsError::ServiceNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListServiceSpecificCredentialsError {}
 /// Errors returned by ListSigningCertificates
 #[derive(Debug, PartialEq)]
 pub enum ListSigningCertificatesError {
@@ -17331,17 +16983,13 @@ impl ListSigningCertificatesError {
 }
 impl fmt::Display for ListSigningCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSigningCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListSigningCertificatesError::NoSuchEntity(ref cause) => cause,
-            ListSigningCertificatesError::ServiceFailure(ref cause) => cause,
+            ListSigningCertificatesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListSigningCertificatesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSigningCertificatesError {}
 /// Errors returned by ListUserPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListUserPoliciesError {
@@ -17386,17 +17034,13 @@ impl ListUserPoliciesError {
 }
 impl fmt::Display for ListUserPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListUserPoliciesError::NoSuchEntity(ref cause) => cause,
-            ListUserPoliciesError::ServiceFailure(ref cause) => cause,
+            ListUserPoliciesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListUserPoliciesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUserPoliciesError {}
 /// Errors returned by ListUserTags
 #[derive(Debug, PartialEq)]
 pub enum ListUserTagsError {
@@ -17441,17 +17085,13 @@ impl ListUserTagsError {
 }
 impl fmt::Display for ListUserTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListUserTagsError::NoSuchEntity(ref cause) => cause,
-            ListUserTagsError::ServiceFailure(ref cause) => cause,
+            ListUserTagsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ListUserTagsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUserTagsError {}
 /// Errors returned by ListUsers
 #[derive(Debug, PartialEq)]
 pub enum ListUsersError {
@@ -17489,16 +17129,12 @@ impl ListUsersError {
 }
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersError::ServiceFailure(ref cause) => cause,
+            ListUsersError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersError {}
 /// Errors returned by ListVirtualMFADevices
 #[derive(Debug, PartialEq)]
 pub enum ListVirtualMFADevicesError {}
@@ -17528,14 +17164,10 @@ impl ListVirtualMFADevicesError {
 }
 impl fmt::Display for ListVirtualMFADevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVirtualMFADevicesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListVirtualMFADevicesError {}
 /// Errors returned by PutGroupPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutGroupPolicyError {
@@ -17594,19 +17226,15 @@ impl PutGroupPolicyError {
 }
 impl fmt::Display for PutGroupPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutGroupPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutGroupPolicyError::LimitExceeded(ref cause) => cause,
-            PutGroupPolicyError::MalformedPolicyDocument(ref cause) => cause,
-            PutGroupPolicyError::NoSuchEntity(ref cause) => cause,
-            PutGroupPolicyError::ServiceFailure(ref cause) => cause,
+            PutGroupPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutGroupPolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            PutGroupPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            PutGroupPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutGroupPolicyError {}
 /// Errors returned by PutRolePermissionsBoundary
 #[derive(Debug, PartialEq)]
 pub enum PutRolePermissionsBoundaryError {
@@ -17678,20 +17306,20 @@ impl PutRolePermissionsBoundaryError {
 }
 impl fmt::Display for PutRolePermissionsBoundaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRolePermissionsBoundaryError {
-    fn description(&self) -> &str {
         match *self {
-            PutRolePermissionsBoundaryError::InvalidInput(ref cause) => cause,
-            PutRolePermissionsBoundaryError::NoSuchEntity(ref cause) => cause,
-            PutRolePermissionsBoundaryError::PolicyNotAttachable(ref cause) => cause,
-            PutRolePermissionsBoundaryError::ServiceFailure(ref cause) => cause,
-            PutRolePermissionsBoundaryError::UnmodifiableEntity(ref cause) => cause,
+            PutRolePermissionsBoundaryError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PutRolePermissionsBoundaryError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            PutRolePermissionsBoundaryError::PolicyNotAttachable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutRolePermissionsBoundaryError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            PutRolePermissionsBoundaryError::UnmodifiableEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutRolePermissionsBoundaryError {}
 /// Errors returned by PutRolePolicy
 #[derive(Debug, PartialEq)]
 pub enum PutRolePolicyError {
@@ -17757,20 +17385,16 @@ impl PutRolePolicyError {
 }
 impl fmt::Display for PutRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRolePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutRolePolicyError::LimitExceeded(ref cause) => cause,
-            PutRolePolicyError::MalformedPolicyDocument(ref cause) => cause,
-            PutRolePolicyError::NoSuchEntity(ref cause) => cause,
-            PutRolePolicyError::ServiceFailure(ref cause) => cause,
-            PutRolePolicyError::UnmodifiableEntity(ref cause) => cause,
+            PutRolePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutRolePolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            PutRolePolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            PutRolePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            PutRolePolicyError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRolePolicyError {}
 /// Errors returned by PutUserPermissionsBoundary
 #[derive(Debug, PartialEq)]
 pub enum PutUserPermissionsBoundaryError {
@@ -17833,19 +17457,17 @@ impl PutUserPermissionsBoundaryError {
 }
 impl fmt::Display for PutUserPermissionsBoundaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutUserPermissionsBoundaryError {
-    fn description(&self) -> &str {
         match *self {
-            PutUserPermissionsBoundaryError::InvalidInput(ref cause) => cause,
-            PutUserPermissionsBoundaryError::NoSuchEntity(ref cause) => cause,
-            PutUserPermissionsBoundaryError::PolicyNotAttachable(ref cause) => cause,
-            PutUserPermissionsBoundaryError::ServiceFailure(ref cause) => cause,
+            PutUserPermissionsBoundaryError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PutUserPermissionsBoundaryError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            PutUserPermissionsBoundaryError::PolicyNotAttachable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutUserPermissionsBoundaryError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutUserPermissionsBoundaryError {}
 /// Errors returned by PutUserPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutUserPolicyError {
@@ -17904,19 +17526,15 @@ impl PutUserPolicyError {
 }
 impl fmt::Display for PutUserPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutUserPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutUserPolicyError::LimitExceeded(ref cause) => cause,
-            PutUserPolicyError::MalformedPolicyDocument(ref cause) => cause,
-            PutUserPolicyError::NoSuchEntity(ref cause) => cause,
-            PutUserPolicyError::ServiceFailure(ref cause) => cause,
+            PutUserPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutUserPolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            PutUserPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            PutUserPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutUserPolicyError {}
 /// Errors returned by RemoveClientIDFromOpenIDConnectProvider
 #[derive(Debug, PartialEq)]
 pub enum RemoveClientIDFromOpenIDConnectProviderError {
@@ -17976,18 +17594,20 @@ impl RemoveClientIDFromOpenIDConnectProviderError {
 }
 impl fmt::Display for RemoveClientIDFromOpenIDConnectProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveClientIDFromOpenIDConnectProviderError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveClientIDFromOpenIDConnectProviderError::InvalidInput(ref cause) => cause,
-            RemoveClientIDFromOpenIDConnectProviderError::NoSuchEntity(ref cause) => cause,
-            RemoveClientIDFromOpenIDConnectProviderError::ServiceFailure(ref cause) => cause,
+            RemoveClientIDFromOpenIDConnectProviderError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveClientIDFromOpenIDConnectProviderError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveClientIDFromOpenIDConnectProviderError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveClientIDFromOpenIDConnectProviderError {}
 /// Errors returned by RemoveRoleFromInstanceProfile
 #[derive(Debug, PartialEq)]
 pub enum RemoveRoleFromInstanceProfileError {
@@ -18052,19 +17672,17 @@ impl RemoveRoleFromInstanceProfileError {
 }
 impl fmt::Display for RemoveRoleFromInstanceProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveRoleFromInstanceProfileError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveRoleFromInstanceProfileError::LimitExceeded(ref cause) => cause,
-            RemoveRoleFromInstanceProfileError::NoSuchEntity(ref cause) => cause,
-            RemoveRoleFromInstanceProfileError::ServiceFailure(ref cause) => cause,
-            RemoveRoleFromInstanceProfileError::UnmodifiableEntity(ref cause) => cause,
+            RemoveRoleFromInstanceProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RemoveRoleFromInstanceProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            RemoveRoleFromInstanceProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            RemoveRoleFromInstanceProfileError::UnmodifiableEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveRoleFromInstanceProfileError {}
 /// Errors returned by RemoveUserFromGroup
 #[derive(Debug, PartialEq)]
 pub enum RemoveUserFromGroupError {
@@ -18116,18 +17734,14 @@ impl RemoveUserFromGroupError {
 }
 impl fmt::Display for RemoveUserFromGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveUserFromGroupError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveUserFromGroupError::LimitExceeded(ref cause) => cause,
-            RemoveUserFromGroupError::NoSuchEntity(ref cause) => cause,
-            RemoveUserFromGroupError::ServiceFailure(ref cause) => cause,
+            RemoveUserFromGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RemoveUserFromGroupError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            RemoveUserFromGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveUserFromGroupError {}
 /// Errors returned by ResetServiceSpecificCredential
 #[derive(Debug, PartialEq)]
 pub enum ResetServiceSpecificCredentialError {
@@ -18167,16 +17781,12 @@ impl ResetServiceSpecificCredentialError {
 }
 impl fmt::Display for ResetServiceSpecificCredentialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetServiceSpecificCredentialError {
-    fn description(&self) -> &str {
         match *self {
-            ResetServiceSpecificCredentialError::NoSuchEntity(ref cause) => cause,
+            ResetServiceSpecificCredentialError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetServiceSpecificCredentialError {}
 /// Errors returned by ResyncMFADevice
 #[derive(Debug, PartialEq)]
 pub enum ResyncMFADeviceError {
@@ -18235,19 +17845,15 @@ impl ResyncMFADeviceError {
 }
 impl fmt::Display for ResyncMFADeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResyncMFADeviceError {
-    fn description(&self) -> &str {
         match *self {
-            ResyncMFADeviceError::InvalidAuthenticationCode(ref cause) => cause,
-            ResyncMFADeviceError::LimitExceeded(ref cause) => cause,
-            ResyncMFADeviceError::NoSuchEntity(ref cause) => cause,
-            ResyncMFADeviceError::ServiceFailure(ref cause) => cause,
+            ResyncMFADeviceError::InvalidAuthenticationCode(ref cause) => write!(f, "{}", cause),
+            ResyncMFADeviceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ResyncMFADeviceError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            ResyncMFADeviceError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResyncMFADeviceError {}
 /// Errors returned by SetDefaultPolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum SetDefaultPolicyVersionError {
@@ -18306,19 +17912,15 @@ impl SetDefaultPolicyVersionError {
 }
 impl fmt::Display for SetDefaultPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetDefaultPolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            SetDefaultPolicyVersionError::InvalidInput(ref cause) => cause,
-            SetDefaultPolicyVersionError::LimitExceeded(ref cause) => cause,
-            SetDefaultPolicyVersionError::NoSuchEntity(ref cause) => cause,
-            SetDefaultPolicyVersionError::ServiceFailure(ref cause) => cause,
+            SetDefaultPolicyVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetDefaultPolicyVersionError {}
 /// Errors returned by SetSecurityTokenServicePreferences
 #[derive(Debug, PartialEq)]
 pub enum SetSecurityTokenServicePreferencesError {
@@ -18360,16 +17962,14 @@ impl SetSecurityTokenServicePreferencesError {
 }
 impl fmt::Display for SetSecurityTokenServicePreferencesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetSecurityTokenServicePreferencesError {
-    fn description(&self) -> &str {
         match *self {
-            SetSecurityTokenServicePreferencesError::ServiceFailure(ref cause) => cause,
+            SetSecurityTokenServicePreferencesError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetSecurityTokenServicePreferencesError {}
 /// Errors returned by SimulateCustomPolicy
 #[derive(Debug, PartialEq)]
 pub enum SimulateCustomPolicyError {
@@ -18414,17 +18014,13 @@ impl SimulateCustomPolicyError {
 }
 impl fmt::Display for SimulateCustomPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SimulateCustomPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            SimulateCustomPolicyError::InvalidInput(ref cause) => cause,
-            SimulateCustomPolicyError::PolicyEvaluation(ref cause) => cause,
+            SimulateCustomPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            SimulateCustomPolicyError::PolicyEvaluation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SimulateCustomPolicyError {}
 /// Errors returned by SimulatePrincipalPolicy
 #[derive(Debug, PartialEq)]
 pub enum SimulatePrincipalPolicyError {
@@ -18476,18 +18072,14 @@ impl SimulatePrincipalPolicyError {
 }
 impl fmt::Display for SimulatePrincipalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SimulatePrincipalPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            SimulatePrincipalPolicyError::InvalidInput(ref cause) => cause,
-            SimulatePrincipalPolicyError::NoSuchEntity(ref cause) => cause,
-            SimulatePrincipalPolicyError::PolicyEvaluation(ref cause) => cause,
+            SimulatePrincipalPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            SimulatePrincipalPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            SimulatePrincipalPolicyError::PolicyEvaluation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SimulatePrincipalPolicyError {}
 /// Errors returned by TagRole
 #[derive(Debug, PartialEq)]
 pub enum TagRoleError {
@@ -18553,20 +18145,16 @@ impl TagRoleError {
 }
 impl fmt::Display for TagRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagRoleError {
-    fn description(&self) -> &str {
         match *self {
-            TagRoleError::ConcurrentModification(ref cause) => cause,
-            TagRoleError::InvalidInput(ref cause) => cause,
-            TagRoleError::LimitExceeded(ref cause) => cause,
-            TagRoleError::NoSuchEntity(ref cause) => cause,
-            TagRoleError::ServiceFailure(ref cause) => cause,
+            TagRoleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagRoleError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TagRoleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            TagRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagRoleError {}
 /// Errors returned by TagUser
 #[derive(Debug, PartialEq)]
 pub enum TagUserError {
@@ -18632,20 +18220,16 @@ impl TagUserError {
 }
 impl fmt::Display for TagUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagUserError {
-    fn description(&self) -> &str {
         match *self {
-            TagUserError::ConcurrentModification(ref cause) => cause,
-            TagUserError::InvalidInput(ref cause) => cause,
-            TagUserError::LimitExceeded(ref cause) => cause,
-            TagUserError::NoSuchEntity(ref cause) => cause,
-            TagUserError::ServiceFailure(ref cause) => cause,
+            TagUserError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagUserError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TagUserError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagUserError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            TagUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagUserError {}
 /// Errors returned by UntagRole
 #[derive(Debug, PartialEq)]
 pub enum UntagRoleError {
@@ -18697,18 +18281,14 @@ impl UntagRoleError {
 }
 impl fmt::Display for UntagRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagRoleError {
-    fn description(&self) -> &str {
         match *self {
-            UntagRoleError::ConcurrentModification(ref cause) => cause,
-            UntagRoleError::NoSuchEntity(ref cause) => cause,
-            UntagRoleError::ServiceFailure(ref cause) => cause,
+            UntagRoleError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UntagRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagRoleError {}
 /// Errors returned by UntagUser
 #[derive(Debug, PartialEq)]
 pub enum UntagUserError {
@@ -18760,18 +18340,14 @@ impl UntagUserError {
 }
 impl fmt::Display for UntagUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagUserError {
-    fn description(&self) -> &str {
         match *self {
-            UntagUserError::ConcurrentModification(ref cause) => cause,
-            UntagUserError::NoSuchEntity(ref cause) => cause,
-            UntagUserError::ServiceFailure(ref cause) => cause,
+            UntagUserError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagUserError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UntagUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagUserError {}
 /// Errors returned by UpdateAccessKey
 #[derive(Debug, PartialEq)]
 pub enum UpdateAccessKeyError {
@@ -18823,18 +18399,14 @@ impl UpdateAccessKeyError {
 }
 impl fmt::Display for UpdateAccessKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAccessKeyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAccessKeyError::LimitExceeded(ref cause) => cause,
-            UpdateAccessKeyError::NoSuchEntity(ref cause) => cause,
-            UpdateAccessKeyError::ServiceFailure(ref cause) => cause,
+            UpdateAccessKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateAccessKeyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateAccessKeyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAccessKeyError {}
 /// Errors returned by UpdateAccountPasswordPolicy
 #[derive(Debug, PartialEq)]
 pub enum UpdateAccountPasswordPolicyError {
@@ -18897,19 +18469,17 @@ impl UpdateAccountPasswordPolicyError {
 }
 impl fmt::Display for UpdateAccountPasswordPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAccountPasswordPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAccountPasswordPolicyError::LimitExceeded(ref cause) => cause,
-            UpdateAccountPasswordPolicyError::MalformedPolicyDocument(ref cause) => cause,
-            UpdateAccountPasswordPolicyError::NoSuchEntity(ref cause) => cause,
-            UpdateAccountPasswordPolicyError::ServiceFailure(ref cause) => cause,
+            UpdateAccountPasswordPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateAccountPasswordPolicyError::MalformedPolicyDocument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAccountPasswordPolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateAccountPasswordPolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAccountPasswordPolicyError {}
 /// Errors returned by UpdateAssumeRolePolicy
 #[derive(Debug, PartialEq)]
 pub enum UpdateAssumeRolePolicyError {
@@ -18977,20 +18547,18 @@ impl UpdateAssumeRolePolicyError {
 }
 impl fmt::Display for UpdateAssumeRolePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAssumeRolePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAssumeRolePolicyError::LimitExceeded(ref cause) => cause,
-            UpdateAssumeRolePolicyError::MalformedPolicyDocument(ref cause) => cause,
-            UpdateAssumeRolePolicyError::NoSuchEntity(ref cause) => cause,
-            UpdateAssumeRolePolicyError::ServiceFailure(ref cause) => cause,
-            UpdateAssumeRolePolicyError::UnmodifiableEntity(ref cause) => cause,
+            UpdateAssumeRolePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateAssumeRolePolicyError::MalformedPolicyDocument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAssumeRolePolicyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateAssumeRolePolicyError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateAssumeRolePolicyError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAssumeRolePolicyError {}
 /// Errors returned by UpdateGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateGroupError {
@@ -19049,19 +18617,15 @@ impl UpdateGroupError {
 }
 impl fmt::Display for UpdateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGroupError::EntityAlreadyExists(ref cause) => cause,
-            UpdateGroupError::LimitExceeded(ref cause) => cause,
-            UpdateGroupError::NoSuchEntity(ref cause) => cause,
-            UpdateGroupError::ServiceFailure(ref cause) => cause,
+            UpdateGroupError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGroupError {}
 /// Errors returned by UpdateLoginProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateLoginProfileError {
@@ -19129,20 +18693,18 @@ impl UpdateLoginProfileError {
 }
 impl fmt::Display for UpdateLoginProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLoginProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLoginProfileError::EntityTemporarilyUnmodifiable(ref cause) => cause,
-            UpdateLoginProfileError::LimitExceeded(ref cause) => cause,
-            UpdateLoginProfileError::NoSuchEntity(ref cause) => cause,
-            UpdateLoginProfileError::PasswordPolicyViolation(ref cause) => cause,
-            UpdateLoginProfileError::ServiceFailure(ref cause) => cause,
+            UpdateLoginProfileError::EntityTemporarilyUnmodifiable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLoginProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateLoginProfileError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateLoginProfileError::PasswordPolicyViolation(ref cause) => write!(f, "{}", cause),
+            UpdateLoginProfileError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLoginProfileError {}
 /// Errors returned by UpdateOpenIDConnectProviderThumbprint
 #[derive(Debug, PartialEq)]
 pub enum UpdateOpenIDConnectProviderThumbprintError {
@@ -19202,18 +18764,20 @@ impl UpdateOpenIDConnectProviderThumbprintError {
 }
 impl fmt::Display for UpdateOpenIDConnectProviderThumbprintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateOpenIDConnectProviderThumbprintError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateOpenIDConnectProviderThumbprintError::InvalidInput(ref cause) => cause,
-            UpdateOpenIDConnectProviderThumbprintError::NoSuchEntity(ref cause) => cause,
-            UpdateOpenIDConnectProviderThumbprintError::ServiceFailure(ref cause) => cause,
+            UpdateOpenIDConnectProviderThumbprintError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateOpenIDConnectProviderThumbprintError::NoSuchEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateOpenIDConnectProviderThumbprintError::ServiceFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateOpenIDConnectProviderThumbprintError {}
 /// Errors returned by UpdateRole
 #[derive(Debug, PartialEq)]
 pub enum UpdateRoleError {
@@ -19265,18 +18829,14 @@ impl UpdateRoleError {
 }
 impl fmt::Display for UpdateRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRoleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRoleError::NoSuchEntity(ref cause) => cause,
-            UpdateRoleError::ServiceFailure(ref cause) => cause,
-            UpdateRoleError::UnmodifiableEntity(ref cause) => cause,
+            UpdateRoleError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateRoleError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateRoleError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRoleError {}
 /// Errors returned by UpdateRoleDescription
 #[derive(Debug, PartialEq)]
 pub enum UpdateRoleDescriptionError {
@@ -19328,18 +18888,14 @@ impl UpdateRoleDescriptionError {
 }
 impl fmt::Display for UpdateRoleDescriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRoleDescriptionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRoleDescriptionError::NoSuchEntity(ref cause) => cause,
-            UpdateRoleDescriptionError::ServiceFailure(ref cause) => cause,
-            UpdateRoleDescriptionError::UnmodifiableEntity(ref cause) => cause,
+            UpdateRoleDescriptionError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateRoleDescriptionError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            UpdateRoleDescriptionError::UnmodifiableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRoleDescriptionError {}
 /// Errors returned by UpdateSAMLProvider
 #[derive(Debug, PartialEq)]
 pub enum UpdateSAMLProviderError {
@@ -19398,19 +18954,15 @@ impl UpdateSAMLProviderError {
 }
 impl fmt::Display for UpdateSAMLProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSAMLProviderError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSAMLProviderError::InvalidInput(ref cause) => cause,
-            UpdateSAMLProviderError::LimitExceeded(ref cause) => cause,
-            UpdateSAMLProviderError::NoSuchEntity(ref cause) => cause,
-            UpdateSAMLProviderError::ServiceFailure(ref cause) => cause,
+            UpdateSAMLProviderError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateSAMLProviderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSAMLProviderError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateSAMLProviderError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSAMLProviderError {}
 /// Errors returned by UpdateSSHPublicKey
 #[derive(Debug, PartialEq)]
 pub enum UpdateSSHPublicKeyError {
@@ -19448,16 +19000,12 @@ impl UpdateSSHPublicKeyError {
 }
 impl fmt::Display for UpdateSSHPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSSHPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSSHPublicKeyError::NoSuchEntity(ref cause) => cause,
+            UpdateSSHPublicKeyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSSHPublicKeyError {}
 /// Errors returned by UpdateServerCertificate
 #[derive(Debug, PartialEq)]
 pub enum UpdateServerCertificateError {
@@ -19516,19 +19064,15 @@ impl UpdateServerCertificateError {
 }
 impl fmt::Display for UpdateServerCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServerCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServerCertificateError::EntityAlreadyExists(ref cause) => cause,
-            UpdateServerCertificateError::LimitExceeded(ref cause) => cause,
-            UpdateServerCertificateError::NoSuchEntity(ref cause) => cause,
-            UpdateServerCertificateError::ServiceFailure(ref cause) => cause,
+            UpdateServerCertificateError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateServerCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateServerCertificateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateServerCertificateError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServerCertificateError {}
 /// Errors returned by UpdateServiceSpecificCredential
 #[derive(Debug, PartialEq)]
 pub enum UpdateServiceSpecificCredentialError {
@@ -19570,16 +19114,12 @@ impl UpdateServiceSpecificCredentialError {
 }
 impl fmt::Display for UpdateServiceSpecificCredentialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServiceSpecificCredentialError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServiceSpecificCredentialError::NoSuchEntity(ref cause) => cause,
+            UpdateServiceSpecificCredentialError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServiceSpecificCredentialError {}
 /// Errors returned by UpdateSigningCertificate
 #[derive(Debug, PartialEq)]
 pub enum UpdateSigningCertificateError {
@@ -19631,18 +19171,14 @@ impl UpdateSigningCertificateError {
 }
 impl fmt::Display for UpdateSigningCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSigningCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSigningCertificateError::LimitExceeded(ref cause) => cause,
-            UpdateSigningCertificateError::NoSuchEntity(ref cause) => cause,
-            UpdateSigningCertificateError::ServiceFailure(ref cause) => cause,
+            UpdateSigningCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSigningCertificateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateSigningCertificateError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSigningCertificateError {}
 /// Errors returned by UpdateUser
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserError {
@@ -19715,21 +19251,17 @@ impl UpdateUserError {
 }
 impl fmt::Display for UpdateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserError::ConcurrentModification(ref cause) => cause,
-            UpdateUserError::EntityAlreadyExists(ref cause) => cause,
-            UpdateUserError::EntityTemporarilyUnmodifiable(ref cause) => cause,
-            UpdateUserError::LimitExceeded(ref cause) => cause,
-            UpdateUserError::NoSuchEntity(ref cause) => cause,
-            UpdateUserError::ServiceFailure(ref cause) => cause,
+            UpdateUserError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::EntityTemporarilyUnmodifiable(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserError {}
 /// Errors returned by UploadSSHPublicKey
 #[derive(Debug, PartialEq)]
 pub enum UploadSSHPublicKeyError {
@@ -19797,20 +19329,18 @@ impl UploadSSHPublicKeyError {
 }
 impl fmt::Display for UploadSSHPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadSSHPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            UploadSSHPublicKeyError::DuplicateSSHPublicKey(ref cause) => cause,
-            UploadSSHPublicKeyError::InvalidPublicKey(ref cause) => cause,
-            UploadSSHPublicKeyError::LimitExceeded(ref cause) => cause,
-            UploadSSHPublicKeyError::NoSuchEntity(ref cause) => cause,
-            UploadSSHPublicKeyError::UnrecognizedPublicKeyEncoding(ref cause) => cause,
+            UploadSSHPublicKeyError::DuplicateSSHPublicKey(ref cause) => write!(f, "{}", cause),
+            UploadSSHPublicKeyError::InvalidPublicKey(ref cause) => write!(f, "{}", cause),
+            UploadSSHPublicKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UploadSSHPublicKeyError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UploadSSHPublicKeyError::UnrecognizedPublicKeyEncoding(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UploadSSHPublicKeyError {}
 /// Errors returned by UploadServerCertificate
 #[derive(Debug, PartialEq)]
 pub enum UploadServerCertificateError {
@@ -19878,20 +19408,16 @@ impl UploadServerCertificateError {
 }
 impl fmt::Display for UploadServerCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadServerCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            UploadServerCertificateError::EntityAlreadyExists(ref cause) => cause,
-            UploadServerCertificateError::KeyPairMismatch(ref cause) => cause,
-            UploadServerCertificateError::LimitExceeded(ref cause) => cause,
-            UploadServerCertificateError::MalformedCertificate(ref cause) => cause,
-            UploadServerCertificateError::ServiceFailure(ref cause) => cause,
+            UploadServerCertificateError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UploadServerCertificateError::KeyPairMismatch(ref cause) => write!(f, "{}", cause),
+            UploadServerCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UploadServerCertificateError::MalformedCertificate(ref cause) => write!(f, "{}", cause),
+            UploadServerCertificateError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UploadServerCertificateError {}
 /// Errors returned by UploadSigningCertificate
 #[derive(Debug, PartialEq)]
 pub enum UploadSigningCertificateError {
@@ -19977,22 +19503,22 @@ impl UploadSigningCertificateError {
 }
 impl fmt::Display for UploadSigningCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadSigningCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            UploadSigningCertificateError::DuplicateCertificate(ref cause) => cause,
-            UploadSigningCertificateError::EntityAlreadyExists(ref cause) => cause,
-            UploadSigningCertificateError::InvalidCertificate(ref cause) => cause,
-            UploadSigningCertificateError::LimitExceeded(ref cause) => cause,
-            UploadSigningCertificateError::MalformedCertificate(ref cause) => cause,
-            UploadSigningCertificateError::NoSuchEntity(ref cause) => cause,
-            UploadSigningCertificateError::ServiceFailure(ref cause) => cause,
+            UploadSigningCertificateError::DuplicateCertificate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UploadSigningCertificateError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UploadSigningCertificateError::InvalidCertificate(ref cause) => write!(f, "{}", cause),
+            UploadSigningCertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UploadSigningCertificateError::MalformedCertificate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UploadSigningCertificateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UploadSigningCertificateError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UploadSigningCertificateError {}
 /// Trait representing the capabilities of the IAM API. IAM clients implement this trait.
 pub trait Iam {
     /// <p>Adds a new client ID (also known as audience) to the list of client IDs already registered for the specified IAM OpenID Connect (OIDC) provider resource.</p> <p>This operation is idempotent; it does not fail or return an error if you add an existing client ID to the provider.</p>

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -942,21 +942,17 @@ impl CancelJobError {
 }
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelJobError {
-    fn description(&self) -> &str {
         match *self {
-            CancelJobError::CanceledJobId(ref cause) => cause,
-            CancelJobError::ExpiredJobId(ref cause) => cause,
-            CancelJobError::InvalidAccessKeyId(ref cause) => cause,
-            CancelJobError::InvalidJobId(ref cause) => cause,
-            CancelJobError::InvalidVersion(ref cause) => cause,
-            CancelJobError::UnableToCancelJobId(ref cause) => cause,
+            CancelJobError::CanceledJobId(ref cause) => write!(f, "{}", cause),
+            CancelJobError::ExpiredJobId(ref cause) => write!(f, "{}", cause),
+            CancelJobError::InvalidAccessKeyId(ref cause) => write!(f, "{}", cause),
+            CancelJobError::InvalidJobId(ref cause) => write!(f, "{}", cause),
+            CancelJobError::InvalidVersion(ref cause) => write!(f, "{}", cause),
+            CancelJobError::UnableToCancelJobId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelJobError {}
 /// Errors returned by CreateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateJobError {
@@ -1099,31 +1095,27 @@ impl CreateJobError {
 }
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobError::BucketPermission(ref cause) => cause,
-            CreateJobError::CreateJobQuotaExceeded(ref cause) => cause,
-            CreateJobError::InvalidAccessKeyId(ref cause) => cause,
-            CreateJobError::InvalidAddress(ref cause) => cause,
-            CreateJobError::InvalidCustoms(ref cause) => cause,
-            CreateJobError::InvalidFileSystem(ref cause) => cause,
-            CreateJobError::InvalidJobId(ref cause) => cause,
-            CreateJobError::InvalidManifestField(ref cause) => cause,
-            CreateJobError::InvalidParameter(ref cause) => cause,
-            CreateJobError::InvalidVersion(ref cause) => cause,
-            CreateJobError::MalformedManifest(ref cause) => cause,
-            CreateJobError::MissingCustoms(ref cause) => cause,
-            CreateJobError::MissingManifestField(ref cause) => cause,
-            CreateJobError::MissingParameter(ref cause) => cause,
-            CreateJobError::MultipleRegions(ref cause) => cause,
-            CreateJobError::NoSuchBucket(ref cause) => cause,
+            CreateJobError::BucketPermission(ref cause) => write!(f, "{}", cause),
+            CreateJobError::CreateJobQuotaExceeded(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidAccessKeyId(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidAddress(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidCustoms(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidFileSystem(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidJobId(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidManifestField(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidVersion(ref cause) => write!(f, "{}", cause),
+            CreateJobError::MalformedManifest(ref cause) => write!(f, "{}", cause),
+            CreateJobError::MissingCustoms(ref cause) => write!(f, "{}", cause),
+            CreateJobError::MissingManifestField(ref cause) => write!(f, "{}", cause),
+            CreateJobError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            CreateJobError::MultipleRegions(ref cause) => write!(f, "{}", cause),
+            CreateJobError::NoSuchBucket(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobError {}
 /// Errors returned by GetShippingLabel
 #[derive(Debug, PartialEq)]
 pub enum GetShippingLabelError {
@@ -1203,22 +1195,18 @@ impl GetShippingLabelError {
 }
 impl fmt::Display for GetShippingLabelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetShippingLabelError {
-    fn description(&self) -> &str {
         match *self {
-            GetShippingLabelError::CanceledJobId(ref cause) => cause,
-            GetShippingLabelError::ExpiredJobId(ref cause) => cause,
-            GetShippingLabelError::InvalidAccessKeyId(ref cause) => cause,
-            GetShippingLabelError::InvalidAddress(ref cause) => cause,
-            GetShippingLabelError::InvalidJobId(ref cause) => cause,
-            GetShippingLabelError::InvalidParameter(ref cause) => cause,
-            GetShippingLabelError::InvalidVersion(ref cause) => cause,
+            GetShippingLabelError::CanceledJobId(ref cause) => write!(f, "{}", cause),
+            GetShippingLabelError::ExpiredJobId(ref cause) => write!(f, "{}", cause),
+            GetShippingLabelError::InvalidAccessKeyId(ref cause) => write!(f, "{}", cause),
+            GetShippingLabelError::InvalidAddress(ref cause) => write!(f, "{}", cause),
+            GetShippingLabelError::InvalidJobId(ref cause) => write!(f, "{}", cause),
+            GetShippingLabelError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetShippingLabelError::InvalidVersion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetShippingLabelError {}
 /// Errors returned by GetStatus
 #[derive(Debug, PartialEq)]
 pub enum GetStatusError {
@@ -1284,20 +1272,16 @@ impl GetStatusError {
 }
 impl fmt::Display for GetStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetStatusError::CanceledJobId(ref cause) => cause,
-            GetStatusError::ExpiredJobId(ref cause) => cause,
-            GetStatusError::InvalidAccessKeyId(ref cause) => cause,
-            GetStatusError::InvalidJobId(ref cause) => cause,
-            GetStatusError::InvalidVersion(ref cause) => cause,
+            GetStatusError::CanceledJobId(ref cause) => write!(f, "{}", cause),
+            GetStatusError::ExpiredJobId(ref cause) => write!(f, "{}", cause),
+            GetStatusError::InvalidAccessKeyId(ref cause) => write!(f, "{}", cause),
+            GetStatusError::InvalidJobId(ref cause) => write!(f, "{}", cause),
+            GetStatusError::InvalidVersion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStatusError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -1349,18 +1333,14 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::InvalidAccessKeyId(ref cause) => cause,
-            ListJobsError::InvalidParameter(ref cause) => cause,
-            ListJobsError::InvalidVersion(ref cause) => cause,
+            ListJobsError::InvalidAccessKeyId(ref cause) => write!(f, "{}", cause),
+            ListJobsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListJobsError::InvalidVersion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by UpdateJob
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobError {
@@ -1517,33 +1497,29 @@ impl UpdateJobError {
 }
 impl fmt::Display for UpdateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateJobError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateJobError::BucketPermission(ref cause) => cause,
-            UpdateJobError::CanceledJobId(ref cause) => cause,
-            UpdateJobError::ExpiredJobId(ref cause) => cause,
-            UpdateJobError::InvalidAccessKeyId(ref cause) => cause,
-            UpdateJobError::InvalidAddress(ref cause) => cause,
-            UpdateJobError::InvalidCustoms(ref cause) => cause,
-            UpdateJobError::InvalidFileSystem(ref cause) => cause,
-            UpdateJobError::InvalidJobId(ref cause) => cause,
-            UpdateJobError::InvalidManifestField(ref cause) => cause,
-            UpdateJobError::InvalidParameter(ref cause) => cause,
-            UpdateJobError::InvalidVersion(ref cause) => cause,
-            UpdateJobError::MalformedManifest(ref cause) => cause,
-            UpdateJobError::MissingCustoms(ref cause) => cause,
-            UpdateJobError::MissingManifestField(ref cause) => cause,
-            UpdateJobError::MissingParameter(ref cause) => cause,
-            UpdateJobError::MultipleRegions(ref cause) => cause,
-            UpdateJobError::NoSuchBucket(ref cause) => cause,
-            UpdateJobError::UnableToUpdateJobId(ref cause) => cause,
+            UpdateJobError::BucketPermission(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::CanceledJobId(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::ExpiredJobId(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidAccessKeyId(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidAddress(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidCustoms(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidFileSystem(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidJobId(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidManifestField(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidVersion(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::MalformedManifest(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::MissingCustoms(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::MissingManifestField(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::MultipleRegions(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::NoSuchBucket(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::UnableToUpdateJobId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateJobError {}
 /// Trait representing the capabilities of the AWS Import/Export API. AWS Import/Export clients implement this trait.
 pub trait ImportExport {
     /// <p>This operation cancels a specified job. Only the job owner can cancel it. The operation fails if the job has already started or is complete.</p>

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -1547,20 +1547,18 @@ impl AddAttributesToFindingsError {
 }
 impl fmt::Display for AddAttributesToFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddAttributesToFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            AddAttributesToFindingsError::AccessDenied(ref cause) => cause,
-            AddAttributesToFindingsError::Internal(ref cause) => cause,
-            AddAttributesToFindingsError::InvalidInput(ref cause) => cause,
-            AddAttributesToFindingsError::NoSuchEntity(ref cause) => cause,
-            AddAttributesToFindingsError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            AddAttributesToFindingsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AddAttributesToFindingsError::Internal(ref cause) => write!(f, "{}", cause),
+            AddAttributesToFindingsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AddAttributesToFindingsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            AddAttributesToFindingsError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddAttributesToFindingsError {}
 /// Errors returned by CreateAssessmentTarget
 #[derive(Debug, PartialEq)]
 pub enum CreateAssessmentTargetError {
@@ -1620,22 +1618,22 @@ impl CreateAssessmentTargetError {
 }
 impl fmt::Display for CreateAssessmentTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAssessmentTargetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAssessmentTargetError::AccessDenied(ref cause) => cause,
-            CreateAssessmentTargetError::Internal(ref cause) => cause,
-            CreateAssessmentTargetError::InvalidCrossAccountRole(ref cause) => cause,
-            CreateAssessmentTargetError::InvalidInput(ref cause) => cause,
-            CreateAssessmentTargetError::LimitExceeded(ref cause) => cause,
-            CreateAssessmentTargetError::NoSuchEntity(ref cause) => cause,
-            CreateAssessmentTargetError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            CreateAssessmentTargetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTargetError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTargetError::InvalidCrossAccountRole(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAssessmentTargetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTargetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTargetError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTargetError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateAssessmentTargetError {}
 /// Errors returned by CreateAssessmentTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateAssessmentTemplateError {
@@ -1694,21 +1692,19 @@ impl CreateAssessmentTemplateError {
 }
 impl fmt::Display for CreateAssessmentTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAssessmentTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAssessmentTemplateError::AccessDenied(ref cause) => cause,
-            CreateAssessmentTemplateError::Internal(ref cause) => cause,
-            CreateAssessmentTemplateError::InvalidInput(ref cause) => cause,
-            CreateAssessmentTemplateError::LimitExceeded(ref cause) => cause,
-            CreateAssessmentTemplateError::NoSuchEntity(ref cause) => cause,
-            CreateAssessmentTemplateError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            CreateAssessmentTemplateError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTemplateError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTemplateError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTemplateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTemplateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateAssessmentTemplateError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateAssessmentTemplateError {}
 /// Errors returned by CreateExclusionsPreview
 #[derive(Debug, PartialEq)]
 pub enum CreateExclusionsPreviewError {
@@ -1767,21 +1763,21 @@ impl CreateExclusionsPreviewError {
 }
 impl fmt::Display for CreateExclusionsPreviewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateExclusionsPreviewError {
-    fn description(&self) -> &str {
         match *self {
-            CreateExclusionsPreviewError::AccessDenied(ref cause) => cause,
-            CreateExclusionsPreviewError::Internal(ref cause) => cause,
-            CreateExclusionsPreviewError::InvalidInput(ref cause) => cause,
-            CreateExclusionsPreviewError::NoSuchEntity(ref cause) => cause,
-            CreateExclusionsPreviewError::PreviewGenerationInProgress(ref cause) => cause,
-            CreateExclusionsPreviewError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            CreateExclusionsPreviewError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateExclusionsPreviewError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateExclusionsPreviewError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateExclusionsPreviewError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            CreateExclusionsPreviewError::PreviewGenerationInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateExclusionsPreviewError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateExclusionsPreviewError {}
 /// Errors returned by CreateResourceGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceGroupError {
@@ -1827,20 +1823,18 @@ impl CreateResourceGroupError {
 }
 impl fmt::Display for CreateResourceGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceGroupError::AccessDenied(ref cause) => cause,
-            CreateResourceGroupError::Internal(ref cause) => cause,
-            CreateResourceGroupError::InvalidInput(ref cause) => cause,
-            CreateResourceGroupError::LimitExceeded(ref cause) => cause,
-            CreateResourceGroupError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            CreateResourceGroupError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateResourceGroupError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateResourceGroupError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateResourceGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateResourceGroupError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateResourceGroupError {}
 /// Errors returned by DeleteAssessmentRun
 #[derive(Debug, PartialEq)]
 pub enum DeleteAssessmentRunError {
@@ -1893,21 +1887,19 @@ impl DeleteAssessmentRunError {
 }
 impl fmt::Display for DeleteAssessmentRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAssessmentRunError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAssessmentRunError::AccessDenied(ref cause) => cause,
-            DeleteAssessmentRunError::AssessmentRunInProgress(ref cause) => cause,
-            DeleteAssessmentRunError::Internal(ref cause) => cause,
-            DeleteAssessmentRunError::InvalidInput(ref cause) => cause,
-            DeleteAssessmentRunError::NoSuchEntity(ref cause) => cause,
-            DeleteAssessmentRunError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            DeleteAssessmentRunError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentRunError::AssessmentRunInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentRunError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentRunError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentRunError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteAssessmentRunError {}
 /// Errors returned by DeleteAssessmentTarget
 #[derive(Debug, PartialEq)]
 pub enum DeleteAssessmentTargetError {
@@ -1960,21 +1952,21 @@ impl DeleteAssessmentTargetError {
 }
 impl fmt::Display for DeleteAssessmentTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAssessmentTargetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAssessmentTargetError::AccessDenied(ref cause) => cause,
-            DeleteAssessmentTargetError::AssessmentRunInProgress(ref cause) => cause,
-            DeleteAssessmentTargetError::Internal(ref cause) => cause,
-            DeleteAssessmentTargetError::InvalidInput(ref cause) => cause,
-            DeleteAssessmentTargetError::NoSuchEntity(ref cause) => cause,
-            DeleteAssessmentTargetError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            DeleteAssessmentTargetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTargetError::AssessmentRunInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAssessmentTargetError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTargetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTargetError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTargetError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteAssessmentTargetError {}
 /// Errors returned by DeleteAssessmentTemplate
 #[derive(Debug, PartialEq)]
 pub enum DeleteAssessmentTemplateError {
@@ -2033,21 +2025,21 @@ impl DeleteAssessmentTemplateError {
 }
 impl fmt::Display for DeleteAssessmentTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAssessmentTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAssessmentTemplateError::AccessDenied(ref cause) => cause,
-            DeleteAssessmentTemplateError::AssessmentRunInProgress(ref cause) => cause,
-            DeleteAssessmentTemplateError::Internal(ref cause) => cause,
-            DeleteAssessmentTemplateError::InvalidInput(ref cause) => cause,
-            DeleteAssessmentTemplateError::NoSuchEntity(ref cause) => cause,
-            DeleteAssessmentTemplateError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            DeleteAssessmentTemplateError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTemplateError::AssessmentRunInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAssessmentTemplateError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTemplateError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTemplateError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            DeleteAssessmentTemplateError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteAssessmentTemplateError {}
 /// Errors returned by DescribeAssessmentRuns
 #[derive(Debug, PartialEq)]
 pub enum DescribeAssessmentRunsError {
@@ -2076,17 +2068,13 @@ impl DescribeAssessmentRunsError {
 }
 impl fmt::Display for DescribeAssessmentRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAssessmentRunsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAssessmentRunsError::Internal(ref cause) => cause,
-            DescribeAssessmentRunsError::InvalidInput(ref cause) => cause,
+            DescribeAssessmentRunsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeAssessmentRunsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAssessmentRunsError {}
 /// Errors returned by DescribeAssessmentTargets
 #[derive(Debug, PartialEq)]
 pub enum DescribeAssessmentTargetsError {
@@ -2117,17 +2105,13 @@ impl DescribeAssessmentTargetsError {
 }
 impl fmt::Display for DescribeAssessmentTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAssessmentTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAssessmentTargetsError::Internal(ref cause) => cause,
-            DescribeAssessmentTargetsError::InvalidInput(ref cause) => cause,
+            DescribeAssessmentTargetsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeAssessmentTargetsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAssessmentTargetsError {}
 /// Errors returned by DescribeAssessmentTemplates
 #[derive(Debug, PartialEq)]
 pub enum DescribeAssessmentTemplatesError {
@@ -2162,17 +2146,13 @@ impl DescribeAssessmentTemplatesError {
 }
 impl fmt::Display for DescribeAssessmentTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAssessmentTemplatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAssessmentTemplatesError::Internal(ref cause) => cause,
-            DescribeAssessmentTemplatesError::InvalidInput(ref cause) => cause,
+            DescribeAssessmentTemplatesError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeAssessmentTemplatesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAssessmentTemplatesError {}
 /// Errors returned by DescribeCrossAccountAccessRole
 #[derive(Debug, PartialEq)]
 pub enum DescribeCrossAccountAccessRoleError {
@@ -2200,16 +2180,12 @@ impl DescribeCrossAccountAccessRoleError {
 }
 impl fmt::Display for DescribeCrossAccountAccessRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCrossAccountAccessRoleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCrossAccountAccessRoleError::Internal(ref cause) => cause,
+            DescribeCrossAccountAccessRoleError::Internal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCrossAccountAccessRoleError {}
 /// Errors returned by DescribeExclusions
 #[derive(Debug, PartialEq)]
 pub enum DescribeExclusionsError {
@@ -2238,17 +2214,13 @@ impl DescribeExclusionsError {
 }
 impl fmt::Display for DescribeExclusionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeExclusionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeExclusionsError::Internal(ref cause) => cause,
-            DescribeExclusionsError::InvalidInput(ref cause) => cause,
+            DescribeExclusionsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeExclusionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeExclusionsError {}
 /// Errors returned by DescribeFindings
 #[derive(Debug, PartialEq)]
 pub enum DescribeFindingsError {
@@ -2277,17 +2249,13 @@ impl DescribeFindingsError {
 }
 impl fmt::Display for DescribeFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFindingsError::Internal(ref cause) => cause,
-            DescribeFindingsError::InvalidInput(ref cause) => cause,
+            DescribeFindingsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeFindingsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFindingsError {}
 /// Errors returned by DescribeResourceGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeResourceGroupsError {
@@ -2316,17 +2284,13 @@ impl DescribeResourceGroupsError {
 }
 impl fmt::Display for DescribeResourceGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeResourceGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeResourceGroupsError::Internal(ref cause) => cause,
-            DescribeResourceGroupsError::InvalidInput(ref cause) => cause,
+            DescribeResourceGroupsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeResourceGroupsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeResourceGroupsError {}
 /// Errors returned by DescribeRulesPackages
 #[derive(Debug, PartialEq)]
 pub enum DescribeRulesPackagesError {
@@ -2355,17 +2319,13 @@ impl DescribeRulesPackagesError {
 }
 impl fmt::Display for DescribeRulesPackagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRulesPackagesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRulesPackagesError::Internal(ref cause) => cause,
-            DescribeRulesPackagesError::InvalidInput(ref cause) => cause,
+            DescribeRulesPackagesError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeRulesPackagesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRulesPackagesError {}
 /// Errors returned by GetAssessmentReport
 #[derive(Debug, PartialEq)]
 pub enum GetAssessmentReportError {
@@ -2425,22 +2385,20 @@ impl GetAssessmentReportError {
 }
 impl fmt::Display for GetAssessmentReportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAssessmentReportError {
-    fn description(&self) -> &str {
         match *self {
-            GetAssessmentReportError::AccessDenied(ref cause) => cause,
-            GetAssessmentReportError::AssessmentRunInProgress(ref cause) => cause,
-            GetAssessmentReportError::Internal(ref cause) => cause,
-            GetAssessmentReportError::InvalidInput(ref cause) => cause,
-            GetAssessmentReportError::NoSuchEntity(ref cause) => cause,
-            GetAssessmentReportError::ServiceTemporarilyUnavailable(ref cause) => cause,
-            GetAssessmentReportError::UnsupportedFeature(ref cause) => cause,
+            GetAssessmentReportError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetAssessmentReportError::AssessmentRunInProgress(ref cause) => write!(f, "{}", cause),
+            GetAssessmentReportError::Internal(ref cause) => write!(f, "{}", cause),
+            GetAssessmentReportError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetAssessmentReportError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            GetAssessmentReportError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAssessmentReportError::UnsupportedFeature(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAssessmentReportError {}
 /// Errors returned by GetExclusionsPreview
 #[derive(Debug, PartialEq)]
 pub enum GetExclusionsPreviewError {
@@ -2479,19 +2437,15 @@ impl GetExclusionsPreviewError {
 }
 impl fmt::Display for GetExclusionsPreviewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetExclusionsPreviewError {
-    fn description(&self) -> &str {
         match *self {
-            GetExclusionsPreviewError::AccessDenied(ref cause) => cause,
-            GetExclusionsPreviewError::Internal(ref cause) => cause,
-            GetExclusionsPreviewError::InvalidInput(ref cause) => cause,
-            GetExclusionsPreviewError::NoSuchEntity(ref cause) => cause,
+            GetExclusionsPreviewError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetExclusionsPreviewError::Internal(ref cause) => write!(f, "{}", cause),
+            GetExclusionsPreviewError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetExclusionsPreviewError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetExclusionsPreviewError {}
 /// Errors returned by GetTelemetryMetadata
 #[derive(Debug, PartialEq)]
 pub enum GetTelemetryMetadataError {
@@ -2530,19 +2484,15 @@ impl GetTelemetryMetadataError {
 }
 impl fmt::Display for GetTelemetryMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTelemetryMetadataError {
-    fn description(&self) -> &str {
         match *self {
-            GetTelemetryMetadataError::AccessDenied(ref cause) => cause,
-            GetTelemetryMetadataError::Internal(ref cause) => cause,
-            GetTelemetryMetadataError::InvalidInput(ref cause) => cause,
-            GetTelemetryMetadataError::NoSuchEntity(ref cause) => cause,
+            GetTelemetryMetadataError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetTelemetryMetadataError::Internal(ref cause) => write!(f, "{}", cause),
+            GetTelemetryMetadataError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTelemetryMetadataError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTelemetryMetadataError {}
 /// Errors returned by ListAssessmentRunAgents
 #[derive(Debug, PartialEq)]
 pub enum ListAssessmentRunAgentsError {
@@ -2587,19 +2537,15 @@ impl ListAssessmentRunAgentsError {
 }
 impl fmt::Display for ListAssessmentRunAgentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssessmentRunAgentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssessmentRunAgentsError::AccessDenied(ref cause) => cause,
-            ListAssessmentRunAgentsError::Internal(ref cause) => cause,
-            ListAssessmentRunAgentsError::InvalidInput(ref cause) => cause,
-            ListAssessmentRunAgentsError::NoSuchEntity(ref cause) => cause,
+            ListAssessmentRunAgentsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAssessmentRunAgentsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListAssessmentRunAgentsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAssessmentRunAgentsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAssessmentRunAgentsError {}
 /// Errors returned by ListAssessmentRuns
 #[derive(Debug, PartialEq)]
 pub enum ListAssessmentRunsError {
@@ -2638,19 +2584,15 @@ impl ListAssessmentRunsError {
 }
 impl fmt::Display for ListAssessmentRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssessmentRunsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssessmentRunsError::AccessDenied(ref cause) => cause,
-            ListAssessmentRunsError::Internal(ref cause) => cause,
-            ListAssessmentRunsError::InvalidInput(ref cause) => cause,
-            ListAssessmentRunsError::NoSuchEntity(ref cause) => cause,
+            ListAssessmentRunsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAssessmentRunsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListAssessmentRunsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAssessmentRunsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAssessmentRunsError {}
 /// Errors returned by ListAssessmentTargets
 #[derive(Debug, PartialEq)]
 pub enum ListAssessmentTargetsError {
@@ -2684,18 +2626,14 @@ impl ListAssessmentTargetsError {
 }
 impl fmt::Display for ListAssessmentTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssessmentTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssessmentTargetsError::AccessDenied(ref cause) => cause,
-            ListAssessmentTargetsError::Internal(ref cause) => cause,
-            ListAssessmentTargetsError::InvalidInput(ref cause) => cause,
+            ListAssessmentTargetsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAssessmentTargetsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListAssessmentTargetsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAssessmentTargetsError {}
 /// Errors returned by ListAssessmentTemplates
 #[derive(Debug, PartialEq)]
 pub enum ListAssessmentTemplatesError {
@@ -2740,19 +2678,15 @@ impl ListAssessmentTemplatesError {
 }
 impl fmt::Display for ListAssessmentTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssessmentTemplatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssessmentTemplatesError::AccessDenied(ref cause) => cause,
-            ListAssessmentTemplatesError::Internal(ref cause) => cause,
-            ListAssessmentTemplatesError::InvalidInput(ref cause) => cause,
-            ListAssessmentTemplatesError::NoSuchEntity(ref cause) => cause,
+            ListAssessmentTemplatesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAssessmentTemplatesError::Internal(ref cause) => write!(f, "{}", cause),
+            ListAssessmentTemplatesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAssessmentTemplatesError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAssessmentTemplatesError {}
 /// Errors returned by ListEventSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum ListEventSubscriptionsError {
@@ -2791,19 +2725,15 @@ impl ListEventSubscriptionsError {
 }
 impl fmt::Display for ListEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEventSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListEventSubscriptionsError::AccessDenied(ref cause) => cause,
-            ListEventSubscriptionsError::Internal(ref cause) => cause,
-            ListEventSubscriptionsError::InvalidInput(ref cause) => cause,
-            ListEventSubscriptionsError::NoSuchEntity(ref cause) => cause,
+            ListEventSubscriptionsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListEventSubscriptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListEventSubscriptionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListEventSubscriptionsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEventSubscriptionsError {}
 /// Errors returned by ListExclusions
 #[derive(Debug, PartialEq)]
 pub enum ListExclusionsError {
@@ -2842,19 +2772,15 @@ impl ListExclusionsError {
 }
 impl fmt::Display for ListExclusionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListExclusionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListExclusionsError::AccessDenied(ref cause) => cause,
-            ListExclusionsError::Internal(ref cause) => cause,
-            ListExclusionsError::InvalidInput(ref cause) => cause,
-            ListExclusionsError::NoSuchEntity(ref cause) => cause,
+            ListExclusionsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListExclusionsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListExclusionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListExclusionsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListExclusionsError {}
 /// Errors returned by ListFindings
 #[derive(Debug, PartialEq)]
 pub enum ListFindingsError {
@@ -2893,19 +2819,15 @@ impl ListFindingsError {
 }
 impl fmt::Display for ListFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFindingsError::AccessDenied(ref cause) => cause,
-            ListFindingsError::Internal(ref cause) => cause,
-            ListFindingsError::InvalidInput(ref cause) => cause,
-            ListFindingsError::NoSuchEntity(ref cause) => cause,
+            ListFindingsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListFindingsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListFindingsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListFindingsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFindingsError {}
 /// Errors returned by ListRulesPackages
 #[derive(Debug, PartialEq)]
 pub enum ListRulesPackagesError {
@@ -2939,18 +2861,14 @@ impl ListRulesPackagesError {
 }
 impl fmt::Display for ListRulesPackagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRulesPackagesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRulesPackagesError::AccessDenied(ref cause) => cause,
-            ListRulesPackagesError::Internal(ref cause) => cause,
-            ListRulesPackagesError::InvalidInput(ref cause) => cause,
+            ListRulesPackagesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListRulesPackagesError::Internal(ref cause) => write!(f, "{}", cause),
+            ListRulesPackagesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRulesPackagesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2989,19 +2907,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AccessDenied(ref cause) => cause,
-            ListTagsForResourceError::Internal(ref cause) => cause,
-            ListTagsForResourceError::InvalidInput(ref cause) => cause,
-            ListTagsForResourceError::NoSuchEntity(ref cause) => cause,
+            ListTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PreviewAgents
 #[derive(Debug, PartialEq)]
 pub enum PreviewAgentsError {
@@ -3047,20 +2961,16 @@ impl PreviewAgentsError {
 }
 impl fmt::Display for PreviewAgentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PreviewAgentsError {
-    fn description(&self) -> &str {
         match *self {
-            PreviewAgentsError::AccessDenied(ref cause) => cause,
-            PreviewAgentsError::Internal(ref cause) => cause,
-            PreviewAgentsError::InvalidCrossAccountRole(ref cause) => cause,
-            PreviewAgentsError::InvalidInput(ref cause) => cause,
-            PreviewAgentsError::NoSuchEntity(ref cause) => cause,
+            PreviewAgentsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            PreviewAgentsError::Internal(ref cause) => write!(f, "{}", cause),
+            PreviewAgentsError::InvalidCrossAccountRole(ref cause) => write!(f, "{}", cause),
+            PreviewAgentsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PreviewAgentsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PreviewAgentsError {}
 /// Errors returned by RegisterCrossAccountAccessRole
 #[derive(Debug, PartialEq)]
 pub enum RegisterCrossAccountAccessRoleError {
@@ -3116,20 +3026,20 @@ impl RegisterCrossAccountAccessRoleError {
 }
 impl fmt::Display for RegisterCrossAccountAccessRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterCrossAccountAccessRoleError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterCrossAccountAccessRoleError::AccessDenied(ref cause) => cause,
-            RegisterCrossAccountAccessRoleError::Internal(ref cause) => cause,
-            RegisterCrossAccountAccessRoleError::InvalidCrossAccountRole(ref cause) => cause,
-            RegisterCrossAccountAccessRoleError::InvalidInput(ref cause) => cause,
-            RegisterCrossAccountAccessRoleError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            RegisterCrossAccountAccessRoleError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RegisterCrossAccountAccessRoleError::Internal(ref cause) => write!(f, "{}", cause),
+            RegisterCrossAccountAccessRoleError::InvalidCrossAccountRole(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterCrossAccountAccessRoleError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RegisterCrossAccountAccessRoleError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterCrossAccountAccessRoleError {}
 /// Errors returned by RemoveAttributesFromFindings
 #[derive(Debug, PartialEq)]
 pub enum RemoveAttributesFromFindingsError {
@@ -3185,20 +3095,18 @@ impl RemoveAttributesFromFindingsError {
 }
 impl fmt::Display for RemoveAttributesFromFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveAttributesFromFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveAttributesFromFindingsError::AccessDenied(ref cause) => cause,
-            RemoveAttributesFromFindingsError::Internal(ref cause) => cause,
-            RemoveAttributesFromFindingsError::InvalidInput(ref cause) => cause,
-            RemoveAttributesFromFindingsError::NoSuchEntity(ref cause) => cause,
-            RemoveAttributesFromFindingsError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            RemoveAttributesFromFindingsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RemoveAttributesFromFindingsError::Internal(ref cause) => write!(f, "{}", cause),
+            RemoveAttributesFromFindingsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RemoveAttributesFromFindingsError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            RemoveAttributesFromFindingsError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveAttributesFromFindingsError {}
 /// Errors returned by SetTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum SetTagsForResourceError {
@@ -3244,20 +3152,18 @@ impl SetTagsForResourceError {
 }
 impl fmt::Display for SetTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            SetTagsForResourceError::AccessDenied(ref cause) => cause,
-            SetTagsForResourceError::Internal(ref cause) => cause,
-            SetTagsForResourceError::InvalidInput(ref cause) => cause,
-            SetTagsForResourceError::NoSuchEntity(ref cause) => cause,
-            SetTagsForResourceError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            SetTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SetTagsForResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            SetTagsForResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            SetTagsForResourceError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            SetTagsForResourceError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetTagsForResourceError {}
 /// Errors returned by StartAssessmentRun
 #[derive(Debug, PartialEq)]
 pub enum StartAssessmentRunError {
@@ -3322,23 +3228,23 @@ impl StartAssessmentRunError {
 }
 impl fmt::Display for StartAssessmentRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartAssessmentRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartAssessmentRunError::AccessDenied(ref cause) => cause,
-            StartAssessmentRunError::AgentsAlreadyRunningAssessment(ref cause) => cause,
-            StartAssessmentRunError::Internal(ref cause) => cause,
-            StartAssessmentRunError::InvalidCrossAccountRole(ref cause) => cause,
-            StartAssessmentRunError::InvalidInput(ref cause) => cause,
-            StartAssessmentRunError::LimitExceeded(ref cause) => cause,
-            StartAssessmentRunError::NoSuchEntity(ref cause) => cause,
-            StartAssessmentRunError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            StartAssessmentRunError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartAssessmentRunError::AgentsAlreadyRunningAssessment(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAssessmentRunError::Internal(ref cause) => write!(f, "{}", cause),
+            StartAssessmentRunError::InvalidCrossAccountRole(ref cause) => write!(f, "{}", cause),
+            StartAssessmentRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartAssessmentRunError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartAssessmentRunError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            StartAssessmentRunError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartAssessmentRunError {}
 /// Errors returned by StopAssessmentRun
 #[derive(Debug, PartialEq)]
 pub enum StopAssessmentRunError {
@@ -3384,20 +3290,18 @@ impl StopAssessmentRunError {
 }
 impl fmt::Display for StopAssessmentRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopAssessmentRunError {
-    fn description(&self) -> &str {
         match *self {
-            StopAssessmentRunError::AccessDenied(ref cause) => cause,
-            StopAssessmentRunError::Internal(ref cause) => cause,
-            StopAssessmentRunError::InvalidInput(ref cause) => cause,
-            StopAssessmentRunError::NoSuchEntity(ref cause) => cause,
-            StopAssessmentRunError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            StopAssessmentRunError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StopAssessmentRunError::Internal(ref cause) => write!(f, "{}", cause),
+            StopAssessmentRunError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StopAssessmentRunError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            StopAssessmentRunError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StopAssessmentRunError {}
 /// Errors returned by SubscribeToEvent
 #[derive(Debug, PartialEq)]
 pub enum SubscribeToEventError {
@@ -3448,21 +3352,19 @@ impl SubscribeToEventError {
 }
 impl fmt::Display for SubscribeToEventError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubscribeToEventError {
-    fn description(&self) -> &str {
         match *self {
-            SubscribeToEventError::AccessDenied(ref cause) => cause,
-            SubscribeToEventError::Internal(ref cause) => cause,
-            SubscribeToEventError::InvalidInput(ref cause) => cause,
-            SubscribeToEventError::LimitExceeded(ref cause) => cause,
-            SubscribeToEventError::NoSuchEntity(ref cause) => cause,
-            SubscribeToEventError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            SubscribeToEventError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SubscribeToEventError::Internal(ref cause) => write!(f, "{}", cause),
+            SubscribeToEventError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            SubscribeToEventError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            SubscribeToEventError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            SubscribeToEventError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SubscribeToEventError {}
 /// Errors returned by UnsubscribeFromEvent
 #[derive(Debug, PartialEq)]
 pub enum UnsubscribeFromEventError {
@@ -3508,20 +3410,18 @@ impl UnsubscribeFromEventError {
 }
 impl fmt::Display for UnsubscribeFromEventError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnsubscribeFromEventError {
-    fn description(&self) -> &str {
         match *self {
-            UnsubscribeFromEventError::AccessDenied(ref cause) => cause,
-            UnsubscribeFromEventError::Internal(ref cause) => cause,
-            UnsubscribeFromEventError::InvalidInput(ref cause) => cause,
-            UnsubscribeFromEventError::NoSuchEntity(ref cause) => cause,
-            UnsubscribeFromEventError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            UnsubscribeFromEventError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromEventError::Internal(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromEventError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromEventError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UnsubscribeFromEventError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UnsubscribeFromEventError {}
 /// Errors returned by UpdateAssessmentTarget
 #[derive(Debug, PartialEq)]
 pub enum UpdateAssessmentTargetError {
@@ -3567,20 +3467,18 @@ impl UpdateAssessmentTargetError {
 }
 impl fmt::Display for UpdateAssessmentTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAssessmentTargetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAssessmentTargetError::AccessDenied(ref cause) => cause,
-            UpdateAssessmentTargetError::Internal(ref cause) => cause,
-            UpdateAssessmentTargetError::InvalidInput(ref cause) => cause,
-            UpdateAssessmentTargetError::NoSuchEntity(ref cause) => cause,
-            UpdateAssessmentTargetError::ServiceTemporarilyUnavailable(ref cause) => cause,
+            UpdateAssessmentTargetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateAssessmentTargetError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateAssessmentTargetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateAssessmentTargetError::NoSuchEntity(ref cause) => write!(f, "{}", cause),
+            UpdateAssessmentTargetError::ServiceTemporarilyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateAssessmentTargetError {}
 /// Trait representing the capabilities of the Amazon Inspector API. Amazon Inspector clients implement this trait.
 pub trait Inspector {
     /// <p>Assigns attributes (key and value pairs) to the findings that are specified by the ARNs of the findings.</p>

--- a/rusoto/services/iot-data/src/generated.rs
+++ b/rusoto/services/iot-data/src/generated.rs
@@ -159,23 +159,21 @@ impl DeleteThingShadowError {
 }
 impl fmt::Display for DeleteThingShadowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteThingShadowError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteThingShadowError::InternalFailure(ref cause) => cause,
-            DeleteThingShadowError::InvalidRequest(ref cause) => cause,
-            DeleteThingShadowError::MethodNotAllowed(ref cause) => cause,
-            DeleteThingShadowError::ResourceNotFound(ref cause) => cause,
-            DeleteThingShadowError::ServiceUnavailable(ref cause) => cause,
-            DeleteThingShadowError::Throttling(ref cause) => cause,
-            DeleteThingShadowError::Unauthorized(ref cause) => cause,
-            DeleteThingShadowError::UnsupportedDocumentEncoding(ref cause) => cause,
+            DeleteThingShadowError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteThingShadowError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteThingShadowError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            DeleteThingShadowError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteThingShadowError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteThingShadowError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteThingShadowError::Unauthorized(ref cause) => write!(f, "{}", cause),
+            DeleteThingShadowError::UnsupportedDocumentEncoding(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteThingShadowError {}
 /// Errors returned by GetThingShadow
 #[derive(Debug, PartialEq)]
 pub enum GetThingShadowError {
@@ -236,23 +234,19 @@ impl GetThingShadowError {
 }
 impl fmt::Display for GetThingShadowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetThingShadowError {
-    fn description(&self) -> &str {
         match *self {
-            GetThingShadowError::InternalFailure(ref cause) => cause,
-            GetThingShadowError::InvalidRequest(ref cause) => cause,
-            GetThingShadowError::MethodNotAllowed(ref cause) => cause,
-            GetThingShadowError::ResourceNotFound(ref cause) => cause,
-            GetThingShadowError::ServiceUnavailable(ref cause) => cause,
-            GetThingShadowError::Throttling(ref cause) => cause,
-            GetThingShadowError::Unauthorized(ref cause) => cause,
-            GetThingShadowError::UnsupportedDocumentEncoding(ref cause) => cause,
+            GetThingShadowError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetThingShadowError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetThingShadowError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            GetThingShadowError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetThingShadowError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetThingShadowError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetThingShadowError::Unauthorized(ref cause) => write!(f, "{}", cause),
+            GetThingShadowError::UnsupportedDocumentEncoding(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetThingShadowError {}
 /// Errors returned by Publish
 #[derive(Debug, PartialEq)]
 pub enum PublishError {
@@ -291,19 +285,15 @@ impl PublishError {
 }
 impl fmt::Display for PublishError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PublishError {
-    fn description(&self) -> &str {
         match *self {
-            PublishError::InternalFailure(ref cause) => cause,
-            PublishError::InvalidRequest(ref cause) => cause,
-            PublishError::MethodNotAllowed(ref cause) => cause,
-            PublishError::Unauthorized(ref cause) => cause,
+            PublishError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PublishError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PublishError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            PublishError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PublishError {}
 /// Errors returned by UpdateThingShadow
 #[derive(Debug, PartialEq)]
 pub enum UpdateThingShadowError {
@@ -373,24 +363,22 @@ impl UpdateThingShadowError {
 }
 impl fmt::Display for UpdateThingShadowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateThingShadowError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateThingShadowError::Conflict(ref cause) => cause,
-            UpdateThingShadowError::InternalFailure(ref cause) => cause,
-            UpdateThingShadowError::InvalidRequest(ref cause) => cause,
-            UpdateThingShadowError::MethodNotAllowed(ref cause) => cause,
-            UpdateThingShadowError::RequestEntityTooLarge(ref cause) => cause,
-            UpdateThingShadowError::ServiceUnavailable(ref cause) => cause,
-            UpdateThingShadowError::Throttling(ref cause) => cause,
-            UpdateThingShadowError::Unauthorized(ref cause) => cause,
-            UpdateThingShadowError::UnsupportedDocumentEncoding(ref cause) => cause,
+            UpdateThingShadowError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::RequestEntityTooLarge(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::Unauthorized(ref cause) => write!(f, "{}", cause),
+            UpdateThingShadowError::UnsupportedDocumentEncoding(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateThingShadowError {}
 /// Trait representing the capabilities of the AWS IoT Data Plane API. AWS IoT Data Plane clients implement this trait.
 pub trait IotData {
     /// <p>Deletes the thing shadow for the specified thing.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/iot/latest/developerguide/API_DeleteThingShadow.html">DeleteThingShadow</a> in the <i>AWS IoT Developer Guide</i>.</p>

--- a/rusoto/services/iot-jobs-data/src/generated.rs
+++ b/rusoto/services/iot-jobs-data/src/generated.rs
@@ -297,21 +297,17 @@ impl DescribeJobExecutionError {
 }
 impl fmt::Display for DescribeJobExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobExecutionError::CertificateValidation(ref cause) => cause,
-            DescribeJobExecutionError::InvalidRequest(ref cause) => cause,
-            DescribeJobExecutionError::ResourceNotFound(ref cause) => cause,
-            DescribeJobExecutionError::ServiceUnavailable(ref cause) => cause,
-            DescribeJobExecutionError::TerminalState(ref cause) => cause,
-            DescribeJobExecutionError::Throttling(ref cause) => cause,
+            DescribeJobExecutionError::CertificateValidation(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::TerminalState(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobExecutionError {}
 /// Errors returned by GetPendingJobExecutions
 #[derive(Debug, PartialEq)]
 pub enum GetPendingJobExecutionsError {
@@ -363,20 +359,18 @@ impl GetPendingJobExecutionsError {
 }
 impl fmt::Display for GetPendingJobExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPendingJobExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetPendingJobExecutionsError::CertificateValidation(ref cause) => cause,
-            GetPendingJobExecutionsError::InvalidRequest(ref cause) => cause,
-            GetPendingJobExecutionsError::ResourceNotFound(ref cause) => cause,
-            GetPendingJobExecutionsError::ServiceUnavailable(ref cause) => cause,
-            GetPendingJobExecutionsError::Throttling(ref cause) => cause,
+            GetPendingJobExecutionsError::CertificateValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPendingJobExecutionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetPendingJobExecutionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetPendingJobExecutionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPendingJobExecutionsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPendingJobExecutionsError {}
 /// Errors returned by StartNextPendingJobExecution
 #[derive(Debug, PartialEq)]
 pub enum StartNextPendingJobExecutionError {
@@ -432,20 +426,22 @@ impl StartNextPendingJobExecutionError {
 }
 impl fmt::Display for StartNextPendingJobExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartNextPendingJobExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StartNextPendingJobExecutionError::CertificateValidation(ref cause) => cause,
-            StartNextPendingJobExecutionError::InvalidRequest(ref cause) => cause,
-            StartNextPendingJobExecutionError::ResourceNotFound(ref cause) => cause,
-            StartNextPendingJobExecutionError::ServiceUnavailable(ref cause) => cause,
-            StartNextPendingJobExecutionError::Throttling(ref cause) => cause,
+            StartNextPendingJobExecutionError::CertificateValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartNextPendingJobExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartNextPendingJobExecutionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartNextPendingJobExecutionError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartNextPendingJobExecutionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartNextPendingJobExecutionError {}
 /// Errors returned by UpdateJobExecution
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobExecutionError {
@@ -500,21 +496,17 @@ impl UpdateJobExecutionError {
 }
 impl fmt::Display for UpdateJobExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateJobExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateJobExecutionError::CertificateValidation(ref cause) => cause,
-            UpdateJobExecutionError::InvalidRequest(ref cause) => cause,
-            UpdateJobExecutionError::InvalidStateTransition(ref cause) => cause,
-            UpdateJobExecutionError::ResourceNotFound(ref cause) => cause,
-            UpdateJobExecutionError::ServiceUnavailable(ref cause) => cause,
-            UpdateJobExecutionError::Throttling(ref cause) => cause,
+            UpdateJobExecutionError::CertificateValidation(ref cause) => write!(f, "{}", cause),
+            UpdateJobExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateJobExecutionError::InvalidStateTransition(ref cause) => write!(f, "{}", cause),
+            UpdateJobExecutionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateJobExecutionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateJobExecutionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateJobExecutionError {}
 /// Trait representing the capabilities of the AWS IoT Jobs Data Plane API. AWS IoT Jobs Data Plane clients implement this trait.
 pub trait IotJobsData {
     /// <p>Gets details of a job execution.</p>

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -8331,22 +8331,20 @@ impl AcceptCertificateTransferError {
 }
 impl fmt::Display for AcceptCertificateTransferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptCertificateTransferError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptCertificateTransferError::InternalFailure(ref cause) => cause,
-            AcceptCertificateTransferError::InvalidRequest(ref cause) => cause,
-            AcceptCertificateTransferError::ResourceNotFound(ref cause) => cause,
-            AcceptCertificateTransferError::ServiceUnavailable(ref cause) => cause,
-            AcceptCertificateTransferError::Throttling(ref cause) => cause,
-            AcceptCertificateTransferError::TransferAlreadyCompleted(ref cause) => cause,
-            AcceptCertificateTransferError::Unauthorized(ref cause) => cause,
+            AcceptCertificateTransferError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AcceptCertificateTransferError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AcceptCertificateTransferError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AcceptCertificateTransferError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AcceptCertificateTransferError::Throttling(ref cause) => write!(f, "{}", cause),
+            AcceptCertificateTransferError::TransferAlreadyCompleted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptCertificateTransferError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptCertificateTransferError {}
 /// Errors returned by AddThingToBillingGroup
 #[derive(Debug, PartialEq)]
 pub enum AddThingToBillingGroupError {
@@ -8391,19 +8389,15 @@ impl AddThingToBillingGroupError {
 }
 impl fmt::Display for AddThingToBillingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddThingToBillingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AddThingToBillingGroupError::InternalFailure(ref cause) => cause,
-            AddThingToBillingGroupError::InvalidRequest(ref cause) => cause,
-            AddThingToBillingGroupError::ResourceNotFound(ref cause) => cause,
-            AddThingToBillingGroupError::Throttling(ref cause) => cause,
+            AddThingToBillingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AddThingToBillingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AddThingToBillingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddThingToBillingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddThingToBillingGroupError {}
 /// Errors returned by AddThingToThingGroup
 #[derive(Debug, PartialEq)]
 pub enum AddThingToThingGroupError {
@@ -8446,19 +8440,15 @@ impl AddThingToThingGroupError {
 }
 impl fmt::Display for AddThingToThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddThingToThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AddThingToThingGroupError::InternalFailure(ref cause) => cause,
-            AddThingToThingGroupError::InvalidRequest(ref cause) => cause,
-            AddThingToThingGroupError::ResourceNotFound(ref cause) => cause,
-            AddThingToThingGroupError::Throttling(ref cause) => cause,
+            AddThingToThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AddThingToThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AddThingToThingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddThingToThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddThingToThingGroupError {}
 /// Errors returned by AssociateTargetsWithJob
 #[derive(Debug, PartialEq)]
 pub enum AssociateTargetsWithJobError {
@@ -8510,20 +8500,16 @@ impl AssociateTargetsWithJobError {
 }
 impl fmt::Display for AssociateTargetsWithJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateTargetsWithJobError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateTargetsWithJobError::InvalidRequest(ref cause) => cause,
-            AssociateTargetsWithJobError::LimitExceeded(ref cause) => cause,
-            AssociateTargetsWithJobError::ResourceNotFound(ref cause) => cause,
-            AssociateTargetsWithJobError::ServiceUnavailable(ref cause) => cause,
-            AssociateTargetsWithJobError::Throttling(ref cause) => cause,
+            AssociateTargetsWithJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AssociateTargetsWithJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateTargetsWithJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateTargetsWithJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AssociateTargetsWithJobError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateTargetsWithJobError {}
 /// Errors returned by AttachPolicy
 #[derive(Debug, PartialEq)]
 pub enum AttachPolicyError {
@@ -8577,22 +8563,18 @@ impl AttachPolicyError {
 }
 impl fmt::Display for AttachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            AttachPolicyError::InternalFailure(ref cause) => cause,
-            AttachPolicyError::InvalidRequest(ref cause) => cause,
-            AttachPolicyError::LimitExceeded(ref cause) => cause,
-            AttachPolicyError::ResourceNotFound(ref cause) => cause,
-            AttachPolicyError::ServiceUnavailable(ref cause) => cause,
-            AttachPolicyError::Throttling(ref cause) => cause,
-            AttachPolicyError::Unauthorized(ref cause) => cause,
+            AttachPolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachPolicyError {}
 /// Errors returned by AttachPrincipalPolicy
 #[derive(Debug, PartialEq)]
 pub enum AttachPrincipalPolicyError {
@@ -8654,22 +8636,18 @@ impl AttachPrincipalPolicyError {
 }
 impl fmt::Display for AttachPrincipalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachPrincipalPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            AttachPrincipalPolicyError::InternalFailure(ref cause) => cause,
-            AttachPrincipalPolicyError::InvalidRequest(ref cause) => cause,
-            AttachPrincipalPolicyError::LimitExceeded(ref cause) => cause,
-            AttachPrincipalPolicyError::ResourceNotFound(ref cause) => cause,
-            AttachPrincipalPolicyError::ServiceUnavailable(ref cause) => cause,
-            AttachPrincipalPolicyError::Throttling(ref cause) => cause,
-            AttachPrincipalPolicyError::Unauthorized(ref cause) => cause,
+            AttachPrincipalPolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AttachPrincipalPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AttachPrincipalPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachPrincipalPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachPrincipalPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AttachPrincipalPolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            AttachPrincipalPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachPrincipalPolicyError {}
 /// Errors returned by AttachSecurityProfile
 #[derive(Debug, PartialEq)]
 pub enum AttachSecurityProfileError {
@@ -8726,21 +8704,17 @@ impl AttachSecurityProfileError {
 }
 impl fmt::Display for AttachSecurityProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachSecurityProfileError {
-    fn description(&self) -> &str {
         match *self {
-            AttachSecurityProfileError::InternalFailure(ref cause) => cause,
-            AttachSecurityProfileError::InvalidRequest(ref cause) => cause,
-            AttachSecurityProfileError::LimitExceeded(ref cause) => cause,
-            AttachSecurityProfileError::ResourceNotFound(ref cause) => cause,
-            AttachSecurityProfileError::Throttling(ref cause) => cause,
-            AttachSecurityProfileError::VersionConflict(ref cause) => cause,
+            AttachSecurityProfileError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AttachSecurityProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AttachSecurityProfileError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AttachSecurityProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachSecurityProfileError::Throttling(ref cause) => write!(f, "{}", cause),
+            AttachSecurityProfileError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachSecurityProfileError {}
 /// Errors returned by AttachThingPrincipal
 #[derive(Debug, PartialEq)]
 pub enum AttachThingPrincipalError {
@@ -8795,21 +8769,17 @@ impl AttachThingPrincipalError {
 }
 impl fmt::Display for AttachThingPrincipalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachThingPrincipalError {
-    fn description(&self) -> &str {
         match *self {
-            AttachThingPrincipalError::InternalFailure(ref cause) => cause,
-            AttachThingPrincipalError::InvalidRequest(ref cause) => cause,
-            AttachThingPrincipalError::ResourceNotFound(ref cause) => cause,
-            AttachThingPrincipalError::ServiceUnavailable(ref cause) => cause,
-            AttachThingPrincipalError::Throttling(ref cause) => cause,
-            AttachThingPrincipalError::Unauthorized(ref cause) => cause,
+            AttachThingPrincipalError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AttachThingPrincipalError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AttachThingPrincipalError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AttachThingPrincipalError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AttachThingPrincipalError::Throttling(ref cause) => write!(f, "{}", cause),
+            AttachThingPrincipalError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachThingPrincipalError {}
 /// Errors returned by CancelAuditMitigationActionsTask
 #[derive(Debug, PartialEq)]
 pub enum CancelAuditMitigationActionsTaskError {
@@ -8858,19 +8828,21 @@ impl CancelAuditMitigationActionsTaskError {
 }
 impl fmt::Display for CancelAuditMitigationActionsTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelAuditMitigationActionsTaskError {
-    fn description(&self) -> &str {
         match *self {
-            CancelAuditMitigationActionsTaskError::InternalFailure(ref cause) => cause,
-            CancelAuditMitigationActionsTaskError::InvalidRequest(ref cause) => cause,
-            CancelAuditMitigationActionsTaskError::ResourceNotFound(ref cause) => cause,
-            CancelAuditMitigationActionsTaskError::Throttling(ref cause) => cause,
+            CancelAuditMitigationActionsTaskError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CancelAuditMitigationActionsTaskError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CancelAuditMitigationActionsTaskError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CancelAuditMitigationActionsTaskError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelAuditMitigationActionsTaskError {}
 /// Errors returned by CancelAuditTask
 #[derive(Debug, PartialEq)]
 pub enum CancelAuditTaskError {
@@ -8909,19 +8881,15 @@ impl CancelAuditTaskError {
 }
 impl fmt::Display for CancelAuditTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelAuditTaskError {
-    fn description(&self) -> &str {
         match *self {
-            CancelAuditTaskError::InternalFailure(ref cause) => cause,
-            CancelAuditTaskError::InvalidRequest(ref cause) => cause,
-            CancelAuditTaskError::ResourceNotFound(ref cause) => cause,
-            CancelAuditTaskError::Throttling(ref cause) => cause,
+            CancelAuditTaskError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CancelAuditTaskError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CancelAuditTaskError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CancelAuditTaskError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelAuditTaskError {}
 /// Errors returned by CancelCertificateTransfer
 #[derive(Debug, PartialEq)]
 pub enum CancelCertificateTransferError {
@@ -8989,22 +8957,20 @@ impl CancelCertificateTransferError {
 }
 impl fmt::Display for CancelCertificateTransferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelCertificateTransferError {
-    fn description(&self) -> &str {
         match *self {
-            CancelCertificateTransferError::InternalFailure(ref cause) => cause,
-            CancelCertificateTransferError::InvalidRequest(ref cause) => cause,
-            CancelCertificateTransferError::ResourceNotFound(ref cause) => cause,
-            CancelCertificateTransferError::ServiceUnavailable(ref cause) => cause,
-            CancelCertificateTransferError::Throttling(ref cause) => cause,
-            CancelCertificateTransferError::TransferAlreadyCompleted(ref cause) => cause,
-            CancelCertificateTransferError::Unauthorized(ref cause) => cause,
+            CancelCertificateTransferError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CancelCertificateTransferError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CancelCertificateTransferError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CancelCertificateTransferError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CancelCertificateTransferError::Throttling(ref cause) => write!(f, "{}", cause),
+            CancelCertificateTransferError::TransferAlreadyCompleted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CancelCertificateTransferError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelCertificateTransferError {}
 /// Errors returned by CancelJob
 #[derive(Debug, PartialEq)]
 pub enum CancelJobError {
@@ -9043,19 +9009,15 @@ impl CancelJobError {
 }
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelJobError {
-    fn description(&self) -> &str {
         match *self {
-            CancelJobError::InvalidRequest(ref cause) => cause,
-            CancelJobError::ResourceNotFound(ref cause) => cause,
-            CancelJobError::ServiceUnavailable(ref cause) => cause,
-            CancelJobError::Throttling(ref cause) => cause,
+            CancelJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CancelJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CancelJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CancelJobError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelJobError {}
 /// Errors returned by CancelJobExecution
 #[derive(Debug, PartialEq)]
 pub enum CancelJobExecutionError {
@@ -9108,21 +9070,17 @@ impl CancelJobExecutionError {
 }
 impl fmt::Display for CancelJobExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelJobExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            CancelJobExecutionError::InvalidRequest(ref cause) => cause,
-            CancelJobExecutionError::InvalidStateTransition(ref cause) => cause,
-            CancelJobExecutionError::ResourceNotFound(ref cause) => cause,
-            CancelJobExecutionError::ServiceUnavailable(ref cause) => cause,
-            CancelJobExecutionError::Throttling(ref cause) => cause,
-            CancelJobExecutionError::VersionConflict(ref cause) => cause,
+            CancelJobExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CancelJobExecutionError::InvalidStateTransition(ref cause) => write!(f, "{}", cause),
+            CancelJobExecutionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CancelJobExecutionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CancelJobExecutionError::Throttling(ref cause) => write!(f, "{}", cause),
+            CancelJobExecutionError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelJobExecutionError {}
 /// Errors returned by ClearDefaultAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum ClearDefaultAuthorizerError {
@@ -9179,21 +9137,17 @@ impl ClearDefaultAuthorizerError {
 }
 impl fmt::Display for ClearDefaultAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ClearDefaultAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            ClearDefaultAuthorizerError::InternalFailure(ref cause) => cause,
-            ClearDefaultAuthorizerError::InvalidRequest(ref cause) => cause,
-            ClearDefaultAuthorizerError::ResourceNotFound(ref cause) => cause,
-            ClearDefaultAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            ClearDefaultAuthorizerError::Throttling(ref cause) => cause,
-            ClearDefaultAuthorizerError::Unauthorized(ref cause) => cause,
+            ClearDefaultAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ClearDefaultAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ClearDefaultAuthorizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ClearDefaultAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ClearDefaultAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            ClearDefaultAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ClearDefaultAuthorizerError {}
 /// Errors returned by ConfirmTopicRuleDestination
 #[derive(Debug, PartialEq)]
 pub enum ConfirmTopicRuleDestinationError {
@@ -9249,20 +9203,20 @@ impl ConfirmTopicRuleDestinationError {
 }
 impl fmt::Display for ConfirmTopicRuleDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmTopicRuleDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => cause,
-            ConfirmTopicRuleDestinationError::Internal(ref cause) => cause,
-            ConfirmTopicRuleDestinationError::InvalidRequest(ref cause) => cause,
-            ConfirmTopicRuleDestinationError::ServiceUnavailable(ref cause) => cause,
-            ConfirmTopicRuleDestinationError::Unauthorized(ref cause) => cause,
+            ConfirmTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConfirmTopicRuleDestinationError::Internal(ref cause) => write!(f, "{}", cause),
+            ConfirmTopicRuleDestinationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ConfirmTopicRuleDestinationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConfirmTopicRuleDestinationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConfirmTopicRuleDestinationError {}
 /// Errors returned by CreateAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum CreateAuthorizerError {
@@ -9318,22 +9272,18 @@ impl CreateAuthorizerError {
 }
 impl fmt::Display for CreateAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAuthorizerError::InternalFailure(ref cause) => cause,
-            CreateAuthorizerError::InvalidRequest(ref cause) => cause,
-            CreateAuthorizerError::LimitExceeded(ref cause) => cause,
-            CreateAuthorizerError::ResourceAlreadyExists(ref cause) => cause,
-            CreateAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            CreateAuthorizerError::Throttling(ref cause) => cause,
-            CreateAuthorizerError::Unauthorized(ref cause) => cause,
+            CreateAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAuthorizerError {}
 /// Errors returned by CreateBillingGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateBillingGroupError {
@@ -9374,19 +9324,15 @@ impl CreateBillingGroupError {
 }
 impl fmt::Display for CreateBillingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBillingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBillingGroupError::InternalFailure(ref cause) => cause,
-            CreateBillingGroupError::InvalidRequest(ref cause) => cause,
-            CreateBillingGroupError::ResourceAlreadyExists(ref cause) => cause,
-            CreateBillingGroupError::Throttling(ref cause) => cause,
+            CreateBillingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateBillingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateBillingGroupError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateBillingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBillingGroupError {}
 /// Errors returned by CreateCertificateFromCsr
 #[derive(Debug, PartialEq)]
 pub enum CreateCertificateFromCsrError {
@@ -9438,20 +9384,16 @@ impl CreateCertificateFromCsrError {
 }
 impl fmt::Display for CreateCertificateFromCsrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCertificateFromCsrError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCertificateFromCsrError::InternalFailure(ref cause) => cause,
-            CreateCertificateFromCsrError::InvalidRequest(ref cause) => cause,
-            CreateCertificateFromCsrError::ServiceUnavailable(ref cause) => cause,
-            CreateCertificateFromCsrError::Throttling(ref cause) => cause,
-            CreateCertificateFromCsrError::Unauthorized(ref cause) => cause,
+            CreateCertificateFromCsrError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateCertificateFromCsrError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateCertificateFromCsrError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateCertificateFromCsrError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateCertificateFromCsrError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCertificateFromCsrError {}
 /// Errors returned by CreateDomainConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainConfigurationError {
@@ -9526,23 +9468,23 @@ impl CreateDomainConfigurationError {
 }
 impl fmt::Display for CreateDomainConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainConfigurationError::CertificateValidation(ref cause) => cause,
-            CreateDomainConfigurationError::InternalFailure(ref cause) => cause,
-            CreateDomainConfigurationError::InvalidRequest(ref cause) => cause,
-            CreateDomainConfigurationError::LimitExceeded(ref cause) => cause,
-            CreateDomainConfigurationError::ResourceAlreadyExists(ref cause) => cause,
-            CreateDomainConfigurationError::ServiceUnavailable(ref cause) => cause,
-            CreateDomainConfigurationError::Throttling(ref cause) => cause,
-            CreateDomainConfigurationError::Unauthorized(ref cause) => cause,
+            CreateDomainConfigurationError::CertificateValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDomainConfigurationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDomainConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateDomainConfigurationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDomainConfigurationError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDomainConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateDomainConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateDomainConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainConfigurationError {}
 /// Errors returned by CreateDynamicThingGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDynamicThingGroupError {
@@ -9608,22 +9550,20 @@ impl CreateDynamicThingGroupError {
 }
 impl fmt::Display for CreateDynamicThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDynamicThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDynamicThingGroupError::InternalFailure(ref cause) => cause,
-            CreateDynamicThingGroupError::InvalidQuery(ref cause) => cause,
-            CreateDynamicThingGroupError::InvalidRequest(ref cause) => cause,
-            CreateDynamicThingGroupError::LimitExceeded(ref cause) => cause,
-            CreateDynamicThingGroupError::ResourceAlreadyExists(ref cause) => cause,
-            CreateDynamicThingGroupError::ResourceNotFound(ref cause) => cause,
-            CreateDynamicThingGroupError::Throttling(ref cause) => cause,
+            CreateDynamicThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDynamicThingGroupError::InvalidQuery(ref cause) => write!(f, "{}", cause),
+            CreateDynamicThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateDynamicThingGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDynamicThingGroupError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDynamicThingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateDynamicThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDynamicThingGroupError {}
 /// Errors returned by CreateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateJobError {
@@ -9672,21 +9612,17 @@ impl CreateJobError {
 }
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobError::InvalidRequest(ref cause) => cause,
-            CreateJobError::LimitExceeded(ref cause) => cause,
-            CreateJobError::ResourceAlreadyExists(ref cause) => cause,
-            CreateJobError::ResourceNotFound(ref cause) => cause,
-            CreateJobError::ServiceUnavailable(ref cause) => cause,
-            CreateJobError::Throttling(ref cause) => cause,
+            CreateJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateJobError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateJobError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobError {}
 /// Errors returned by CreateKeysAndCertificate
 #[derive(Debug, PartialEq)]
 pub enum CreateKeysAndCertificateError {
@@ -9738,20 +9674,16 @@ impl CreateKeysAndCertificateError {
 }
 impl fmt::Display for CreateKeysAndCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateKeysAndCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateKeysAndCertificateError::InternalFailure(ref cause) => cause,
-            CreateKeysAndCertificateError::InvalidRequest(ref cause) => cause,
-            CreateKeysAndCertificateError::ServiceUnavailable(ref cause) => cause,
-            CreateKeysAndCertificateError::Throttling(ref cause) => cause,
-            CreateKeysAndCertificateError::Unauthorized(ref cause) => cause,
+            CreateKeysAndCertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateKeysAndCertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateKeysAndCertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateKeysAndCertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateKeysAndCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateKeysAndCertificateError {}
 /// Errors returned by CreateMitigationAction
 #[derive(Debug, PartialEq)]
 pub enum CreateMitigationActionError {
@@ -9803,20 +9735,16 @@ impl CreateMitigationActionError {
 }
 impl fmt::Display for CreateMitigationActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMitigationActionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMitigationActionError::InternalFailure(ref cause) => cause,
-            CreateMitigationActionError::InvalidRequest(ref cause) => cause,
-            CreateMitigationActionError::LimitExceeded(ref cause) => cause,
-            CreateMitigationActionError::ResourceAlreadyExists(ref cause) => cause,
-            CreateMitigationActionError::Throttling(ref cause) => cause,
+            CreateMitigationActionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateMitigationActionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateMitigationActionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateMitigationActionError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateMitigationActionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMitigationActionError {}
 /// Errors returned by CreateOTAUpdate
 #[derive(Debug, PartialEq)]
 pub enum CreateOTAUpdateError {
@@ -9877,23 +9805,19 @@ impl CreateOTAUpdateError {
 }
 impl fmt::Display for CreateOTAUpdateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOTAUpdateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOTAUpdateError::InternalFailure(ref cause) => cause,
-            CreateOTAUpdateError::InvalidRequest(ref cause) => cause,
-            CreateOTAUpdateError::LimitExceeded(ref cause) => cause,
-            CreateOTAUpdateError::ResourceAlreadyExists(ref cause) => cause,
-            CreateOTAUpdateError::ResourceNotFound(ref cause) => cause,
-            CreateOTAUpdateError::ServiceUnavailable(ref cause) => cause,
-            CreateOTAUpdateError::Throttling(ref cause) => cause,
-            CreateOTAUpdateError::Unauthorized(ref cause) => cause,
+            CreateOTAUpdateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateOTAUpdateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateOTAUpdateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateOTAUpdateError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateOTAUpdateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateOTAUpdateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateOTAUpdateError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateOTAUpdateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateOTAUpdateError {}
 /// Errors returned by CreatePolicy
 #[derive(Debug, PartialEq)]
 pub enum CreatePolicyError {
@@ -9947,22 +9871,18 @@ impl CreatePolicyError {
 }
 impl fmt::Display for CreatePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePolicyError::InternalFailure(ref cause) => cause,
-            CreatePolicyError::InvalidRequest(ref cause) => cause,
-            CreatePolicyError::MalformedPolicy(ref cause) => cause,
-            CreatePolicyError::ResourceAlreadyExists(ref cause) => cause,
-            CreatePolicyError::ServiceUnavailable(ref cause) => cause,
-            CreatePolicyError::Throttling(ref cause) => cause,
-            CreatePolicyError::Unauthorized(ref cause) => cause,
+            CreatePolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::MalformedPolicy(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePolicyError {}
 /// Errors returned by CreatePolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum CreatePolicyVersionError {
@@ -10027,23 +9947,19 @@ impl CreatePolicyVersionError {
 }
 impl fmt::Display for CreatePolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePolicyVersionError::InternalFailure(ref cause) => cause,
-            CreatePolicyVersionError::InvalidRequest(ref cause) => cause,
-            CreatePolicyVersionError::MalformedPolicy(ref cause) => cause,
-            CreatePolicyVersionError::ResourceNotFound(ref cause) => cause,
-            CreatePolicyVersionError::ServiceUnavailable(ref cause) => cause,
-            CreatePolicyVersionError::Throttling(ref cause) => cause,
-            CreatePolicyVersionError::Unauthorized(ref cause) => cause,
-            CreatePolicyVersionError::VersionsLimitExceeded(ref cause) => cause,
+            CreatePolicyVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::MalformedPolicy(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
+            CreatePolicyVersionError::VersionsLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePolicyVersionError {}
 /// Errors returned by CreateProvisioningClaim
 #[derive(Debug, PartialEq)]
 pub enum CreateProvisioningClaimError {
@@ -10102,21 +10018,17 @@ impl CreateProvisioningClaimError {
 }
 impl fmt::Display for CreateProvisioningClaimError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProvisioningClaimError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProvisioningClaimError::InternalFailure(ref cause) => cause,
-            CreateProvisioningClaimError::InvalidRequest(ref cause) => cause,
-            CreateProvisioningClaimError::ResourceNotFound(ref cause) => cause,
-            CreateProvisioningClaimError::ServiceUnavailable(ref cause) => cause,
-            CreateProvisioningClaimError::Throttling(ref cause) => cause,
-            CreateProvisioningClaimError::Unauthorized(ref cause) => cause,
+            CreateProvisioningClaimError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningClaimError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningClaimError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningClaimError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningClaimError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningClaimError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProvisioningClaimError {}
 /// Errors returned by CreateProvisioningTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateProvisioningTemplateError {
@@ -10179,21 +10091,19 @@ impl CreateProvisioningTemplateError {
 }
 impl fmt::Display for CreateProvisioningTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProvisioningTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProvisioningTemplateError::InternalFailure(ref cause) => cause,
-            CreateProvisioningTemplateError::InvalidRequest(ref cause) => cause,
-            CreateProvisioningTemplateError::LimitExceeded(ref cause) => cause,
-            CreateProvisioningTemplateError::ResourceAlreadyExists(ref cause) => cause,
-            CreateProvisioningTemplateError::Throttling(ref cause) => cause,
-            CreateProvisioningTemplateError::Unauthorized(ref cause) => cause,
+            CreateProvisioningTemplateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningTemplateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningTemplateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningTemplateError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProvisioningTemplateError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningTemplateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProvisioningTemplateError {}
 /// Errors returned by CreateProvisioningTemplateVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateProvisioningTemplateVersionError {
@@ -10263,22 +10173,30 @@ impl CreateProvisioningTemplateVersionError {
 }
 impl fmt::Display for CreateProvisioningTemplateVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProvisioningTemplateVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProvisioningTemplateVersionError::ConflictingResourceUpdate(ref cause) => cause,
-            CreateProvisioningTemplateVersionError::InternalFailure(ref cause) => cause,
-            CreateProvisioningTemplateVersionError::InvalidRequest(ref cause) => cause,
-            CreateProvisioningTemplateVersionError::ResourceNotFound(ref cause) => cause,
-            CreateProvisioningTemplateVersionError::Throttling(ref cause) => cause,
-            CreateProvisioningTemplateVersionError::Unauthorized(ref cause) => cause,
-            CreateProvisioningTemplateVersionError::VersionsLimitExceeded(ref cause) => cause,
+            CreateProvisioningTemplateVersionError::ConflictingResourceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProvisioningTemplateVersionError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProvisioningTemplateVersionError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProvisioningTemplateVersionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProvisioningTemplateVersionError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningTemplateVersionError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProvisioningTemplateVersionError::VersionsLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateProvisioningTemplateVersionError {}
 /// Errors returned by CreateRoleAlias
 #[derive(Debug, PartialEq)]
 pub enum CreateRoleAliasError {
@@ -10334,22 +10252,18 @@ impl CreateRoleAliasError {
 }
 impl fmt::Display for CreateRoleAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRoleAliasError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRoleAliasError::InternalFailure(ref cause) => cause,
-            CreateRoleAliasError::InvalidRequest(ref cause) => cause,
-            CreateRoleAliasError::LimitExceeded(ref cause) => cause,
-            CreateRoleAliasError::ResourceAlreadyExists(ref cause) => cause,
-            CreateRoleAliasError::ServiceUnavailable(ref cause) => cause,
-            CreateRoleAliasError::Throttling(ref cause) => cause,
-            CreateRoleAliasError::Unauthorized(ref cause) => cause,
+            CreateRoleAliasError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateRoleAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateRoleAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRoleAliasError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateRoleAliasError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateRoleAliasError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateRoleAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRoleAliasError {}
 /// Errors returned by CreateScheduledAudit
 #[derive(Debug, PartialEq)]
 pub enum CreateScheduledAuditError {
@@ -10397,20 +10311,16 @@ impl CreateScheduledAuditError {
 }
 impl fmt::Display for CreateScheduledAuditError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateScheduledAuditError {
-    fn description(&self) -> &str {
         match *self {
-            CreateScheduledAuditError::InternalFailure(ref cause) => cause,
-            CreateScheduledAuditError::InvalidRequest(ref cause) => cause,
-            CreateScheduledAuditError::LimitExceeded(ref cause) => cause,
-            CreateScheduledAuditError::ResourceAlreadyExists(ref cause) => cause,
-            CreateScheduledAuditError::Throttling(ref cause) => cause,
+            CreateScheduledAuditError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateScheduledAuditError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateScheduledAuditError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateScheduledAuditError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateScheduledAuditError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateScheduledAuditError {}
 /// Errors returned by CreateSecurityProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateSecurityProfileError {
@@ -10455,19 +10365,15 @@ impl CreateSecurityProfileError {
 }
 impl fmt::Display for CreateSecurityProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSecurityProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSecurityProfileError::InternalFailure(ref cause) => cause,
-            CreateSecurityProfileError::InvalidRequest(ref cause) => cause,
-            CreateSecurityProfileError::ResourceAlreadyExists(ref cause) => cause,
-            CreateSecurityProfileError::Throttling(ref cause) => cause,
+            CreateSecurityProfileError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateSecurityProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateSecurityProfileError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateSecurityProfileError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSecurityProfileError {}
 /// Errors returned by CreateStream
 #[derive(Debug, PartialEq)]
 pub enum CreateStreamError {
@@ -10526,23 +10432,19 @@ impl CreateStreamError {
 }
 impl fmt::Display for CreateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStreamError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStreamError::InternalFailure(ref cause) => cause,
-            CreateStreamError::InvalidRequest(ref cause) => cause,
-            CreateStreamError::LimitExceeded(ref cause) => cause,
-            CreateStreamError::ResourceAlreadyExists(ref cause) => cause,
-            CreateStreamError::ResourceNotFound(ref cause) => cause,
-            CreateStreamError::ServiceUnavailable(ref cause) => cause,
-            CreateStreamError::Throttling(ref cause) => cause,
-            CreateStreamError::Unauthorized(ref cause) => cause,
+            CreateStreamError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStreamError {}
 /// Errors returned by CreateThing
 #[derive(Debug, PartialEq)]
 pub enum CreateThingError {
@@ -10596,22 +10498,18 @@ impl CreateThingError {
 }
 impl fmt::Display for CreateThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateThingError {
-    fn description(&self) -> &str {
         match *self {
-            CreateThingError::InternalFailure(ref cause) => cause,
-            CreateThingError::InvalidRequest(ref cause) => cause,
-            CreateThingError::ResourceAlreadyExists(ref cause) => cause,
-            CreateThingError::ResourceNotFound(ref cause) => cause,
-            CreateThingError::ServiceUnavailable(ref cause) => cause,
-            CreateThingError::Throttling(ref cause) => cause,
-            CreateThingError::Unauthorized(ref cause) => cause,
+            CreateThingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateThingError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateThingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateThingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateThingError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateThingError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateThingError {}
 /// Errors returned by CreateThingGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateThingGroupError {
@@ -10652,19 +10550,15 @@ impl CreateThingGroupError {
 }
 impl fmt::Display for CreateThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateThingGroupError::InternalFailure(ref cause) => cause,
-            CreateThingGroupError::InvalidRequest(ref cause) => cause,
-            CreateThingGroupError::ResourceAlreadyExists(ref cause) => cause,
-            CreateThingGroupError::Throttling(ref cause) => cause,
+            CreateThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateThingGroupError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateThingGroupError {}
 /// Errors returned by CreateThingType
 #[derive(Debug, PartialEq)]
 pub enum CreateThingTypeError {
@@ -10715,21 +10609,17 @@ impl CreateThingTypeError {
 }
 impl fmt::Display for CreateThingTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateThingTypeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateThingTypeError::InternalFailure(ref cause) => cause,
-            CreateThingTypeError::InvalidRequest(ref cause) => cause,
-            CreateThingTypeError::ResourceAlreadyExists(ref cause) => cause,
-            CreateThingTypeError::ServiceUnavailable(ref cause) => cause,
-            CreateThingTypeError::Throttling(ref cause) => cause,
-            CreateThingTypeError::Unauthorized(ref cause) => cause,
+            CreateThingTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateThingTypeError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateThingTypeError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateThingTypeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateThingTypeError::Throttling(ref cause) => write!(f, "{}", cause),
+            CreateThingTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateThingTypeError {}
 /// Errors returned by CreateTopicRule
 #[derive(Debug, PartialEq)]
 pub enum CreateTopicRuleError {
@@ -10782,21 +10672,17 @@ impl CreateTopicRuleError {
 }
 impl fmt::Display for CreateTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTopicRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTopicRuleError::ConflictingResourceUpdate(ref cause) => cause,
-            CreateTopicRuleError::Internal(ref cause) => cause,
-            CreateTopicRuleError::InvalidRequest(ref cause) => cause,
-            CreateTopicRuleError::ResourceAlreadyExists(ref cause) => cause,
-            CreateTopicRuleError::ServiceUnavailable(ref cause) => cause,
-            CreateTopicRuleError::SqlParse(ref cause) => cause,
+            CreateTopicRuleError::ConflictingResourceUpdate(ref cause) => write!(f, "{}", cause),
+            CreateTopicRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateTopicRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateTopicRuleError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateTopicRuleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateTopicRuleError::SqlParse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTopicRuleError {}
 /// Errors returned by CreateTopicRuleDestination
 #[derive(Debug, PartialEq)]
 pub enum CreateTopicRuleDestinationError {
@@ -10850,20 +10736,22 @@ impl CreateTopicRuleDestinationError {
 }
 impl fmt::Display for CreateTopicRuleDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTopicRuleDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => cause,
-            CreateTopicRuleDestinationError::Internal(ref cause) => cause,
-            CreateTopicRuleDestinationError::InvalidRequest(ref cause) => cause,
-            CreateTopicRuleDestinationError::ResourceAlreadyExists(ref cause) => cause,
-            CreateTopicRuleDestinationError::ServiceUnavailable(ref cause) => cause,
+            CreateTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTopicRuleDestinationError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateTopicRuleDestinationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateTopicRuleDestinationError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTopicRuleDestinationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateTopicRuleDestinationError {}
 /// Errors returned by DeleteAccountAuditConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteAccountAuditConfigurationError {
@@ -10912,19 +10800,21 @@ impl DeleteAccountAuditConfigurationError {
 }
 impl fmt::Display for DeleteAccountAuditConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAccountAuditConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAccountAuditConfigurationError::InternalFailure(ref cause) => cause,
-            DeleteAccountAuditConfigurationError::InvalidRequest(ref cause) => cause,
-            DeleteAccountAuditConfigurationError::ResourceNotFound(ref cause) => cause,
-            DeleteAccountAuditConfigurationError::Throttling(ref cause) => cause,
+            DeleteAccountAuditConfigurationError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAccountAuditConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAccountAuditConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAccountAuditConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAccountAuditConfigurationError {}
 /// Errors returned by DeleteAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum DeleteAuthorizerError {
@@ -10978,22 +10868,18 @@ impl DeleteAuthorizerError {
 }
 impl fmt::Display for DeleteAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAuthorizerError::DeleteConflict(ref cause) => cause,
-            DeleteAuthorizerError::InternalFailure(ref cause) => cause,
-            DeleteAuthorizerError::InvalidRequest(ref cause) => cause,
-            DeleteAuthorizerError::ResourceNotFound(ref cause) => cause,
-            DeleteAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            DeleteAuthorizerError::Throttling(ref cause) => cause,
-            DeleteAuthorizerError::Unauthorized(ref cause) => cause,
+            DeleteAuthorizerError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAuthorizerError {}
 /// Errors returned by DeleteBillingGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteBillingGroupError {
@@ -11032,19 +10918,15 @@ impl DeleteBillingGroupError {
 }
 impl fmt::Display for DeleteBillingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBillingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBillingGroupError::InternalFailure(ref cause) => cause,
-            DeleteBillingGroupError::InvalidRequest(ref cause) => cause,
-            DeleteBillingGroupError::Throttling(ref cause) => cause,
-            DeleteBillingGroupError::VersionConflict(ref cause) => cause,
+            DeleteBillingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBillingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBillingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteBillingGroupError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBillingGroupError {}
 /// Errors returned by DeleteCACertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteCACertificateError {
@@ -11104,22 +10986,18 @@ impl DeleteCACertificateError {
 }
 impl fmt::Display for DeleteCACertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCACertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCACertificateError::CertificateState(ref cause) => cause,
-            DeleteCACertificateError::InternalFailure(ref cause) => cause,
-            DeleteCACertificateError::InvalidRequest(ref cause) => cause,
-            DeleteCACertificateError::ResourceNotFound(ref cause) => cause,
-            DeleteCACertificateError::ServiceUnavailable(ref cause) => cause,
-            DeleteCACertificateError::Throttling(ref cause) => cause,
-            DeleteCACertificateError::Unauthorized(ref cause) => cause,
+            DeleteCACertificateError::CertificateState(ref cause) => write!(f, "{}", cause),
+            DeleteCACertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteCACertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteCACertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCACertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteCACertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteCACertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCACertificateError {}
 /// Errors returned by DeleteCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteCertificateError {
@@ -11180,23 +11058,19 @@ impl DeleteCertificateError {
 }
 impl fmt::Display for DeleteCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCertificateError::CertificateState(ref cause) => cause,
-            DeleteCertificateError::DeleteConflict(ref cause) => cause,
-            DeleteCertificateError::InternalFailure(ref cause) => cause,
-            DeleteCertificateError::InvalidRequest(ref cause) => cause,
-            DeleteCertificateError::ResourceNotFound(ref cause) => cause,
-            DeleteCertificateError::ServiceUnavailable(ref cause) => cause,
-            DeleteCertificateError::Throttling(ref cause) => cause,
-            DeleteCertificateError::Unauthorized(ref cause) => cause,
+            DeleteCertificateError::CertificateState(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCertificateError {}
 /// Errors returned by DeleteDomainConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainConfigurationError {
@@ -11257,21 +11131,17 @@ impl DeleteDomainConfigurationError {
 }
 impl fmt::Display for DeleteDomainConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainConfigurationError::InternalFailure(ref cause) => cause,
-            DeleteDomainConfigurationError::InvalidRequest(ref cause) => cause,
-            DeleteDomainConfigurationError::ResourceNotFound(ref cause) => cause,
-            DeleteDomainConfigurationError::ServiceUnavailable(ref cause) => cause,
-            DeleteDomainConfigurationError::Throttling(ref cause) => cause,
-            DeleteDomainConfigurationError::Unauthorized(ref cause) => cause,
+            DeleteDomainConfigurationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDomainConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDomainConfigurationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDomainConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteDomainConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteDomainConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainConfigurationError {}
 /// Errors returned by DeleteDynamicThingGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDynamicThingGroupError {
@@ -11316,19 +11186,15 @@ impl DeleteDynamicThingGroupError {
 }
 impl fmt::Display for DeleteDynamicThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDynamicThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDynamicThingGroupError::InternalFailure(ref cause) => cause,
-            DeleteDynamicThingGroupError::InvalidRequest(ref cause) => cause,
-            DeleteDynamicThingGroupError::Throttling(ref cause) => cause,
-            DeleteDynamicThingGroupError::VersionConflict(ref cause) => cause,
+            DeleteDynamicThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDynamicThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDynamicThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteDynamicThingGroupError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDynamicThingGroupError {}
 /// Errors returned by DeleteJob
 #[derive(Debug, PartialEq)]
 pub enum DeleteJobError {
@@ -11377,21 +11243,17 @@ impl DeleteJobError {
 }
 impl fmt::Display for DeleteJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteJobError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteJobError::InvalidRequest(ref cause) => cause,
-            DeleteJobError::InvalidStateTransition(ref cause) => cause,
-            DeleteJobError::LimitExceeded(ref cause) => cause,
-            DeleteJobError::ResourceNotFound(ref cause) => cause,
-            DeleteJobError::ServiceUnavailable(ref cause) => cause,
-            DeleteJobError::Throttling(ref cause) => cause,
+            DeleteJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::InvalidStateTransition(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteJobError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteJobError {}
 /// Errors returned by DeleteJobExecution
 #[derive(Debug, PartialEq)]
 pub enum DeleteJobExecutionError {
@@ -11439,20 +11301,16 @@ impl DeleteJobExecutionError {
 }
 impl fmt::Display for DeleteJobExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteJobExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteJobExecutionError::InvalidRequest(ref cause) => cause,
-            DeleteJobExecutionError::InvalidStateTransition(ref cause) => cause,
-            DeleteJobExecutionError::ResourceNotFound(ref cause) => cause,
-            DeleteJobExecutionError::ServiceUnavailable(ref cause) => cause,
-            DeleteJobExecutionError::Throttling(ref cause) => cause,
+            DeleteJobExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteJobExecutionError::InvalidStateTransition(ref cause) => write!(f, "{}", cause),
+            DeleteJobExecutionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteJobExecutionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteJobExecutionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteJobExecutionError {}
 /// Errors returned by DeleteMitigationAction
 #[derive(Debug, PartialEq)]
 pub enum DeleteMitigationActionError {
@@ -11490,18 +11348,14 @@ impl DeleteMitigationActionError {
 }
 impl fmt::Display for DeleteMitigationActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMitigationActionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMitigationActionError::InternalFailure(ref cause) => cause,
-            DeleteMitigationActionError::InvalidRequest(ref cause) => cause,
-            DeleteMitigationActionError::Throttling(ref cause) => cause,
+            DeleteMitigationActionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteMitigationActionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMitigationActionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMitigationActionError {}
 /// Errors returned by DeleteOTAUpdate
 #[derive(Debug, PartialEq)]
 pub enum DeleteOTAUpdateError {
@@ -11555,22 +11409,18 @@ impl DeleteOTAUpdateError {
 }
 impl fmt::Display for DeleteOTAUpdateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOTAUpdateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteOTAUpdateError::InternalFailure(ref cause) => cause,
-            DeleteOTAUpdateError::InvalidRequest(ref cause) => cause,
-            DeleteOTAUpdateError::ResourceNotFound(ref cause) => cause,
-            DeleteOTAUpdateError::ServiceUnavailable(ref cause) => cause,
-            DeleteOTAUpdateError::Throttling(ref cause) => cause,
-            DeleteOTAUpdateError::Unauthorized(ref cause) => cause,
-            DeleteOTAUpdateError::VersionConflict(ref cause) => cause,
+            DeleteOTAUpdateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteOTAUpdateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteOTAUpdateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteOTAUpdateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteOTAUpdateError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteOTAUpdateError::Unauthorized(ref cause) => write!(f, "{}", cause),
+            DeleteOTAUpdateError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteOTAUpdateError {}
 /// Errors returned by DeletePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeletePolicyError {
@@ -11624,22 +11474,18 @@ impl DeletePolicyError {
 }
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePolicyError::DeleteConflict(ref cause) => cause,
-            DeletePolicyError::InternalFailure(ref cause) => cause,
-            DeletePolicyError::InvalidRequest(ref cause) => cause,
-            DeletePolicyError::ResourceNotFound(ref cause) => cause,
-            DeletePolicyError::ServiceUnavailable(ref cause) => cause,
-            DeletePolicyError::Throttling(ref cause) => cause,
-            DeletePolicyError::Unauthorized(ref cause) => cause,
+            DeletePolicyError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePolicyError {}
 /// Errors returned by DeletePolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum DeletePolicyVersionError {
@@ -11697,22 +11543,18 @@ impl DeletePolicyVersionError {
 }
 impl fmt::Display for DeletePolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePolicyVersionError::DeleteConflict(ref cause) => cause,
-            DeletePolicyVersionError::InternalFailure(ref cause) => cause,
-            DeletePolicyVersionError::InvalidRequest(ref cause) => cause,
-            DeletePolicyVersionError::ResourceNotFound(ref cause) => cause,
-            DeletePolicyVersionError::ServiceUnavailable(ref cause) => cause,
-            DeletePolicyVersionError::Throttling(ref cause) => cause,
-            DeletePolicyVersionError::Unauthorized(ref cause) => cause,
+            DeletePolicyVersionError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeletePolicyVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePolicyVersionError {}
 /// Errors returned by DeleteProvisioningTemplate
 #[derive(Debug, PartialEq)]
 pub enum DeleteProvisioningTemplateError {
@@ -11775,21 +11617,17 @@ impl DeleteProvisioningTemplateError {
 }
 impl fmt::Display for DeleteProvisioningTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProvisioningTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProvisioningTemplateError::DeleteConflict(ref cause) => cause,
-            DeleteProvisioningTemplateError::InternalFailure(ref cause) => cause,
-            DeleteProvisioningTemplateError::InvalidRequest(ref cause) => cause,
-            DeleteProvisioningTemplateError::ResourceNotFound(ref cause) => cause,
-            DeleteProvisioningTemplateError::Throttling(ref cause) => cause,
-            DeleteProvisioningTemplateError::Unauthorized(ref cause) => cause,
+            DeleteProvisioningTemplateError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningTemplateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningTemplateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningTemplateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningTemplateError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningTemplateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProvisioningTemplateError {}
 /// Errors returned by DeleteProvisioningTemplateVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteProvisioningTemplateVersionError {
@@ -11852,21 +11690,27 @@ impl DeleteProvisioningTemplateVersionError {
 }
 impl fmt::Display for DeleteProvisioningTemplateVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProvisioningTemplateVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProvisioningTemplateVersionError::DeleteConflict(ref cause) => cause,
-            DeleteProvisioningTemplateVersionError::InternalFailure(ref cause) => cause,
-            DeleteProvisioningTemplateVersionError::InvalidRequest(ref cause) => cause,
-            DeleteProvisioningTemplateVersionError::ResourceNotFound(ref cause) => cause,
-            DeleteProvisioningTemplateVersionError::Throttling(ref cause) => cause,
-            DeleteProvisioningTemplateVersionError::Unauthorized(ref cause) => cause,
+            DeleteProvisioningTemplateVersionError::DeleteConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisioningTemplateVersionError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisioningTemplateVersionError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisioningTemplateVersionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisioningTemplateVersionError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningTemplateVersionError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteProvisioningTemplateVersionError {}
 /// Errors returned by DeleteRegistrationCode
 #[derive(Debug, PartialEq)]
 pub enum DeleteRegistrationCodeError {
@@ -11916,20 +11760,16 @@ impl DeleteRegistrationCodeError {
 }
 impl fmt::Display for DeleteRegistrationCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRegistrationCodeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRegistrationCodeError::InternalFailure(ref cause) => cause,
-            DeleteRegistrationCodeError::ResourceNotFound(ref cause) => cause,
-            DeleteRegistrationCodeError::ServiceUnavailable(ref cause) => cause,
-            DeleteRegistrationCodeError::Throttling(ref cause) => cause,
-            DeleteRegistrationCodeError::Unauthorized(ref cause) => cause,
+            DeleteRegistrationCodeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRegistrationCodeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRegistrationCodeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteRegistrationCodeError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteRegistrationCodeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRegistrationCodeError {}
 /// Errors returned by DeleteRoleAlias
 #[derive(Debug, PartialEq)]
 pub enum DeleteRoleAliasError {
@@ -11983,22 +11823,18 @@ impl DeleteRoleAliasError {
 }
 impl fmt::Display for DeleteRoleAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRoleAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRoleAliasError::DeleteConflict(ref cause) => cause,
-            DeleteRoleAliasError::InternalFailure(ref cause) => cause,
-            DeleteRoleAliasError::InvalidRequest(ref cause) => cause,
-            DeleteRoleAliasError::ResourceNotFound(ref cause) => cause,
-            DeleteRoleAliasError::ServiceUnavailable(ref cause) => cause,
-            DeleteRoleAliasError::Throttling(ref cause) => cause,
-            DeleteRoleAliasError::Unauthorized(ref cause) => cause,
+            DeleteRoleAliasError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteRoleAliasError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRoleAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteRoleAliasError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRoleAliasError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteRoleAliasError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteRoleAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRoleAliasError {}
 /// Errors returned by DeleteScheduledAudit
 #[derive(Debug, PartialEq)]
 pub enum DeleteScheduledAuditError {
@@ -12041,19 +11877,15 @@ impl DeleteScheduledAuditError {
 }
 impl fmt::Display for DeleteScheduledAuditError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScheduledAuditError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScheduledAuditError::InternalFailure(ref cause) => cause,
-            DeleteScheduledAuditError::InvalidRequest(ref cause) => cause,
-            DeleteScheduledAuditError::ResourceNotFound(ref cause) => cause,
-            DeleteScheduledAuditError::Throttling(ref cause) => cause,
+            DeleteScheduledAuditError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteScheduledAuditError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteScheduledAuditError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteScheduledAuditError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScheduledAuditError {}
 /// Errors returned by DeleteSecurityProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteSecurityProfileError {
@@ -12098,19 +11930,15 @@ impl DeleteSecurityProfileError {
 }
 impl fmt::Display for DeleteSecurityProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSecurityProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSecurityProfileError::InternalFailure(ref cause) => cause,
-            DeleteSecurityProfileError::InvalidRequest(ref cause) => cause,
-            DeleteSecurityProfileError::Throttling(ref cause) => cause,
-            DeleteSecurityProfileError::VersionConflict(ref cause) => cause,
+            DeleteSecurityProfileError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteSecurityProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteSecurityProfileError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteSecurityProfileError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSecurityProfileError {}
 /// Errors returned by DeleteStream
 #[derive(Debug, PartialEq)]
 pub enum DeleteStreamError {
@@ -12164,22 +11992,18 @@ impl DeleteStreamError {
 }
 impl fmt::Display for DeleteStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStreamError::DeleteConflict(ref cause) => cause,
-            DeleteStreamError::InternalFailure(ref cause) => cause,
-            DeleteStreamError::InvalidRequest(ref cause) => cause,
-            DeleteStreamError::ResourceNotFound(ref cause) => cause,
-            DeleteStreamError::ServiceUnavailable(ref cause) => cause,
-            DeleteStreamError::Throttling(ref cause) => cause,
-            DeleteStreamError::Unauthorized(ref cause) => cause,
+            DeleteStreamError::DeleteConflict(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStreamError {}
 /// Errors returned by DeleteThing
 #[derive(Debug, PartialEq)]
 pub enum DeleteThingError {
@@ -12233,22 +12057,18 @@ impl DeleteThingError {
 }
 impl fmt::Display for DeleteThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteThingError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteThingError::InternalFailure(ref cause) => cause,
-            DeleteThingError::InvalidRequest(ref cause) => cause,
-            DeleteThingError::ResourceNotFound(ref cause) => cause,
-            DeleteThingError::ServiceUnavailable(ref cause) => cause,
-            DeleteThingError::Throttling(ref cause) => cause,
-            DeleteThingError::Unauthorized(ref cause) => cause,
-            DeleteThingError::VersionConflict(ref cause) => cause,
+            DeleteThingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteThingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteThingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteThingError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteThingError::Unauthorized(ref cause) => write!(f, "{}", cause),
+            DeleteThingError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteThingError {}
 /// Errors returned by DeleteThingGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteThingGroupError {
@@ -12287,19 +12107,15 @@ impl DeleteThingGroupError {
 }
 impl fmt::Display for DeleteThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteThingGroupError::InternalFailure(ref cause) => cause,
-            DeleteThingGroupError::InvalidRequest(ref cause) => cause,
-            DeleteThingGroupError::Throttling(ref cause) => cause,
-            DeleteThingGroupError::VersionConflict(ref cause) => cause,
+            DeleteThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteThingGroupError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteThingGroupError {}
 /// Errors returned by DeleteThingType
 #[derive(Debug, PartialEq)]
 pub enum DeleteThingTypeError {
@@ -12348,21 +12164,17 @@ impl DeleteThingTypeError {
 }
 impl fmt::Display for DeleteThingTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteThingTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteThingTypeError::InternalFailure(ref cause) => cause,
-            DeleteThingTypeError::InvalidRequest(ref cause) => cause,
-            DeleteThingTypeError::ResourceNotFound(ref cause) => cause,
-            DeleteThingTypeError::ServiceUnavailable(ref cause) => cause,
-            DeleteThingTypeError::Throttling(ref cause) => cause,
-            DeleteThingTypeError::Unauthorized(ref cause) => cause,
+            DeleteThingTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteThingTypeError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteThingTypeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteThingTypeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteThingTypeError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeleteThingTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteThingTypeError {}
 /// Errors returned by DeleteTopicRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteTopicRuleError {
@@ -12408,20 +12220,16 @@ impl DeleteTopicRuleError {
 }
 impl fmt::Display for DeleteTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTopicRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTopicRuleError::ConflictingResourceUpdate(ref cause) => cause,
-            DeleteTopicRuleError::Internal(ref cause) => cause,
-            DeleteTopicRuleError::InvalidRequest(ref cause) => cause,
-            DeleteTopicRuleError::ServiceUnavailable(ref cause) => cause,
-            DeleteTopicRuleError::Unauthorized(ref cause) => cause,
+            DeleteTopicRuleError::ConflictingResourceUpdate(ref cause) => write!(f, "{}", cause),
+            DeleteTopicRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteTopicRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteTopicRuleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteTopicRuleError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTopicRuleError {}
 /// Errors returned by DeleteTopicRuleDestination
 #[derive(Debug, PartialEq)]
 pub enum DeleteTopicRuleDestinationError {
@@ -12475,20 +12283,20 @@ impl DeleteTopicRuleDestinationError {
 }
 impl fmt::Display for DeleteTopicRuleDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTopicRuleDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => cause,
-            DeleteTopicRuleDestinationError::Internal(ref cause) => cause,
-            DeleteTopicRuleDestinationError::InvalidRequest(ref cause) => cause,
-            DeleteTopicRuleDestinationError::ServiceUnavailable(ref cause) => cause,
-            DeleteTopicRuleDestinationError::Unauthorized(ref cause) => cause,
+            DeleteTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteTopicRuleDestinationError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteTopicRuleDestinationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteTopicRuleDestinationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteTopicRuleDestinationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTopicRuleDestinationError {}
 /// Errors returned by DeleteV2LoggingLevel
 #[derive(Debug, PartialEq)]
 pub enum DeleteV2LoggingLevelError {
@@ -12524,18 +12332,14 @@ impl DeleteV2LoggingLevelError {
 }
 impl fmt::Display for DeleteV2LoggingLevelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteV2LoggingLevelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteV2LoggingLevelError::Internal(ref cause) => cause,
-            DeleteV2LoggingLevelError::InvalidRequest(ref cause) => cause,
-            DeleteV2LoggingLevelError::ServiceUnavailable(ref cause) => cause,
+            DeleteV2LoggingLevelError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteV2LoggingLevelError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteV2LoggingLevelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteV2LoggingLevelError {}
 /// Errors returned by DeprecateThingType
 #[derive(Debug, PartialEq)]
 pub enum DeprecateThingTypeError {
@@ -12586,21 +12390,17 @@ impl DeprecateThingTypeError {
 }
 impl fmt::Display for DeprecateThingTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeprecateThingTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeprecateThingTypeError::InternalFailure(ref cause) => cause,
-            DeprecateThingTypeError::InvalidRequest(ref cause) => cause,
-            DeprecateThingTypeError::ResourceNotFound(ref cause) => cause,
-            DeprecateThingTypeError::ServiceUnavailable(ref cause) => cause,
-            DeprecateThingTypeError::Throttling(ref cause) => cause,
-            DeprecateThingTypeError::Unauthorized(ref cause) => cause,
+            DeprecateThingTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeprecateThingTypeError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeprecateThingTypeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeprecateThingTypeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeprecateThingTypeError::Throttling(ref cause) => write!(f, "{}", cause),
+            DeprecateThingTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeprecateThingTypeError {}
 /// Errors returned by DescribeAccountAuditConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountAuditConfigurationError {
@@ -12635,17 +12435,15 @@ impl DescribeAccountAuditConfigurationError {
 }
 impl fmt::Display for DescribeAccountAuditConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountAuditConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAccountAuditConfigurationError::InternalFailure(ref cause) => cause,
-            DescribeAccountAuditConfigurationError::Throttling(ref cause) => cause,
+            DescribeAccountAuditConfigurationError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAccountAuditConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAccountAuditConfigurationError {}
 /// Errors returned by DescribeAuditFinding
 #[derive(Debug, PartialEq)]
 pub enum DescribeAuditFindingError {
@@ -12688,19 +12486,15 @@ impl DescribeAuditFindingError {
 }
 impl fmt::Display for DescribeAuditFindingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAuditFindingError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAuditFindingError::InternalFailure(ref cause) => cause,
-            DescribeAuditFindingError::InvalidRequest(ref cause) => cause,
-            DescribeAuditFindingError::ResourceNotFound(ref cause) => cause,
-            DescribeAuditFindingError::Throttling(ref cause) => cause,
+            DescribeAuditFindingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeAuditFindingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeAuditFindingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeAuditFindingError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAuditFindingError {}
 /// Errors returned by DescribeAuditMitigationActionsTask
 #[derive(Debug, PartialEq)]
 pub enum DescribeAuditMitigationActionsTaskError {
@@ -12749,19 +12543,23 @@ impl DescribeAuditMitigationActionsTaskError {
 }
 impl fmt::Display for DescribeAuditMitigationActionsTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAuditMitigationActionsTaskError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAuditMitigationActionsTaskError::InternalFailure(ref cause) => cause,
-            DescribeAuditMitigationActionsTaskError::InvalidRequest(ref cause) => cause,
-            DescribeAuditMitigationActionsTaskError::ResourceNotFound(ref cause) => cause,
-            DescribeAuditMitigationActionsTaskError::Throttling(ref cause) => cause,
+            DescribeAuditMitigationActionsTaskError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAuditMitigationActionsTaskError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAuditMitigationActionsTaskError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAuditMitigationActionsTaskError::Throttling(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAuditMitigationActionsTaskError {}
 /// Errors returned by DescribeAuditTask
 #[derive(Debug, PartialEq)]
 pub enum DescribeAuditTaskError {
@@ -12800,19 +12598,15 @@ impl DescribeAuditTaskError {
 }
 impl fmt::Display for DescribeAuditTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAuditTaskError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAuditTaskError::InternalFailure(ref cause) => cause,
-            DescribeAuditTaskError::InvalidRequest(ref cause) => cause,
-            DescribeAuditTaskError::ResourceNotFound(ref cause) => cause,
-            DescribeAuditTaskError::Throttling(ref cause) => cause,
+            DescribeAuditTaskError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeAuditTaskError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeAuditTaskError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeAuditTaskError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAuditTaskError {}
 /// Errors returned by DescribeAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum DescribeAuthorizerError {
@@ -12863,21 +12657,17 @@ impl DescribeAuthorizerError {
 }
 impl fmt::Display for DescribeAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAuthorizerError::InternalFailure(ref cause) => cause,
-            DescribeAuthorizerError::InvalidRequest(ref cause) => cause,
-            DescribeAuthorizerError::ResourceNotFound(ref cause) => cause,
-            DescribeAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            DescribeAuthorizerError::Throttling(ref cause) => cause,
-            DescribeAuthorizerError::Unauthorized(ref cause) => cause,
+            DescribeAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeAuthorizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAuthorizerError {}
 /// Errors returned by DescribeBillingGroup
 #[derive(Debug, PartialEq)]
 pub enum DescribeBillingGroupError {
@@ -12920,19 +12710,15 @@ impl DescribeBillingGroupError {
 }
 impl fmt::Display for DescribeBillingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBillingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBillingGroupError::InternalFailure(ref cause) => cause,
-            DescribeBillingGroupError::InvalidRequest(ref cause) => cause,
-            DescribeBillingGroupError::ResourceNotFound(ref cause) => cause,
-            DescribeBillingGroupError::Throttling(ref cause) => cause,
+            DescribeBillingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeBillingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBillingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeBillingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBillingGroupError {}
 /// Errors returned by DescribeCACertificate
 #[derive(Debug, PartialEq)]
 pub enum DescribeCACertificateError {
@@ -12989,21 +12775,17 @@ impl DescribeCACertificateError {
 }
 impl fmt::Display for DescribeCACertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCACertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCACertificateError::InternalFailure(ref cause) => cause,
-            DescribeCACertificateError::InvalidRequest(ref cause) => cause,
-            DescribeCACertificateError::ResourceNotFound(ref cause) => cause,
-            DescribeCACertificateError::ServiceUnavailable(ref cause) => cause,
-            DescribeCACertificateError::Throttling(ref cause) => cause,
-            DescribeCACertificateError::Unauthorized(ref cause) => cause,
+            DescribeCACertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeCACertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeCACertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeCACertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeCACertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeCACertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCACertificateError {}
 /// Errors returned by DescribeCertificate
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificateError {
@@ -13056,21 +12838,17 @@ impl DescribeCertificateError {
 }
 impl fmt::Display for DescribeCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificateError::InternalFailure(ref cause) => cause,
-            DescribeCertificateError::InvalidRequest(ref cause) => cause,
-            DescribeCertificateError::ResourceNotFound(ref cause) => cause,
-            DescribeCertificateError::ServiceUnavailable(ref cause) => cause,
-            DescribeCertificateError::Throttling(ref cause) => cause,
-            DescribeCertificateError::Unauthorized(ref cause) => cause,
+            DescribeCertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCertificateError {}
 /// Errors returned by DescribeDefaultAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum DescribeDefaultAuthorizerError {
@@ -13131,21 +12909,17 @@ impl DescribeDefaultAuthorizerError {
 }
 impl fmt::Display for DescribeDefaultAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDefaultAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDefaultAuthorizerError::InternalFailure(ref cause) => cause,
-            DescribeDefaultAuthorizerError::InvalidRequest(ref cause) => cause,
-            DescribeDefaultAuthorizerError::ResourceNotFound(ref cause) => cause,
-            DescribeDefaultAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            DescribeDefaultAuthorizerError::Throttling(ref cause) => cause,
-            DescribeDefaultAuthorizerError::Unauthorized(ref cause) => cause,
+            DescribeDefaultAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeDefaultAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeDefaultAuthorizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDefaultAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeDefaultAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeDefaultAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDefaultAuthorizerError {}
 /// Errors returned by DescribeDomainConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeDomainConfigurationError {
@@ -13201,20 +12975,18 @@ impl DescribeDomainConfigurationError {
 }
 impl fmt::Display for DescribeDomainConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDomainConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDomainConfigurationError::InternalFailure(ref cause) => cause,
-            DescribeDomainConfigurationError::ResourceNotFound(ref cause) => cause,
-            DescribeDomainConfigurationError::ServiceUnavailable(ref cause) => cause,
-            DescribeDomainConfigurationError::Throttling(ref cause) => cause,
-            DescribeDomainConfigurationError::Unauthorized(ref cause) => cause,
+            DescribeDomainConfigurationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeDomainConfigurationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDomainConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDomainConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeDomainConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDomainConfigurationError {}
 /// Errors returned by DescribeEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointError {
@@ -13253,19 +13025,15 @@ impl DescribeEndpointError {
 }
 impl fmt::Display for DescribeEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEndpointError::InternalFailure(ref cause) => cause,
-            DescribeEndpointError::InvalidRequest(ref cause) => cause,
-            DescribeEndpointError::Throttling(ref cause) => cause,
-            DescribeEndpointError::Unauthorized(ref cause) => cause,
+            DescribeEndpointError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEndpointError {}
 /// Errors returned by DescribeEventConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventConfigurationsError {
@@ -13300,17 +13068,13 @@ impl DescribeEventConfigurationsError {
 }
 impl fmt::Display for DescribeEventConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventConfigurationsError::InternalFailure(ref cause) => cause,
-            DescribeEventConfigurationsError::Throttling(ref cause) => cause,
+            DescribeEventConfigurationsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeEventConfigurationsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventConfigurationsError {}
 /// Errors returned by DescribeIndex
 #[derive(Debug, PartialEq)]
 pub enum DescribeIndexError {
@@ -13359,21 +13123,17 @@ impl DescribeIndexError {
 }
 impl fmt::Display for DescribeIndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIndexError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIndexError::InternalFailure(ref cause) => cause,
-            DescribeIndexError::InvalidRequest(ref cause) => cause,
-            DescribeIndexError::ResourceNotFound(ref cause) => cause,
-            DescribeIndexError::ServiceUnavailable(ref cause) => cause,
-            DescribeIndexError::Throttling(ref cause) => cause,
-            DescribeIndexError::Unauthorized(ref cause) => cause,
+            DescribeIndexError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeIndexError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeIndexError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeIndexError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeIndexError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeIndexError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIndexError {}
 /// Errors returned by DescribeJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobError {
@@ -13412,19 +13172,15 @@ impl DescribeJobError {
 }
 impl fmt::Display for DescribeJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobError::InvalidRequest(ref cause) => cause,
-            DescribeJobError::ResourceNotFound(ref cause) => cause,
-            DescribeJobError::ServiceUnavailable(ref cause) => cause,
-            DescribeJobError::Throttling(ref cause) => cause,
+            DescribeJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeJobError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobError {}
 /// Errors returned by DescribeJobExecution
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobExecutionError {
@@ -13467,19 +13223,15 @@ impl DescribeJobExecutionError {
 }
 impl fmt::Display for DescribeJobExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobExecutionError::InvalidRequest(ref cause) => cause,
-            DescribeJobExecutionError::ResourceNotFound(ref cause) => cause,
-            DescribeJobExecutionError::ServiceUnavailable(ref cause) => cause,
-            DescribeJobExecutionError::Throttling(ref cause) => cause,
+            DescribeJobExecutionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeJobExecutionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobExecutionError {}
 /// Errors returned by DescribeMitigationAction
 #[derive(Debug, PartialEq)]
 pub enum DescribeMitigationActionError {
@@ -13524,19 +13276,15 @@ impl DescribeMitigationActionError {
 }
 impl fmt::Display for DescribeMitigationActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMitigationActionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMitigationActionError::InternalFailure(ref cause) => cause,
-            DescribeMitigationActionError::InvalidRequest(ref cause) => cause,
-            DescribeMitigationActionError::ResourceNotFound(ref cause) => cause,
-            DescribeMitigationActionError::Throttling(ref cause) => cause,
+            DescribeMitigationActionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeMitigationActionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMitigationActionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMitigationActionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMitigationActionError {}
 /// Errors returned by DescribeProvisioningTemplate
 #[derive(Debug, PartialEq)]
 pub enum DescribeProvisioningTemplateError {
@@ -13592,20 +13340,18 @@ impl DescribeProvisioningTemplateError {
 }
 impl fmt::Display for DescribeProvisioningTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProvisioningTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProvisioningTemplateError::InternalFailure(ref cause) => cause,
-            DescribeProvisioningTemplateError::InvalidRequest(ref cause) => cause,
-            DescribeProvisioningTemplateError::ResourceNotFound(ref cause) => cause,
-            DescribeProvisioningTemplateError::Throttling(ref cause) => cause,
-            DescribeProvisioningTemplateError::Unauthorized(ref cause) => cause,
+            DescribeProvisioningTemplateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeProvisioningTemplateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeProvisioningTemplateError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProvisioningTemplateError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeProvisioningTemplateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProvisioningTemplateError {}
 /// Errors returned by DescribeProvisioningTemplateVersion
 #[derive(Debug, PartialEq)]
 pub enum DescribeProvisioningTemplateVersionError {
@@ -13661,20 +13407,26 @@ impl DescribeProvisioningTemplateVersionError {
 }
 impl fmt::Display for DescribeProvisioningTemplateVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProvisioningTemplateVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProvisioningTemplateVersionError::InternalFailure(ref cause) => cause,
-            DescribeProvisioningTemplateVersionError::InvalidRequest(ref cause) => cause,
-            DescribeProvisioningTemplateVersionError::ResourceNotFound(ref cause) => cause,
-            DescribeProvisioningTemplateVersionError::Throttling(ref cause) => cause,
-            DescribeProvisioningTemplateVersionError::Unauthorized(ref cause) => cause,
+            DescribeProvisioningTemplateVersionError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProvisioningTemplateVersionError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProvisioningTemplateVersionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProvisioningTemplateVersionError::Throttling(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProvisioningTemplateVersionError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeProvisioningTemplateVersionError {}
 /// Errors returned by DescribeRoleAlias
 #[derive(Debug, PartialEq)]
 pub enum DescribeRoleAliasError {
@@ -13725,21 +13477,17 @@ impl DescribeRoleAliasError {
 }
 impl fmt::Display for DescribeRoleAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRoleAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRoleAliasError::InternalFailure(ref cause) => cause,
-            DescribeRoleAliasError::InvalidRequest(ref cause) => cause,
-            DescribeRoleAliasError::ResourceNotFound(ref cause) => cause,
-            DescribeRoleAliasError::ServiceUnavailable(ref cause) => cause,
-            DescribeRoleAliasError::Throttling(ref cause) => cause,
-            DescribeRoleAliasError::Unauthorized(ref cause) => cause,
+            DescribeRoleAliasError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeRoleAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeRoleAliasError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeRoleAliasError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeRoleAliasError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeRoleAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRoleAliasError {}
 /// Errors returned by DescribeScheduledAudit
 #[derive(Debug, PartialEq)]
 pub enum DescribeScheduledAuditError {
@@ -13784,19 +13532,15 @@ impl DescribeScheduledAuditError {
 }
 impl fmt::Display for DescribeScheduledAuditError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScheduledAuditError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScheduledAuditError::InternalFailure(ref cause) => cause,
-            DescribeScheduledAuditError::InvalidRequest(ref cause) => cause,
-            DescribeScheduledAuditError::ResourceNotFound(ref cause) => cause,
-            DescribeScheduledAuditError::Throttling(ref cause) => cause,
+            DescribeScheduledAuditError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeScheduledAuditError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeScheduledAuditError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeScheduledAuditError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScheduledAuditError {}
 /// Errors returned by DescribeSecurityProfile
 #[derive(Debug, PartialEq)]
 pub enum DescribeSecurityProfileError {
@@ -13841,19 +13585,15 @@ impl DescribeSecurityProfileError {
 }
 impl fmt::Display for DescribeSecurityProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSecurityProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSecurityProfileError::InternalFailure(ref cause) => cause,
-            DescribeSecurityProfileError::InvalidRequest(ref cause) => cause,
-            DescribeSecurityProfileError::ResourceNotFound(ref cause) => cause,
-            DescribeSecurityProfileError::Throttling(ref cause) => cause,
+            DescribeSecurityProfileError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeSecurityProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeSecurityProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeSecurityProfileError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSecurityProfileError {}
 /// Errors returned by DescribeStream
 #[derive(Debug, PartialEq)]
 pub enum DescribeStreamError {
@@ -13902,21 +13642,17 @@ impl DescribeStreamError {
 }
 impl fmt::Display for DescribeStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStreamError::InternalFailure(ref cause) => cause,
-            DescribeStreamError::InvalidRequest(ref cause) => cause,
-            DescribeStreamError::ResourceNotFound(ref cause) => cause,
-            DescribeStreamError::ServiceUnavailable(ref cause) => cause,
-            DescribeStreamError::Throttling(ref cause) => cause,
-            DescribeStreamError::Unauthorized(ref cause) => cause,
+            DescribeStreamError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStreamError {}
 /// Errors returned by DescribeThing
 #[derive(Debug, PartialEq)]
 pub enum DescribeThingError {
@@ -13965,21 +13701,17 @@ impl DescribeThingError {
 }
 impl fmt::Display for DescribeThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeThingError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeThingError::InternalFailure(ref cause) => cause,
-            DescribeThingError::InvalidRequest(ref cause) => cause,
-            DescribeThingError::ResourceNotFound(ref cause) => cause,
-            DescribeThingError::ServiceUnavailable(ref cause) => cause,
-            DescribeThingError::Throttling(ref cause) => cause,
-            DescribeThingError::Unauthorized(ref cause) => cause,
+            DescribeThingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeThingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeThingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeThingError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeThingError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeThingError {}
 /// Errors returned by DescribeThingGroup
 #[derive(Debug, PartialEq)]
 pub enum DescribeThingGroupError {
@@ -14018,19 +13750,15 @@ impl DescribeThingGroupError {
 }
 impl fmt::Display for DescribeThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeThingGroupError::InternalFailure(ref cause) => cause,
-            DescribeThingGroupError::InvalidRequest(ref cause) => cause,
-            DescribeThingGroupError::ResourceNotFound(ref cause) => cause,
-            DescribeThingGroupError::Throttling(ref cause) => cause,
+            DescribeThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeThingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeThingGroupError {}
 /// Errors returned by DescribeThingRegistrationTask
 #[derive(Debug, PartialEq)]
 pub enum DescribeThingRegistrationTaskError {
@@ -14086,20 +13814,20 @@ impl DescribeThingRegistrationTaskError {
 }
 impl fmt::Display for DescribeThingRegistrationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeThingRegistrationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeThingRegistrationTaskError::InternalFailure(ref cause) => cause,
-            DescribeThingRegistrationTaskError::InvalidRequest(ref cause) => cause,
-            DescribeThingRegistrationTaskError::ResourceNotFound(ref cause) => cause,
-            DescribeThingRegistrationTaskError::Throttling(ref cause) => cause,
-            DescribeThingRegistrationTaskError::Unauthorized(ref cause) => cause,
+            DescribeThingRegistrationTaskError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeThingRegistrationTaskError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeThingRegistrationTaskError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeThingRegistrationTaskError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeThingRegistrationTaskError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeThingRegistrationTaskError {}
 /// Errors returned by DescribeThingType
 #[derive(Debug, PartialEq)]
 pub enum DescribeThingTypeError {
@@ -14150,21 +13878,17 @@ impl DescribeThingTypeError {
 }
 impl fmt::Display for DescribeThingTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeThingTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeThingTypeError::InternalFailure(ref cause) => cause,
-            DescribeThingTypeError::InvalidRequest(ref cause) => cause,
-            DescribeThingTypeError::ResourceNotFound(ref cause) => cause,
-            DescribeThingTypeError::ServiceUnavailable(ref cause) => cause,
-            DescribeThingTypeError::Throttling(ref cause) => cause,
-            DescribeThingTypeError::Unauthorized(ref cause) => cause,
+            DescribeThingTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeThingTypeError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeThingTypeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeThingTypeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeThingTypeError::Throttling(ref cause) => write!(f, "{}", cause),
+            DescribeThingTypeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeThingTypeError {}
 /// Errors returned by DetachPolicy
 #[derive(Debug, PartialEq)]
 pub enum DetachPolicyError {
@@ -14213,21 +13937,17 @@ impl DetachPolicyError {
 }
 impl fmt::Display for DetachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DetachPolicyError::InternalFailure(ref cause) => cause,
-            DetachPolicyError::InvalidRequest(ref cause) => cause,
-            DetachPolicyError::LimitExceeded(ref cause) => cause,
-            DetachPolicyError::ServiceUnavailable(ref cause) => cause,
-            DetachPolicyError::Throttling(ref cause) => cause,
-            DetachPolicyError::Unauthorized(ref cause) => cause,
+            DetachPolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachPolicyError {}
 /// Errors returned by DetachPrincipalPolicy
 #[derive(Debug, PartialEq)]
 pub enum DetachPrincipalPolicyError {
@@ -14284,21 +14004,17 @@ impl DetachPrincipalPolicyError {
 }
 impl fmt::Display for DetachPrincipalPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachPrincipalPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DetachPrincipalPolicyError::InternalFailure(ref cause) => cause,
-            DetachPrincipalPolicyError::InvalidRequest(ref cause) => cause,
-            DetachPrincipalPolicyError::ResourceNotFound(ref cause) => cause,
-            DetachPrincipalPolicyError::ServiceUnavailable(ref cause) => cause,
-            DetachPrincipalPolicyError::Throttling(ref cause) => cause,
-            DetachPrincipalPolicyError::Unauthorized(ref cause) => cause,
+            DetachPrincipalPolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DetachPrincipalPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetachPrincipalPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetachPrincipalPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DetachPrincipalPolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            DetachPrincipalPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachPrincipalPolicyError {}
 /// Errors returned by DetachSecurityProfile
 #[derive(Debug, PartialEq)]
 pub enum DetachSecurityProfileError {
@@ -14343,19 +14059,15 @@ impl DetachSecurityProfileError {
 }
 impl fmt::Display for DetachSecurityProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachSecurityProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DetachSecurityProfileError::InternalFailure(ref cause) => cause,
-            DetachSecurityProfileError::InvalidRequest(ref cause) => cause,
-            DetachSecurityProfileError::ResourceNotFound(ref cause) => cause,
-            DetachSecurityProfileError::Throttling(ref cause) => cause,
+            DetachSecurityProfileError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DetachSecurityProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetachSecurityProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetachSecurityProfileError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachSecurityProfileError {}
 /// Errors returned by DetachThingPrincipal
 #[derive(Debug, PartialEq)]
 pub enum DetachThingPrincipalError {
@@ -14410,21 +14122,17 @@ impl DetachThingPrincipalError {
 }
 impl fmt::Display for DetachThingPrincipalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachThingPrincipalError {
-    fn description(&self) -> &str {
         match *self {
-            DetachThingPrincipalError::InternalFailure(ref cause) => cause,
-            DetachThingPrincipalError::InvalidRequest(ref cause) => cause,
-            DetachThingPrincipalError::ResourceNotFound(ref cause) => cause,
-            DetachThingPrincipalError::ServiceUnavailable(ref cause) => cause,
-            DetachThingPrincipalError::Throttling(ref cause) => cause,
-            DetachThingPrincipalError::Unauthorized(ref cause) => cause,
+            DetachThingPrincipalError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DetachThingPrincipalError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DetachThingPrincipalError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetachThingPrincipalError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DetachThingPrincipalError::Throttling(ref cause) => write!(f, "{}", cause),
+            DetachThingPrincipalError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachThingPrincipalError {}
 /// Errors returned by DisableTopicRule
 #[derive(Debug, PartialEq)]
 pub enum DisableTopicRuleError {
@@ -14470,20 +14178,16 @@ impl DisableTopicRuleError {
 }
 impl fmt::Display for DisableTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableTopicRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DisableTopicRuleError::ConflictingResourceUpdate(ref cause) => cause,
-            DisableTopicRuleError::Internal(ref cause) => cause,
-            DisableTopicRuleError::InvalidRequest(ref cause) => cause,
-            DisableTopicRuleError::ServiceUnavailable(ref cause) => cause,
-            DisableTopicRuleError::Unauthorized(ref cause) => cause,
+            DisableTopicRuleError::ConflictingResourceUpdate(ref cause) => write!(f, "{}", cause),
+            DisableTopicRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            DisableTopicRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DisableTopicRuleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DisableTopicRuleError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableTopicRuleError {}
 /// Errors returned by EnableTopicRule
 #[derive(Debug, PartialEq)]
 pub enum EnableTopicRuleError {
@@ -14529,20 +14233,16 @@ impl EnableTopicRuleError {
 }
 impl fmt::Display for EnableTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableTopicRuleError {
-    fn description(&self) -> &str {
         match *self {
-            EnableTopicRuleError::ConflictingResourceUpdate(ref cause) => cause,
-            EnableTopicRuleError::Internal(ref cause) => cause,
-            EnableTopicRuleError::InvalidRequest(ref cause) => cause,
-            EnableTopicRuleError::ServiceUnavailable(ref cause) => cause,
-            EnableTopicRuleError::Unauthorized(ref cause) => cause,
+            EnableTopicRuleError::ConflictingResourceUpdate(ref cause) => write!(f, "{}", cause),
+            EnableTopicRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            EnableTopicRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            EnableTopicRuleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            EnableTopicRuleError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableTopicRuleError {}
 /// Errors returned by GetCardinality
 #[derive(Debug, PartialEq)]
 pub enum GetCardinalityError {
@@ -14606,24 +14306,20 @@ impl GetCardinalityError {
 }
 impl fmt::Display for GetCardinalityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCardinalityError {
-    fn description(&self) -> &str {
         match *self {
-            GetCardinalityError::IndexNotReady(ref cause) => cause,
-            GetCardinalityError::InternalFailure(ref cause) => cause,
-            GetCardinalityError::InvalidAggregation(ref cause) => cause,
-            GetCardinalityError::InvalidQuery(ref cause) => cause,
-            GetCardinalityError::InvalidRequest(ref cause) => cause,
-            GetCardinalityError::ResourceNotFound(ref cause) => cause,
-            GetCardinalityError::ServiceUnavailable(ref cause) => cause,
-            GetCardinalityError::Throttling(ref cause) => cause,
-            GetCardinalityError::Unauthorized(ref cause) => cause,
+            GetCardinalityError::IndexNotReady(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::InvalidAggregation(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::InvalidQuery(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetCardinalityError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCardinalityError {}
 /// Errors returned by GetEffectivePolicies
 #[derive(Debug, PartialEq)]
 pub enum GetEffectivePoliciesError {
@@ -14683,22 +14379,18 @@ impl GetEffectivePoliciesError {
 }
 impl fmt::Display for GetEffectivePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEffectivePoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            GetEffectivePoliciesError::InternalFailure(ref cause) => cause,
-            GetEffectivePoliciesError::InvalidRequest(ref cause) => cause,
-            GetEffectivePoliciesError::LimitExceeded(ref cause) => cause,
-            GetEffectivePoliciesError::ResourceNotFound(ref cause) => cause,
-            GetEffectivePoliciesError::ServiceUnavailable(ref cause) => cause,
-            GetEffectivePoliciesError::Throttling(ref cause) => cause,
-            GetEffectivePoliciesError::Unauthorized(ref cause) => cause,
+            GetEffectivePoliciesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetEffectivePoliciesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetEffectivePoliciesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetEffectivePoliciesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetEffectivePoliciesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetEffectivePoliciesError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetEffectivePoliciesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEffectivePoliciesError {}
 /// Errors returned by GetIndexingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetIndexingConfigurationError {
@@ -14750,20 +14442,16 @@ impl GetIndexingConfigurationError {
 }
 impl fmt::Display for GetIndexingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIndexingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetIndexingConfigurationError::InternalFailure(ref cause) => cause,
-            GetIndexingConfigurationError::InvalidRequest(ref cause) => cause,
-            GetIndexingConfigurationError::ServiceUnavailable(ref cause) => cause,
-            GetIndexingConfigurationError::Throttling(ref cause) => cause,
-            GetIndexingConfigurationError::Unauthorized(ref cause) => cause,
+            GetIndexingConfigurationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetIndexingConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetIndexingConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetIndexingConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetIndexingConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIndexingConfigurationError {}
 /// Errors returned by GetJobDocument
 #[derive(Debug, PartialEq)]
 pub enum GetJobDocumentError {
@@ -14802,19 +14490,15 @@ impl GetJobDocumentError {
 }
 impl fmt::Display for GetJobDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobDocumentError::InvalidRequest(ref cause) => cause,
-            GetJobDocumentError::ResourceNotFound(ref cause) => cause,
-            GetJobDocumentError::ServiceUnavailable(ref cause) => cause,
-            GetJobDocumentError::Throttling(ref cause) => cause,
+            GetJobDocumentError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetJobDocumentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetJobDocumentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetJobDocumentError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobDocumentError {}
 /// Errors returned by GetLoggingOptions
 #[derive(Debug, PartialEq)]
 pub enum GetLoggingOptionsError {
@@ -14850,18 +14534,14 @@ impl GetLoggingOptionsError {
 }
 impl fmt::Display for GetLoggingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoggingOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoggingOptionsError::Internal(ref cause) => cause,
-            GetLoggingOptionsError::InvalidRequest(ref cause) => cause,
-            GetLoggingOptionsError::ServiceUnavailable(ref cause) => cause,
+            GetLoggingOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            GetLoggingOptionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetLoggingOptionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoggingOptionsError {}
 /// Errors returned by GetOTAUpdate
 #[derive(Debug, PartialEq)]
 pub enum GetOTAUpdateError {
@@ -14910,21 +14590,17 @@ impl GetOTAUpdateError {
 }
 impl fmt::Display for GetOTAUpdateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOTAUpdateError {
-    fn description(&self) -> &str {
         match *self {
-            GetOTAUpdateError::InternalFailure(ref cause) => cause,
-            GetOTAUpdateError::InvalidRequest(ref cause) => cause,
-            GetOTAUpdateError::ResourceNotFound(ref cause) => cause,
-            GetOTAUpdateError::ServiceUnavailable(ref cause) => cause,
-            GetOTAUpdateError::Throttling(ref cause) => cause,
-            GetOTAUpdateError::Unauthorized(ref cause) => cause,
+            GetOTAUpdateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetOTAUpdateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetOTAUpdateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetOTAUpdateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetOTAUpdateError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetOTAUpdateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOTAUpdateError {}
 /// Errors returned by GetPercentiles
 #[derive(Debug, PartialEq)]
 pub enum GetPercentilesError {
@@ -14988,24 +14664,20 @@ impl GetPercentilesError {
 }
 impl fmt::Display for GetPercentilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPercentilesError {
-    fn description(&self) -> &str {
         match *self {
-            GetPercentilesError::IndexNotReady(ref cause) => cause,
-            GetPercentilesError::InternalFailure(ref cause) => cause,
-            GetPercentilesError::InvalidAggregation(ref cause) => cause,
-            GetPercentilesError::InvalidQuery(ref cause) => cause,
-            GetPercentilesError::InvalidRequest(ref cause) => cause,
-            GetPercentilesError::ResourceNotFound(ref cause) => cause,
-            GetPercentilesError::ServiceUnavailable(ref cause) => cause,
-            GetPercentilesError::Throttling(ref cause) => cause,
-            GetPercentilesError::Unauthorized(ref cause) => cause,
+            GetPercentilesError::IndexNotReady(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::InvalidAggregation(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::InvalidQuery(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetPercentilesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPercentilesError {}
 /// Errors returned by GetPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetPolicyError {
@@ -15054,21 +14726,17 @@ impl GetPolicyError {
 }
 impl fmt::Display for GetPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPolicyError::InternalFailure(ref cause) => cause,
-            GetPolicyError::InvalidRequest(ref cause) => cause,
-            GetPolicyError::ResourceNotFound(ref cause) => cause,
-            GetPolicyError::ServiceUnavailable(ref cause) => cause,
-            GetPolicyError::Throttling(ref cause) => cause,
-            GetPolicyError::Unauthorized(ref cause) => cause,
+            GetPolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPolicyError {}
 /// Errors returned by GetPolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum GetPolicyVersionError {
@@ -15117,21 +14785,17 @@ impl GetPolicyVersionError {
 }
 impl fmt::Display for GetPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetPolicyVersionError::InternalFailure(ref cause) => cause,
-            GetPolicyVersionError::InvalidRequest(ref cause) => cause,
-            GetPolicyVersionError::ResourceNotFound(ref cause) => cause,
-            GetPolicyVersionError::ServiceUnavailable(ref cause) => cause,
-            GetPolicyVersionError::Throttling(ref cause) => cause,
-            GetPolicyVersionError::Unauthorized(ref cause) => cause,
+            GetPolicyVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetPolicyVersionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetPolicyVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetPolicyVersionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPolicyVersionError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetPolicyVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPolicyVersionError {}
 /// Errors returned by GetRegistrationCode
 #[derive(Debug, PartialEq)]
 pub enum GetRegistrationCodeError {
@@ -15177,20 +14841,16 @@ impl GetRegistrationCodeError {
 }
 impl fmt::Display for GetRegistrationCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRegistrationCodeError {
-    fn description(&self) -> &str {
         match *self {
-            GetRegistrationCodeError::InternalFailure(ref cause) => cause,
-            GetRegistrationCodeError::InvalidRequest(ref cause) => cause,
-            GetRegistrationCodeError::ServiceUnavailable(ref cause) => cause,
-            GetRegistrationCodeError::Throttling(ref cause) => cause,
-            GetRegistrationCodeError::Unauthorized(ref cause) => cause,
+            GetRegistrationCodeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetRegistrationCodeError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetRegistrationCodeError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetRegistrationCodeError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetRegistrationCodeError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRegistrationCodeError {}
 /// Errors returned by GetStatistics
 #[derive(Debug, PartialEq)]
 pub enum GetStatisticsError {
@@ -15254,24 +14914,20 @@ impl GetStatisticsError {
 }
 impl fmt::Display for GetStatisticsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStatisticsError {
-    fn description(&self) -> &str {
         match *self {
-            GetStatisticsError::IndexNotReady(ref cause) => cause,
-            GetStatisticsError::InternalFailure(ref cause) => cause,
-            GetStatisticsError::InvalidAggregation(ref cause) => cause,
-            GetStatisticsError::InvalidQuery(ref cause) => cause,
-            GetStatisticsError::InvalidRequest(ref cause) => cause,
-            GetStatisticsError::ResourceNotFound(ref cause) => cause,
-            GetStatisticsError::ServiceUnavailable(ref cause) => cause,
-            GetStatisticsError::Throttling(ref cause) => cause,
-            GetStatisticsError::Unauthorized(ref cause) => cause,
+            GetStatisticsError::IndexNotReady(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::InvalidAggregation(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::InvalidQuery(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::Throttling(ref cause) => write!(f, "{}", cause),
+            GetStatisticsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStatisticsError {}
 /// Errors returned by GetTopicRule
 #[derive(Debug, PartialEq)]
 pub enum GetTopicRuleError {
@@ -15310,19 +14966,15 @@ impl GetTopicRuleError {
 }
 impl fmt::Display for GetTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTopicRuleError {
-    fn description(&self) -> &str {
         match *self {
-            GetTopicRuleError::Internal(ref cause) => cause,
-            GetTopicRuleError::InvalidRequest(ref cause) => cause,
-            GetTopicRuleError::ServiceUnavailable(ref cause) => cause,
-            GetTopicRuleError::Unauthorized(ref cause) => cause,
+            GetTopicRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            GetTopicRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetTopicRuleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetTopicRuleError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTopicRuleError {}
 /// Errors returned by GetTopicRuleDestination
 #[derive(Debug, PartialEq)]
 pub enum GetTopicRuleDestinationError {
@@ -15367,19 +15019,15 @@ impl GetTopicRuleDestinationError {
 }
 impl fmt::Display for GetTopicRuleDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTopicRuleDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            GetTopicRuleDestinationError::Internal(ref cause) => cause,
-            GetTopicRuleDestinationError::InvalidRequest(ref cause) => cause,
-            GetTopicRuleDestinationError::ServiceUnavailable(ref cause) => cause,
-            GetTopicRuleDestinationError::Unauthorized(ref cause) => cause,
+            GetTopicRuleDestinationError::Internal(ref cause) => write!(f, "{}", cause),
+            GetTopicRuleDestinationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetTopicRuleDestinationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetTopicRuleDestinationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTopicRuleDestinationError {}
 /// Errors returned by GetV2LoggingOptions
 #[derive(Debug, PartialEq)]
 pub enum GetV2LoggingOptionsError {
@@ -15415,18 +15063,14 @@ impl GetV2LoggingOptionsError {
 }
 impl fmt::Display for GetV2LoggingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetV2LoggingOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetV2LoggingOptionsError::Internal(ref cause) => cause,
-            GetV2LoggingOptionsError::NotConfigured(ref cause) => cause,
-            GetV2LoggingOptionsError::ServiceUnavailable(ref cause) => cause,
+            GetV2LoggingOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            GetV2LoggingOptionsError::NotConfigured(ref cause) => write!(f, "{}", cause),
+            GetV2LoggingOptionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetV2LoggingOptionsError {}
 /// Errors returned by ListActiveViolations
 #[derive(Debug, PartialEq)]
 pub enum ListActiveViolationsError {
@@ -15469,19 +15113,15 @@ impl ListActiveViolationsError {
 }
 impl fmt::Display for ListActiveViolationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListActiveViolationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListActiveViolationsError::InternalFailure(ref cause) => cause,
-            ListActiveViolationsError::InvalidRequest(ref cause) => cause,
-            ListActiveViolationsError::ResourceNotFound(ref cause) => cause,
-            ListActiveViolationsError::Throttling(ref cause) => cause,
+            ListActiveViolationsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListActiveViolationsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListActiveViolationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListActiveViolationsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListActiveViolationsError {}
 /// Errors returned by ListAttachedPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListAttachedPoliciesError {
@@ -15541,22 +15181,18 @@ impl ListAttachedPoliciesError {
 }
 impl fmt::Display for ListAttachedPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttachedPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttachedPoliciesError::InternalFailure(ref cause) => cause,
-            ListAttachedPoliciesError::InvalidRequest(ref cause) => cause,
-            ListAttachedPoliciesError::LimitExceeded(ref cause) => cause,
-            ListAttachedPoliciesError::ResourceNotFound(ref cause) => cause,
-            ListAttachedPoliciesError::ServiceUnavailable(ref cause) => cause,
-            ListAttachedPoliciesError::Throttling(ref cause) => cause,
-            ListAttachedPoliciesError::Unauthorized(ref cause) => cause,
+            ListAttachedPoliciesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListAttachedPoliciesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListAttachedPoliciesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListAttachedPoliciesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListAttachedPoliciesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListAttachedPoliciesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListAttachedPoliciesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttachedPoliciesError {}
 /// Errors returned by ListAuditFindings
 #[derive(Debug, PartialEq)]
 pub enum ListAuditFindingsError {
@@ -15590,18 +15226,14 @@ impl ListAuditFindingsError {
 }
 impl fmt::Display for ListAuditFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAuditFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAuditFindingsError::InternalFailure(ref cause) => cause,
-            ListAuditFindingsError::InvalidRequest(ref cause) => cause,
-            ListAuditFindingsError::Throttling(ref cause) => cause,
+            ListAuditFindingsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListAuditFindingsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListAuditFindingsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAuditFindingsError {}
 /// Errors returned by ListAuditMitigationActionsExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListAuditMitigationActionsExecutionsError {
@@ -15643,18 +15275,20 @@ impl ListAuditMitigationActionsExecutionsError {
 }
 impl fmt::Display for ListAuditMitigationActionsExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAuditMitigationActionsExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAuditMitigationActionsExecutionsError::InternalFailure(ref cause) => cause,
-            ListAuditMitigationActionsExecutionsError::InvalidRequest(ref cause) => cause,
-            ListAuditMitigationActionsExecutionsError::Throttling(ref cause) => cause,
+            ListAuditMitigationActionsExecutionsError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAuditMitigationActionsExecutionsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAuditMitigationActionsExecutionsError::Throttling(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListAuditMitigationActionsExecutionsError {}
 /// Errors returned by ListAuditMitigationActionsTasks
 #[derive(Debug, PartialEq)]
 pub enum ListAuditMitigationActionsTasksError {
@@ -15696,18 +15330,18 @@ impl ListAuditMitigationActionsTasksError {
 }
 impl fmt::Display for ListAuditMitigationActionsTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAuditMitigationActionsTasksError {
-    fn description(&self) -> &str {
         match *self {
-            ListAuditMitigationActionsTasksError::InternalFailure(ref cause) => cause,
-            ListAuditMitigationActionsTasksError::InvalidRequest(ref cause) => cause,
-            ListAuditMitigationActionsTasksError::Throttling(ref cause) => cause,
+            ListAuditMitigationActionsTasksError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAuditMitigationActionsTasksError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAuditMitigationActionsTasksError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAuditMitigationActionsTasksError {}
 /// Errors returned by ListAuditTasks
 #[derive(Debug, PartialEq)]
 pub enum ListAuditTasksError {
@@ -15741,18 +15375,14 @@ impl ListAuditTasksError {
 }
 impl fmt::Display for ListAuditTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAuditTasksError {
-    fn description(&self) -> &str {
         match *self {
-            ListAuditTasksError::InternalFailure(ref cause) => cause,
-            ListAuditTasksError::InvalidRequest(ref cause) => cause,
-            ListAuditTasksError::Throttling(ref cause) => cause,
+            ListAuditTasksError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListAuditTasksError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListAuditTasksError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAuditTasksError {}
 /// Errors returned by ListAuthorizers
 #[derive(Debug, PartialEq)]
 pub enum ListAuthorizersError {
@@ -15796,20 +15426,16 @@ impl ListAuthorizersError {
 }
 impl fmt::Display for ListAuthorizersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAuthorizersError {
-    fn description(&self) -> &str {
         match *self {
-            ListAuthorizersError::InternalFailure(ref cause) => cause,
-            ListAuthorizersError::InvalidRequest(ref cause) => cause,
-            ListAuthorizersError::ServiceUnavailable(ref cause) => cause,
-            ListAuthorizersError::Throttling(ref cause) => cause,
-            ListAuthorizersError::Unauthorized(ref cause) => cause,
+            ListAuthorizersError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListAuthorizersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListAuthorizersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListAuthorizersError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListAuthorizersError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAuthorizersError {}
 /// Errors returned by ListBillingGroups
 #[derive(Debug, PartialEq)]
 pub enum ListBillingGroupsError {
@@ -15848,19 +15474,15 @@ impl ListBillingGroupsError {
 }
 impl fmt::Display for ListBillingGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBillingGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBillingGroupsError::InternalFailure(ref cause) => cause,
-            ListBillingGroupsError::InvalidRequest(ref cause) => cause,
-            ListBillingGroupsError::ResourceNotFound(ref cause) => cause,
-            ListBillingGroupsError::Throttling(ref cause) => cause,
+            ListBillingGroupsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListBillingGroupsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListBillingGroupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListBillingGroupsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBillingGroupsError {}
 /// Errors returned by ListCACertificates
 #[derive(Debug, PartialEq)]
 pub enum ListCACertificatesError {
@@ -15906,20 +15528,16 @@ impl ListCACertificatesError {
 }
 impl fmt::Display for ListCACertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCACertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListCACertificatesError::InternalFailure(ref cause) => cause,
-            ListCACertificatesError::InvalidRequest(ref cause) => cause,
-            ListCACertificatesError::ServiceUnavailable(ref cause) => cause,
-            ListCACertificatesError::Throttling(ref cause) => cause,
-            ListCACertificatesError::Unauthorized(ref cause) => cause,
+            ListCACertificatesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListCACertificatesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListCACertificatesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListCACertificatesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListCACertificatesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCACertificatesError {}
 /// Errors returned by ListCertificates
 #[derive(Debug, PartialEq)]
 pub enum ListCertificatesError {
@@ -15963,20 +15581,16 @@ impl ListCertificatesError {
 }
 impl fmt::Display for ListCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListCertificatesError::InternalFailure(ref cause) => cause,
-            ListCertificatesError::InvalidRequest(ref cause) => cause,
-            ListCertificatesError::ServiceUnavailable(ref cause) => cause,
-            ListCertificatesError::Throttling(ref cause) => cause,
-            ListCertificatesError::Unauthorized(ref cause) => cause,
+            ListCertificatesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListCertificatesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCertificatesError {}
 /// Errors returned by ListCertificatesByCA
 #[derive(Debug, PartialEq)]
 pub enum ListCertificatesByCAError {
@@ -16024,20 +15638,16 @@ impl ListCertificatesByCAError {
 }
 impl fmt::Display for ListCertificatesByCAError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCertificatesByCAError {
-    fn description(&self) -> &str {
         match *self {
-            ListCertificatesByCAError::InternalFailure(ref cause) => cause,
-            ListCertificatesByCAError::InvalidRequest(ref cause) => cause,
-            ListCertificatesByCAError::ServiceUnavailable(ref cause) => cause,
-            ListCertificatesByCAError::Throttling(ref cause) => cause,
-            ListCertificatesByCAError::Unauthorized(ref cause) => cause,
+            ListCertificatesByCAError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListCertificatesByCAError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListCertificatesByCAError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListCertificatesByCAError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListCertificatesByCAError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCertificatesByCAError {}
 /// Errors returned by ListDomainConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListDomainConfigurationsError {
@@ -16089,20 +15699,16 @@ impl ListDomainConfigurationsError {
 }
 impl fmt::Display for ListDomainConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDomainConfigurationsError::InternalFailure(ref cause) => cause,
-            ListDomainConfigurationsError::InvalidRequest(ref cause) => cause,
-            ListDomainConfigurationsError::ServiceUnavailable(ref cause) => cause,
-            ListDomainConfigurationsError::Throttling(ref cause) => cause,
-            ListDomainConfigurationsError::Unauthorized(ref cause) => cause,
+            ListDomainConfigurationsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDomainConfigurationsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDomainConfigurationsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListDomainConfigurationsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListDomainConfigurationsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDomainConfigurationsError {}
 /// Errors returned by ListIndices
 #[derive(Debug, PartialEq)]
 pub enum ListIndicesError {
@@ -16146,20 +15752,16 @@ impl ListIndicesError {
 }
 impl fmt::Display for ListIndicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIndicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListIndicesError::InternalFailure(ref cause) => cause,
-            ListIndicesError::InvalidRequest(ref cause) => cause,
-            ListIndicesError::ServiceUnavailable(ref cause) => cause,
-            ListIndicesError::Throttling(ref cause) => cause,
-            ListIndicesError::Unauthorized(ref cause) => cause,
+            ListIndicesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListIndicesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListIndicesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListIndicesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListIndicesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIndicesError {}
 /// Errors returned by ListJobExecutionsForJob
 #[derive(Debug, PartialEq)]
 pub enum ListJobExecutionsForJobError {
@@ -16204,19 +15806,15 @@ impl ListJobExecutionsForJobError {
 }
 impl fmt::Display for ListJobExecutionsForJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobExecutionsForJobError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobExecutionsForJobError::InvalidRequest(ref cause) => cause,
-            ListJobExecutionsForJobError::ResourceNotFound(ref cause) => cause,
-            ListJobExecutionsForJobError::ServiceUnavailable(ref cause) => cause,
-            ListJobExecutionsForJobError::Throttling(ref cause) => cause,
+            ListJobExecutionsForJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListJobExecutionsForJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListJobExecutionsForJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListJobExecutionsForJobError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobExecutionsForJobError {}
 /// Errors returned by ListJobExecutionsForThing
 #[derive(Debug, PartialEq)]
 pub enum ListJobExecutionsForThingError {
@@ -16263,19 +15861,15 @@ impl ListJobExecutionsForThingError {
 }
 impl fmt::Display for ListJobExecutionsForThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobExecutionsForThingError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobExecutionsForThingError::InvalidRequest(ref cause) => cause,
-            ListJobExecutionsForThingError::ResourceNotFound(ref cause) => cause,
-            ListJobExecutionsForThingError::ServiceUnavailable(ref cause) => cause,
-            ListJobExecutionsForThingError::Throttling(ref cause) => cause,
+            ListJobExecutionsForThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListJobExecutionsForThingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListJobExecutionsForThingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListJobExecutionsForThingError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobExecutionsForThingError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -16314,19 +15908,15 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::InvalidRequest(ref cause) => cause,
-            ListJobsError::ResourceNotFound(ref cause) => cause,
-            ListJobsError::ServiceUnavailable(ref cause) => cause,
-            ListJobsError::Throttling(ref cause) => cause,
+            ListJobsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListJobsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListJobsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListJobsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by ListMitigationActions
 #[derive(Debug, PartialEq)]
 pub enum ListMitigationActionsError {
@@ -16364,18 +15954,14 @@ impl ListMitigationActionsError {
 }
 impl fmt::Display for ListMitigationActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMitigationActionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMitigationActionsError::InternalFailure(ref cause) => cause,
-            ListMitigationActionsError::InvalidRequest(ref cause) => cause,
-            ListMitigationActionsError::Throttling(ref cause) => cause,
+            ListMitigationActionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListMitigationActionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListMitigationActionsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMitigationActionsError {}
 /// Errors returned by ListOTAUpdates
 #[derive(Debug, PartialEq)]
 pub enum ListOTAUpdatesError {
@@ -16419,20 +16005,16 @@ impl ListOTAUpdatesError {
 }
 impl fmt::Display for ListOTAUpdatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOTAUpdatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListOTAUpdatesError::InternalFailure(ref cause) => cause,
-            ListOTAUpdatesError::InvalidRequest(ref cause) => cause,
-            ListOTAUpdatesError::ServiceUnavailable(ref cause) => cause,
-            ListOTAUpdatesError::Throttling(ref cause) => cause,
-            ListOTAUpdatesError::Unauthorized(ref cause) => cause,
+            ListOTAUpdatesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListOTAUpdatesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListOTAUpdatesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListOTAUpdatesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListOTAUpdatesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOTAUpdatesError {}
 /// Errors returned by ListOutgoingCertificates
 #[derive(Debug, PartialEq)]
 pub enum ListOutgoingCertificatesError {
@@ -16484,20 +16066,16 @@ impl ListOutgoingCertificatesError {
 }
 impl fmt::Display for ListOutgoingCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOutgoingCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListOutgoingCertificatesError::InternalFailure(ref cause) => cause,
-            ListOutgoingCertificatesError::InvalidRequest(ref cause) => cause,
-            ListOutgoingCertificatesError::ServiceUnavailable(ref cause) => cause,
-            ListOutgoingCertificatesError::Throttling(ref cause) => cause,
-            ListOutgoingCertificatesError::Unauthorized(ref cause) => cause,
+            ListOutgoingCertificatesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListOutgoingCertificatesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListOutgoingCertificatesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListOutgoingCertificatesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListOutgoingCertificatesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOutgoingCertificatesError {}
 /// Errors returned by ListPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListPoliciesError {
@@ -16541,20 +16119,16 @@ impl ListPoliciesError {
 }
 impl fmt::Display for ListPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPoliciesError::InternalFailure(ref cause) => cause,
-            ListPoliciesError::InvalidRequest(ref cause) => cause,
-            ListPoliciesError::ServiceUnavailable(ref cause) => cause,
-            ListPoliciesError::Throttling(ref cause) => cause,
-            ListPoliciesError::Unauthorized(ref cause) => cause,
+            ListPoliciesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPoliciesError {}
 /// Errors returned by ListPolicyPrincipals
 #[derive(Debug, PartialEq)]
 pub enum ListPolicyPrincipalsError {
@@ -16609,21 +16183,17 @@ impl ListPolicyPrincipalsError {
 }
 impl fmt::Display for ListPolicyPrincipalsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPolicyPrincipalsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPolicyPrincipalsError::InternalFailure(ref cause) => cause,
-            ListPolicyPrincipalsError::InvalidRequest(ref cause) => cause,
-            ListPolicyPrincipalsError::ResourceNotFound(ref cause) => cause,
-            ListPolicyPrincipalsError::ServiceUnavailable(ref cause) => cause,
-            ListPolicyPrincipalsError::Throttling(ref cause) => cause,
-            ListPolicyPrincipalsError::Unauthorized(ref cause) => cause,
+            ListPolicyPrincipalsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListPolicyPrincipalsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPolicyPrincipalsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPolicyPrincipalsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPolicyPrincipalsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListPolicyPrincipalsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPolicyPrincipalsError {}
 /// Errors returned by ListPolicyVersions
 #[derive(Debug, PartialEq)]
 pub enum ListPolicyVersionsError {
@@ -16674,21 +16244,17 @@ impl ListPolicyVersionsError {
 }
 impl fmt::Display for ListPolicyVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPolicyVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPolicyVersionsError::InternalFailure(ref cause) => cause,
-            ListPolicyVersionsError::InvalidRequest(ref cause) => cause,
-            ListPolicyVersionsError::ResourceNotFound(ref cause) => cause,
-            ListPolicyVersionsError::ServiceUnavailable(ref cause) => cause,
-            ListPolicyVersionsError::Throttling(ref cause) => cause,
-            ListPolicyVersionsError::Unauthorized(ref cause) => cause,
+            ListPolicyVersionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListPolicyVersionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPolicyVersionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPolicyVersionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPolicyVersionsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListPolicyVersionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPolicyVersionsError {}
 /// Errors returned by ListPrincipalPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListPrincipalPoliciesError {
@@ -16745,21 +16311,17 @@ impl ListPrincipalPoliciesError {
 }
 impl fmt::Display for ListPrincipalPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPrincipalPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPrincipalPoliciesError::InternalFailure(ref cause) => cause,
-            ListPrincipalPoliciesError::InvalidRequest(ref cause) => cause,
-            ListPrincipalPoliciesError::ResourceNotFound(ref cause) => cause,
-            ListPrincipalPoliciesError::ServiceUnavailable(ref cause) => cause,
-            ListPrincipalPoliciesError::Throttling(ref cause) => cause,
-            ListPrincipalPoliciesError::Unauthorized(ref cause) => cause,
+            ListPrincipalPoliciesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListPrincipalPoliciesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPrincipalPoliciesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPrincipalPoliciesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPrincipalPoliciesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListPrincipalPoliciesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPrincipalPoliciesError {}
 /// Errors returned by ListPrincipalThings
 #[derive(Debug, PartialEq)]
 pub enum ListPrincipalThingsError {
@@ -16812,21 +16374,17 @@ impl ListPrincipalThingsError {
 }
 impl fmt::Display for ListPrincipalThingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPrincipalThingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPrincipalThingsError::InternalFailure(ref cause) => cause,
-            ListPrincipalThingsError::InvalidRequest(ref cause) => cause,
-            ListPrincipalThingsError::ResourceNotFound(ref cause) => cause,
-            ListPrincipalThingsError::ServiceUnavailable(ref cause) => cause,
-            ListPrincipalThingsError::Throttling(ref cause) => cause,
-            ListPrincipalThingsError::Unauthorized(ref cause) => cause,
+            ListPrincipalThingsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListPrincipalThingsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPrincipalThingsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListPrincipalThingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPrincipalThingsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListPrincipalThingsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPrincipalThingsError {}
 /// Errors returned by ListProvisioningTemplateVersions
 #[derive(Debug, PartialEq)]
 pub enum ListProvisioningTemplateVersionsError {
@@ -16882,20 +16440,24 @@ impl ListProvisioningTemplateVersionsError {
 }
 impl fmt::Display for ListProvisioningTemplateVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProvisioningTemplateVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProvisioningTemplateVersionsError::InternalFailure(ref cause) => cause,
-            ListProvisioningTemplateVersionsError::InvalidRequest(ref cause) => cause,
-            ListProvisioningTemplateVersionsError::ResourceNotFound(ref cause) => cause,
-            ListProvisioningTemplateVersionsError::Throttling(ref cause) => cause,
-            ListProvisioningTemplateVersionsError::Unauthorized(ref cause) => cause,
+            ListProvisioningTemplateVersionsError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisioningTemplateVersionsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisioningTemplateVersionsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisioningTemplateVersionsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListProvisioningTemplateVersionsError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListProvisioningTemplateVersionsError {}
 /// Errors returned by ListProvisioningTemplates
 #[derive(Debug, PartialEq)]
 pub enum ListProvisioningTemplatesError {
@@ -16942,19 +16504,15 @@ impl ListProvisioningTemplatesError {
 }
 impl fmt::Display for ListProvisioningTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProvisioningTemplatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListProvisioningTemplatesError::InternalFailure(ref cause) => cause,
-            ListProvisioningTemplatesError::InvalidRequest(ref cause) => cause,
-            ListProvisioningTemplatesError::Throttling(ref cause) => cause,
-            ListProvisioningTemplatesError::Unauthorized(ref cause) => cause,
+            ListProvisioningTemplatesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListProvisioningTemplatesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListProvisioningTemplatesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListProvisioningTemplatesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProvisioningTemplatesError {}
 /// Errors returned by ListRoleAliases
 #[derive(Debug, PartialEq)]
 pub enum ListRoleAliasesError {
@@ -16998,20 +16556,16 @@ impl ListRoleAliasesError {
 }
 impl fmt::Display for ListRoleAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRoleAliasesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRoleAliasesError::InternalFailure(ref cause) => cause,
-            ListRoleAliasesError::InvalidRequest(ref cause) => cause,
-            ListRoleAliasesError::ServiceUnavailable(ref cause) => cause,
-            ListRoleAliasesError::Throttling(ref cause) => cause,
-            ListRoleAliasesError::Unauthorized(ref cause) => cause,
+            ListRoleAliasesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListRoleAliasesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListRoleAliasesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListRoleAliasesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListRoleAliasesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRoleAliasesError {}
 /// Errors returned by ListScheduledAudits
 #[derive(Debug, PartialEq)]
 pub enum ListScheduledAuditsError {
@@ -17045,18 +16599,14 @@ impl ListScheduledAuditsError {
 }
 impl fmt::Display for ListScheduledAuditsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListScheduledAuditsError {
-    fn description(&self) -> &str {
         match *self {
-            ListScheduledAuditsError::InternalFailure(ref cause) => cause,
-            ListScheduledAuditsError::InvalidRequest(ref cause) => cause,
-            ListScheduledAuditsError::Throttling(ref cause) => cause,
+            ListScheduledAuditsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListScheduledAuditsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListScheduledAuditsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListScheduledAuditsError {}
 /// Errors returned by ListSecurityProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListSecurityProfilesError {
@@ -17092,18 +16642,14 @@ impl ListSecurityProfilesError {
 }
 impl fmt::Display for ListSecurityProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSecurityProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            ListSecurityProfilesError::InternalFailure(ref cause) => cause,
-            ListSecurityProfilesError::InvalidRequest(ref cause) => cause,
-            ListSecurityProfilesError::Throttling(ref cause) => cause,
+            ListSecurityProfilesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListSecurityProfilesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListSecurityProfilesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSecurityProfilesError {}
 /// Errors returned by ListSecurityProfilesForTarget
 #[derive(Debug, PartialEq)]
 pub enum ListSecurityProfilesForTargetError {
@@ -17152,19 +16698,19 @@ impl ListSecurityProfilesForTargetError {
 }
 impl fmt::Display for ListSecurityProfilesForTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSecurityProfilesForTargetError {
-    fn description(&self) -> &str {
         match *self {
-            ListSecurityProfilesForTargetError::InternalFailure(ref cause) => cause,
-            ListSecurityProfilesForTargetError::InvalidRequest(ref cause) => cause,
-            ListSecurityProfilesForTargetError::ResourceNotFound(ref cause) => cause,
-            ListSecurityProfilesForTargetError::Throttling(ref cause) => cause,
+            ListSecurityProfilesForTargetError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListSecurityProfilesForTargetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListSecurityProfilesForTargetError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListSecurityProfilesForTargetError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSecurityProfilesForTargetError {}
 /// Errors returned by ListStreams
 #[derive(Debug, PartialEq)]
 pub enum ListStreamsError {
@@ -17208,20 +16754,16 @@ impl ListStreamsError {
 }
 impl fmt::Display for ListStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStreamsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStreamsError::InternalFailure(ref cause) => cause,
-            ListStreamsError::InvalidRequest(ref cause) => cause,
-            ListStreamsError::ServiceUnavailable(ref cause) => cause,
-            ListStreamsError::Throttling(ref cause) => cause,
-            ListStreamsError::Unauthorized(ref cause) => cause,
+            ListStreamsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListStreamsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListStreamsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListStreamsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListStreamsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStreamsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -17262,19 +16804,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalFailure(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::Throttling(ref cause) => cause,
+            ListTagsForResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTargetsForPolicy
 #[derive(Debug, PartialEq)]
 pub enum ListTargetsForPolicyError {
@@ -17334,22 +16872,18 @@ impl ListTargetsForPolicyError {
 }
 impl fmt::Display for ListTargetsForPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTargetsForPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            ListTargetsForPolicyError::InternalFailure(ref cause) => cause,
-            ListTargetsForPolicyError::InvalidRequest(ref cause) => cause,
-            ListTargetsForPolicyError::LimitExceeded(ref cause) => cause,
-            ListTargetsForPolicyError::ResourceNotFound(ref cause) => cause,
-            ListTargetsForPolicyError::ServiceUnavailable(ref cause) => cause,
-            ListTargetsForPolicyError::Throttling(ref cause) => cause,
-            ListTargetsForPolicyError::Unauthorized(ref cause) => cause,
+            ListTargetsForPolicyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTargetsForPolicyError {}
 /// Errors returned by ListTargetsForSecurityProfile
 #[derive(Debug, PartialEq)]
 pub enum ListTargetsForSecurityProfileError {
@@ -17398,19 +16932,19 @@ impl ListTargetsForSecurityProfileError {
 }
 impl fmt::Display for ListTargetsForSecurityProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTargetsForSecurityProfileError {
-    fn description(&self) -> &str {
         match *self {
-            ListTargetsForSecurityProfileError::InternalFailure(ref cause) => cause,
-            ListTargetsForSecurityProfileError::InvalidRequest(ref cause) => cause,
-            ListTargetsForSecurityProfileError::ResourceNotFound(ref cause) => cause,
-            ListTargetsForSecurityProfileError::Throttling(ref cause) => cause,
+            ListTargetsForSecurityProfileError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTargetsForSecurityProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTargetsForSecurityProfileError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTargetsForSecurityProfileError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTargetsForSecurityProfileError {}
 /// Errors returned by ListThingGroups
 #[derive(Debug, PartialEq)]
 pub enum ListThingGroupsError {
@@ -17444,18 +16978,14 @@ impl ListThingGroupsError {
 }
 impl fmt::Display for ListThingGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingGroupsError::InternalFailure(ref cause) => cause,
-            ListThingGroupsError::InvalidRequest(ref cause) => cause,
-            ListThingGroupsError::ResourceNotFound(ref cause) => cause,
+            ListThingGroupsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingGroupsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingGroupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingGroupsError {}
 /// Errors returned by ListThingGroupsForThing
 #[derive(Debug, PartialEq)]
 pub enum ListThingGroupsForThingError {
@@ -17495,18 +17025,14 @@ impl ListThingGroupsForThingError {
 }
 impl fmt::Display for ListThingGroupsForThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingGroupsForThingError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingGroupsForThingError::InternalFailure(ref cause) => cause,
-            ListThingGroupsForThingError::InvalidRequest(ref cause) => cause,
-            ListThingGroupsForThingError::ResourceNotFound(ref cause) => cause,
+            ListThingGroupsForThingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingGroupsForThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingGroupsForThingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingGroupsForThingError {}
 /// Errors returned by ListThingPrincipals
 #[derive(Debug, PartialEq)]
 pub enum ListThingPrincipalsError {
@@ -17559,21 +17085,17 @@ impl ListThingPrincipalsError {
 }
 impl fmt::Display for ListThingPrincipalsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingPrincipalsError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingPrincipalsError::InternalFailure(ref cause) => cause,
-            ListThingPrincipalsError::InvalidRequest(ref cause) => cause,
-            ListThingPrincipalsError::ResourceNotFound(ref cause) => cause,
-            ListThingPrincipalsError::ServiceUnavailable(ref cause) => cause,
-            ListThingPrincipalsError::Throttling(ref cause) => cause,
-            ListThingPrincipalsError::Unauthorized(ref cause) => cause,
+            ListThingPrincipalsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingPrincipalsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingPrincipalsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListThingPrincipalsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListThingPrincipalsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListThingPrincipalsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingPrincipalsError {}
 /// Errors returned by ListThingRegistrationTaskReports
 #[derive(Debug, PartialEq)]
 pub enum ListThingRegistrationTaskReportsError {
@@ -17622,19 +17144,21 @@ impl ListThingRegistrationTaskReportsError {
 }
 impl fmt::Display for ListThingRegistrationTaskReportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingRegistrationTaskReportsError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingRegistrationTaskReportsError::InternalFailure(ref cause) => cause,
-            ListThingRegistrationTaskReportsError::InvalidRequest(ref cause) => cause,
-            ListThingRegistrationTaskReportsError::Throttling(ref cause) => cause,
-            ListThingRegistrationTaskReportsError::Unauthorized(ref cause) => cause,
+            ListThingRegistrationTaskReportsError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListThingRegistrationTaskReportsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListThingRegistrationTaskReportsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListThingRegistrationTaskReportsError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListThingRegistrationTaskReportsError {}
 /// Errors returned by ListThingRegistrationTasks
 #[derive(Debug, PartialEq)]
 pub enum ListThingRegistrationTasksError {
@@ -17683,19 +17207,15 @@ impl ListThingRegistrationTasksError {
 }
 impl fmt::Display for ListThingRegistrationTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingRegistrationTasksError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingRegistrationTasksError::InternalFailure(ref cause) => cause,
-            ListThingRegistrationTasksError::InvalidRequest(ref cause) => cause,
-            ListThingRegistrationTasksError::Throttling(ref cause) => cause,
-            ListThingRegistrationTasksError::Unauthorized(ref cause) => cause,
+            ListThingRegistrationTasksError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingRegistrationTasksError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingRegistrationTasksError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListThingRegistrationTasksError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingRegistrationTasksError {}
 /// Errors returned by ListThingTypes
 #[derive(Debug, PartialEq)]
 pub enum ListThingTypesError {
@@ -17739,20 +17259,16 @@ impl ListThingTypesError {
 }
 impl fmt::Display for ListThingTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingTypesError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingTypesError::InternalFailure(ref cause) => cause,
-            ListThingTypesError::InvalidRequest(ref cause) => cause,
-            ListThingTypesError::ServiceUnavailable(ref cause) => cause,
-            ListThingTypesError::Throttling(ref cause) => cause,
-            ListThingTypesError::Unauthorized(ref cause) => cause,
+            ListThingTypesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingTypesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingTypesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListThingTypesError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListThingTypesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingTypesError {}
 /// Errors returned by ListThings
 #[derive(Debug, PartialEq)]
 pub enum ListThingsError {
@@ -17796,20 +17312,16 @@ impl ListThingsError {
 }
 impl fmt::Display for ListThingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingsError::InternalFailure(ref cause) => cause,
-            ListThingsError::InvalidRequest(ref cause) => cause,
-            ListThingsError::ServiceUnavailable(ref cause) => cause,
-            ListThingsError::Throttling(ref cause) => cause,
-            ListThingsError::Unauthorized(ref cause) => cause,
+            ListThingsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListThingsError::Throttling(ref cause) => write!(f, "{}", cause),
+            ListThingsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingsError {}
 /// Errors returned by ListThingsInBillingGroup
 #[derive(Debug, PartialEq)]
 pub enum ListThingsInBillingGroupError {
@@ -17854,19 +17366,15 @@ impl ListThingsInBillingGroupError {
 }
 impl fmt::Display for ListThingsInBillingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingsInBillingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingsInBillingGroupError::InternalFailure(ref cause) => cause,
-            ListThingsInBillingGroupError::InvalidRequest(ref cause) => cause,
-            ListThingsInBillingGroupError::ResourceNotFound(ref cause) => cause,
-            ListThingsInBillingGroupError::Throttling(ref cause) => cause,
+            ListThingsInBillingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingsInBillingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingsInBillingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListThingsInBillingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingsInBillingGroupError {}
 /// Errors returned by ListThingsInThingGroup
 #[derive(Debug, PartialEq)]
 pub enum ListThingsInThingGroupError {
@@ -17906,18 +17414,14 @@ impl ListThingsInThingGroupError {
 }
 impl fmt::Display for ListThingsInThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListThingsInThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ListThingsInThingGroupError::InternalFailure(ref cause) => cause,
-            ListThingsInThingGroupError::InvalidRequest(ref cause) => cause,
-            ListThingsInThingGroupError::ResourceNotFound(ref cause) => cause,
+            ListThingsInThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListThingsInThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListThingsInThingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListThingsInThingGroupError {}
 /// Errors returned by ListTopicRuleDestinations
 #[derive(Debug, PartialEq)]
 pub enum ListTopicRuleDestinationsError {
@@ -17962,19 +17466,15 @@ impl ListTopicRuleDestinationsError {
 }
 impl fmt::Display for ListTopicRuleDestinationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTopicRuleDestinationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTopicRuleDestinationsError::Internal(ref cause) => cause,
-            ListTopicRuleDestinationsError::InvalidRequest(ref cause) => cause,
-            ListTopicRuleDestinationsError::ServiceUnavailable(ref cause) => cause,
-            ListTopicRuleDestinationsError::Unauthorized(ref cause) => cause,
+            ListTopicRuleDestinationsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListTopicRuleDestinationsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTopicRuleDestinationsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListTopicRuleDestinationsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTopicRuleDestinationsError {}
 /// Errors returned by ListTopicRules
 #[derive(Debug, PartialEq)]
 pub enum ListTopicRulesError {
@@ -18008,18 +17508,14 @@ impl ListTopicRulesError {
 }
 impl fmt::Display for ListTopicRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTopicRulesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTopicRulesError::Internal(ref cause) => cause,
-            ListTopicRulesError::InvalidRequest(ref cause) => cause,
-            ListTopicRulesError::ServiceUnavailable(ref cause) => cause,
+            ListTopicRulesError::Internal(ref cause) => write!(f, "{}", cause),
+            ListTopicRulesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTopicRulesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTopicRulesError {}
 /// Errors returned by ListV2LoggingLevels
 #[derive(Debug, PartialEq)]
 pub enum ListV2LoggingLevelsError {
@@ -18060,19 +17556,15 @@ impl ListV2LoggingLevelsError {
 }
 impl fmt::Display for ListV2LoggingLevelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListV2LoggingLevelsError {
-    fn description(&self) -> &str {
         match *self {
-            ListV2LoggingLevelsError::Internal(ref cause) => cause,
-            ListV2LoggingLevelsError::InvalidRequest(ref cause) => cause,
-            ListV2LoggingLevelsError::NotConfigured(ref cause) => cause,
-            ListV2LoggingLevelsError::ServiceUnavailable(ref cause) => cause,
+            ListV2LoggingLevelsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListV2LoggingLevelsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListV2LoggingLevelsError::NotConfigured(ref cause) => write!(f, "{}", cause),
+            ListV2LoggingLevelsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListV2LoggingLevelsError {}
 /// Errors returned by ListViolationEvents
 #[derive(Debug, PartialEq)]
 pub enum ListViolationEventsError {
@@ -18106,18 +17598,14 @@ impl ListViolationEventsError {
 }
 impl fmt::Display for ListViolationEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListViolationEventsError {
-    fn description(&self) -> &str {
         match *self {
-            ListViolationEventsError::InternalFailure(ref cause) => cause,
-            ListViolationEventsError::InvalidRequest(ref cause) => cause,
-            ListViolationEventsError::Throttling(ref cause) => cause,
+            ListViolationEventsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListViolationEventsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListViolationEventsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListViolationEventsError {}
 /// Errors returned by RegisterCACertificate
 #[derive(Debug, PartialEq)]
 pub enum RegisterCACertificateError {
@@ -18193,24 +17681,22 @@ impl RegisterCACertificateError {
 }
 impl fmt::Display for RegisterCACertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterCACertificateError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterCACertificateError::CertificateValidation(ref cause) => cause,
-            RegisterCACertificateError::InternalFailure(ref cause) => cause,
-            RegisterCACertificateError::InvalidRequest(ref cause) => cause,
-            RegisterCACertificateError::LimitExceeded(ref cause) => cause,
-            RegisterCACertificateError::RegistrationCodeValidation(ref cause) => cause,
-            RegisterCACertificateError::ResourceAlreadyExists(ref cause) => cause,
-            RegisterCACertificateError::ServiceUnavailable(ref cause) => cause,
-            RegisterCACertificateError::Throttling(ref cause) => cause,
-            RegisterCACertificateError::Unauthorized(ref cause) => cause,
+            RegisterCACertificateError::CertificateValidation(ref cause) => write!(f, "{}", cause),
+            RegisterCACertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            RegisterCACertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RegisterCACertificateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RegisterCACertificateError::RegistrationCodeValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterCACertificateError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            RegisterCACertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RegisterCACertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            RegisterCACertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterCACertificateError {}
 /// Errors returned by RegisterCertificate
 #[derive(Debug, PartialEq)]
 pub enum RegisterCertificateError {
@@ -18284,24 +17770,20 @@ impl RegisterCertificateError {
 }
 impl fmt::Display for RegisterCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterCertificateError::CertificateConflict(ref cause) => cause,
-            RegisterCertificateError::CertificateState(ref cause) => cause,
-            RegisterCertificateError::CertificateValidation(ref cause) => cause,
-            RegisterCertificateError::InternalFailure(ref cause) => cause,
-            RegisterCertificateError::InvalidRequest(ref cause) => cause,
-            RegisterCertificateError::ResourceAlreadyExists(ref cause) => cause,
-            RegisterCertificateError::ServiceUnavailable(ref cause) => cause,
-            RegisterCertificateError::Throttling(ref cause) => cause,
-            RegisterCertificateError::Unauthorized(ref cause) => cause,
+            RegisterCertificateError::CertificateConflict(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::CertificateState(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::CertificateValidation(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            RegisterCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterCertificateError {}
 /// Errors returned by RegisterThing
 #[derive(Debug, PartialEq)]
 pub enum RegisterThingError {
@@ -18359,22 +17841,18 @@ impl RegisterThingError {
 }
 impl fmt::Display for RegisterThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterThingError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterThingError::ConflictingResourceUpdate(ref cause) => cause,
-            RegisterThingError::InternalFailure(ref cause) => cause,
-            RegisterThingError::InvalidRequest(ref cause) => cause,
-            RegisterThingError::ResourceRegistrationFailure(ref cause) => cause,
-            RegisterThingError::ServiceUnavailable(ref cause) => cause,
-            RegisterThingError::Throttling(ref cause) => cause,
-            RegisterThingError::Unauthorized(ref cause) => cause,
+            RegisterThingError::ConflictingResourceUpdate(ref cause) => write!(f, "{}", cause),
+            RegisterThingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            RegisterThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RegisterThingError::ResourceRegistrationFailure(ref cause) => write!(f, "{}", cause),
+            RegisterThingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RegisterThingError::Throttling(ref cause) => write!(f, "{}", cause),
+            RegisterThingError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterThingError {}
 /// Errors returned by RejectCertificateTransfer
 #[derive(Debug, PartialEq)]
 pub enum RejectCertificateTransferError {
@@ -18442,22 +17920,20 @@ impl RejectCertificateTransferError {
 }
 impl fmt::Display for RejectCertificateTransferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RejectCertificateTransferError {
-    fn description(&self) -> &str {
         match *self {
-            RejectCertificateTransferError::InternalFailure(ref cause) => cause,
-            RejectCertificateTransferError::InvalidRequest(ref cause) => cause,
-            RejectCertificateTransferError::ResourceNotFound(ref cause) => cause,
-            RejectCertificateTransferError::ServiceUnavailable(ref cause) => cause,
-            RejectCertificateTransferError::Throttling(ref cause) => cause,
-            RejectCertificateTransferError::TransferAlreadyCompleted(ref cause) => cause,
-            RejectCertificateTransferError::Unauthorized(ref cause) => cause,
+            RejectCertificateTransferError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            RejectCertificateTransferError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RejectCertificateTransferError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RejectCertificateTransferError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RejectCertificateTransferError::Throttling(ref cause) => write!(f, "{}", cause),
+            RejectCertificateTransferError::TransferAlreadyCompleted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RejectCertificateTransferError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RejectCertificateTransferError {}
 /// Errors returned by RemoveThingFromBillingGroup
 #[derive(Debug, PartialEq)]
 pub enum RemoveThingFromBillingGroupError {
@@ -18506,19 +17982,15 @@ impl RemoveThingFromBillingGroupError {
 }
 impl fmt::Display for RemoveThingFromBillingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveThingFromBillingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveThingFromBillingGroupError::InternalFailure(ref cause) => cause,
-            RemoveThingFromBillingGroupError::InvalidRequest(ref cause) => cause,
-            RemoveThingFromBillingGroupError::ResourceNotFound(ref cause) => cause,
-            RemoveThingFromBillingGroupError::Throttling(ref cause) => cause,
+            RemoveThingFromBillingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            RemoveThingFromBillingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RemoveThingFromBillingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveThingFromBillingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveThingFromBillingGroupError {}
 /// Errors returned by RemoveThingFromThingGroup
 #[derive(Debug, PartialEq)]
 pub enum RemoveThingFromThingGroupError {
@@ -18565,19 +18037,15 @@ impl RemoveThingFromThingGroupError {
 }
 impl fmt::Display for RemoveThingFromThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveThingFromThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveThingFromThingGroupError::InternalFailure(ref cause) => cause,
-            RemoveThingFromThingGroupError::InvalidRequest(ref cause) => cause,
-            RemoveThingFromThingGroupError::ResourceNotFound(ref cause) => cause,
-            RemoveThingFromThingGroupError::Throttling(ref cause) => cause,
+            RemoveThingFromThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            RemoveThingFromThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RemoveThingFromThingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RemoveThingFromThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveThingFromThingGroupError {}
 /// Errors returned by ReplaceTopicRule
 #[derive(Debug, PartialEq)]
 pub enum ReplaceTopicRuleError {
@@ -18628,21 +18096,17 @@ impl ReplaceTopicRuleError {
 }
 impl fmt::Display for ReplaceTopicRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReplaceTopicRuleError {
-    fn description(&self) -> &str {
         match *self {
-            ReplaceTopicRuleError::ConflictingResourceUpdate(ref cause) => cause,
-            ReplaceTopicRuleError::Internal(ref cause) => cause,
-            ReplaceTopicRuleError::InvalidRequest(ref cause) => cause,
-            ReplaceTopicRuleError::ServiceUnavailable(ref cause) => cause,
-            ReplaceTopicRuleError::SqlParse(ref cause) => cause,
-            ReplaceTopicRuleError::Unauthorized(ref cause) => cause,
+            ReplaceTopicRuleError::ConflictingResourceUpdate(ref cause) => write!(f, "{}", cause),
+            ReplaceTopicRuleError::Internal(ref cause) => write!(f, "{}", cause),
+            ReplaceTopicRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ReplaceTopicRuleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ReplaceTopicRuleError::SqlParse(ref cause) => write!(f, "{}", cause),
+            ReplaceTopicRuleError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReplaceTopicRuleError {}
 /// Errors returned by SearchIndex
 #[derive(Debug, PartialEq)]
 pub enum SearchIndexError {
@@ -18701,23 +18165,19 @@ impl SearchIndexError {
 }
 impl fmt::Display for SearchIndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchIndexError {
-    fn description(&self) -> &str {
         match *self {
-            SearchIndexError::IndexNotReady(ref cause) => cause,
-            SearchIndexError::InternalFailure(ref cause) => cause,
-            SearchIndexError::InvalidQuery(ref cause) => cause,
-            SearchIndexError::InvalidRequest(ref cause) => cause,
-            SearchIndexError::ResourceNotFound(ref cause) => cause,
-            SearchIndexError::ServiceUnavailable(ref cause) => cause,
-            SearchIndexError::Throttling(ref cause) => cause,
-            SearchIndexError::Unauthorized(ref cause) => cause,
+            SearchIndexError::IndexNotReady(ref cause) => write!(f, "{}", cause),
+            SearchIndexError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            SearchIndexError::InvalidQuery(ref cause) => write!(f, "{}", cause),
+            SearchIndexError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SearchIndexError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SearchIndexError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            SearchIndexError::Throttling(ref cause) => write!(f, "{}", cause),
+            SearchIndexError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchIndexError {}
 /// Errors returned by SetDefaultAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum SetDefaultAuthorizerError {
@@ -18779,22 +18239,18 @@ impl SetDefaultAuthorizerError {
 }
 impl fmt::Display for SetDefaultAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetDefaultAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            SetDefaultAuthorizerError::InternalFailure(ref cause) => cause,
-            SetDefaultAuthorizerError::InvalidRequest(ref cause) => cause,
-            SetDefaultAuthorizerError::ResourceAlreadyExists(ref cause) => cause,
-            SetDefaultAuthorizerError::ResourceNotFound(ref cause) => cause,
-            SetDefaultAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            SetDefaultAuthorizerError::Throttling(ref cause) => cause,
-            SetDefaultAuthorizerError::Unauthorized(ref cause) => cause,
+            SetDefaultAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            SetDefaultAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SetDefaultAuthorizerError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            SetDefaultAuthorizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetDefaultAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            SetDefaultAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            SetDefaultAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetDefaultAuthorizerError {}
 /// Errors returned by SetDefaultPolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum SetDefaultPolicyVersionError {
@@ -18853,21 +18309,17 @@ impl SetDefaultPolicyVersionError {
 }
 impl fmt::Display for SetDefaultPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetDefaultPolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            SetDefaultPolicyVersionError::InternalFailure(ref cause) => cause,
-            SetDefaultPolicyVersionError::InvalidRequest(ref cause) => cause,
-            SetDefaultPolicyVersionError::ResourceNotFound(ref cause) => cause,
-            SetDefaultPolicyVersionError::ServiceUnavailable(ref cause) => cause,
-            SetDefaultPolicyVersionError::Throttling(ref cause) => cause,
-            SetDefaultPolicyVersionError::Unauthorized(ref cause) => cause,
+            SetDefaultPolicyVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::Throttling(ref cause) => write!(f, "{}", cause),
+            SetDefaultPolicyVersionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetDefaultPolicyVersionError {}
 /// Errors returned by SetLoggingOptions
 #[derive(Debug, PartialEq)]
 pub enum SetLoggingOptionsError {
@@ -18903,18 +18355,14 @@ impl SetLoggingOptionsError {
 }
 impl fmt::Display for SetLoggingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetLoggingOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            SetLoggingOptionsError::Internal(ref cause) => cause,
-            SetLoggingOptionsError::InvalidRequest(ref cause) => cause,
-            SetLoggingOptionsError::ServiceUnavailable(ref cause) => cause,
+            SetLoggingOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            SetLoggingOptionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SetLoggingOptionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetLoggingOptionsError {}
 /// Errors returned by SetV2LoggingLevel
 #[derive(Debug, PartialEq)]
 pub enum SetV2LoggingLevelError {
@@ -18955,19 +18403,15 @@ impl SetV2LoggingLevelError {
 }
 impl fmt::Display for SetV2LoggingLevelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetV2LoggingLevelError {
-    fn description(&self) -> &str {
         match *self {
-            SetV2LoggingLevelError::Internal(ref cause) => cause,
-            SetV2LoggingLevelError::InvalidRequest(ref cause) => cause,
-            SetV2LoggingLevelError::NotConfigured(ref cause) => cause,
-            SetV2LoggingLevelError::ServiceUnavailable(ref cause) => cause,
+            SetV2LoggingLevelError::Internal(ref cause) => write!(f, "{}", cause),
+            SetV2LoggingLevelError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SetV2LoggingLevelError::NotConfigured(ref cause) => write!(f, "{}", cause),
+            SetV2LoggingLevelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetV2LoggingLevelError {}
 /// Errors returned by SetV2LoggingOptions
 #[derive(Debug, PartialEq)]
 pub enum SetV2LoggingOptionsError {
@@ -19003,18 +18447,14 @@ impl SetV2LoggingOptionsError {
 }
 impl fmt::Display for SetV2LoggingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetV2LoggingOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            SetV2LoggingOptionsError::Internal(ref cause) => cause,
-            SetV2LoggingOptionsError::InvalidRequest(ref cause) => cause,
-            SetV2LoggingOptionsError::ServiceUnavailable(ref cause) => cause,
+            SetV2LoggingOptionsError::Internal(ref cause) => write!(f, "{}", cause),
+            SetV2LoggingOptionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SetV2LoggingOptionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetV2LoggingOptionsError {}
 /// Errors returned by StartAuditMitigationActionsTask
 #[derive(Debug, PartialEq)]
 pub enum StartAuditMitigationActionsTaskError {
@@ -19070,20 +18510,24 @@ impl StartAuditMitigationActionsTaskError {
 }
 impl fmt::Display for StartAuditMitigationActionsTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartAuditMitigationActionsTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartAuditMitigationActionsTaskError::InternalFailure(ref cause) => cause,
-            StartAuditMitigationActionsTaskError::InvalidRequest(ref cause) => cause,
-            StartAuditMitigationActionsTaskError::LimitExceeded(ref cause) => cause,
-            StartAuditMitigationActionsTaskError::TaskAlreadyExists(ref cause) => cause,
-            StartAuditMitigationActionsTaskError::Throttling(ref cause) => cause,
+            StartAuditMitigationActionsTaskError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAuditMitigationActionsTaskError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAuditMitigationActionsTaskError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAuditMitigationActionsTaskError::TaskAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAuditMitigationActionsTaskError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartAuditMitigationActionsTaskError {}
 /// Errors returned by StartOnDemandAuditTask
 #[derive(Debug, PartialEq)]
 pub enum StartOnDemandAuditTaskError {
@@ -19128,19 +18572,15 @@ impl StartOnDemandAuditTaskError {
 }
 impl fmt::Display for StartOnDemandAuditTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartOnDemandAuditTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartOnDemandAuditTaskError::InternalFailure(ref cause) => cause,
-            StartOnDemandAuditTaskError::InvalidRequest(ref cause) => cause,
-            StartOnDemandAuditTaskError::LimitExceeded(ref cause) => cause,
-            StartOnDemandAuditTaskError::Throttling(ref cause) => cause,
+            StartOnDemandAuditTaskError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartOnDemandAuditTaskError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartOnDemandAuditTaskError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartOnDemandAuditTaskError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartOnDemandAuditTaskError {}
 /// Errors returned by StartThingRegistrationTask
 #[derive(Debug, PartialEq)]
 pub enum StartThingRegistrationTaskError {
@@ -19189,19 +18629,15 @@ impl StartThingRegistrationTaskError {
 }
 impl fmt::Display for StartThingRegistrationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartThingRegistrationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartThingRegistrationTaskError::InternalFailure(ref cause) => cause,
-            StartThingRegistrationTaskError::InvalidRequest(ref cause) => cause,
-            StartThingRegistrationTaskError::Throttling(ref cause) => cause,
-            StartThingRegistrationTaskError::Unauthorized(ref cause) => cause,
+            StartThingRegistrationTaskError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartThingRegistrationTaskError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartThingRegistrationTaskError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartThingRegistrationTaskError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartThingRegistrationTaskError {}
 /// Errors returned by StopThingRegistrationTask
 #[derive(Debug, PartialEq)]
 pub enum StopThingRegistrationTaskError {
@@ -19255,20 +18691,16 @@ impl StopThingRegistrationTaskError {
 }
 impl fmt::Display for StopThingRegistrationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopThingRegistrationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StopThingRegistrationTaskError::InternalFailure(ref cause) => cause,
-            StopThingRegistrationTaskError::InvalidRequest(ref cause) => cause,
-            StopThingRegistrationTaskError::ResourceNotFound(ref cause) => cause,
-            StopThingRegistrationTaskError::Throttling(ref cause) => cause,
-            StopThingRegistrationTaskError::Unauthorized(ref cause) => cause,
+            StopThingRegistrationTaskError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StopThingRegistrationTaskError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopThingRegistrationTaskError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopThingRegistrationTaskError::Throttling(ref cause) => write!(f, "{}", cause),
+            StopThingRegistrationTaskError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopThingRegistrationTaskError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -19312,20 +18744,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalFailure(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::Throttling(ref cause) => cause,
+            TagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TestAuthorization
 #[derive(Debug, PartialEq)]
 pub enum TestAuthorizationError {
@@ -19381,22 +18809,18 @@ impl TestAuthorizationError {
 }
 impl fmt::Display for TestAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            TestAuthorizationError::InternalFailure(ref cause) => cause,
-            TestAuthorizationError::InvalidRequest(ref cause) => cause,
-            TestAuthorizationError::LimitExceeded(ref cause) => cause,
-            TestAuthorizationError::ResourceNotFound(ref cause) => cause,
-            TestAuthorizationError::ServiceUnavailable(ref cause) => cause,
-            TestAuthorizationError::Throttling(ref cause) => cause,
-            TestAuthorizationError::Unauthorized(ref cause) => cause,
+            TestAuthorizationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TestAuthorizationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TestAuthorizationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TestAuthorizationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TestAuthorizationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            TestAuthorizationError::Throttling(ref cause) => write!(f, "{}", cause),
+            TestAuthorizationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestAuthorizationError {}
 /// Errors returned by TestInvokeAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum TestInvokeAuthorizerError {
@@ -19458,22 +18882,18 @@ impl TestInvokeAuthorizerError {
 }
 impl fmt::Display for TestInvokeAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestInvokeAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            TestInvokeAuthorizerError::InternalFailure(ref cause) => cause,
-            TestInvokeAuthorizerError::InvalidRequest(ref cause) => cause,
-            TestInvokeAuthorizerError::InvalidResponse(ref cause) => cause,
-            TestInvokeAuthorizerError::ResourceNotFound(ref cause) => cause,
-            TestInvokeAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            TestInvokeAuthorizerError::Throttling(ref cause) => cause,
-            TestInvokeAuthorizerError::Unauthorized(ref cause) => cause,
+            TestInvokeAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::InvalidResponse(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            TestInvokeAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestInvokeAuthorizerError {}
 /// Errors returned by TransferCertificate
 #[derive(Debug, PartialEq)]
 pub enum TransferCertificateError {
@@ -19540,23 +18960,19 @@ impl TransferCertificateError {
 }
 impl fmt::Display for TransferCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TransferCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            TransferCertificateError::CertificateState(ref cause) => cause,
-            TransferCertificateError::InternalFailure(ref cause) => cause,
-            TransferCertificateError::InvalidRequest(ref cause) => cause,
-            TransferCertificateError::ResourceNotFound(ref cause) => cause,
-            TransferCertificateError::ServiceUnavailable(ref cause) => cause,
-            TransferCertificateError::Throttling(ref cause) => cause,
-            TransferCertificateError::TransferConflict(ref cause) => cause,
-            TransferCertificateError::Unauthorized(ref cause) => cause,
+            TransferCertificateError::CertificateState(ref cause) => write!(f, "{}", cause),
+            TransferCertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TransferCertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TransferCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TransferCertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            TransferCertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            TransferCertificateError::TransferConflict(ref cause) => write!(f, "{}", cause),
+            TransferCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TransferCertificateError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -19595,19 +19011,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalFailure(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::Throttling(ref cause) => cause,
+            UntagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateAccountAuditConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateAccountAuditConfigurationError {
@@ -19649,18 +19061,18 @@ impl UpdateAccountAuditConfigurationError {
 }
 impl fmt::Display for UpdateAccountAuditConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAccountAuditConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAccountAuditConfigurationError::InternalFailure(ref cause) => cause,
-            UpdateAccountAuditConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateAccountAuditConfigurationError::Throttling(ref cause) => cause,
+            UpdateAccountAuditConfigurationError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAccountAuditConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAccountAuditConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAccountAuditConfigurationError {}
 /// Errors returned by UpdateAuthorizer
 #[derive(Debug, PartialEq)]
 pub enum UpdateAuthorizerError {
@@ -19714,22 +19126,18 @@ impl UpdateAuthorizerError {
 }
 impl fmt::Display for UpdateAuthorizerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAuthorizerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAuthorizerError::InternalFailure(ref cause) => cause,
-            UpdateAuthorizerError::InvalidRequest(ref cause) => cause,
-            UpdateAuthorizerError::LimitExceeded(ref cause) => cause,
-            UpdateAuthorizerError::ResourceNotFound(ref cause) => cause,
-            UpdateAuthorizerError::ServiceUnavailable(ref cause) => cause,
-            UpdateAuthorizerError::Throttling(ref cause) => cause,
-            UpdateAuthorizerError::Unauthorized(ref cause) => cause,
+            UpdateAuthorizerError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateAuthorizerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAuthorizerError {}
 /// Errors returned by UpdateBillingGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateBillingGroupError {
@@ -19773,20 +19181,16 @@ impl UpdateBillingGroupError {
 }
 impl fmt::Display for UpdateBillingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBillingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBillingGroupError::InternalFailure(ref cause) => cause,
-            UpdateBillingGroupError::InvalidRequest(ref cause) => cause,
-            UpdateBillingGroupError::ResourceNotFound(ref cause) => cause,
-            UpdateBillingGroupError::Throttling(ref cause) => cause,
-            UpdateBillingGroupError::VersionConflict(ref cause) => cause,
+            UpdateBillingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateBillingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBillingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateBillingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateBillingGroupError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBillingGroupError {}
 /// Errors returned by UpdateCACertificate
 #[derive(Debug, PartialEq)]
 pub enum UpdateCACertificateError {
@@ -19839,21 +19243,17 @@ impl UpdateCACertificateError {
 }
 impl fmt::Display for UpdateCACertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCACertificateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCACertificateError::InternalFailure(ref cause) => cause,
-            UpdateCACertificateError::InvalidRequest(ref cause) => cause,
-            UpdateCACertificateError::ResourceNotFound(ref cause) => cause,
-            UpdateCACertificateError::ServiceUnavailable(ref cause) => cause,
-            UpdateCACertificateError::Throttling(ref cause) => cause,
-            UpdateCACertificateError::Unauthorized(ref cause) => cause,
+            UpdateCACertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateCACertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateCACertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateCACertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateCACertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateCACertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCACertificateError {}
 /// Errors returned by UpdateCertificate
 #[derive(Debug, PartialEq)]
 pub enum UpdateCertificateError {
@@ -19909,22 +19309,18 @@ impl UpdateCertificateError {
 }
 impl fmt::Display for UpdateCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCertificateError::CertificateState(ref cause) => cause,
-            UpdateCertificateError::InternalFailure(ref cause) => cause,
-            UpdateCertificateError::InvalidRequest(ref cause) => cause,
-            UpdateCertificateError::ResourceNotFound(ref cause) => cause,
-            UpdateCertificateError::ServiceUnavailable(ref cause) => cause,
-            UpdateCertificateError::Throttling(ref cause) => cause,
-            UpdateCertificateError::Unauthorized(ref cause) => cause,
+            UpdateCertificateError::CertificateState(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateCertificateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCertificateError {}
 /// Errors returned by UpdateDomainConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainConfigurationError {
@@ -19992,22 +19388,20 @@ impl UpdateDomainConfigurationError {
 }
 impl fmt::Display for UpdateDomainConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainConfigurationError::CertificateValidation(ref cause) => cause,
-            UpdateDomainConfigurationError::InternalFailure(ref cause) => cause,
-            UpdateDomainConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateDomainConfigurationError::ResourceNotFound(ref cause) => cause,
-            UpdateDomainConfigurationError::ServiceUnavailable(ref cause) => cause,
-            UpdateDomainConfigurationError::Throttling(ref cause) => cause,
-            UpdateDomainConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateDomainConfigurationError::CertificateValidation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDomainConfigurationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDomainConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainConfigurationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDomainConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateDomainConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateDomainConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainConfigurationError {}
 /// Errors returned by UpdateDynamicThingGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateDynamicThingGroupError {
@@ -20066,21 +19460,17 @@ impl UpdateDynamicThingGroupError {
 }
 impl fmt::Display for UpdateDynamicThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDynamicThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDynamicThingGroupError::InternalFailure(ref cause) => cause,
-            UpdateDynamicThingGroupError::InvalidQuery(ref cause) => cause,
-            UpdateDynamicThingGroupError::InvalidRequest(ref cause) => cause,
-            UpdateDynamicThingGroupError::ResourceNotFound(ref cause) => cause,
-            UpdateDynamicThingGroupError::Throttling(ref cause) => cause,
-            UpdateDynamicThingGroupError::VersionConflict(ref cause) => cause,
+            UpdateDynamicThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDynamicThingGroupError::InvalidQuery(ref cause) => write!(f, "{}", cause),
+            UpdateDynamicThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDynamicThingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDynamicThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateDynamicThingGroupError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDynamicThingGroupError {}
 /// Errors returned by UpdateEventConfigurations
 #[derive(Debug, PartialEq)]
 pub enum UpdateEventConfigurationsError {
@@ -20120,18 +19510,14 @@ impl UpdateEventConfigurationsError {
 }
 impl fmt::Display for UpdateEventConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEventConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEventConfigurationsError::InternalFailure(ref cause) => cause,
-            UpdateEventConfigurationsError::InvalidRequest(ref cause) => cause,
-            UpdateEventConfigurationsError::Throttling(ref cause) => cause,
+            UpdateEventConfigurationsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateEventConfigurationsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateEventConfigurationsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEventConfigurationsError {}
 /// Errors returned by UpdateIndexingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateIndexingConfigurationError {
@@ -20187,20 +19573,18 @@ impl UpdateIndexingConfigurationError {
 }
 impl fmt::Display for UpdateIndexingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIndexingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIndexingConfigurationError::InternalFailure(ref cause) => cause,
-            UpdateIndexingConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateIndexingConfigurationError::ServiceUnavailable(ref cause) => cause,
-            UpdateIndexingConfigurationError::Throttling(ref cause) => cause,
-            UpdateIndexingConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateIndexingConfigurationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateIndexingConfigurationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateIndexingConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateIndexingConfigurationError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateIndexingConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIndexingConfigurationError {}
 /// Errors returned by UpdateJob
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobError {
@@ -20239,19 +19623,15 @@ impl UpdateJobError {
 }
 impl fmt::Display for UpdateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateJobError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateJobError::InvalidRequest(ref cause) => cause,
-            UpdateJobError::ResourceNotFound(ref cause) => cause,
-            UpdateJobError::ServiceUnavailable(ref cause) => cause,
-            UpdateJobError::Throttling(ref cause) => cause,
+            UpdateJobError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateJobError {}
 /// Errors returned by UpdateMitigationAction
 #[derive(Debug, PartialEq)]
 pub enum UpdateMitigationActionError {
@@ -20296,19 +19676,15 @@ impl UpdateMitigationActionError {
 }
 impl fmt::Display for UpdateMitigationActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMitigationActionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMitigationActionError::InternalFailure(ref cause) => cause,
-            UpdateMitigationActionError::InvalidRequest(ref cause) => cause,
-            UpdateMitigationActionError::ResourceNotFound(ref cause) => cause,
-            UpdateMitigationActionError::Throttling(ref cause) => cause,
+            UpdateMitigationActionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateMitigationActionError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateMitigationActionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMitigationActionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMitigationActionError {}
 /// Errors returned by UpdateProvisioningTemplate
 #[derive(Debug, PartialEq)]
 pub enum UpdateProvisioningTemplateError {
@@ -20364,20 +19740,18 @@ impl UpdateProvisioningTemplateError {
 }
 impl fmt::Display for UpdateProvisioningTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProvisioningTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProvisioningTemplateError::ConflictingResourceUpdate(ref cause) => cause,
-            UpdateProvisioningTemplateError::InternalFailure(ref cause) => cause,
-            UpdateProvisioningTemplateError::InvalidRequest(ref cause) => cause,
-            UpdateProvisioningTemplateError::ResourceNotFound(ref cause) => cause,
-            UpdateProvisioningTemplateError::Unauthorized(ref cause) => cause,
+            UpdateProvisioningTemplateError::ConflictingResourceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateProvisioningTemplateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateProvisioningTemplateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateProvisioningTemplateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateProvisioningTemplateError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProvisioningTemplateError {}
 /// Errors returned by UpdateRoleAlias
 #[derive(Debug, PartialEq)]
 pub enum UpdateRoleAliasError {
@@ -20426,21 +19800,17 @@ impl UpdateRoleAliasError {
 }
 impl fmt::Display for UpdateRoleAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRoleAliasError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRoleAliasError::InternalFailure(ref cause) => cause,
-            UpdateRoleAliasError::InvalidRequest(ref cause) => cause,
-            UpdateRoleAliasError::ResourceNotFound(ref cause) => cause,
-            UpdateRoleAliasError::ServiceUnavailable(ref cause) => cause,
-            UpdateRoleAliasError::Throttling(ref cause) => cause,
-            UpdateRoleAliasError::Unauthorized(ref cause) => cause,
+            UpdateRoleAliasError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateRoleAliasError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateRoleAliasError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRoleAliasError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateRoleAliasError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateRoleAliasError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRoleAliasError {}
 /// Errors returned by UpdateScheduledAudit
 #[derive(Debug, PartialEq)]
 pub enum UpdateScheduledAuditError {
@@ -20483,19 +19853,15 @@ impl UpdateScheduledAuditError {
 }
 impl fmt::Display for UpdateScheduledAuditError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateScheduledAuditError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateScheduledAuditError::InternalFailure(ref cause) => cause,
-            UpdateScheduledAuditError::InvalidRequest(ref cause) => cause,
-            UpdateScheduledAuditError::ResourceNotFound(ref cause) => cause,
-            UpdateScheduledAuditError::Throttling(ref cause) => cause,
+            UpdateScheduledAuditError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateScheduledAuditError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateScheduledAuditError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateScheduledAuditError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateScheduledAuditError {}
 /// Errors returned by UpdateSecurityProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateSecurityProfileError {
@@ -20547,20 +19913,16 @@ impl UpdateSecurityProfileError {
 }
 impl fmt::Display for UpdateSecurityProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSecurityProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSecurityProfileError::InternalFailure(ref cause) => cause,
-            UpdateSecurityProfileError::InvalidRequest(ref cause) => cause,
-            UpdateSecurityProfileError::ResourceNotFound(ref cause) => cause,
-            UpdateSecurityProfileError::Throttling(ref cause) => cause,
-            UpdateSecurityProfileError::VersionConflict(ref cause) => cause,
+            UpdateSecurityProfileError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateSecurityProfileError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateSecurityProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateSecurityProfileError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateSecurityProfileError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSecurityProfileError {}
 /// Errors returned by UpdateStream
 #[derive(Debug, PartialEq)]
 pub enum UpdateStreamError {
@@ -20609,21 +19971,17 @@ impl UpdateStreamError {
 }
 impl fmt::Display for UpdateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStreamError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStreamError::InternalFailure(ref cause) => cause,
-            UpdateStreamError::InvalidRequest(ref cause) => cause,
-            UpdateStreamError::ResourceNotFound(ref cause) => cause,
-            UpdateStreamError::ServiceUnavailable(ref cause) => cause,
-            UpdateStreamError::Throttling(ref cause) => cause,
-            UpdateStreamError::Unauthorized(ref cause) => cause,
+            UpdateStreamError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStreamError {}
 /// Errors returned by UpdateThing
 #[derive(Debug, PartialEq)]
 pub enum UpdateThingError {
@@ -20677,22 +20035,18 @@ impl UpdateThingError {
 }
 impl fmt::Display for UpdateThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateThingError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateThingError::InternalFailure(ref cause) => cause,
-            UpdateThingError::InvalidRequest(ref cause) => cause,
-            UpdateThingError::ResourceNotFound(ref cause) => cause,
-            UpdateThingError::ServiceUnavailable(ref cause) => cause,
-            UpdateThingError::Throttling(ref cause) => cause,
-            UpdateThingError::Unauthorized(ref cause) => cause,
-            UpdateThingError::VersionConflict(ref cause) => cause,
+            UpdateThingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateThingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateThingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateThingError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateThingError::Unauthorized(ref cause) => write!(f, "{}", cause),
+            UpdateThingError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateThingError {}
 /// Errors returned by UpdateThingGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateThingGroupError {
@@ -20736,20 +20090,16 @@ impl UpdateThingGroupError {
 }
 impl fmt::Display for UpdateThingGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateThingGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateThingGroupError::InternalFailure(ref cause) => cause,
-            UpdateThingGroupError::InvalidRequest(ref cause) => cause,
-            UpdateThingGroupError::ResourceNotFound(ref cause) => cause,
-            UpdateThingGroupError::Throttling(ref cause) => cause,
-            UpdateThingGroupError::VersionConflict(ref cause) => cause,
+            UpdateThingGroupError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateThingGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateThingGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateThingGroupError::Throttling(ref cause) => write!(f, "{}", cause),
+            UpdateThingGroupError::VersionConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateThingGroupError {}
 /// Errors returned by UpdateThingGroupsForThing
 #[derive(Debug, PartialEq)]
 pub enum UpdateThingGroupsForThingError {
@@ -20796,19 +20146,15 @@ impl UpdateThingGroupsForThingError {
 }
 impl fmt::Display for UpdateThingGroupsForThingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateThingGroupsForThingError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateThingGroupsForThingError::InternalFailure(ref cause) => cause,
-            UpdateThingGroupsForThingError::InvalidRequest(ref cause) => cause,
-            UpdateThingGroupsForThingError::ResourceNotFound(ref cause) => cause,
-            UpdateThingGroupsForThingError::Throttling(ref cause) => cause,
+            UpdateThingGroupsForThingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateThingGroupsForThingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateThingGroupsForThingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateThingGroupsForThingError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateThingGroupsForThingError {}
 /// Errors returned by UpdateTopicRuleDestination
 #[derive(Debug, PartialEq)]
 pub enum UpdateTopicRuleDestinationError {
@@ -20862,20 +20208,20 @@ impl UpdateTopicRuleDestinationError {
 }
 impl fmt::Display for UpdateTopicRuleDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTopicRuleDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => cause,
-            UpdateTopicRuleDestinationError::Internal(ref cause) => cause,
-            UpdateTopicRuleDestinationError::InvalidRequest(ref cause) => cause,
-            UpdateTopicRuleDestinationError::ServiceUnavailable(ref cause) => cause,
-            UpdateTopicRuleDestinationError::Unauthorized(ref cause) => cause,
+            UpdateTopicRuleDestinationError::ConflictingResourceUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTopicRuleDestinationError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateTopicRuleDestinationError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateTopicRuleDestinationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTopicRuleDestinationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTopicRuleDestinationError {}
 /// Errors returned by ValidateSecurityProfileBehaviors
 #[derive(Debug, PartialEq)]
 pub enum ValidateSecurityProfileBehaviorsError {
@@ -20917,18 +20263,18 @@ impl ValidateSecurityProfileBehaviorsError {
 }
 impl fmt::Display for ValidateSecurityProfileBehaviorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ValidateSecurityProfileBehaviorsError {
-    fn description(&self) -> &str {
         match *self {
-            ValidateSecurityProfileBehaviorsError::InternalFailure(ref cause) => cause,
-            ValidateSecurityProfileBehaviorsError::InvalidRequest(ref cause) => cause,
-            ValidateSecurityProfileBehaviorsError::Throttling(ref cause) => cause,
+            ValidateSecurityProfileBehaviorsError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ValidateSecurityProfileBehaviorsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ValidateSecurityProfileBehaviorsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ValidateSecurityProfileBehaviorsError {}
 /// Trait representing the capabilities of the AWS IoT API. AWS IoT clients implement this trait.
 pub trait Iot {
     /// <p>Accepts a pending certificate transfer. The default state of the certificate is INACTIVE.</p> <p>To check for pending certificate transfers, call <a>ListCertificates</a> to enumerate your certificates.</p>

--- a/rusoto/services/iot1click-devices/src/generated.rs
+++ b/rusoto/services/iot1click-devices/src/generated.rs
@@ -404,18 +404,14 @@ impl ClaimDevicesByClaimCodeError {
 }
 impl fmt::Display for ClaimDevicesByClaimCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ClaimDevicesByClaimCodeError {
-    fn description(&self) -> &str {
         match *self {
-            ClaimDevicesByClaimCodeError::Forbidden(ref cause) => cause,
-            ClaimDevicesByClaimCodeError::InternalFailure(ref cause) => cause,
-            ClaimDevicesByClaimCodeError::InvalidRequest(ref cause) => cause,
+            ClaimDevicesByClaimCodeError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ClaimDevicesByClaimCodeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ClaimDevicesByClaimCodeError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ClaimDevicesByClaimCodeError {}
 /// Errors returned by DescribeDevice
 #[derive(Debug, PartialEq)]
 pub enum DescribeDeviceError {
@@ -448,18 +444,14 @@ impl DescribeDeviceError {
 }
 impl fmt::Display for DescribeDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDeviceError::InternalFailure(ref cause) => cause,
-            DescribeDeviceError::InvalidRequest(ref cause) => cause,
-            DescribeDeviceError::ResourceNotFound(ref cause) => cause,
+            DescribeDeviceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeDeviceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDeviceError {}
 /// Errors returned by FinalizeDeviceClaim
 #[derive(Debug, PartialEq)]
 pub enum FinalizeDeviceClaimError {
@@ -508,20 +500,16 @@ impl FinalizeDeviceClaimError {
 }
 impl fmt::Display for FinalizeDeviceClaimError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FinalizeDeviceClaimError {
-    fn description(&self) -> &str {
         match *self {
-            FinalizeDeviceClaimError::InternalFailure(ref cause) => cause,
-            FinalizeDeviceClaimError::InvalidRequest(ref cause) => cause,
-            FinalizeDeviceClaimError::PreconditionFailed(ref cause) => cause,
-            FinalizeDeviceClaimError::ResourceConflict(ref cause) => cause,
-            FinalizeDeviceClaimError::ResourceNotFound(ref cause) => cause,
+            FinalizeDeviceClaimError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            FinalizeDeviceClaimError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            FinalizeDeviceClaimError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            FinalizeDeviceClaimError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            FinalizeDeviceClaimError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for FinalizeDeviceClaimError {}
 /// Errors returned by GetDeviceMethods
 #[derive(Debug, PartialEq)]
 pub enum GetDeviceMethodsError {
@@ -554,18 +542,14 @@ impl GetDeviceMethodsError {
 }
 impl fmt::Display for GetDeviceMethodsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeviceMethodsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeviceMethodsError::InternalFailure(ref cause) => cause,
-            GetDeviceMethodsError::InvalidRequest(ref cause) => cause,
-            GetDeviceMethodsError::ResourceNotFound(ref cause) => cause,
+            GetDeviceMethodsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetDeviceMethodsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetDeviceMethodsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDeviceMethodsError {}
 /// Errors returned by InitiateDeviceClaim
 #[derive(Debug, PartialEq)]
 pub enum InitiateDeviceClaimError {
@@ -607,19 +591,15 @@ impl InitiateDeviceClaimError {
 }
 impl fmt::Display for InitiateDeviceClaimError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitiateDeviceClaimError {
-    fn description(&self) -> &str {
         match *self {
-            InitiateDeviceClaimError::InternalFailure(ref cause) => cause,
-            InitiateDeviceClaimError::InvalidRequest(ref cause) => cause,
-            InitiateDeviceClaimError::ResourceConflict(ref cause) => cause,
-            InitiateDeviceClaimError::ResourceNotFound(ref cause) => cause,
+            InitiateDeviceClaimError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            InitiateDeviceClaimError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            InitiateDeviceClaimError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            InitiateDeviceClaimError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InitiateDeviceClaimError {}
 /// Errors returned by InvokeDeviceMethod
 #[derive(Debug, PartialEq)]
 pub enum InvokeDeviceMethodError {
@@ -671,21 +651,17 @@ impl InvokeDeviceMethodError {
 }
 impl fmt::Display for InvokeDeviceMethodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InvokeDeviceMethodError {
-    fn description(&self) -> &str {
         match *self {
-            InvokeDeviceMethodError::InternalFailure(ref cause) => cause,
-            InvokeDeviceMethodError::InvalidRequest(ref cause) => cause,
-            InvokeDeviceMethodError::PreconditionFailed(ref cause) => cause,
-            InvokeDeviceMethodError::RangeNotSatisfiable(ref cause) => cause,
-            InvokeDeviceMethodError::ResourceConflict(ref cause) => cause,
-            InvokeDeviceMethodError::ResourceNotFound(ref cause) => cause,
+            InvokeDeviceMethodError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            InvokeDeviceMethodError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            InvokeDeviceMethodError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            InvokeDeviceMethodError::RangeNotSatisfiable(ref cause) => write!(f, "{}", cause),
+            InvokeDeviceMethodError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            InvokeDeviceMethodError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InvokeDeviceMethodError {}
 /// Errors returned by ListDeviceEvents
 #[derive(Debug, PartialEq)]
 pub enum ListDeviceEventsError {
@@ -725,19 +701,15 @@ impl ListDeviceEventsError {
 }
 impl fmt::Display for ListDeviceEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeviceEventsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeviceEventsError::InternalFailure(ref cause) => cause,
-            ListDeviceEventsError::InvalidRequest(ref cause) => cause,
-            ListDeviceEventsError::RangeNotSatisfiable(ref cause) => cause,
-            ListDeviceEventsError::ResourceNotFound(ref cause) => cause,
+            ListDeviceEventsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDeviceEventsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDeviceEventsError::RangeNotSatisfiable(ref cause) => write!(f, "{}", cause),
+            ListDeviceEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeviceEventsError {}
 /// Errors returned by ListDevices
 #[derive(Debug, PartialEq)]
 pub enum ListDevicesError {
@@ -770,18 +742,14 @@ impl ListDevicesError {
 }
 impl fmt::Display for ListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDevicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDevicesError::InternalFailure(ref cause) => cause,
-            ListDevicesError::InvalidRequest(ref cause) => cause,
-            ListDevicesError::RangeNotSatisfiable(ref cause) => cause,
+            ListDevicesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::RangeNotSatisfiable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDevicesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -811,17 +779,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalFailure(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -854,18 +818,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalFailure(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UnclaimDevice
 #[derive(Debug, PartialEq)]
 pub enum UnclaimDeviceError {
@@ -898,18 +858,14 @@ impl UnclaimDeviceError {
 }
 impl fmt::Display for UnclaimDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnclaimDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            UnclaimDeviceError::InternalFailure(ref cause) => cause,
-            UnclaimDeviceError::InvalidRequest(ref cause) => cause,
-            UnclaimDeviceError::ResourceNotFound(ref cause) => cause,
+            UnclaimDeviceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UnclaimDeviceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UnclaimDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnclaimDeviceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -942,18 +898,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalFailure(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateDeviceState
 #[derive(Debug, PartialEq)]
 pub enum UpdateDeviceStateError {
@@ -986,18 +938,14 @@ impl UpdateDeviceStateError {
 }
 impl fmt::Display for UpdateDeviceStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDeviceStateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDeviceStateError::InternalFailure(ref cause) => cause,
-            UpdateDeviceStateError::InvalidRequest(ref cause) => cause,
-            UpdateDeviceStateError::ResourceNotFound(ref cause) => cause,
+            UpdateDeviceStateError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStateError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDeviceStateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDeviceStateError {}
 /// Trait representing the capabilities of the AWS IoT 1-Click Devices Service API. AWS IoT 1-Click Devices Service clients implement this trait.
 pub trait Iot1ClickDevices {
     /// <p>Adds device(s) to your account (i.e., claim one or more devices) if and only if you

--- a/rusoto/services/iot1click-projects/src/generated.rs
+++ b/rusoto/services/iot1click-projects/src/generated.rs
@@ -477,19 +477,19 @@ impl AssociateDeviceWithPlacementError {
 }
 impl fmt::Display for AssociateDeviceWithPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDeviceWithPlacementError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDeviceWithPlacementError::InternalFailure(ref cause) => cause,
-            AssociateDeviceWithPlacementError::InvalidRequest(ref cause) => cause,
-            AssociateDeviceWithPlacementError::ResourceConflict(ref cause) => cause,
-            AssociateDeviceWithPlacementError::ResourceNotFound(ref cause) => cause,
+            AssociateDeviceWithPlacementError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            AssociateDeviceWithPlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AssociateDeviceWithPlacementError::ResourceConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDeviceWithPlacementError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateDeviceWithPlacementError {}
 /// Errors returned by CreatePlacement
 #[derive(Debug, PartialEq)]
 pub enum CreatePlacementError {
@@ -528,19 +528,15 @@ impl CreatePlacementError {
 }
 impl fmt::Display for CreatePlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePlacementError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePlacementError::InternalFailure(ref cause) => cause,
-            CreatePlacementError::InvalidRequest(ref cause) => cause,
-            CreatePlacementError::ResourceConflict(ref cause) => cause,
-            CreatePlacementError::ResourceNotFound(ref cause) => cause,
+            CreatePlacementError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreatePlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreatePlacementError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            CreatePlacementError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePlacementError {}
 /// Errors returned by CreateProject
 #[derive(Debug, PartialEq)]
 pub enum CreateProjectError {
@@ -574,18 +570,14 @@ impl CreateProjectError {
 }
 impl fmt::Display for CreateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProjectError::InternalFailure(ref cause) => cause,
-            CreateProjectError::InvalidRequest(ref cause) => cause,
-            CreateProjectError::ResourceConflict(ref cause) => cause,
+            CreateProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ResourceConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProjectError {}
 /// Errors returned by DeletePlacement
 #[derive(Debug, PartialEq)]
 pub enum DeletePlacementError {
@@ -624,19 +616,15 @@ impl DeletePlacementError {
 }
 impl fmt::Display for DeletePlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePlacementError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePlacementError::InternalFailure(ref cause) => cause,
-            DeletePlacementError::InvalidRequest(ref cause) => cause,
-            DeletePlacementError::ResourceNotFound(ref cause) => cause,
-            DeletePlacementError::TooManyRequests(ref cause) => cause,
+            DeletePlacementError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeletePlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeletePlacementError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeletePlacementError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePlacementError {}
 /// Errors returned by DeleteProject
 #[derive(Debug, PartialEq)]
 pub enum DeleteProjectError {
@@ -675,19 +663,15 @@ impl DeleteProjectError {
 }
 impl fmt::Display for DeleteProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProjectError::InternalFailure(ref cause) => cause,
-            DeleteProjectError::InvalidRequest(ref cause) => cause,
-            DeleteProjectError::ResourceNotFound(ref cause) => cause,
-            DeleteProjectError::TooManyRequests(ref cause) => cause,
+            DeleteProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProjectError {}
 /// Errors returned by DescribePlacement
 #[derive(Debug, PartialEq)]
 pub enum DescribePlacementError {
@@ -721,18 +705,14 @@ impl DescribePlacementError {
 }
 impl fmt::Display for DescribePlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePlacementError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePlacementError::InternalFailure(ref cause) => cause,
-            DescribePlacementError::InvalidRequest(ref cause) => cause,
-            DescribePlacementError::ResourceNotFound(ref cause) => cause,
+            DescribePlacementError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribePlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribePlacementError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePlacementError {}
 /// Errors returned by DescribeProject
 #[derive(Debug, PartialEq)]
 pub enum DescribeProjectError {
@@ -766,18 +746,14 @@ impl DescribeProjectError {
 }
 impl fmt::Display for DescribeProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProjectError::InternalFailure(ref cause) => cause,
-            DescribeProjectError::InvalidRequest(ref cause) => cause,
-            DescribeProjectError::ResourceNotFound(ref cause) => cause,
+            DescribeProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProjectError {}
 /// Errors returned by DisassociateDeviceFromPlacement
 #[derive(Debug, PartialEq)]
 pub enum DisassociateDeviceFromPlacementError {
@@ -826,19 +802,23 @@ impl DisassociateDeviceFromPlacementError {
 }
 impl fmt::Display for DisassociateDeviceFromPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateDeviceFromPlacementError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateDeviceFromPlacementError::InternalFailure(ref cause) => cause,
-            DisassociateDeviceFromPlacementError::InvalidRequest(ref cause) => cause,
-            DisassociateDeviceFromPlacementError::ResourceNotFound(ref cause) => cause,
-            DisassociateDeviceFromPlacementError::TooManyRequests(ref cause) => cause,
+            DisassociateDeviceFromPlacementError::InternalFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDeviceFromPlacementError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDeviceFromPlacementError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDeviceFromPlacementError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateDeviceFromPlacementError {}
 /// Errors returned by GetDevicesInPlacement
 #[derive(Debug, PartialEq)]
 pub enum GetDevicesInPlacementError {
@@ -878,18 +858,14 @@ impl GetDevicesInPlacementError {
 }
 impl fmt::Display for GetDevicesInPlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDevicesInPlacementError {
-    fn description(&self) -> &str {
         match *self {
-            GetDevicesInPlacementError::InternalFailure(ref cause) => cause,
-            GetDevicesInPlacementError::InvalidRequest(ref cause) => cause,
-            GetDevicesInPlacementError::ResourceNotFound(ref cause) => cause,
+            GetDevicesInPlacementError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetDevicesInPlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetDevicesInPlacementError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDevicesInPlacementError {}
 /// Errors returned by ListPlacements
 #[derive(Debug, PartialEq)]
 pub enum ListPlacementsError {
@@ -923,18 +899,14 @@ impl ListPlacementsError {
 }
 impl fmt::Display for ListPlacementsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPlacementsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPlacementsError::InternalFailure(ref cause) => cause,
-            ListPlacementsError::InvalidRequest(ref cause) => cause,
-            ListPlacementsError::ResourceNotFound(ref cause) => cause,
+            ListPlacementsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListPlacementsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPlacementsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPlacementsError {}
 /// Errors returned by ListProjects
 #[derive(Debug, PartialEq)]
 pub enum ListProjectsError {
@@ -963,17 +935,13 @@ impl ListProjectsError {
 }
 impl fmt::Display for ListProjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProjectsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProjectsError::InternalFailure(ref cause) => cause,
-            ListProjectsError::InvalidRequest(ref cause) => cause,
+            ListProjectsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProjectsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1009,18 +977,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalFailure(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1054,18 +1018,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalFailure(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1099,18 +1059,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalFailure(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdatePlacement
 #[derive(Debug, PartialEq)]
 pub enum UpdatePlacementError {
@@ -1149,19 +1105,15 @@ impl UpdatePlacementError {
 }
 impl fmt::Display for UpdatePlacementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePlacementError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePlacementError::InternalFailure(ref cause) => cause,
-            UpdatePlacementError::InvalidRequest(ref cause) => cause,
-            UpdatePlacementError::ResourceNotFound(ref cause) => cause,
-            UpdatePlacementError::TooManyRequests(ref cause) => cause,
+            UpdatePlacementError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdatePlacementError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdatePlacementError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePlacementError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePlacementError {}
 /// Errors returned by UpdateProject
 #[derive(Debug, PartialEq)]
 pub enum UpdateProjectError {
@@ -1200,19 +1152,15 @@ impl UpdateProjectError {
 }
 impl fmt::Display for UpdateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProjectError::InternalFailure(ref cause) => cause,
-            UpdateProjectError::InvalidRequest(ref cause) => cause,
-            UpdateProjectError::ResourceNotFound(ref cause) => cause,
-            UpdateProjectError::TooManyRequests(ref cause) => cause,
+            UpdateProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProjectError {}
 /// Trait representing the capabilities of the AWS IoT 1-Click Projects API. AWS IoT 1-Click Projects clients implement this trait.
 pub trait Iot1ClickProjects {
     /// <p>Associates a physical device with a placement.</p>

--- a/rusoto/services/iotanalytics/src/generated.rs
+++ b/rusoto/services/iotanalytics/src/generated.rs
@@ -1777,20 +1777,16 @@ impl BatchPutMessageError {
 }
 impl fmt::Display for BatchPutMessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchPutMessageError {
-    fn description(&self) -> &str {
         match *self {
-            BatchPutMessageError::InternalFailure(ref cause) => cause,
-            BatchPutMessageError::InvalidRequest(ref cause) => cause,
-            BatchPutMessageError::ResourceNotFound(ref cause) => cause,
-            BatchPutMessageError::ServiceUnavailable(ref cause) => cause,
-            BatchPutMessageError::Throttling(ref cause) => cause,
+            BatchPutMessageError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            BatchPutMessageError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            BatchPutMessageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            BatchPutMessageError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            BatchPutMessageError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchPutMessageError {}
 /// Errors returned by CancelPipelineReprocessing
 #[derive(Debug, PartialEq)]
 pub enum CancelPipelineReprocessingError {
@@ -1846,20 +1842,18 @@ impl CancelPipelineReprocessingError {
 }
 impl fmt::Display for CancelPipelineReprocessingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelPipelineReprocessingError {
-    fn description(&self) -> &str {
         match *self {
-            CancelPipelineReprocessingError::InternalFailure(ref cause) => cause,
-            CancelPipelineReprocessingError::InvalidRequest(ref cause) => cause,
-            CancelPipelineReprocessingError::ResourceNotFound(ref cause) => cause,
-            CancelPipelineReprocessingError::ServiceUnavailable(ref cause) => cause,
-            CancelPipelineReprocessingError::Throttling(ref cause) => cause,
+            CancelPipelineReprocessingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CancelPipelineReprocessingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CancelPipelineReprocessingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CancelPipelineReprocessingError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CancelPipelineReprocessingError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelPipelineReprocessingError {}
 /// Errors returned by CreateChannel
 #[derive(Debug, PartialEq)]
 pub enum CreateChannelError {
@@ -1908,21 +1902,17 @@ impl CreateChannelError {
 }
 impl fmt::Display for CreateChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateChannelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateChannelError::InternalFailure(ref cause) => cause,
-            CreateChannelError::InvalidRequest(ref cause) => cause,
-            CreateChannelError::LimitExceeded(ref cause) => cause,
-            CreateChannelError::ResourceAlreadyExists(ref cause) => cause,
-            CreateChannelError::ServiceUnavailable(ref cause) => cause,
-            CreateChannelError::Throttling(ref cause) => cause,
+            CreateChannelError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateChannelError {}
 /// Errors returned by CreateDataset
 #[derive(Debug, PartialEq)]
 pub enum CreateDatasetError {
@@ -1971,21 +1961,17 @@ impl CreateDatasetError {
 }
 impl fmt::Display for CreateDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDatasetError::InternalFailure(ref cause) => cause,
-            CreateDatasetError::InvalidRequest(ref cause) => cause,
-            CreateDatasetError::LimitExceeded(ref cause) => cause,
-            CreateDatasetError::ResourceAlreadyExists(ref cause) => cause,
-            CreateDatasetError::ServiceUnavailable(ref cause) => cause,
-            CreateDatasetError::Throttling(ref cause) => cause,
+            CreateDatasetError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDatasetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateDatasetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDatasetError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateDatasetError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateDatasetError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDatasetError {}
 /// Errors returned by CreateDatasetContent
 #[derive(Debug, PartialEq)]
 pub enum CreateDatasetContentError {
@@ -2035,20 +2021,16 @@ impl CreateDatasetContentError {
 }
 impl fmt::Display for CreateDatasetContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDatasetContentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDatasetContentError::InternalFailure(ref cause) => cause,
-            CreateDatasetContentError::InvalidRequest(ref cause) => cause,
-            CreateDatasetContentError::ResourceNotFound(ref cause) => cause,
-            CreateDatasetContentError::ServiceUnavailable(ref cause) => cause,
-            CreateDatasetContentError::Throttling(ref cause) => cause,
+            CreateDatasetContentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDatasetContentError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateDatasetContentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateDatasetContentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateDatasetContentError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDatasetContentError {}
 /// Errors returned by CreateDatastore
 #[derive(Debug, PartialEq)]
 pub enum CreateDatastoreError {
@@ -2099,21 +2081,17 @@ impl CreateDatastoreError {
 }
 impl fmt::Display for CreateDatastoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDatastoreError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDatastoreError::InternalFailure(ref cause) => cause,
-            CreateDatastoreError::InvalidRequest(ref cause) => cause,
-            CreateDatastoreError::LimitExceeded(ref cause) => cause,
-            CreateDatastoreError::ResourceAlreadyExists(ref cause) => cause,
-            CreateDatastoreError::ServiceUnavailable(ref cause) => cause,
-            CreateDatastoreError::Throttling(ref cause) => cause,
+            CreateDatastoreError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateDatastoreError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateDatastoreError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDatastoreError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateDatastoreError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateDatastoreError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDatastoreError {}
 /// Errors returned by CreatePipeline
 #[derive(Debug, PartialEq)]
 pub enum CreatePipelineError {
@@ -2164,21 +2142,17 @@ impl CreatePipelineError {
 }
 impl fmt::Display for CreatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePipelineError::InternalFailure(ref cause) => cause,
-            CreatePipelineError::InvalidRequest(ref cause) => cause,
-            CreatePipelineError::LimitExceeded(ref cause) => cause,
-            CreatePipelineError::ResourceAlreadyExists(ref cause) => cause,
-            CreatePipelineError::ServiceUnavailable(ref cause) => cause,
-            CreatePipelineError::Throttling(ref cause) => cause,
+            CreatePipelineError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreatePipelineError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePipelineError {}
 /// Errors returned by DeleteChannel
 #[derive(Debug, PartialEq)]
 pub enum DeleteChannelError {
@@ -2222,20 +2196,16 @@ impl DeleteChannelError {
 }
 impl fmt::Display for DeleteChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteChannelError::InternalFailure(ref cause) => cause,
-            DeleteChannelError::InvalidRequest(ref cause) => cause,
-            DeleteChannelError::ResourceNotFound(ref cause) => cause,
-            DeleteChannelError::ServiceUnavailable(ref cause) => cause,
-            DeleteChannelError::Throttling(ref cause) => cause,
+            DeleteChannelError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteChannelError {}
 /// Errors returned by DeleteDataset
 #[derive(Debug, PartialEq)]
 pub enum DeleteDatasetError {
@@ -2279,20 +2249,16 @@ impl DeleteDatasetError {
 }
 impl fmt::Display for DeleteDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDatasetError::InternalFailure(ref cause) => cause,
-            DeleteDatasetError::InvalidRequest(ref cause) => cause,
-            DeleteDatasetError::ResourceNotFound(ref cause) => cause,
-            DeleteDatasetError::ServiceUnavailable(ref cause) => cause,
-            DeleteDatasetError::Throttling(ref cause) => cause,
+            DeleteDatasetError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDatasetError {}
 /// Errors returned by DeleteDatasetContent
 #[derive(Debug, PartialEq)]
 pub enum DeleteDatasetContentError {
@@ -2342,20 +2308,16 @@ impl DeleteDatasetContentError {
 }
 impl fmt::Display for DeleteDatasetContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDatasetContentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDatasetContentError::InternalFailure(ref cause) => cause,
-            DeleteDatasetContentError::InvalidRequest(ref cause) => cause,
-            DeleteDatasetContentError::ResourceNotFound(ref cause) => cause,
-            DeleteDatasetContentError::ServiceUnavailable(ref cause) => cause,
-            DeleteDatasetContentError::Throttling(ref cause) => cause,
+            DeleteDatasetContentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetContentError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetContentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetContentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteDatasetContentError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDatasetContentError {}
 /// Errors returned by DeleteDatastore
 #[derive(Debug, PartialEq)]
 pub enum DeleteDatastoreError {
@@ -2399,20 +2361,16 @@ impl DeleteDatastoreError {
 }
 impl fmt::Display for DeleteDatastoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDatastoreError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDatastoreError::InternalFailure(ref cause) => cause,
-            DeleteDatastoreError::InvalidRequest(ref cause) => cause,
-            DeleteDatastoreError::ResourceNotFound(ref cause) => cause,
-            DeleteDatastoreError::ServiceUnavailable(ref cause) => cause,
-            DeleteDatastoreError::Throttling(ref cause) => cause,
+            DeleteDatastoreError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDatastoreError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteDatastoreError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDatastoreError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteDatastoreError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDatastoreError {}
 /// Errors returned by DeletePipeline
 #[derive(Debug, PartialEq)]
 pub enum DeletePipelineError {
@@ -2456,20 +2414,16 @@ impl DeletePipelineError {
 }
 impl fmt::Display for DeletePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePipelineError::InternalFailure(ref cause) => cause,
-            DeletePipelineError::InvalidRequest(ref cause) => cause,
-            DeletePipelineError::ResourceNotFound(ref cause) => cause,
-            DeletePipelineError::ServiceUnavailable(ref cause) => cause,
-            DeletePipelineError::Throttling(ref cause) => cause,
+            DeletePipelineError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeletePipelineError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePipelineError {}
 /// Errors returned by DescribeChannel
 #[derive(Debug, PartialEq)]
 pub enum DescribeChannelError {
@@ -2513,20 +2467,16 @@ impl DescribeChannelError {
 }
 impl fmt::Display for DescribeChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeChannelError::InternalFailure(ref cause) => cause,
-            DescribeChannelError::InvalidRequest(ref cause) => cause,
-            DescribeChannelError::ResourceNotFound(ref cause) => cause,
-            DescribeChannelError::ServiceUnavailable(ref cause) => cause,
-            DescribeChannelError::Throttling(ref cause) => cause,
+            DescribeChannelError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeChannelError {}
 /// Errors returned by DescribeDataset
 #[derive(Debug, PartialEq)]
 pub enum DescribeDatasetError {
@@ -2570,20 +2520,16 @@ impl DescribeDatasetError {
 }
 impl fmt::Display for DescribeDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDatasetError::InternalFailure(ref cause) => cause,
-            DescribeDatasetError::InvalidRequest(ref cause) => cause,
-            DescribeDatasetError::ResourceNotFound(ref cause) => cause,
-            DescribeDatasetError::ServiceUnavailable(ref cause) => cause,
-            DescribeDatasetError::Throttling(ref cause) => cause,
+            DescribeDatasetError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeDatasetError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDatasetError {}
 /// Errors returned by DescribeDatastore
 #[derive(Debug, PartialEq)]
 pub enum DescribeDatastoreError {
@@ -2629,20 +2575,16 @@ impl DescribeDatastoreError {
 }
 impl fmt::Display for DescribeDatastoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDatastoreError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDatastoreError::InternalFailure(ref cause) => cause,
-            DescribeDatastoreError::InvalidRequest(ref cause) => cause,
-            DescribeDatastoreError::ResourceNotFound(ref cause) => cause,
-            DescribeDatastoreError::ServiceUnavailable(ref cause) => cause,
-            DescribeDatastoreError::Throttling(ref cause) => cause,
+            DescribeDatastoreError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeDatastoreError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeDatastoreError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDatastoreError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeDatastoreError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDatastoreError {}
 /// Errors returned by DescribeLoggingOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoggingOptionsError {
@@ -2694,20 +2636,16 @@ impl DescribeLoggingOptionsError {
 }
 impl fmt::Display for DescribeLoggingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoggingOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoggingOptionsError::InternalFailure(ref cause) => cause,
-            DescribeLoggingOptionsError::InvalidRequest(ref cause) => cause,
-            DescribeLoggingOptionsError::ResourceNotFound(ref cause) => cause,
-            DescribeLoggingOptionsError::ServiceUnavailable(ref cause) => cause,
-            DescribeLoggingOptionsError::Throttling(ref cause) => cause,
+            DescribeLoggingOptionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeLoggingOptionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeLoggingOptionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeLoggingOptionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeLoggingOptionsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLoggingOptionsError {}
 /// Errors returned by DescribePipeline
 #[derive(Debug, PartialEq)]
 pub enum DescribePipelineError {
@@ -2751,20 +2689,16 @@ impl DescribePipelineError {
 }
 impl fmt::Display for DescribePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePipelineError::InternalFailure(ref cause) => cause,
-            DescribePipelineError::InvalidRequest(ref cause) => cause,
-            DescribePipelineError::ResourceNotFound(ref cause) => cause,
-            DescribePipelineError::ServiceUnavailable(ref cause) => cause,
-            DescribePipelineError::Throttling(ref cause) => cause,
+            DescribePipelineError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribePipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribePipelineError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribePipelineError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePipelineError {}
 /// Errors returned by GetDatasetContent
 #[derive(Debug, PartialEq)]
 pub enum GetDatasetContentError {
@@ -2810,20 +2744,16 @@ impl GetDatasetContentError {
 }
 impl fmt::Display for GetDatasetContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDatasetContentError {
-    fn description(&self) -> &str {
         match *self {
-            GetDatasetContentError::InternalFailure(ref cause) => cause,
-            GetDatasetContentError::InvalidRequest(ref cause) => cause,
-            GetDatasetContentError::ResourceNotFound(ref cause) => cause,
-            GetDatasetContentError::ServiceUnavailable(ref cause) => cause,
-            GetDatasetContentError::Throttling(ref cause) => cause,
+            GetDatasetContentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetDatasetContentError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetDatasetContentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetDatasetContentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDatasetContentError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDatasetContentError {}
 /// Errors returned by ListChannels
 #[derive(Debug, PartialEq)]
 pub enum ListChannelsError {
@@ -2862,19 +2792,15 @@ impl ListChannelsError {
 }
 impl fmt::Display for ListChannelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListChannelsError {
-    fn description(&self) -> &str {
         match *self {
-            ListChannelsError::InternalFailure(ref cause) => cause,
-            ListChannelsError::InvalidRequest(ref cause) => cause,
-            ListChannelsError::ServiceUnavailable(ref cause) => cause,
-            ListChannelsError::Throttling(ref cause) => cause,
+            ListChannelsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListChannelsError {}
 /// Errors returned by ListDatasetContents
 #[derive(Debug, PartialEq)]
 pub enum ListDatasetContentsError {
@@ -2922,20 +2848,16 @@ impl ListDatasetContentsError {
 }
 impl fmt::Display for ListDatasetContentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDatasetContentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDatasetContentsError::InternalFailure(ref cause) => cause,
-            ListDatasetContentsError::InvalidRequest(ref cause) => cause,
-            ListDatasetContentsError::ResourceNotFound(ref cause) => cause,
-            ListDatasetContentsError::ServiceUnavailable(ref cause) => cause,
-            ListDatasetContentsError::Throttling(ref cause) => cause,
+            ListDatasetContentsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDatasetContentsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDatasetContentsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListDatasetContentsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListDatasetContentsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDatasetContentsError {}
 /// Errors returned by ListDatasets
 #[derive(Debug, PartialEq)]
 pub enum ListDatasetsError {
@@ -2974,19 +2896,15 @@ impl ListDatasetsError {
 }
 impl fmt::Display for ListDatasetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDatasetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDatasetsError::InternalFailure(ref cause) => cause,
-            ListDatasetsError::InvalidRequest(ref cause) => cause,
-            ListDatasetsError::ServiceUnavailable(ref cause) => cause,
-            ListDatasetsError::Throttling(ref cause) => cause,
+            ListDatasetsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDatasetsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDatasetsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListDatasetsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDatasetsError {}
 /// Errors returned by ListDatastores
 #[derive(Debug, PartialEq)]
 pub enum ListDatastoresError {
@@ -3025,19 +2943,15 @@ impl ListDatastoresError {
 }
 impl fmt::Display for ListDatastoresError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDatastoresError {
-    fn description(&self) -> &str {
         match *self {
-            ListDatastoresError::InternalFailure(ref cause) => cause,
-            ListDatastoresError::InvalidRequest(ref cause) => cause,
-            ListDatastoresError::ServiceUnavailable(ref cause) => cause,
-            ListDatastoresError::Throttling(ref cause) => cause,
+            ListDatastoresError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListDatastoresError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDatastoresError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListDatastoresError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDatastoresError {}
 /// Errors returned by ListPipelines
 #[derive(Debug, PartialEq)]
 pub enum ListPipelinesError {
@@ -3076,19 +2990,15 @@ impl ListPipelinesError {
 }
 impl fmt::Display for ListPipelinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPipelinesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPipelinesError::InternalFailure(ref cause) => cause,
-            ListPipelinesError::InvalidRequest(ref cause) => cause,
-            ListPipelinesError::ServiceUnavailable(ref cause) => cause,
-            ListPipelinesError::Throttling(ref cause) => cause,
+            ListPipelinesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListPipelinesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListPipelinesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPipelinesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPipelinesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3141,21 +3051,17 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalFailure(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
-            ListTagsForResourceError::LimitExceeded(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::ServiceUnavailable(ref cause) => cause,
-            ListTagsForResourceError::Throttling(ref cause) => cause,
+            ListTagsForResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PutLoggingOptions
 #[derive(Debug, PartialEq)]
 pub enum PutLoggingOptionsError {
@@ -3196,19 +3102,15 @@ impl PutLoggingOptionsError {
 }
 impl fmt::Display for PutLoggingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLoggingOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            PutLoggingOptionsError::InternalFailure(ref cause) => cause,
-            PutLoggingOptionsError::InvalidRequest(ref cause) => cause,
-            PutLoggingOptionsError::ServiceUnavailable(ref cause) => cause,
-            PutLoggingOptionsError::Throttling(ref cause) => cause,
+            PutLoggingOptionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PutLoggingOptionsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutLoggingOptionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            PutLoggingOptionsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLoggingOptionsError {}
 /// Errors returned by RunPipelineActivity
 #[derive(Debug, PartialEq)]
 pub enum RunPipelineActivityError {
@@ -3249,19 +3151,15 @@ impl RunPipelineActivityError {
 }
 impl fmt::Display for RunPipelineActivityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RunPipelineActivityError {
-    fn description(&self) -> &str {
         match *self {
-            RunPipelineActivityError::InternalFailure(ref cause) => cause,
-            RunPipelineActivityError::InvalidRequest(ref cause) => cause,
-            RunPipelineActivityError::ServiceUnavailable(ref cause) => cause,
-            RunPipelineActivityError::Throttling(ref cause) => cause,
+            RunPipelineActivityError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            RunPipelineActivityError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RunPipelineActivityError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RunPipelineActivityError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RunPipelineActivityError {}
 /// Errors returned by SampleChannelData
 #[derive(Debug, PartialEq)]
 pub enum SampleChannelDataError {
@@ -3307,20 +3205,16 @@ impl SampleChannelDataError {
 }
 impl fmt::Display for SampleChannelDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SampleChannelDataError {
-    fn description(&self) -> &str {
         match *self {
-            SampleChannelDataError::InternalFailure(ref cause) => cause,
-            SampleChannelDataError::InvalidRequest(ref cause) => cause,
-            SampleChannelDataError::ResourceNotFound(ref cause) => cause,
-            SampleChannelDataError::ServiceUnavailable(ref cause) => cause,
-            SampleChannelDataError::Throttling(ref cause) => cause,
+            SampleChannelDataError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            SampleChannelDataError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SampleChannelDataError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SampleChannelDataError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            SampleChannelDataError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SampleChannelDataError {}
 /// Errors returned by StartPipelineReprocessing
 #[derive(Debug, PartialEq)]
 pub enum StartPipelineReprocessingError {
@@ -3381,21 +3275,19 @@ impl StartPipelineReprocessingError {
 }
 impl fmt::Display for StartPipelineReprocessingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartPipelineReprocessingError {
-    fn description(&self) -> &str {
         match *self {
-            StartPipelineReprocessingError::InternalFailure(ref cause) => cause,
-            StartPipelineReprocessingError::InvalidRequest(ref cause) => cause,
-            StartPipelineReprocessingError::ResourceAlreadyExists(ref cause) => cause,
-            StartPipelineReprocessingError::ResourceNotFound(ref cause) => cause,
-            StartPipelineReprocessingError::ServiceUnavailable(ref cause) => cause,
-            StartPipelineReprocessingError::Throttling(ref cause) => cause,
+            StartPipelineReprocessingError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartPipelineReprocessingError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartPipelineReprocessingError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartPipelineReprocessingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartPipelineReprocessingError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            StartPipelineReprocessingError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartPipelineReprocessingError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3444,21 +3336,17 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalFailure(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::ServiceUnavailable(ref cause) => cause,
-            TagResourceError::Throttling(ref cause) => cause,
+            TagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3507,21 +3395,17 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalFailure(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::LimitExceeded(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::ServiceUnavailable(ref cause) => cause,
-            UntagResourceError::Throttling(ref cause) => cause,
+            UntagResourceError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateChannel
 #[derive(Debug, PartialEq)]
 pub enum UpdateChannelError {
@@ -3565,20 +3449,16 @@ impl UpdateChannelError {
 }
 impl fmt::Display for UpdateChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateChannelError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateChannelError::InternalFailure(ref cause) => cause,
-            UpdateChannelError::InvalidRequest(ref cause) => cause,
-            UpdateChannelError::ResourceNotFound(ref cause) => cause,
-            UpdateChannelError::ServiceUnavailable(ref cause) => cause,
-            UpdateChannelError::Throttling(ref cause) => cause,
+            UpdateChannelError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateChannelError {}
 /// Errors returned by UpdateDataset
 #[derive(Debug, PartialEq)]
 pub enum UpdateDatasetError {
@@ -3622,20 +3502,16 @@ impl UpdateDatasetError {
 }
 impl fmt::Display for UpdateDatasetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDatasetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDatasetError::InternalFailure(ref cause) => cause,
-            UpdateDatasetError::InvalidRequest(ref cause) => cause,
-            UpdateDatasetError::ResourceNotFound(ref cause) => cause,
-            UpdateDatasetError::ServiceUnavailable(ref cause) => cause,
-            UpdateDatasetError::Throttling(ref cause) => cause,
+            UpdateDatasetError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDatasetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDatasetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDatasetError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateDatasetError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDatasetError {}
 /// Errors returned by UpdateDatastore
 #[derive(Debug, PartialEq)]
 pub enum UpdateDatastoreError {
@@ -3679,20 +3555,16 @@ impl UpdateDatastoreError {
 }
 impl fmt::Display for UpdateDatastoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDatastoreError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDatastoreError::InternalFailure(ref cause) => cause,
-            UpdateDatastoreError::InvalidRequest(ref cause) => cause,
-            UpdateDatastoreError::ResourceNotFound(ref cause) => cause,
-            UpdateDatastoreError::ServiceUnavailable(ref cause) => cause,
-            UpdateDatastoreError::Throttling(ref cause) => cause,
+            UpdateDatastoreError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDatastoreError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDatastoreError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDatastoreError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateDatastoreError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDatastoreError {}
 /// Errors returned by UpdatePipeline
 #[derive(Debug, PartialEq)]
 pub enum UpdatePipelineError {
@@ -3741,21 +3613,17 @@ impl UpdatePipelineError {
 }
 impl fmt::Display for UpdatePipelineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePipelineError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePipelineError::InternalFailure(ref cause) => cause,
-            UpdatePipelineError::InvalidRequest(ref cause) => cause,
-            UpdatePipelineError::LimitExceeded(ref cause) => cause,
-            UpdatePipelineError::ResourceNotFound(ref cause) => cause,
-            UpdatePipelineError::ServiceUnavailable(ref cause) => cause,
-            UpdatePipelineError::Throttling(ref cause) => cause,
+            UpdatePipelineError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdatePipelineError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePipelineError {}
 /// Trait representing the capabilities of the AWS IoT Analytics API. AWS IoT Analytics clients implement this trait.
 pub trait IotAnalytics {
     /// <p>Sends messages to a channel.</p>

--- a/rusoto/services/kafka/src/generated.rs
+++ b/rusoto/services/kafka/src/generated.rs
@@ -1209,22 +1209,18 @@ impl CreateClusterError {
 }
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterError::BadRequest(ref cause) => cause,
-            CreateClusterError::Conflict(ref cause) => cause,
-            CreateClusterError::Forbidden(ref cause) => cause,
-            CreateClusterError::InternalServerError(ref cause) => cause,
-            CreateClusterError::ServiceUnavailable(ref cause) => cause,
-            CreateClusterError::TooManyRequests(ref cause) => cause,
-            CreateClusterError::Unauthorized(ref cause) => cause,
+            CreateClusterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterError {}
 /// Errors returned by CreateConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateConfigurationError {
@@ -1289,22 +1285,18 @@ impl CreateConfigurationError {
 }
 impl fmt::Display for CreateConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConfigurationError::BadRequest(ref cause) => cause,
-            CreateConfigurationError::Conflict(ref cause) => cause,
-            CreateConfigurationError::Forbidden(ref cause) => cause,
-            CreateConfigurationError::InternalServerError(ref cause) => cause,
-            CreateConfigurationError::ServiceUnavailable(ref cause) => cause,
-            CreateConfigurationError::TooManyRequests(ref cause) => cause,
-            CreateConfigurationError::Unauthorized(ref cause) => cause,
+            CreateConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConfigurationError {}
 /// Errors returned by DeleteCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterError {
@@ -1347,19 +1339,15 @@ impl DeleteClusterError {
 }
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterError::BadRequest(ref cause) => cause,
-            DeleteClusterError::Forbidden(ref cause) => cause,
-            DeleteClusterError::InternalServerError(ref cause) => cause,
-            DeleteClusterError::NotFound(ref cause) => cause,
+            DeleteClusterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClusterError {}
 /// Errors returned by DescribeCluster
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterError {
@@ -1408,20 +1396,16 @@ impl DescribeClusterError {
 }
 impl fmt::Display for DescribeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterError::BadRequest(ref cause) => cause,
-            DescribeClusterError::Forbidden(ref cause) => cause,
-            DescribeClusterError::InternalServerError(ref cause) => cause,
-            DescribeClusterError::NotFound(ref cause) => cause,
-            DescribeClusterError::Unauthorized(ref cause) => cause,
+            DescribeClusterError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeClusterError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterError {}
 /// Errors returned by DescribeClusterOperation
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterOperationError {
@@ -1474,20 +1458,16 @@ impl DescribeClusterOperationError {
 }
 impl fmt::Display for DescribeClusterOperationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterOperationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterOperationError::BadRequest(ref cause) => cause,
-            DescribeClusterOperationError::Forbidden(ref cause) => cause,
-            DescribeClusterOperationError::InternalServerError(ref cause) => cause,
-            DescribeClusterOperationError::NotFound(ref cause) => cause,
-            DescribeClusterOperationError::Unauthorized(ref cause) => cause,
+            DescribeClusterOperationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeClusterOperationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeClusterOperationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeClusterOperationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeClusterOperationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterOperationError {}
 /// Errors returned by DescribeConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationError {
@@ -1546,21 +1526,17 @@ impl DescribeConfigurationError {
 }
 impl fmt::Display for DescribeConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationError::BadRequest(ref cause) => cause,
-            DescribeConfigurationError::Forbidden(ref cause) => cause,
-            DescribeConfigurationError::InternalServerError(ref cause) => cause,
-            DescribeConfigurationError::NotFound(ref cause) => cause,
-            DescribeConfigurationError::ServiceUnavailable(ref cause) => cause,
-            DescribeConfigurationError::Unauthorized(ref cause) => cause,
+            DescribeConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationError {}
 /// Errors returned by DescribeConfigurationRevision
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationRevisionError {
@@ -1629,21 +1605,21 @@ impl DescribeConfigurationRevisionError {
 }
 impl fmt::Display for DescribeConfigurationRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationRevisionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationRevisionError::BadRequest(ref cause) => cause,
-            DescribeConfigurationRevisionError::Forbidden(ref cause) => cause,
-            DescribeConfigurationRevisionError::InternalServerError(ref cause) => cause,
-            DescribeConfigurationRevisionError::NotFound(ref cause) => cause,
-            DescribeConfigurationRevisionError::ServiceUnavailable(ref cause) => cause,
-            DescribeConfigurationRevisionError::Unauthorized(ref cause) => cause,
+            DescribeConfigurationRevisionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationRevisionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationRevisionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigurationRevisionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationRevisionError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigurationRevisionError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationRevisionError {}
 /// Errors returned by GetBootstrapBrokers
 #[derive(Debug, PartialEq)]
 pub enum GetBootstrapBrokersError {
@@ -1694,20 +1670,16 @@ impl GetBootstrapBrokersError {
 }
 impl fmt::Display for GetBootstrapBrokersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBootstrapBrokersError {
-    fn description(&self) -> &str {
         match *self {
-            GetBootstrapBrokersError::BadRequest(ref cause) => cause,
-            GetBootstrapBrokersError::Conflict(ref cause) => cause,
-            GetBootstrapBrokersError::Forbidden(ref cause) => cause,
-            GetBootstrapBrokersError::InternalServerError(ref cause) => cause,
-            GetBootstrapBrokersError::Unauthorized(ref cause) => cause,
+            GetBootstrapBrokersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBootstrapBrokersError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetBootstrapBrokersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetBootstrapBrokersError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetBootstrapBrokersError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBootstrapBrokersError {}
 /// Errors returned by ListClusterOperations
 #[derive(Debug, PartialEq)]
 pub enum ListClusterOperationsError {
@@ -1752,19 +1724,15 @@ impl ListClusterOperationsError {
 }
 impl fmt::Display for ListClusterOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClusterOperationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListClusterOperationsError::BadRequest(ref cause) => cause,
-            ListClusterOperationsError::Forbidden(ref cause) => cause,
-            ListClusterOperationsError::InternalServerError(ref cause) => cause,
-            ListClusterOperationsError::Unauthorized(ref cause) => cause,
+            ListClusterOperationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListClusterOperationsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListClusterOperationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListClusterOperationsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListClusterOperationsError {}
 /// Errors returned by ListClusters
 #[derive(Debug, PartialEq)]
 pub enum ListClustersError {
@@ -1807,19 +1775,15 @@ impl ListClustersError {
 }
 impl fmt::Display for ListClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClustersError {
-    fn description(&self) -> &str {
         match *self {
-            ListClustersError::BadRequest(ref cause) => cause,
-            ListClustersError::Forbidden(ref cause) => cause,
-            ListClustersError::InternalServerError(ref cause) => cause,
-            ListClustersError::Unauthorized(ref cause) => cause,
+            ListClustersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListClustersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListClustersError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListClustersError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListClustersError {}
 /// Errors returned by ListConfigurationRevisions
 #[derive(Debug, PartialEq)]
 pub enum ListConfigurationRevisionsError {
@@ -1886,21 +1850,21 @@ impl ListConfigurationRevisionsError {
 }
 impl fmt::Display for ListConfigurationRevisionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConfigurationRevisionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListConfigurationRevisionsError::BadRequest(ref cause) => cause,
-            ListConfigurationRevisionsError::Forbidden(ref cause) => cause,
-            ListConfigurationRevisionsError::InternalServerError(ref cause) => cause,
-            ListConfigurationRevisionsError::NotFound(ref cause) => cause,
-            ListConfigurationRevisionsError::ServiceUnavailable(ref cause) => cause,
-            ListConfigurationRevisionsError::Unauthorized(ref cause) => cause,
+            ListConfigurationRevisionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListConfigurationRevisionsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListConfigurationRevisionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListConfigurationRevisionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListConfigurationRevisionsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListConfigurationRevisionsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListConfigurationRevisionsError {}
 /// Errors returned by ListConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListConfigurationsError {
@@ -1953,20 +1917,16 @@ impl ListConfigurationsError {
 }
 impl fmt::Display for ListConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListConfigurationsError::BadRequest(ref cause) => cause,
-            ListConfigurationsError::Forbidden(ref cause) => cause,
-            ListConfigurationsError::InternalServerError(ref cause) => cause,
-            ListConfigurationsError::ServiceUnavailable(ref cause) => cause,
-            ListConfigurationsError::Unauthorized(ref cause) => cause,
+            ListConfigurationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListConfigurationsError {}
 /// Errors returned by ListNodes
 #[derive(Debug, PartialEq)]
 pub enum ListNodesError {
@@ -2009,19 +1969,15 @@ impl ListNodesError {
 }
 impl fmt::Display for ListNodesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListNodesError {
-    fn description(&self) -> &str {
         match *self {
-            ListNodesError::BadRequest(ref cause) => cause,
-            ListNodesError::Forbidden(ref cause) => cause,
-            ListNodesError::InternalServerError(ref cause) => cause,
-            ListNodesError::NotFound(ref cause) => cause,
+            ListNodesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListNodesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListNodesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListNodesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListNodesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2060,18 +2016,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
-            ListTagsForResourceError::NotFound(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2108,18 +2060,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::InternalServerError(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2156,18 +2104,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::InternalServerError(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateBrokerCount
 #[derive(Debug, PartialEq)]
 pub enum UpdateBrokerCountError {
@@ -2220,20 +2164,16 @@ impl UpdateBrokerCountError {
 }
 impl fmt::Display for UpdateBrokerCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBrokerCountError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBrokerCountError::BadRequest(ref cause) => cause,
-            UpdateBrokerCountError::Forbidden(ref cause) => cause,
-            UpdateBrokerCountError::InternalServerError(ref cause) => cause,
-            UpdateBrokerCountError::ServiceUnavailable(ref cause) => cause,
-            UpdateBrokerCountError::Unauthorized(ref cause) => cause,
+            UpdateBrokerCountError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerCountError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerCountError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerCountError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerCountError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBrokerCountError {}
 /// Errors returned by UpdateBrokerStorage
 #[derive(Debug, PartialEq)]
 pub enum UpdateBrokerStorageError {
@@ -2286,20 +2226,16 @@ impl UpdateBrokerStorageError {
 }
 impl fmt::Display for UpdateBrokerStorageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBrokerStorageError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBrokerStorageError::BadRequest(ref cause) => cause,
-            UpdateBrokerStorageError::Forbidden(ref cause) => cause,
-            UpdateBrokerStorageError::InternalServerError(ref cause) => cause,
-            UpdateBrokerStorageError::ServiceUnavailable(ref cause) => cause,
-            UpdateBrokerStorageError::Unauthorized(ref cause) => cause,
+            UpdateBrokerStorageError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerStorageError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerStorageError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerStorageError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerStorageError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBrokerStorageError {}
 /// Errors returned by UpdateClusterConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateClusterConfigurationError {
@@ -2366,21 +2302,21 @@ impl UpdateClusterConfigurationError {
 }
 impl fmt::Display for UpdateClusterConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClusterConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClusterConfigurationError::BadRequest(ref cause) => cause,
-            UpdateClusterConfigurationError::Forbidden(ref cause) => cause,
-            UpdateClusterConfigurationError::InternalServerError(ref cause) => cause,
-            UpdateClusterConfigurationError::NotFound(ref cause) => cause,
-            UpdateClusterConfigurationError::ServiceUnavailable(ref cause) => cause,
-            UpdateClusterConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateClusterConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateClusterConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateClusterConfigurationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateClusterConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClusterConfigurationError {}
 /// Trait representing the capabilities of the Kafka API. Kafka clients implement this trait.
 pub trait Kafka {
     /// <pre><code>        &lt;p&gt;Creates a new MSK cluster.&lt;/p&gt;

--- a/rusoto/services/kinesis-video-archived-media/src/generated.rs
+++ b/rusoto/services/kinesis-video-archived-media/src/generated.rs
@@ -343,23 +343,27 @@ impl GetDASHStreamingSessionURLError {
 }
 impl fmt::Display for GetDASHStreamingSessionURLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDASHStreamingSessionURLError {
-    fn description(&self) -> &str {
         match *self {
-            GetDASHStreamingSessionURLError::ClientLimitExceeded(ref cause) => cause,
-            GetDASHStreamingSessionURLError::InvalidArgument(ref cause) => cause,
-            GetDASHStreamingSessionURLError::InvalidCodecPrivateData(ref cause) => cause,
-            GetDASHStreamingSessionURLError::MissingCodecPrivateData(ref cause) => cause,
-            GetDASHStreamingSessionURLError::NoDataRetention(ref cause) => cause,
-            GetDASHStreamingSessionURLError::NotAuthorized(ref cause) => cause,
-            GetDASHStreamingSessionURLError::ResourceNotFound(ref cause) => cause,
-            GetDASHStreamingSessionURLError::UnsupportedStreamMediaType(ref cause) => cause,
+            GetDASHStreamingSessionURLError::ClientLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDASHStreamingSessionURLError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetDASHStreamingSessionURLError::InvalidCodecPrivateData(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDASHStreamingSessionURLError::MissingCodecPrivateData(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDASHStreamingSessionURLError::NoDataRetention(ref cause) => write!(f, "{}", cause),
+            GetDASHStreamingSessionURLError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetDASHStreamingSessionURLError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetDASHStreamingSessionURLError::UnsupportedStreamMediaType(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetDASHStreamingSessionURLError {}
 /// Errors returned by GetHLSStreamingSessionURL
 #[derive(Debug, PartialEq)]
 pub enum GetHLSStreamingSessionURLError {
@@ -434,23 +438,27 @@ impl GetHLSStreamingSessionURLError {
 }
 impl fmt::Display for GetHLSStreamingSessionURLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHLSStreamingSessionURLError {
-    fn description(&self) -> &str {
         match *self {
-            GetHLSStreamingSessionURLError::ClientLimitExceeded(ref cause) => cause,
-            GetHLSStreamingSessionURLError::InvalidArgument(ref cause) => cause,
-            GetHLSStreamingSessionURLError::InvalidCodecPrivateData(ref cause) => cause,
-            GetHLSStreamingSessionURLError::MissingCodecPrivateData(ref cause) => cause,
-            GetHLSStreamingSessionURLError::NoDataRetention(ref cause) => cause,
-            GetHLSStreamingSessionURLError::NotAuthorized(ref cause) => cause,
-            GetHLSStreamingSessionURLError::ResourceNotFound(ref cause) => cause,
-            GetHLSStreamingSessionURLError::UnsupportedStreamMediaType(ref cause) => cause,
+            GetHLSStreamingSessionURLError::ClientLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetHLSStreamingSessionURLError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetHLSStreamingSessionURLError::InvalidCodecPrivateData(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetHLSStreamingSessionURLError::MissingCodecPrivateData(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetHLSStreamingSessionURLError::NoDataRetention(ref cause) => write!(f, "{}", cause),
+            GetHLSStreamingSessionURLError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetHLSStreamingSessionURLError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetHLSStreamingSessionURLError::UnsupportedStreamMediaType(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetHLSStreamingSessionURLError {}
 /// Errors returned by GetMediaForFragmentList
 #[derive(Debug, PartialEq)]
 pub enum GetMediaForFragmentListError {
@@ -497,19 +505,15 @@ impl GetMediaForFragmentListError {
 }
 impl fmt::Display for GetMediaForFragmentListError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMediaForFragmentListError {
-    fn description(&self) -> &str {
         match *self {
-            GetMediaForFragmentListError::ClientLimitExceeded(ref cause) => cause,
-            GetMediaForFragmentListError::InvalidArgument(ref cause) => cause,
-            GetMediaForFragmentListError::NotAuthorized(ref cause) => cause,
-            GetMediaForFragmentListError::ResourceNotFound(ref cause) => cause,
+            GetMediaForFragmentListError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetMediaForFragmentListError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetMediaForFragmentListError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetMediaForFragmentListError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMediaForFragmentListError {}
 /// Errors returned by ListFragments
 #[derive(Debug, PartialEq)]
 pub enum ListFragmentsError {
@@ -548,19 +552,15 @@ impl ListFragmentsError {
 }
 impl fmt::Display for ListFragmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFragmentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFragmentsError::ClientLimitExceeded(ref cause) => cause,
-            ListFragmentsError::InvalidArgument(ref cause) => cause,
-            ListFragmentsError::NotAuthorized(ref cause) => cause,
-            ListFragmentsError::ResourceNotFound(ref cause) => cause,
+            ListFragmentsError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListFragmentsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListFragmentsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListFragmentsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFragmentsError {}
 /// Trait representing the capabilities of the Kinesis Video Archived Media API. Kinesis Video Archived Media clients implement this trait.
 pub trait KinesisVideoArchivedMedia {
     /// <p><p>Retrieves an MPEG Dynamic Adaptive Streaming over HTTP (DASH) URL for the stream. You can then open the URL in a media player to view the stream contents.</p> <p>Both the <code>StreamName</code> and the <code>StreamARN</code> parameters are optional, but you must specify either the <code>StreamName</code> or the <code>StreamARN</code> when invoking this API operation.</p> <p>An Amazon Kinesis video stream has the following requirements for providing data through MPEG-DASH:</p> <ul> <li> <p>The media must contain h.264 or h.265 encoded video and, optionally, AAC or G.711 encoded audio. Specifically, the codec ID of track 1 should be <code>V<em>MPEG/ISO/AVC</code> (for h.264) or V</em>MPEGH/ISO/HEVC (for H.265). Optionally, the codec ID of track 2 should be <code>A<em>AAC</code> (for AAC) or A</em>MS/ACM (for G.711).</p> </li> <li> <p>Data retention must be greater than 0.</p> </li> <li> <p>The video track of each fragment must contain codec private data in the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265 format. For more information, see <a href="https://www.iso.org/standard/55980.html">MPEG-4 specification ISO/IEC 14496-15</a>. For information about adapting stream data to a given format, see <a href="http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html">NAL Adaptation Flags</a>.</p> </li> <li> <p>The audio track (if present) of each fragment must contain codec private data in the AAC format (<a href="https://www.iso.org/standard/43345.html">AAC specification ISO/IEC 13818-7</a>) or the <a href="http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html">MS Wave format</a>.</p> </li> </ul> <p>The following procedure shows how to use MPEG-DASH with Kinesis Video Streams:</p> <ol> <li> <p>Get an endpoint using <a href="http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_GetDataEndpoint.html">GetDataEndpoint</a>, specifying <code>GET<em>DASH</em>STREAMING<em>SESSION</em>URL</code> for the <code>APIName</code> parameter.</p> </li> <li> <p>Retrieve the MPEG-DASH URL using <code>GetDASHStreamingSessionURL</code>. Kinesis Video Streams creates an MPEG-DASH streaming session to be used for accessing content in a stream using the MPEG-DASH protocol. <code>GetDASHStreamingSessionURL</code> returns an authenticated URL (that includes an encrypted session token) for the session&#39;s MPEG-DASH <i>manifest</i> (the root resource needed for streaming with MPEG-DASH).</p> <note> <p>Don&#39;t share or store this token where an unauthorized entity could access it. The token provides access to the content of the stream. Safeguard the token with the same measures that you would use with your AWS credentials.</p> </note> <p>The media that is made available through the manifest consists only of the requested stream, time range, and format. No other media data (such as frames outside the requested window or alternate bitrates) is made available.</p> </li> <li> <p>Provide the URL (containing the encrypted session token) for the MPEG-DASH manifest to a media player that supports the MPEG-DASH protocol. Kinesis Video Streams makes the initialization fragment and media fragments available through the manifest URL. The initialization fragment contains the codec private data for the stream, and other data needed to set up the video or audio decoder and renderer. The media fragments contain encoded video frames or encoded audio samples.</p> </li> <li> <p>The media player receives the authenticated URL and requests stream metadata and media data normally. When the media player requests data, it calls the following actions:</p> <ul> <li> <p> <b>GetDASHManifest:</b> Retrieves an MPEG DASH manifest, which contains the metadata for the media that you want to playback.</p> </li> <li> <p> <b>GetMP4InitFragment:</b> Retrieves the MP4 initialization fragment. The media player typically loads the initialization fragment before loading any media fragments. This fragment contains the &quot;<code>fytp</code>&quot; and &quot;<code>moov</code>&quot; MP4 atoms, and the child atoms that are needed to initialize the media player decoder.</p> <p>The initialization fragment does not correspond to a fragment in a Kinesis video stream. It contains only the codec private data for the stream and respective track, which the media player needs to decode the media frames.</p> </li> <li> <p> <b>GetMP4MediaFragment:</b> Retrieves MP4 media fragments. These fragments contain the &quot;<code>moof</code>&quot; and &quot;<code>mdat</code>&quot; MP4 atoms and their child atoms, containing the encoded fragment&#39;s media frames and their timestamps. </p> <note> <p>After the first media fragment is made available in a streaming session, any fragments that don&#39;t contain the same codec private data cause an error to be returned when those different media fragments are loaded. Therefore, the codec private data should not change between fragments in a session. This also means that the session fails if the fragments in a stream change from having only video to having both audio and video.</p> </note> <p>Data retrieved with this action is billable. See <a href="https://aws.amazon.com/kinesis/video-streams/pricing/">Pricing</a> for details.</p> </li> </ul> </li> </ol> <note> <p>The following restrictions apply to MPEG-DASH sessions:</p> <ul> <li> <p>A streaming session URL should not be shared between players. The service might throttle a session if multiple media players are sharing it. For connection limits, see <a href="http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html">Kinesis Video Streams Limits</a>.</p> </li> <li> <p>A Kinesis video stream can have a maximum of ten active MPEG-DASH streaming sessions. If a new session is created when the maximum number of sessions is already active, the oldest (earliest created) session is closed. The number of active <code>GetMedia</code> connections on a Kinesis video stream does not count against this limit, and the number of active MPEG-DASH sessions does not count against the active <code>GetMedia</code> connection limit.</p> <note> <p>The maximum limits for active HLS and MPEG-DASH streaming sessions are independent of each other. </p> </note> </li> </ul> </note> <p>You can monitor the amount of data that the media player consumes by monitoring the <code>GetMP4MediaFragment.OutgoingBytes</code> Amazon CloudWatch metric. For information about using CloudWatch to monitor Kinesis Video Streams, see <a href="http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/monitoring.html">Monitoring Kinesis Video Streams</a>. For pricing information, see <a href="https://aws.amazon.com/kinesis/video-streams/pricing/">Amazon Kinesis Video Streams Pricing</a> and <a href="https://aws.amazon.com/pricing/">AWS Pricing</a>. Charges for both HLS sessions and outgoing AWS data apply.</p> <p>For more information about HLS, see <a href="https://developer.apple.com/streaming/">HTTP Live Streaming</a> on the <a href="https://developer.apple.com">Apple Developer site</a>.</p> <important> <p>If an error is thrown after invoking a Kinesis Video Streams archived media API, in addition to the HTTP status code and the response body, it includes the following pieces of information: </p> <ul> <li> <p> <code>x-amz-ErrorType</code> HTTP header – contains a more specific error type in addition to what the HTTP status code provides. </p> </li> <li> <p> <code>x-amz-RequestId</code> HTTP header – if you want to report an issue to AWS, the support team can better diagnose the problem if given the Request Id.</p> </li> </ul> <p>Both the HTTP status code and the ErrorType header can be utilized to make programmatic decisions about whether errors are retry-able and under what conditions, as well as provide information on what actions the client programmer might need to take in order to successfully try again.</p> <p>For more information, see the <b>Errors</b> section at the bottom of this topic, as well as <a href="https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/CommonErrors.html">Common Errors</a>. </p> </important></p>

--- a/rusoto/services/kinesis-video-media/src/generated.rs
+++ b/rusoto/services/kinesis-video-media/src/generated.rs
@@ -114,21 +114,17 @@ impl GetMediaError {
 }
 impl fmt::Display for GetMediaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMediaError {
-    fn description(&self) -> &str {
         match *self {
-            GetMediaError::ClientLimitExceeded(ref cause) => cause,
-            GetMediaError::ConnectionLimitExceeded(ref cause) => cause,
-            GetMediaError::InvalidArgument(ref cause) => cause,
-            GetMediaError::InvalidEndpoint(ref cause) => cause,
-            GetMediaError::NotAuthorized(ref cause) => cause,
-            GetMediaError::ResourceNotFound(ref cause) => cause,
+            GetMediaError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetMediaError::ConnectionLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetMediaError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetMediaError::InvalidEndpoint(ref cause) => write!(f, "{}", cause),
+            GetMediaError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetMediaError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMediaError {}
 /// Trait representing the capabilities of the Kinesis Video Media API. Kinesis Video Media clients implement this trait.
 pub trait KinesisVideoMedia {
     /// <p><p> Use this API to retrieve media content from a Kinesis video stream. In the request, you identify the stream name or stream Amazon Resource Name (ARN), and the starting chunk. Kinesis Video Streams then returns a stream of chunks in order by fragment number.</p> <note> <p>You must first call the <code>GetDataEndpoint</code> API to get an endpoint. Then send the <code>GetMedia</code> requests to this endpoint using the <a href="https://docs.aws.amazon.com/cli/latest/reference/">--endpoint-url parameter</a>. </p> </note> <p>When you put media data (fragments) on a stream, Kinesis Video Streams stores each incoming fragment and related metadata in what is called a &quot;chunk.&quot; For more information, see <a href="https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_dataplane_PutMedia.html">PutMedia</a>. The <code>GetMedia</code> API returns a stream of these chunks starting from the chunk that you specify in the request. </p> <p>The following limits apply when using the <code>GetMedia</code> API:</p> <ul> <li> <p>A client can call <code>GetMedia</code> up to five times per second per stream. </p> </li> <li> <p>Kinesis Video Streams sends media data at a rate of up to 25 megabytes per second (or 200 megabits per second) during a <code>GetMedia</code> session. </p> </li> </ul> <note> <p>If an error is thrown after invoking a Kinesis Video Streams media API, in addition to the HTTP status code and the response body, it includes the following pieces of information: </p> <ul> <li> <p> <code>x-amz-ErrorType</code> HTTP header – contains a more specific error type in addition to what the HTTP status code provides. </p> </li> <li> <p> <code>x-amz-RequestId</code> HTTP header – if you want to report an issue to AWS, the support team can better diagnose the problem if given the Request Id.</p> </li> </ul> <p>Both the HTTP status code and the ErrorType header can be utilized to make programmatic decisions about whether errors are retry-able and under what conditions, as well as provide information on what actions the client programmer might need to take in order to successfully try again.</p> <p>For more information, see the <b>Errors</b> section at the bottom of this topic, as well as <a href="https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/CommonErrors.html">Common Errors</a>. </p> </note></p>

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -1078,19 +1078,15 @@ impl AddTagsToStreamError {
 }
 impl fmt::Display for AddTagsToStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToStreamError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToStreamError::InvalidArgument(ref cause) => cause,
-            AddTagsToStreamError::LimitExceeded(ref cause) => cause,
-            AddTagsToStreamError::ResourceInUse(ref cause) => cause,
-            AddTagsToStreamError::ResourceNotFound(ref cause) => cause,
+            AddTagsToStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            AddTagsToStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddTagsToStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            AddTagsToStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToStreamError {}
 /// Errors returned by CreateStream
 #[derive(Debug, PartialEq)]
 pub enum CreateStreamError {
@@ -1124,18 +1120,14 @@ impl CreateStreamError {
 }
 impl fmt::Display for CreateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStreamError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStreamError::InvalidArgument(ref cause) => cause,
-            CreateStreamError::LimitExceeded(ref cause) => cause,
-            CreateStreamError::ResourceInUse(ref cause) => cause,
+            CreateStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStreamError {}
 /// Errors returned by DecreaseStreamRetentionPeriod
 #[derive(Debug, PartialEq)]
 pub enum DecreaseStreamRetentionPeriodError {
@@ -1184,19 +1176,19 @@ impl DecreaseStreamRetentionPeriodError {
 }
 impl fmt::Display for DecreaseStreamRetentionPeriodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DecreaseStreamRetentionPeriodError {
-    fn description(&self) -> &str {
         match *self {
-            DecreaseStreamRetentionPeriodError::InvalidArgument(ref cause) => cause,
-            DecreaseStreamRetentionPeriodError::LimitExceeded(ref cause) => cause,
-            DecreaseStreamRetentionPeriodError::ResourceInUse(ref cause) => cause,
-            DecreaseStreamRetentionPeriodError::ResourceNotFound(ref cause) => cause,
+            DecreaseStreamRetentionPeriodError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DecreaseStreamRetentionPeriodError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DecreaseStreamRetentionPeriodError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DecreaseStreamRetentionPeriodError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DecreaseStreamRetentionPeriodError {}
 /// Errors returned by DeleteStream
 #[derive(Debug, PartialEq)]
 pub enum DeleteStreamError {
@@ -1230,18 +1222,14 @@ impl DeleteStreamError {
 }
 impl fmt::Display for DeleteStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStreamError::LimitExceeded(ref cause) => cause,
-            DeleteStreamError::ResourceInUse(ref cause) => cause,
-            DeleteStreamError::ResourceNotFound(ref cause) => cause,
+            DeleteStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStreamError {}
 /// Errors returned by DeregisterStreamConsumer
 #[derive(Debug, PartialEq)]
 pub enum DeregisterStreamConsumerError {
@@ -1281,18 +1269,14 @@ impl DeregisterStreamConsumerError {
 }
 impl fmt::Display for DeregisterStreamConsumerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterStreamConsumerError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterStreamConsumerError::InvalidArgument(ref cause) => cause,
-            DeregisterStreamConsumerError::LimitExceeded(ref cause) => cause,
-            DeregisterStreamConsumerError::ResourceNotFound(ref cause) => cause,
+            DeregisterStreamConsumerError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DeregisterStreamConsumerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeregisterStreamConsumerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterStreamConsumerError {}
 /// Errors returned by DescribeLimits
 #[derive(Debug, PartialEq)]
 pub enum DescribeLimitsError {
@@ -1316,16 +1300,12 @@ impl DescribeLimitsError {
 }
 impl fmt::Display for DescribeLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLimitsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLimitsError::LimitExceeded(ref cause) => cause,
+            DescribeLimitsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLimitsError {}
 /// Errors returned by DescribeStream
 #[derive(Debug, PartialEq)]
 pub enum DescribeStreamError {
@@ -1354,17 +1334,13 @@ impl DescribeStreamError {
 }
 impl fmt::Display for DescribeStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStreamError::LimitExceeded(ref cause) => cause,
-            DescribeStreamError::ResourceNotFound(ref cause) => cause,
+            DescribeStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStreamError {}
 /// Errors returned by DescribeStreamConsumer
 #[derive(Debug, PartialEq)]
 pub enum DescribeStreamConsumerError {
@@ -1404,18 +1380,14 @@ impl DescribeStreamConsumerError {
 }
 impl fmt::Display for DescribeStreamConsumerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStreamConsumerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStreamConsumerError::InvalidArgument(ref cause) => cause,
-            DescribeStreamConsumerError::LimitExceeded(ref cause) => cause,
-            DescribeStreamConsumerError::ResourceNotFound(ref cause) => cause,
+            DescribeStreamConsumerError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeStreamConsumerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeStreamConsumerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStreamConsumerError {}
 /// Errors returned by DescribeStreamSummary
 #[derive(Debug, PartialEq)]
 pub enum DescribeStreamSummaryError {
@@ -1446,17 +1418,13 @@ impl DescribeStreamSummaryError {
 }
 impl fmt::Display for DescribeStreamSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStreamSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStreamSummaryError::LimitExceeded(ref cause) => cause,
-            DescribeStreamSummaryError::ResourceNotFound(ref cause) => cause,
+            DescribeStreamSummaryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeStreamSummaryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStreamSummaryError {}
 /// Errors returned by DisableEnhancedMonitoring
 #[derive(Debug, PartialEq)]
 pub enum DisableEnhancedMonitoringError {
@@ -1503,19 +1471,15 @@ impl DisableEnhancedMonitoringError {
 }
 impl fmt::Display for DisableEnhancedMonitoringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableEnhancedMonitoringError {
-    fn description(&self) -> &str {
         match *self {
-            DisableEnhancedMonitoringError::InvalidArgument(ref cause) => cause,
-            DisableEnhancedMonitoringError::LimitExceeded(ref cause) => cause,
-            DisableEnhancedMonitoringError::ResourceInUse(ref cause) => cause,
-            DisableEnhancedMonitoringError::ResourceNotFound(ref cause) => cause,
+            DisableEnhancedMonitoringError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DisableEnhancedMonitoringError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DisableEnhancedMonitoringError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DisableEnhancedMonitoringError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableEnhancedMonitoringError {}
 /// Errors returned by EnableEnhancedMonitoring
 #[derive(Debug, PartialEq)]
 pub enum EnableEnhancedMonitoringError {
@@ -1562,19 +1526,15 @@ impl EnableEnhancedMonitoringError {
 }
 impl fmt::Display for EnableEnhancedMonitoringError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableEnhancedMonitoringError {
-    fn description(&self) -> &str {
         match *self {
-            EnableEnhancedMonitoringError::InvalidArgument(ref cause) => cause,
-            EnableEnhancedMonitoringError::LimitExceeded(ref cause) => cause,
-            EnableEnhancedMonitoringError::ResourceInUse(ref cause) => cause,
-            EnableEnhancedMonitoringError::ResourceNotFound(ref cause) => cause,
+            EnableEnhancedMonitoringError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            EnableEnhancedMonitoringError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            EnableEnhancedMonitoringError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            EnableEnhancedMonitoringError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableEnhancedMonitoringError {}
 /// Errors returned by GetRecords
 #[derive(Debug, PartialEq)]
 pub enum GetRecordsError {
@@ -1645,25 +1605,21 @@ impl GetRecordsError {
 }
 impl fmt::Display for GetRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRecordsError::ExpiredIterator(ref cause) => cause,
-            GetRecordsError::InvalidArgument(ref cause) => cause,
-            GetRecordsError::KMSAccessDenied(ref cause) => cause,
-            GetRecordsError::KMSDisabled(ref cause) => cause,
-            GetRecordsError::KMSInvalidState(ref cause) => cause,
-            GetRecordsError::KMSNotFound(ref cause) => cause,
-            GetRecordsError::KMSOptInRequired(ref cause) => cause,
-            GetRecordsError::KMSThrottling(ref cause) => cause,
-            GetRecordsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetRecordsError::ResourceNotFound(ref cause) => cause,
+            GetRecordsError::ExpiredIterator(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::KMSAccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::KMSDisabled(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::KMSNotFound(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::KMSOptInRequired(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::KMSThrottling(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            GetRecordsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRecordsError {}
 /// Errors returned by GetShardIterator
 #[derive(Debug, PartialEq)]
 pub enum GetShardIteratorError {
@@ -1699,18 +1655,16 @@ impl GetShardIteratorError {
 }
 impl fmt::Display for GetShardIteratorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetShardIteratorError {
-    fn description(&self) -> &str {
         match *self {
-            GetShardIteratorError::InvalidArgument(ref cause) => cause,
-            GetShardIteratorError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetShardIteratorError::ResourceNotFound(ref cause) => cause,
+            GetShardIteratorError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetShardIteratorError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetShardIteratorError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetShardIteratorError {}
 /// Errors returned by IncreaseStreamRetentionPeriod
 #[derive(Debug, PartialEq)]
 pub enum IncreaseStreamRetentionPeriodError {
@@ -1759,19 +1713,19 @@ impl IncreaseStreamRetentionPeriodError {
 }
 impl fmt::Display for IncreaseStreamRetentionPeriodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for IncreaseStreamRetentionPeriodError {
-    fn description(&self) -> &str {
         match *self {
-            IncreaseStreamRetentionPeriodError::InvalidArgument(ref cause) => cause,
-            IncreaseStreamRetentionPeriodError::LimitExceeded(ref cause) => cause,
-            IncreaseStreamRetentionPeriodError::ResourceInUse(ref cause) => cause,
-            IncreaseStreamRetentionPeriodError::ResourceNotFound(ref cause) => cause,
+            IncreaseStreamRetentionPeriodError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            IncreaseStreamRetentionPeriodError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            IncreaseStreamRetentionPeriodError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            IncreaseStreamRetentionPeriodError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for IncreaseStreamRetentionPeriodError {}
 /// Errors returned by ListShards
 #[derive(Debug, PartialEq)]
 pub enum ListShardsError {
@@ -1815,20 +1769,16 @@ impl ListShardsError {
 }
 impl fmt::Display for ListShardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListShardsError {
-    fn description(&self) -> &str {
         match *self {
-            ListShardsError::ExpiredNextToken(ref cause) => cause,
-            ListShardsError::InvalidArgument(ref cause) => cause,
-            ListShardsError::LimitExceeded(ref cause) => cause,
-            ListShardsError::ResourceInUse(ref cause) => cause,
-            ListShardsError::ResourceNotFound(ref cause) => cause,
+            ListShardsError::ExpiredNextToken(ref cause) => write!(f, "{}", cause),
+            ListShardsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListShardsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListShardsError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            ListShardsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListShardsError {}
 /// Errors returned by ListStreamConsumers
 #[derive(Debug, PartialEq)]
 pub enum ListStreamConsumersError {
@@ -1876,20 +1826,16 @@ impl ListStreamConsumersError {
 }
 impl fmt::Display for ListStreamConsumersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStreamConsumersError {
-    fn description(&self) -> &str {
         match *self {
-            ListStreamConsumersError::ExpiredNextToken(ref cause) => cause,
-            ListStreamConsumersError::InvalidArgument(ref cause) => cause,
-            ListStreamConsumersError::LimitExceeded(ref cause) => cause,
-            ListStreamConsumersError::ResourceInUse(ref cause) => cause,
-            ListStreamConsumersError::ResourceNotFound(ref cause) => cause,
+            ListStreamConsumersError::ExpiredNextToken(ref cause) => write!(f, "{}", cause),
+            ListStreamConsumersError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListStreamConsumersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListStreamConsumersError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            ListStreamConsumersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStreamConsumersError {}
 /// Errors returned by ListStreams
 #[derive(Debug, PartialEq)]
 pub enum ListStreamsError {
@@ -1913,16 +1859,12 @@ impl ListStreamsError {
 }
 impl fmt::Display for ListStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStreamsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStreamsError::LimitExceeded(ref cause) => cause,
+            ListStreamsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStreamsError {}
 /// Errors returned by ListTagsForStream
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForStreamError {
@@ -1956,18 +1898,14 @@ impl ListTagsForStreamError {
 }
 impl fmt::Display for ListTagsForStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForStreamError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForStreamError::InvalidArgument(ref cause) => cause,
-            ListTagsForStreamError::LimitExceeded(ref cause) => cause,
-            ListTagsForStreamError::ResourceNotFound(ref cause) => cause,
+            ListTagsForStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListTagsForStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForStreamError {}
 /// Errors returned by MergeShards
 #[derive(Debug, PartialEq)]
 pub enum MergeShardsError {
@@ -2006,19 +1944,15 @@ impl MergeShardsError {
 }
 impl fmt::Display for MergeShardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MergeShardsError {
-    fn description(&self) -> &str {
         match *self {
-            MergeShardsError::InvalidArgument(ref cause) => cause,
-            MergeShardsError::LimitExceeded(ref cause) => cause,
-            MergeShardsError::ResourceInUse(ref cause) => cause,
-            MergeShardsError::ResourceNotFound(ref cause) => cause,
+            MergeShardsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            MergeShardsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            MergeShardsError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            MergeShardsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for MergeShardsError {}
 /// Errors returned by PutRecord
 #[derive(Debug, PartialEq)]
 pub enum PutRecordError {
@@ -2084,24 +2018,20 @@ impl PutRecordError {
 }
 impl fmt::Display for PutRecordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRecordError {
-    fn description(&self) -> &str {
         match *self {
-            PutRecordError::InvalidArgument(ref cause) => cause,
-            PutRecordError::KMSAccessDenied(ref cause) => cause,
-            PutRecordError::KMSDisabled(ref cause) => cause,
-            PutRecordError::KMSInvalidState(ref cause) => cause,
-            PutRecordError::KMSNotFound(ref cause) => cause,
-            PutRecordError::KMSOptInRequired(ref cause) => cause,
-            PutRecordError::KMSThrottling(ref cause) => cause,
-            PutRecordError::ProvisionedThroughputExceeded(ref cause) => cause,
-            PutRecordError::ResourceNotFound(ref cause) => cause,
+            PutRecordError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            PutRecordError::KMSAccessDenied(ref cause) => write!(f, "{}", cause),
+            PutRecordError::KMSDisabled(ref cause) => write!(f, "{}", cause),
+            PutRecordError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            PutRecordError::KMSNotFound(ref cause) => write!(f, "{}", cause),
+            PutRecordError::KMSOptInRequired(ref cause) => write!(f, "{}", cause),
+            PutRecordError::KMSThrottling(ref cause) => write!(f, "{}", cause),
+            PutRecordError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            PutRecordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRecordError {}
 /// Errors returned by PutRecords
 #[derive(Debug, PartialEq)]
 pub enum PutRecordsError {
@@ -2167,24 +2097,20 @@ impl PutRecordsError {
 }
 impl fmt::Display for PutRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            PutRecordsError::InvalidArgument(ref cause) => cause,
-            PutRecordsError::KMSAccessDenied(ref cause) => cause,
-            PutRecordsError::KMSDisabled(ref cause) => cause,
-            PutRecordsError::KMSInvalidState(ref cause) => cause,
-            PutRecordsError::KMSNotFound(ref cause) => cause,
-            PutRecordsError::KMSOptInRequired(ref cause) => cause,
-            PutRecordsError::KMSThrottling(ref cause) => cause,
-            PutRecordsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            PutRecordsError::ResourceNotFound(ref cause) => cause,
+            PutRecordsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::KMSAccessDenied(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::KMSDisabled(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::KMSNotFound(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::KMSOptInRequired(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::KMSThrottling(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            PutRecordsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRecordsError {}
 /// Errors returned by RegisterStreamConsumer
 #[derive(Debug, PartialEq)]
 pub enum RegisterStreamConsumerError {
@@ -2231,19 +2157,15 @@ impl RegisterStreamConsumerError {
 }
 impl fmt::Display for RegisterStreamConsumerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterStreamConsumerError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterStreamConsumerError::InvalidArgument(ref cause) => cause,
-            RegisterStreamConsumerError::LimitExceeded(ref cause) => cause,
-            RegisterStreamConsumerError::ResourceInUse(ref cause) => cause,
-            RegisterStreamConsumerError::ResourceNotFound(ref cause) => cause,
+            RegisterStreamConsumerError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            RegisterStreamConsumerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RegisterStreamConsumerError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            RegisterStreamConsumerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterStreamConsumerError {}
 /// Errors returned by RemoveTagsFromStream
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromStreamError {
@@ -2286,19 +2208,15 @@ impl RemoveTagsFromStreamError {
 }
 impl fmt::Display for RemoveTagsFromStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromStreamError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromStreamError::InvalidArgument(ref cause) => cause,
-            RemoveTagsFromStreamError::LimitExceeded(ref cause) => cause,
-            RemoveTagsFromStreamError::ResourceInUse(ref cause) => cause,
-            RemoveTagsFromStreamError::ResourceNotFound(ref cause) => cause,
+            RemoveTagsFromStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromStreamError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromStreamError {}
 /// Errors returned by SplitShard
 #[derive(Debug, PartialEq)]
 pub enum SplitShardError {
@@ -2337,19 +2255,15 @@ impl SplitShardError {
 }
 impl fmt::Display for SplitShardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SplitShardError {
-    fn description(&self) -> &str {
         match *self {
-            SplitShardError::InvalidArgument(ref cause) => cause,
-            SplitShardError::LimitExceeded(ref cause) => cause,
-            SplitShardError::ResourceInUse(ref cause) => cause,
-            SplitShardError::ResourceNotFound(ref cause) => cause,
+            SplitShardError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            SplitShardError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            SplitShardError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            SplitShardError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SplitShardError {}
 /// Errors returned by StartStreamEncryption
 #[derive(Debug, PartialEq)]
 pub enum StartStreamEncryptionError {
@@ -2428,25 +2342,21 @@ impl StartStreamEncryptionError {
 }
 impl fmt::Display for StartStreamEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartStreamEncryptionError {
-    fn description(&self) -> &str {
         match *self {
-            StartStreamEncryptionError::InvalidArgument(ref cause) => cause,
-            StartStreamEncryptionError::KMSAccessDenied(ref cause) => cause,
-            StartStreamEncryptionError::KMSDisabled(ref cause) => cause,
-            StartStreamEncryptionError::KMSInvalidState(ref cause) => cause,
-            StartStreamEncryptionError::KMSNotFound(ref cause) => cause,
-            StartStreamEncryptionError::KMSOptInRequired(ref cause) => cause,
-            StartStreamEncryptionError::KMSThrottling(ref cause) => cause,
-            StartStreamEncryptionError::LimitExceeded(ref cause) => cause,
-            StartStreamEncryptionError::ResourceInUse(ref cause) => cause,
-            StartStreamEncryptionError::ResourceNotFound(ref cause) => cause,
+            StartStreamEncryptionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::KMSAccessDenied(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::KMSDisabled(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::KMSNotFound(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::KMSOptInRequired(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::KMSThrottling(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StartStreamEncryptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartStreamEncryptionError {}
 /// Errors returned by StopStreamEncryption
 #[derive(Debug, PartialEq)]
 pub enum StopStreamEncryptionError {
@@ -2489,19 +2399,15 @@ impl StopStreamEncryptionError {
 }
 impl fmt::Display for StopStreamEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopStreamEncryptionError {
-    fn description(&self) -> &str {
         match *self {
-            StopStreamEncryptionError::InvalidArgument(ref cause) => cause,
-            StopStreamEncryptionError::LimitExceeded(ref cause) => cause,
-            StopStreamEncryptionError::ResourceInUse(ref cause) => cause,
-            StopStreamEncryptionError::ResourceNotFound(ref cause) => cause,
+            StopStreamEncryptionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            StopStreamEncryptionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StopStreamEncryptionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StopStreamEncryptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopStreamEncryptionError {}
 /// Errors returned by SubscribeToShard
 #[derive(Debug, PartialEq)]
 pub enum SubscribeToShardError {
@@ -2540,19 +2446,15 @@ impl SubscribeToShardError {
 }
 impl fmt::Display for SubscribeToShardError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubscribeToShardError {
-    fn description(&self) -> &str {
         match *self {
-            SubscribeToShardError::InvalidArgument(ref cause) => cause,
-            SubscribeToShardError::LimitExceeded(ref cause) => cause,
-            SubscribeToShardError::ResourceInUse(ref cause) => cause,
-            SubscribeToShardError::ResourceNotFound(ref cause) => cause,
+            SubscribeToShardError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            SubscribeToShardError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            SubscribeToShardError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            SubscribeToShardError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SubscribeToShardError {}
 /// Errors returned by UpdateShardCount
 #[derive(Debug, PartialEq)]
 pub enum UpdateShardCountError {
@@ -2591,19 +2493,15 @@ impl UpdateShardCountError {
 }
 impl fmt::Display for UpdateShardCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateShardCountError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateShardCountError::InvalidArgument(ref cause) => cause,
-            UpdateShardCountError::LimitExceeded(ref cause) => cause,
-            UpdateShardCountError::ResourceInUse(ref cause) => cause,
-            UpdateShardCountError::ResourceNotFound(ref cause) => cause,
+            UpdateShardCountError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateShardCountError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateShardCountError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateShardCountError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateShardCountError {}
 /// Trait representing the capabilities of the Kinesis API. Kinesis clients implement this trait.
 pub trait Kinesis {
     /// <p>Adds or updates tags for the specified Kinesis data stream. Each time you invoke this operation, you can specify up to 10 tags. If you want to add more than 10 tags to your stream, you can invoke this operation multiple times. In total, each stream can have up to 50 tags.</p> <p>If tags have already been assigned to the stream, <code>AddTagsToStream</code> overwrites any existing tags that correspond to the specified tag keys.</p> <p> <a>AddTagsToStream</a> has a limit of five transactions per second per account.</p>

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -1309,20 +1309,26 @@ impl AddApplicationCloudWatchLoggingOptionError {
 }
 impl fmt::Display for AddApplicationCloudWatchLoggingOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddApplicationCloudWatchLoggingOptionError {
-    fn description(&self) -> &str {
         match *self {
-            AddApplicationCloudWatchLoggingOptionError::ConcurrentModification(ref cause) => cause,
-            AddApplicationCloudWatchLoggingOptionError::InvalidArgument(ref cause) => cause,
-            AddApplicationCloudWatchLoggingOptionError::ResourceInUse(ref cause) => cause,
-            AddApplicationCloudWatchLoggingOptionError::ResourceNotFound(ref cause) => cause,
-            AddApplicationCloudWatchLoggingOptionError::UnsupportedOperation(ref cause) => cause,
+            AddApplicationCloudWatchLoggingOptionError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationCloudWatchLoggingOptionError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationCloudWatchLoggingOptionError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationCloudWatchLoggingOptionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationCloudWatchLoggingOptionError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddApplicationCloudWatchLoggingOptionError {}
 /// Errors returned by AddApplicationInput
 #[derive(Debug, PartialEq)]
 pub enum AddApplicationInputError {
@@ -1377,21 +1383,17 @@ impl AddApplicationInputError {
 }
 impl fmt::Display for AddApplicationInputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddApplicationInputError {
-    fn description(&self) -> &str {
         match *self {
-            AddApplicationInputError::CodeValidation(ref cause) => cause,
-            AddApplicationInputError::ConcurrentModification(ref cause) => cause,
-            AddApplicationInputError::InvalidArgument(ref cause) => cause,
-            AddApplicationInputError::ResourceInUse(ref cause) => cause,
-            AddApplicationInputError::ResourceNotFound(ref cause) => cause,
-            AddApplicationInputError::UnsupportedOperation(ref cause) => cause,
+            AddApplicationInputError::CodeValidation(ref cause) => write!(f, "{}", cause),
+            AddApplicationInputError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            AddApplicationInputError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            AddApplicationInputError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            AddApplicationInputError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddApplicationInputError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddApplicationInputError {}
 /// Errors returned by AddApplicationInputProcessingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum AddApplicationInputProcessingConfigurationError {
@@ -1451,24 +1453,26 @@ impl AddApplicationInputProcessingConfigurationError {
 }
 impl fmt::Display for AddApplicationInputProcessingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddApplicationInputProcessingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
             AddApplicationInputProcessingConfigurationError::ConcurrentModification(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            AddApplicationInputProcessingConfigurationError::InvalidArgument(ref cause) => cause,
-            AddApplicationInputProcessingConfigurationError::ResourceInUse(ref cause) => cause,
-            AddApplicationInputProcessingConfigurationError::ResourceNotFound(ref cause) => cause,
+            AddApplicationInputProcessingConfigurationError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationInputProcessingConfigurationError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationInputProcessingConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
             AddApplicationInputProcessingConfigurationError::UnsupportedOperation(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for AddApplicationInputProcessingConfigurationError {}
 /// Errors returned by AddApplicationOutput
 #[derive(Debug, PartialEq)]
 pub enum AddApplicationOutputError {
@@ -1520,20 +1524,16 @@ impl AddApplicationOutputError {
 }
 impl fmt::Display for AddApplicationOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddApplicationOutputError {
-    fn description(&self) -> &str {
         match *self {
-            AddApplicationOutputError::ConcurrentModification(ref cause) => cause,
-            AddApplicationOutputError::InvalidArgument(ref cause) => cause,
-            AddApplicationOutputError::ResourceInUse(ref cause) => cause,
-            AddApplicationOutputError::ResourceNotFound(ref cause) => cause,
-            AddApplicationOutputError::UnsupportedOperation(ref cause) => cause,
+            AddApplicationOutputError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            AddApplicationOutputError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            AddApplicationOutputError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            AddApplicationOutputError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddApplicationOutputError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddApplicationOutputError {}
 /// Errors returned by AddApplicationReferenceDataSource
 #[derive(Debug, PartialEq)]
 pub enum AddApplicationReferenceDataSourceError {
@@ -1589,20 +1589,26 @@ impl AddApplicationReferenceDataSourceError {
 }
 impl fmt::Display for AddApplicationReferenceDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddApplicationReferenceDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddApplicationReferenceDataSourceError::ConcurrentModification(ref cause) => cause,
-            AddApplicationReferenceDataSourceError::InvalidArgument(ref cause) => cause,
-            AddApplicationReferenceDataSourceError::ResourceInUse(ref cause) => cause,
-            AddApplicationReferenceDataSourceError::ResourceNotFound(ref cause) => cause,
-            AddApplicationReferenceDataSourceError::UnsupportedOperation(ref cause) => cause,
+            AddApplicationReferenceDataSourceError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationReferenceDataSourceError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationReferenceDataSourceError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationReferenceDataSourceError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddApplicationReferenceDataSourceError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddApplicationReferenceDataSourceError {}
 /// Errors returned by CreateApplication
 #[derive(Debug, PartialEq)]
 pub enum CreateApplicationError {
@@ -1653,21 +1659,17 @@ impl CreateApplicationError {
 }
 impl fmt::Display for CreateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApplicationError::CodeValidation(ref cause) => cause,
-            CreateApplicationError::ConcurrentModification(ref cause) => cause,
-            CreateApplicationError::InvalidArgument(ref cause) => cause,
-            CreateApplicationError::LimitExceeded(ref cause) => cause,
-            CreateApplicationError::ResourceInUse(ref cause) => cause,
-            CreateApplicationError::TooManyTags(ref cause) => cause,
+            CreateApplicationError::CodeValidation(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApplicationError {}
 /// Errors returned by DeleteApplication
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationError {
@@ -1710,19 +1712,15 @@ impl DeleteApplicationError {
 }
 impl fmt::Display for DeleteApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationError::ConcurrentModification(ref cause) => cause,
-            DeleteApplicationError::ResourceInUse(ref cause) => cause,
-            DeleteApplicationError::ResourceNotFound(ref cause) => cause,
-            DeleteApplicationError::UnsupportedOperation(ref cause) => cause,
+            DeleteApplicationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApplicationError {}
 /// Errors returned by DeleteApplicationCloudWatchLoggingOption
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationCloudWatchLoggingOptionError {
@@ -1782,22 +1780,26 @@ impl DeleteApplicationCloudWatchLoggingOptionError {
 }
 impl fmt::Display for DeleteApplicationCloudWatchLoggingOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationCloudWatchLoggingOptionError {
-    fn description(&self) -> &str {
         match *self {
             DeleteApplicationCloudWatchLoggingOptionError::ConcurrentModification(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DeleteApplicationCloudWatchLoggingOptionError::InvalidArgument(ref cause) => cause,
-            DeleteApplicationCloudWatchLoggingOptionError::ResourceInUse(ref cause) => cause,
-            DeleteApplicationCloudWatchLoggingOptionError::ResourceNotFound(ref cause) => cause,
-            DeleteApplicationCloudWatchLoggingOptionError::UnsupportedOperation(ref cause) => cause,
+            DeleteApplicationCloudWatchLoggingOptionError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationCloudWatchLoggingOptionError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationCloudWatchLoggingOptionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationCloudWatchLoggingOptionError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteApplicationCloudWatchLoggingOptionError {}
 /// Errors returned by DeleteApplicationInputProcessingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationInputProcessingConfigurationError {
@@ -1861,26 +1863,26 @@ impl DeleteApplicationInputProcessingConfigurationError {
 }
 impl fmt::Display for DeleteApplicationInputProcessingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationInputProcessingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
             DeleteApplicationInputProcessingConfigurationError::ConcurrentModification(
                 ref cause,
-            ) => cause,
-            DeleteApplicationInputProcessingConfigurationError::InvalidArgument(ref cause) => cause,
-            DeleteApplicationInputProcessingConfigurationError::ResourceInUse(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DeleteApplicationInputProcessingConfigurationError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationInputProcessingConfigurationError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteApplicationInputProcessingConfigurationError::ResourceNotFound(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DeleteApplicationInputProcessingConfigurationError::UnsupportedOperation(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteApplicationInputProcessingConfigurationError {}
 /// Errors returned by DeleteApplicationOutput
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationOutputError {
@@ -1934,20 +1936,18 @@ impl DeleteApplicationOutputError {
 }
 impl fmt::Display for DeleteApplicationOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationOutputError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationOutputError::ConcurrentModification(ref cause) => cause,
-            DeleteApplicationOutputError::InvalidArgument(ref cause) => cause,
-            DeleteApplicationOutputError::ResourceInUse(ref cause) => cause,
-            DeleteApplicationOutputError::ResourceNotFound(ref cause) => cause,
-            DeleteApplicationOutputError::UnsupportedOperation(ref cause) => cause,
+            DeleteApplicationOutputError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationOutputError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationOutputError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationOutputError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationOutputError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApplicationOutputError {}
 /// Errors returned by DeleteApplicationReferenceDataSource
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationReferenceDataSourceError {
@@ -2003,20 +2003,26 @@ impl DeleteApplicationReferenceDataSourceError {
 }
 impl fmt::Display for DeleteApplicationReferenceDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationReferenceDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationReferenceDataSourceError::ConcurrentModification(ref cause) => cause,
-            DeleteApplicationReferenceDataSourceError::InvalidArgument(ref cause) => cause,
-            DeleteApplicationReferenceDataSourceError::ResourceInUse(ref cause) => cause,
-            DeleteApplicationReferenceDataSourceError::ResourceNotFound(ref cause) => cause,
-            DeleteApplicationReferenceDataSourceError::UnsupportedOperation(ref cause) => cause,
+            DeleteApplicationReferenceDataSourceError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationReferenceDataSourceError::InvalidArgument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationReferenceDataSourceError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationReferenceDataSourceError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteApplicationReferenceDataSourceError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteApplicationReferenceDataSourceError {}
 /// Errors returned by DescribeApplication
 #[derive(Debug, PartialEq)]
 pub enum DescribeApplicationError {
@@ -2049,17 +2055,13 @@ impl DescribeApplicationError {
 }
 impl fmt::Display for DescribeApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeApplicationError::ResourceNotFound(ref cause) => cause,
-            DescribeApplicationError::UnsupportedOperation(ref cause) => cause,
+            DescribeApplicationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeApplicationError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeApplicationError {}
 /// Errors returned by DiscoverInputSchema
 #[derive(Debug, PartialEq)]
 pub enum DiscoverInputSchemaError {
@@ -2104,19 +2106,17 @@ impl DiscoverInputSchemaError {
 }
 impl fmt::Display for DiscoverInputSchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DiscoverInputSchemaError {
-    fn description(&self) -> &str {
         match *self {
-            DiscoverInputSchemaError::InvalidArgument(ref cause) => cause,
-            DiscoverInputSchemaError::ResourceProvisionedThroughputExceeded(ref cause) => cause,
-            DiscoverInputSchemaError::ServiceUnavailable(ref cause) => cause,
-            DiscoverInputSchemaError::UnableToDetectSchema(ref cause) => cause,
+            DiscoverInputSchemaError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DiscoverInputSchemaError::ResourceProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DiscoverInputSchemaError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DiscoverInputSchemaError::UnableToDetectSchema(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DiscoverInputSchemaError {}
 /// Errors returned by ListApplications
 #[derive(Debug, PartialEq)]
 pub enum ListApplicationsError {}
@@ -2134,14 +2134,10 @@ impl ListApplicationsError {
 }
 impl fmt::Display for ListApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApplicationsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListApplicationsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -2179,18 +2175,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::ConcurrentModification(ref cause) => cause,
-            ListTagsForResourceError::InvalidArgument(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by StartApplication
 #[derive(Debug, PartialEq)]
 pub enum StartApplicationError {
@@ -2238,20 +2230,18 @@ impl StartApplicationError {
 }
 impl fmt::Display for StartApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            StartApplicationError::InvalidApplicationConfiguration(ref cause) => cause,
-            StartApplicationError::InvalidArgument(ref cause) => cause,
-            StartApplicationError::ResourceInUse(ref cause) => cause,
-            StartApplicationError::ResourceNotFound(ref cause) => cause,
-            StartApplicationError::UnsupportedOperation(ref cause) => cause,
+            StartApplicationError::InvalidApplicationConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartApplicationError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            StartApplicationError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StartApplicationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartApplicationError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartApplicationError {}
 /// Errors returned by StopApplication
 #[derive(Debug, PartialEq)]
 pub enum StopApplicationError {
@@ -2287,18 +2277,14 @@ impl StopApplicationError {
 }
 impl fmt::Display for StopApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            StopApplicationError::ResourceInUse(ref cause) => cause,
-            StopApplicationError::ResourceNotFound(ref cause) => cause,
-            StopApplicationError::UnsupportedOperation(ref cause) => cause,
+            StopApplicationError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StopApplicationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopApplicationError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopApplicationError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2342,20 +2328,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ConcurrentModification(ref cause) => cause,
-            TagResourceError::InvalidArgument(ref cause) => cause,
-            TagResourceError::ResourceInUse(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2401,20 +2383,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ConcurrentModification(ref cause) => cause,
-            UntagResourceError::InvalidArgument(ref cause) => cause,
-            UntagResourceError::ResourceInUse(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::TooManyTags(ref cause) => cause,
+            UntagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateApplication
 #[derive(Debug, PartialEq)]
 pub enum UpdateApplicationError {
@@ -2467,21 +2445,17 @@ impl UpdateApplicationError {
 }
 impl fmt::Display for UpdateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApplicationError::CodeValidation(ref cause) => cause,
-            UpdateApplicationError::ConcurrentModification(ref cause) => cause,
-            UpdateApplicationError::InvalidArgument(ref cause) => cause,
-            UpdateApplicationError::ResourceInUse(ref cause) => cause,
-            UpdateApplicationError::ResourceNotFound(ref cause) => cause,
-            UpdateApplicationError::UnsupportedOperation(ref cause) => cause,
+            UpdateApplicationError::CodeValidation(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApplicationError {}
 /// Trait representing the capabilities of the Kinesis Analytics API. Kinesis Analytics clients implement this trait.
 pub trait KinesisAnalytics {
     /// <p><note> <p>This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only supports SQL applications. Version 2 of the API supports SQL and Java applications. For more information about version 2, see <a href="/kinesisanalytics/latest/apiv2/Welcome.html">Amazon Kinesis Data Analytics API V2 Documentation</a>.</p> </note> <p>Adds a CloudWatch log stream to monitor application configuration errors. For more information about using CloudWatch log streams with Amazon Kinesis Analytics applications, see <a href="https://docs.aws.amazon.com/kinesisanalytics/latest/dev/cloudwatch-logs.html">Working with Amazon CloudWatch Logs</a>.</p></p>

--- a/rusoto/services/kinesisvideo/src/generated.rs
+++ b/rusoto/services/kinesisvideo/src/generated.rs
@@ -658,21 +658,21 @@ impl CreateSignalingChannelError {
 }
 impl fmt::Display for CreateSignalingChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSignalingChannelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSignalingChannelError::AccessDenied(ref cause) => cause,
-            CreateSignalingChannelError::AccountChannelLimitExceeded(ref cause) => cause,
-            CreateSignalingChannelError::ClientLimitExceeded(ref cause) => cause,
-            CreateSignalingChannelError::InvalidArgument(ref cause) => cause,
-            CreateSignalingChannelError::ResourceInUse(ref cause) => cause,
-            CreateSignalingChannelError::TagsPerResourceExceededLimit(ref cause) => cause,
+            CreateSignalingChannelError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateSignalingChannelError::AccountChannelLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSignalingChannelError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSignalingChannelError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateSignalingChannelError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateSignalingChannelError::TagsPerResourceExceededLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateSignalingChannelError {}
 /// Errors returned by CreateStream
 #[derive(Debug, PartialEq)]
 pub enum CreateStreamError {
@@ -732,22 +732,18 @@ impl CreateStreamError {
 }
 impl fmt::Display for CreateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStreamError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStreamError::AccountStreamLimitExceeded(ref cause) => cause,
-            CreateStreamError::ClientLimitExceeded(ref cause) => cause,
-            CreateStreamError::DeviceStreamLimitExceeded(ref cause) => cause,
-            CreateStreamError::InvalidArgument(ref cause) => cause,
-            CreateStreamError::InvalidDevice(ref cause) => cause,
-            CreateStreamError::ResourceInUse(ref cause) => cause,
-            CreateStreamError::TagsPerResourceExceededLimit(ref cause) => cause,
+            CreateStreamError::AccountStreamLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::DeviceStreamLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::InvalidDevice(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateStreamError::TagsPerResourceExceededLimit(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStreamError {}
 /// Errors returned by DeleteSignalingChannel
 #[derive(Debug, PartialEq)]
 pub enum DeleteSignalingChannelError {
@@ -799,20 +795,16 @@ impl DeleteSignalingChannelError {
 }
 impl fmt::Display for DeleteSignalingChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSignalingChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSignalingChannelError::AccessDenied(ref cause) => cause,
-            DeleteSignalingChannelError::ClientLimitExceeded(ref cause) => cause,
-            DeleteSignalingChannelError::InvalidArgument(ref cause) => cause,
-            DeleteSignalingChannelError::ResourceNotFound(ref cause) => cause,
-            DeleteSignalingChannelError::VersionMismatch(ref cause) => cause,
+            DeleteSignalingChannelError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteSignalingChannelError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteSignalingChannelError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DeleteSignalingChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteSignalingChannelError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSignalingChannelError {}
 /// Errors returned by DeleteStream
 #[derive(Debug, PartialEq)]
 pub enum DeleteStreamError {
@@ -856,20 +848,16 @@ impl DeleteStreamError {
 }
 impl fmt::Display for DeleteStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStreamError::ClientLimitExceeded(ref cause) => cause,
-            DeleteStreamError::InvalidArgument(ref cause) => cause,
-            DeleteStreamError::NotAuthorized(ref cause) => cause,
-            DeleteStreamError::ResourceNotFound(ref cause) => cause,
-            DeleteStreamError::VersionMismatch(ref cause) => cause,
+            DeleteStreamError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteStreamError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStreamError {}
 /// Errors returned by DescribeSignalingChannel
 #[derive(Debug, PartialEq)]
 pub enum DescribeSignalingChannelError {
@@ -916,19 +904,15 @@ impl DescribeSignalingChannelError {
 }
 impl fmt::Display for DescribeSignalingChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSignalingChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSignalingChannelError::AccessDenied(ref cause) => cause,
-            DescribeSignalingChannelError::ClientLimitExceeded(ref cause) => cause,
-            DescribeSignalingChannelError::InvalidArgument(ref cause) => cause,
-            DescribeSignalingChannelError::ResourceNotFound(ref cause) => cause,
+            DescribeSignalingChannelError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeSignalingChannelError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeSignalingChannelError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeSignalingChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSignalingChannelError {}
 /// Errors returned by DescribeStream
 #[derive(Debug, PartialEq)]
 pub enum DescribeStreamError {
@@ -967,19 +951,15 @@ impl DescribeStreamError {
 }
 impl fmt::Display for DescribeStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStreamError::ClientLimitExceeded(ref cause) => cause,
-            DescribeStreamError::InvalidArgument(ref cause) => cause,
-            DescribeStreamError::NotAuthorized(ref cause) => cause,
-            DescribeStreamError::ResourceNotFound(ref cause) => cause,
+            DescribeStreamError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            DescribeStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStreamError {}
 /// Errors returned by GetDataEndpoint
 #[derive(Debug, PartialEq)]
 pub enum GetDataEndpointError {
@@ -1018,19 +998,15 @@ impl GetDataEndpointError {
 }
 impl fmt::Display for GetDataEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDataEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            GetDataEndpointError::ClientLimitExceeded(ref cause) => cause,
-            GetDataEndpointError::InvalidArgument(ref cause) => cause,
-            GetDataEndpointError::NotAuthorized(ref cause) => cause,
-            GetDataEndpointError::ResourceNotFound(ref cause) => cause,
+            GetDataEndpointError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetDataEndpointError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetDataEndpointError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            GetDataEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDataEndpointError {}
 /// Errors returned by GetSignalingChannelEndpoint
 #[derive(Debug, PartialEq)]
 pub enum GetSignalingChannelEndpointError {
@@ -1086,20 +1062,18 @@ impl GetSignalingChannelEndpointError {
 }
 impl fmt::Display for GetSignalingChannelEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSignalingChannelEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            GetSignalingChannelEndpointError::AccessDenied(ref cause) => cause,
-            GetSignalingChannelEndpointError::ClientLimitExceeded(ref cause) => cause,
-            GetSignalingChannelEndpointError::InvalidArgument(ref cause) => cause,
-            GetSignalingChannelEndpointError::ResourceInUse(ref cause) => cause,
-            GetSignalingChannelEndpointError::ResourceNotFound(ref cause) => cause,
+            GetSignalingChannelEndpointError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetSignalingChannelEndpointError::ClientLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetSignalingChannelEndpointError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetSignalingChannelEndpointError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            GetSignalingChannelEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSignalingChannelEndpointError {}
 /// Errors returned by ListSignalingChannels
 #[derive(Debug, PartialEq)]
 pub enum ListSignalingChannelsError {
@@ -1137,18 +1111,14 @@ impl ListSignalingChannelsError {
 }
 impl fmt::Display for ListSignalingChannelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSignalingChannelsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSignalingChannelsError::AccessDenied(ref cause) => cause,
-            ListSignalingChannelsError::ClientLimitExceeded(ref cause) => cause,
-            ListSignalingChannelsError::InvalidArgument(ref cause) => cause,
+            ListSignalingChannelsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListSignalingChannelsError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListSignalingChannelsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSignalingChannelsError {}
 /// Errors returned by ListStreams
 #[derive(Debug, PartialEq)]
 pub enum ListStreamsError {
@@ -1177,17 +1147,13 @@ impl ListStreamsError {
 }
 impl fmt::Display for ListStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStreamsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStreamsError::ClientLimitExceeded(ref cause) => cause,
-            ListStreamsError::InvalidArgument(ref cause) => cause,
+            ListStreamsError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListStreamsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStreamsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1230,19 +1196,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AccessDenied(ref cause) => cause,
-            ListTagsForResourceError::ClientLimitExceeded(ref cause) => cause,
-            ListTagsForResourceError::InvalidArgument(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTagsForStream
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForStreamError {
@@ -1290,20 +1252,16 @@ impl ListTagsForStreamError {
 }
 impl fmt::Display for ListTagsForStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForStreamError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForStreamError::ClientLimitExceeded(ref cause) => cause,
-            ListTagsForStreamError::InvalidArgument(ref cause) => cause,
-            ListTagsForStreamError::InvalidResourceFormat(ref cause) => cause,
-            ListTagsForStreamError::NotAuthorized(ref cause) => cause,
-            ListTagsForStreamError::ResourceNotFound(ref cause) => cause,
+            ListTagsForStreamError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            ListTagsForStreamError::InvalidResourceFormat(ref cause) => write!(f, "{}", cause),
+            ListTagsForStreamError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            ListTagsForStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForStreamError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1349,20 +1307,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AccessDenied(ref cause) => cause,
-            TagResourceError::ClientLimitExceeded(ref cause) => cause,
-            TagResourceError::InvalidArgument(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TagsPerResourceExceededLimit(ref cause) => cause,
+            TagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagsPerResourceExceededLimit(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TagStream
 #[derive(Debug, PartialEq)]
 pub enum TagStreamError {
@@ -1413,21 +1367,17 @@ impl TagStreamError {
 }
 impl fmt::Display for TagStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagStreamError {
-    fn description(&self) -> &str {
         match *self {
-            TagStreamError::ClientLimitExceeded(ref cause) => cause,
-            TagStreamError::InvalidArgument(ref cause) => cause,
-            TagStreamError::InvalidResourceFormat(ref cause) => cause,
-            TagStreamError::NotAuthorized(ref cause) => cause,
-            TagStreamError::ResourceNotFound(ref cause) => cause,
-            TagStreamError::TagsPerResourceExceededLimit(ref cause) => cause,
+            TagStreamError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            TagStreamError::InvalidResourceFormat(ref cause) => write!(f, "{}", cause),
+            TagStreamError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            TagStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagStreamError::TagsPerResourceExceededLimit(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagStreamError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1466,19 +1416,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AccessDenied(ref cause) => cause,
-            UntagResourceError::ClientLimitExceeded(ref cause) => cause,
-            UntagResourceError::InvalidArgument(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UntagStream
 #[derive(Debug, PartialEq)]
 pub enum UntagStreamError {
@@ -1522,20 +1468,16 @@ impl UntagStreamError {
 }
 impl fmt::Display for UntagStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagStreamError {
-    fn description(&self) -> &str {
         match *self {
-            UntagStreamError::ClientLimitExceeded(ref cause) => cause,
-            UntagStreamError::InvalidArgument(ref cause) => cause,
-            UntagStreamError::InvalidResourceFormat(ref cause) => cause,
-            UntagStreamError::NotAuthorized(ref cause) => cause,
-            UntagStreamError::ResourceNotFound(ref cause) => cause,
+            UntagStreamError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UntagStreamError::InvalidResourceFormat(ref cause) => write!(f, "{}", cause),
+            UntagStreamError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UntagStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagStreamError {}
 /// Errors returned by UpdateDataRetention
 #[derive(Debug, PartialEq)]
 pub enum UpdateDataRetentionError {
@@ -1588,21 +1530,17 @@ impl UpdateDataRetentionError {
 }
 impl fmt::Display for UpdateDataRetentionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDataRetentionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDataRetentionError::ClientLimitExceeded(ref cause) => cause,
-            UpdateDataRetentionError::InvalidArgument(ref cause) => cause,
-            UpdateDataRetentionError::NotAuthorized(ref cause) => cause,
-            UpdateDataRetentionError::ResourceInUse(ref cause) => cause,
-            UpdateDataRetentionError::ResourceNotFound(ref cause) => cause,
-            UpdateDataRetentionError::VersionMismatch(ref cause) => cause,
+            UpdateDataRetentionError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDataRetentionError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateDataRetentionError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateDataRetentionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateDataRetentionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDataRetentionError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDataRetentionError {}
 /// Errors returned by UpdateSignalingChannel
 #[derive(Debug, PartialEq)]
 pub enum UpdateSignalingChannelError {
@@ -1661,21 +1599,17 @@ impl UpdateSignalingChannelError {
 }
 impl fmt::Display for UpdateSignalingChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSignalingChannelError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSignalingChannelError::AccessDenied(ref cause) => cause,
-            UpdateSignalingChannelError::ClientLimitExceeded(ref cause) => cause,
-            UpdateSignalingChannelError::InvalidArgument(ref cause) => cause,
-            UpdateSignalingChannelError::ResourceInUse(ref cause) => cause,
-            UpdateSignalingChannelError::ResourceNotFound(ref cause) => cause,
-            UpdateSignalingChannelError::VersionMismatch(ref cause) => cause,
+            UpdateSignalingChannelError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateSignalingChannelError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSignalingChannelError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateSignalingChannelError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateSignalingChannelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateSignalingChannelError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSignalingChannelError {}
 /// Errors returned by UpdateStream
 #[derive(Debug, PartialEq)]
 pub enum UpdateStreamError {
@@ -1724,21 +1658,17 @@ impl UpdateStreamError {
 }
 impl fmt::Display for UpdateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStreamError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStreamError::ClientLimitExceeded(ref cause) => cause,
-            UpdateStreamError::InvalidArgument(ref cause) => cause,
-            UpdateStreamError::NotAuthorized(ref cause) => cause,
-            UpdateStreamError::ResourceInUse(ref cause) => cause,
-            UpdateStreamError::ResourceNotFound(ref cause) => cause,
-            UpdateStreamError::VersionMismatch(ref cause) => cause,
+            UpdateStreamError::ClientLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateStreamError::VersionMismatch(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStreamError {}
 /// Trait representing the capabilities of the Kinesis Video API. Kinesis Video clients implement this trait.
 pub trait KinesisVideo {
     /// <p>Creates a signaling channel. </p> <p> <code>CreateSignalingChannel</code> is an asynchronous operation.</p>

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -1498,20 +1498,16 @@ impl CancelKeyDeletionError {
 }
 impl fmt::Display for CancelKeyDeletionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelKeyDeletionError {
-    fn description(&self) -> &str {
         match *self {
-            CancelKeyDeletionError::DependencyTimeout(ref cause) => cause,
-            CancelKeyDeletionError::InvalidArn(ref cause) => cause,
-            CancelKeyDeletionError::KMSInternal(ref cause) => cause,
-            CancelKeyDeletionError::KMSInvalidState(ref cause) => cause,
-            CancelKeyDeletionError::NotFound(ref cause) => cause,
+            CancelKeyDeletionError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            CancelKeyDeletionError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CancelKeyDeletionError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            CancelKeyDeletionError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            CancelKeyDeletionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelKeyDeletionError {}
 /// Errors returned by ConnectCustomKeyStore
 #[derive(Debug, PartialEq)]
 pub enum ConnectCustomKeyStoreError {
@@ -1563,20 +1559,22 @@ impl ConnectCustomKeyStoreError {
 }
 impl fmt::Display for ConnectCustomKeyStoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConnectCustomKeyStoreError {
-    fn description(&self) -> &str {
         match *self {
-            ConnectCustomKeyStoreError::CloudHsmClusterInvalidConfiguration(ref cause) => cause,
-            ConnectCustomKeyStoreError::CloudHsmClusterNotActive(ref cause) => cause,
-            ConnectCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => cause,
-            ConnectCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => cause,
-            ConnectCustomKeyStoreError::KMSInternal(ref cause) => cause,
+            ConnectCustomKeyStoreError::CloudHsmClusterInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConnectCustomKeyStoreError::CloudHsmClusterNotActive(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConnectCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConnectCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => write!(f, "{}", cause),
+            ConnectCustomKeyStoreError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ConnectCustomKeyStoreError {}
 /// Errors returned by CreateAlias
 #[derive(Debug, PartialEq)]
 pub enum CreateAliasError {
@@ -1630,22 +1628,18 @@ impl CreateAliasError {
 }
 impl fmt::Display for CreateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAliasError::AlreadyExists(ref cause) => cause,
-            CreateAliasError::DependencyTimeout(ref cause) => cause,
-            CreateAliasError::InvalidAliasName(ref cause) => cause,
-            CreateAliasError::KMSInternal(ref cause) => cause,
-            CreateAliasError::KMSInvalidState(ref cause) => cause,
-            CreateAliasError::LimitExceeded(ref cause) => cause,
-            CreateAliasError::NotFound(ref cause) => cause,
+            CreateAliasError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::InvalidAliasName(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAliasError {}
 /// Errors returned by CreateCustomKeyStore
 #[derive(Debug, PartialEq)]
 pub enum CreateCustomKeyStoreError {
@@ -1711,22 +1705,22 @@ impl CreateCustomKeyStoreError {
 }
 impl fmt::Display for CreateCustomKeyStoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCustomKeyStoreError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCustomKeyStoreError::CloudHsmClusterInUse(ref cause) => cause,
-            CreateCustomKeyStoreError::CloudHsmClusterInvalidConfiguration(ref cause) => cause,
-            CreateCustomKeyStoreError::CloudHsmClusterNotActive(ref cause) => cause,
-            CreateCustomKeyStoreError::CloudHsmClusterNotFound(ref cause) => cause,
-            CreateCustomKeyStoreError::CustomKeyStoreNameInUse(ref cause) => cause,
-            CreateCustomKeyStoreError::IncorrectTrustAnchor(ref cause) => cause,
-            CreateCustomKeyStoreError::KMSInternal(ref cause) => cause,
+            CreateCustomKeyStoreError::CloudHsmClusterInUse(ref cause) => write!(f, "{}", cause),
+            CreateCustomKeyStoreError::CloudHsmClusterInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCustomKeyStoreError::CloudHsmClusterNotActive(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCustomKeyStoreError::CloudHsmClusterNotFound(ref cause) => write!(f, "{}", cause),
+            CreateCustomKeyStoreError::CustomKeyStoreNameInUse(ref cause) => write!(f, "{}", cause),
+            CreateCustomKeyStoreError::IncorrectTrustAnchor(ref cause) => write!(f, "{}", cause),
+            CreateCustomKeyStoreError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCustomKeyStoreError {}
 /// Errors returned by CreateGrant
 #[derive(Debug, PartialEq)]
 pub enum CreateGrantError {
@@ -1785,23 +1779,19 @@ impl CreateGrantError {
 }
 impl fmt::Display for CreateGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGrantError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGrantError::DependencyTimeout(ref cause) => cause,
-            CreateGrantError::Disabled(ref cause) => cause,
-            CreateGrantError::InvalidArn(ref cause) => cause,
-            CreateGrantError::InvalidGrantToken(ref cause) => cause,
-            CreateGrantError::KMSInternal(ref cause) => cause,
-            CreateGrantError::KMSInvalidState(ref cause) => cause,
-            CreateGrantError::LimitExceeded(ref cause) => cause,
-            CreateGrantError::NotFound(ref cause) => cause,
+            CreateGrantError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            CreateGrantError::Disabled(ref cause) => write!(f, "{}", cause),
+            CreateGrantError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateGrantError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            CreateGrantError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            CreateGrantError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            CreateGrantError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGrantError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGrantError {}
 /// Errors returned by CreateKey
 #[derive(Debug, PartialEq)]
 pub enum CreateKeyError {
@@ -1872,25 +1862,23 @@ impl CreateKeyError {
 }
 impl fmt::Display for CreateKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateKeyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateKeyError::CloudHsmClusterInvalidConfiguration(ref cause) => cause,
-            CreateKeyError::CustomKeyStoreInvalidState(ref cause) => cause,
-            CreateKeyError::CustomKeyStoreNotFound(ref cause) => cause,
-            CreateKeyError::DependencyTimeout(ref cause) => cause,
-            CreateKeyError::InvalidArn(ref cause) => cause,
-            CreateKeyError::KMSInternal(ref cause) => cause,
-            CreateKeyError::LimitExceeded(ref cause) => cause,
-            CreateKeyError::MalformedPolicyDocument(ref cause) => cause,
-            CreateKeyError::Tag(ref cause) => cause,
-            CreateKeyError::UnsupportedOperation(ref cause) => cause,
+            CreateKeyError::CloudHsmClusterInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateKeyError::CustomKeyStoreInvalidState(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::CustomKeyStoreNotFound(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::Tag(ref cause) => write!(f, "{}", cause),
+            CreateKeyError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateKeyError {}
 /// Errors returned by Decrypt
 #[derive(Debug, PartialEq)]
 pub enum DecryptError {
@@ -1959,25 +1947,21 @@ impl DecryptError {
 }
 impl fmt::Display for DecryptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DecryptError {
-    fn description(&self) -> &str {
         match *self {
-            DecryptError::DependencyTimeout(ref cause) => cause,
-            DecryptError::Disabled(ref cause) => cause,
-            DecryptError::IncorrectKey(ref cause) => cause,
-            DecryptError::InvalidCiphertext(ref cause) => cause,
-            DecryptError::InvalidGrantToken(ref cause) => cause,
-            DecryptError::InvalidKeyUsage(ref cause) => cause,
-            DecryptError::KMSInternal(ref cause) => cause,
-            DecryptError::KMSInvalidState(ref cause) => cause,
-            DecryptError::KeyUnavailable(ref cause) => cause,
-            DecryptError::NotFound(ref cause) => cause,
+            DecryptError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            DecryptError::Disabled(ref cause) => write!(f, "{}", cause),
+            DecryptError::IncorrectKey(ref cause) => write!(f, "{}", cause),
+            DecryptError::InvalidCiphertext(ref cause) => write!(f, "{}", cause),
+            DecryptError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            DecryptError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            DecryptError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            DecryptError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            DecryptError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            DecryptError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DecryptError {}
 /// Errors returned by DeleteAlias
 #[derive(Debug, PartialEq)]
 pub enum DeleteAliasError {
@@ -2016,19 +2000,15 @@ impl DeleteAliasError {
 }
 impl fmt::Display for DeleteAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAliasError::DependencyTimeout(ref cause) => cause,
-            DeleteAliasError::KMSInternal(ref cause) => cause,
-            DeleteAliasError::KMSInvalidState(ref cause) => cause,
-            DeleteAliasError::NotFound(ref cause) => cause,
+            DeleteAliasError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAliasError {}
 /// Errors returned by DeleteCustomKeyStore
 #[derive(Debug, PartialEq)]
 pub enum DeleteCustomKeyStoreError {
@@ -2073,19 +2053,17 @@ impl DeleteCustomKeyStoreError {
 }
 impl fmt::Display for DeleteCustomKeyStoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCustomKeyStoreError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCustomKeyStoreError::CustomKeyStoreHasCMKs(ref cause) => cause,
-            DeleteCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => cause,
-            DeleteCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => cause,
-            DeleteCustomKeyStoreError::KMSInternal(ref cause) => cause,
+            DeleteCustomKeyStoreError::CustomKeyStoreHasCMKs(ref cause) => write!(f, "{}", cause),
+            DeleteCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCustomKeyStoreError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCustomKeyStoreError {}
 /// Errors returned by DeleteImportedKeyMaterial
 #[derive(Debug, PartialEq)]
 pub enum DeleteImportedKeyMaterialError {
@@ -2144,21 +2122,19 @@ impl DeleteImportedKeyMaterialError {
 }
 impl fmt::Display for DeleteImportedKeyMaterialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteImportedKeyMaterialError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteImportedKeyMaterialError::DependencyTimeout(ref cause) => cause,
-            DeleteImportedKeyMaterialError::InvalidArn(ref cause) => cause,
-            DeleteImportedKeyMaterialError::KMSInternal(ref cause) => cause,
-            DeleteImportedKeyMaterialError::KMSInvalidState(ref cause) => cause,
-            DeleteImportedKeyMaterialError::NotFound(ref cause) => cause,
-            DeleteImportedKeyMaterialError::UnsupportedOperation(ref cause) => cause,
+            DeleteImportedKeyMaterialError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteImportedKeyMaterialError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DeleteImportedKeyMaterialError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            DeleteImportedKeyMaterialError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            DeleteImportedKeyMaterialError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteImportedKeyMaterialError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteImportedKeyMaterialError {}
 /// Errors returned by DescribeCustomKeyStores
 #[derive(Debug, PartialEq)]
 pub enum DescribeCustomKeyStoresError {
@@ -2189,17 +2165,15 @@ impl DescribeCustomKeyStoresError {
 }
 impl fmt::Display for DescribeCustomKeyStoresError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCustomKeyStoresError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCustomKeyStoresError::CustomKeyStoreNotFound(ref cause) => cause,
-            DescribeCustomKeyStoresError::KMSInternal(ref cause) => cause,
+            DescribeCustomKeyStoresError::CustomKeyStoreNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCustomKeyStoresError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCustomKeyStoresError {}
 /// Errors returned by DescribeKey
 #[derive(Debug, PartialEq)]
 pub enum DescribeKeyError {
@@ -2238,19 +2212,15 @@ impl DescribeKeyError {
 }
 impl fmt::Display for DescribeKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeKeyError::DependencyTimeout(ref cause) => cause,
-            DescribeKeyError::InvalidArn(ref cause) => cause,
-            DescribeKeyError::KMSInternal(ref cause) => cause,
-            DescribeKeyError::NotFound(ref cause) => cause,
+            DescribeKeyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeKeyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DescribeKeyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            DescribeKeyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeKeyError {}
 /// Errors returned by DisableKey
 #[derive(Debug, PartialEq)]
 pub enum DisableKeyError {
@@ -2294,20 +2264,16 @@ impl DisableKeyError {
 }
 impl fmt::Display for DisableKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DisableKeyError::DependencyTimeout(ref cause) => cause,
-            DisableKeyError::InvalidArn(ref cause) => cause,
-            DisableKeyError::KMSInternal(ref cause) => cause,
-            DisableKeyError::KMSInvalidState(ref cause) => cause,
-            DisableKeyError::NotFound(ref cause) => cause,
+            DisableKeyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            DisableKeyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DisableKeyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            DisableKeyError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            DisableKeyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableKeyError {}
 /// Errors returned by DisableKeyRotation
 #[derive(Debug, PartialEq)]
 pub enum DisableKeyRotationError {
@@ -2365,22 +2331,18 @@ impl DisableKeyRotationError {
 }
 impl fmt::Display for DisableKeyRotationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableKeyRotationError {
-    fn description(&self) -> &str {
         match *self {
-            DisableKeyRotationError::DependencyTimeout(ref cause) => cause,
-            DisableKeyRotationError::Disabled(ref cause) => cause,
-            DisableKeyRotationError::InvalidArn(ref cause) => cause,
-            DisableKeyRotationError::KMSInternal(ref cause) => cause,
-            DisableKeyRotationError::KMSInvalidState(ref cause) => cause,
-            DisableKeyRotationError::NotFound(ref cause) => cause,
-            DisableKeyRotationError::UnsupportedOperation(ref cause) => cause,
+            DisableKeyRotationError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            DisableKeyRotationError::Disabled(ref cause) => write!(f, "{}", cause),
+            DisableKeyRotationError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DisableKeyRotationError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            DisableKeyRotationError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            DisableKeyRotationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DisableKeyRotationError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableKeyRotationError {}
 /// Errors returned by DisconnectCustomKeyStore
 #[derive(Debug, PartialEq)]
 pub enum DisconnectCustomKeyStoreError {
@@ -2420,18 +2382,18 @@ impl DisconnectCustomKeyStoreError {
 }
 impl fmt::Display for DisconnectCustomKeyStoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisconnectCustomKeyStoreError {
-    fn description(&self) -> &str {
         match *self {
-            DisconnectCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => cause,
-            DisconnectCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => cause,
-            DisconnectCustomKeyStoreError::KMSInternal(ref cause) => cause,
+            DisconnectCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisconnectCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisconnectCustomKeyStoreError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisconnectCustomKeyStoreError {}
 /// Errors returned by EnableKey
 #[derive(Debug, PartialEq)]
 pub enum EnableKeyError {
@@ -2480,21 +2442,17 @@ impl EnableKeyError {
 }
 impl fmt::Display for EnableKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableKeyError {
-    fn description(&self) -> &str {
         match *self {
-            EnableKeyError::DependencyTimeout(ref cause) => cause,
-            EnableKeyError::InvalidArn(ref cause) => cause,
-            EnableKeyError::KMSInternal(ref cause) => cause,
-            EnableKeyError::KMSInvalidState(ref cause) => cause,
-            EnableKeyError::LimitExceeded(ref cause) => cause,
-            EnableKeyError::NotFound(ref cause) => cause,
+            EnableKeyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            EnableKeyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            EnableKeyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            EnableKeyError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            EnableKeyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            EnableKeyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableKeyError {}
 /// Errors returned by EnableKeyRotation
 #[derive(Debug, PartialEq)]
 pub enum EnableKeyRotationError {
@@ -2550,22 +2508,18 @@ impl EnableKeyRotationError {
 }
 impl fmt::Display for EnableKeyRotationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableKeyRotationError {
-    fn description(&self) -> &str {
         match *self {
-            EnableKeyRotationError::DependencyTimeout(ref cause) => cause,
-            EnableKeyRotationError::Disabled(ref cause) => cause,
-            EnableKeyRotationError::InvalidArn(ref cause) => cause,
-            EnableKeyRotationError::KMSInternal(ref cause) => cause,
-            EnableKeyRotationError::KMSInvalidState(ref cause) => cause,
-            EnableKeyRotationError::NotFound(ref cause) => cause,
-            EnableKeyRotationError::UnsupportedOperation(ref cause) => cause,
+            EnableKeyRotationError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            EnableKeyRotationError::Disabled(ref cause) => write!(f, "{}", cause),
+            EnableKeyRotationError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            EnableKeyRotationError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            EnableKeyRotationError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            EnableKeyRotationError::NotFound(ref cause) => write!(f, "{}", cause),
+            EnableKeyRotationError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableKeyRotationError {}
 /// Errors returned by Encrypt
 #[derive(Debug, PartialEq)]
 pub enum EncryptError {
@@ -2624,23 +2578,19 @@ impl EncryptError {
 }
 impl fmt::Display for EncryptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EncryptError {
-    fn description(&self) -> &str {
         match *self {
-            EncryptError::DependencyTimeout(ref cause) => cause,
-            EncryptError::Disabled(ref cause) => cause,
-            EncryptError::InvalidGrantToken(ref cause) => cause,
-            EncryptError::InvalidKeyUsage(ref cause) => cause,
-            EncryptError::KMSInternal(ref cause) => cause,
-            EncryptError::KMSInvalidState(ref cause) => cause,
-            EncryptError::KeyUnavailable(ref cause) => cause,
-            EncryptError::NotFound(ref cause) => cause,
+            EncryptError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            EncryptError::Disabled(ref cause) => write!(f, "{}", cause),
+            EncryptError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            EncryptError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            EncryptError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            EncryptError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            EncryptError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            EncryptError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EncryptError {}
 /// Errors returned by GenerateDataKey
 #[derive(Debug, PartialEq)]
 pub enum GenerateDataKeyError {
@@ -2699,23 +2649,19 @@ impl GenerateDataKeyError {
 }
 impl fmt::Display for GenerateDataKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateDataKeyError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateDataKeyError::DependencyTimeout(ref cause) => cause,
-            GenerateDataKeyError::Disabled(ref cause) => cause,
-            GenerateDataKeyError::InvalidGrantToken(ref cause) => cause,
-            GenerateDataKeyError::InvalidKeyUsage(ref cause) => cause,
-            GenerateDataKeyError::KMSInternal(ref cause) => cause,
-            GenerateDataKeyError::KMSInvalidState(ref cause) => cause,
-            GenerateDataKeyError::KeyUnavailable(ref cause) => cause,
-            GenerateDataKeyError::NotFound(ref cause) => cause,
+            GenerateDataKeyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyError::Disabled(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateDataKeyError {}
 /// Errors returned by GenerateDataKeyPair
 #[derive(Debug, PartialEq)]
 pub enum GenerateDataKeyPairError {
@@ -2778,23 +2724,19 @@ impl GenerateDataKeyPairError {
 }
 impl fmt::Display for GenerateDataKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateDataKeyPairError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateDataKeyPairError::DependencyTimeout(ref cause) => cause,
-            GenerateDataKeyPairError::Disabled(ref cause) => cause,
-            GenerateDataKeyPairError::InvalidGrantToken(ref cause) => cause,
-            GenerateDataKeyPairError::InvalidKeyUsage(ref cause) => cause,
-            GenerateDataKeyPairError::KMSInternal(ref cause) => cause,
-            GenerateDataKeyPairError::KMSInvalidState(ref cause) => cause,
-            GenerateDataKeyPairError::KeyUnavailable(ref cause) => cause,
-            GenerateDataKeyPairError::NotFound(ref cause) => cause,
+            GenerateDataKeyPairError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairError::Disabled(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateDataKeyPairError {}
 /// Errors returned by GenerateDataKeyPairWithoutPlaintext
 #[derive(Debug, PartialEq)]
 pub enum GenerateDataKeyPairWithoutPlaintextError {
@@ -2871,23 +2813,31 @@ impl GenerateDataKeyPairWithoutPlaintextError {
 }
 impl fmt::Display for GenerateDataKeyPairWithoutPlaintextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateDataKeyPairWithoutPlaintextError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateDataKeyPairWithoutPlaintextError::DependencyTimeout(ref cause) => cause,
-            GenerateDataKeyPairWithoutPlaintextError::Disabled(ref cause) => cause,
-            GenerateDataKeyPairWithoutPlaintextError::InvalidGrantToken(ref cause) => cause,
-            GenerateDataKeyPairWithoutPlaintextError::InvalidKeyUsage(ref cause) => cause,
-            GenerateDataKeyPairWithoutPlaintextError::KMSInternal(ref cause) => cause,
-            GenerateDataKeyPairWithoutPlaintextError::KMSInvalidState(ref cause) => cause,
-            GenerateDataKeyPairWithoutPlaintextError::KeyUnavailable(ref cause) => cause,
-            GenerateDataKeyPairWithoutPlaintextError::NotFound(ref cause) => cause,
+            GenerateDataKeyPairWithoutPlaintextError::DependencyTimeout(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyPairWithoutPlaintextError::Disabled(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyPairWithoutPlaintextError::InvalidGrantToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyPairWithoutPlaintextError::InvalidKeyUsage(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyPairWithoutPlaintextError::KMSInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyPairWithoutPlaintextError::KMSInvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyPairWithoutPlaintextError::KeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyPairWithoutPlaintextError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateDataKeyPairWithoutPlaintextError {}
 /// Errors returned by GenerateDataKeyWithoutPlaintext
 #[derive(Debug, PartialEq)]
 pub enum GenerateDataKeyWithoutPlaintextError {
@@ -2964,23 +2914,29 @@ impl GenerateDataKeyWithoutPlaintextError {
 }
 impl fmt::Display for GenerateDataKeyWithoutPlaintextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateDataKeyWithoutPlaintextError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateDataKeyWithoutPlaintextError::DependencyTimeout(ref cause) => cause,
-            GenerateDataKeyWithoutPlaintextError::Disabled(ref cause) => cause,
-            GenerateDataKeyWithoutPlaintextError::InvalidGrantToken(ref cause) => cause,
-            GenerateDataKeyWithoutPlaintextError::InvalidKeyUsage(ref cause) => cause,
-            GenerateDataKeyWithoutPlaintextError::KMSInternal(ref cause) => cause,
-            GenerateDataKeyWithoutPlaintextError::KMSInvalidState(ref cause) => cause,
-            GenerateDataKeyWithoutPlaintextError::KeyUnavailable(ref cause) => cause,
-            GenerateDataKeyWithoutPlaintextError::NotFound(ref cause) => cause,
+            GenerateDataKeyWithoutPlaintextError::DependencyTimeout(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyWithoutPlaintextError::Disabled(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyWithoutPlaintextError::InvalidGrantToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyWithoutPlaintextError::InvalidKeyUsage(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyWithoutPlaintextError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            GenerateDataKeyWithoutPlaintextError::KMSInvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyWithoutPlaintextError::KeyUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GenerateDataKeyWithoutPlaintextError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateDataKeyWithoutPlaintextError {}
 /// Errors returned by GenerateRandom
 #[derive(Debug, PartialEq)]
 pub enum GenerateRandomError {
@@ -3023,19 +2979,15 @@ impl GenerateRandomError {
 }
 impl fmt::Display for GenerateRandomError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateRandomError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateRandomError::CustomKeyStoreInvalidState(ref cause) => cause,
-            GenerateRandomError::CustomKeyStoreNotFound(ref cause) => cause,
-            GenerateRandomError::DependencyTimeout(ref cause) => cause,
-            GenerateRandomError::KMSInternal(ref cause) => cause,
+            GenerateRandomError::CustomKeyStoreInvalidState(ref cause) => write!(f, "{}", cause),
+            GenerateRandomError::CustomKeyStoreNotFound(ref cause) => write!(f, "{}", cause),
+            GenerateRandomError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            GenerateRandomError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateRandomError {}
 /// Errors returned by GetKeyPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetKeyPolicyError {
@@ -3079,20 +3031,16 @@ impl GetKeyPolicyError {
 }
 impl fmt::Display for GetKeyPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetKeyPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetKeyPolicyError::DependencyTimeout(ref cause) => cause,
-            GetKeyPolicyError::InvalidArn(ref cause) => cause,
-            GetKeyPolicyError::KMSInternal(ref cause) => cause,
-            GetKeyPolicyError::KMSInvalidState(ref cause) => cause,
-            GetKeyPolicyError::NotFound(ref cause) => cause,
+            GetKeyPolicyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            GetKeyPolicyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetKeyPolicyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            GetKeyPolicyError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            GetKeyPolicyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetKeyPolicyError {}
 /// Errors returned by GetKeyRotationStatus
 #[derive(Debug, PartialEq)]
 pub enum GetKeyRotationStatusError {
@@ -3147,21 +3095,17 @@ impl GetKeyRotationStatusError {
 }
 impl fmt::Display for GetKeyRotationStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetKeyRotationStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetKeyRotationStatusError::DependencyTimeout(ref cause) => cause,
-            GetKeyRotationStatusError::InvalidArn(ref cause) => cause,
-            GetKeyRotationStatusError::KMSInternal(ref cause) => cause,
-            GetKeyRotationStatusError::KMSInvalidState(ref cause) => cause,
-            GetKeyRotationStatusError::NotFound(ref cause) => cause,
-            GetKeyRotationStatusError::UnsupportedOperation(ref cause) => cause,
+            GetKeyRotationStatusError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            GetKeyRotationStatusError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetKeyRotationStatusError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            GetKeyRotationStatusError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            GetKeyRotationStatusError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetKeyRotationStatusError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetKeyRotationStatusError {}
 /// Errors returned by GetParametersForImport
 #[derive(Debug, PartialEq)]
 pub enum GetParametersForImportError {
@@ -3216,21 +3160,17 @@ impl GetParametersForImportError {
 }
 impl fmt::Display for GetParametersForImportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetParametersForImportError {
-    fn description(&self) -> &str {
         match *self {
-            GetParametersForImportError::DependencyTimeout(ref cause) => cause,
-            GetParametersForImportError::InvalidArn(ref cause) => cause,
-            GetParametersForImportError::KMSInternal(ref cause) => cause,
-            GetParametersForImportError::KMSInvalidState(ref cause) => cause,
-            GetParametersForImportError::NotFound(ref cause) => cause,
-            GetParametersForImportError::UnsupportedOperation(ref cause) => cause,
+            GetParametersForImportError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            GetParametersForImportError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetParametersForImportError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            GetParametersForImportError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            GetParametersForImportError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetParametersForImportError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetParametersForImportError {}
 /// Errors returned by GetPublicKey
 #[derive(Debug, PartialEq)]
 pub enum GetPublicKeyError {
@@ -3299,25 +3239,21 @@ impl GetPublicKeyError {
 }
 impl fmt::Display for GetPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPublicKeyError::DependencyTimeout(ref cause) => cause,
-            GetPublicKeyError::Disabled(ref cause) => cause,
-            GetPublicKeyError::InvalidArn(ref cause) => cause,
-            GetPublicKeyError::InvalidGrantToken(ref cause) => cause,
-            GetPublicKeyError::InvalidKeyUsage(ref cause) => cause,
-            GetPublicKeyError::KMSInternal(ref cause) => cause,
-            GetPublicKeyError::KMSInvalidState(ref cause) => cause,
-            GetPublicKeyError::KeyUnavailable(ref cause) => cause,
-            GetPublicKeyError::NotFound(ref cause) => cause,
-            GetPublicKeyError::UnsupportedOperation(ref cause) => cause,
+            GetPublicKeyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::Disabled(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetPublicKeyError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPublicKeyError {}
 /// Errors returned by ImportKeyMaterial
 #[derive(Debug, PartialEq)]
 pub enum ImportKeyMaterialError {
@@ -3394,25 +3330,21 @@ impl ImportKeyMaterialError {
 }
 impl fmt::Display for ImportKeyMaterialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportKeyMaterialError {
-    fn description(&self) -> &str {
         match *self {
-            ImportKeyMaterialError::DependencyTimeout(ref cause) => cause,
-            ImportKeyMaterialError::ExpiredImportToken(ref cause) => cause,
-            ImportKeyMaterialError::IncorrectKeyMaterial(ref cause) => cause,
-            ImportKeyMaterialError::InvalidArn(ref cause) => cause,
-            ImportKeyMaterialError::InvalidCiphertext(ref cause) => cause,
-            ImportKeyMaterialError::InvalidImportToken(ref cause) => cause,
-            ImportKeyMaterialError::KMSInternal(ref cause) => cause,
-            ImportKeyMaterialError::KMSInvalidState(ref cause) => cause,
-            ImportKeyMaterialError::NotFound(ref cause) => cause,
-            ImportKeyMaterialError::UnsupportedOperation(ref cause) => cause,
+            ImportKeyMaterialError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::ExpiredImportToken(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::IncorrectKeyMaterial(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::InvalidCiphertext(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::InvalidImportToken(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::NotFound(ref cause) => write!(f, "{}", cause),
+            ImportKeyMaterialError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportKeyMaterialError {}
 /// Errors returned by ListAliases
 #[derive(Debug, PartialEq)]
 pub enum ListAliasesError {
@@ -3456,20 +3388,16 @@ impl ListAliasesError {
 }
 impl fmt::Display for ListAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAliasesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAliasesError::DependencyTimeout(ref cause) => cause,
-            ListAliasesError::InvalidArn(ref cause) => cause,
-            ListAliasesError::InvalidMarker(ref cause) => cause,
-            ListAliasesError::KMSInternal(ref cause) => cause,
-            ListAliasesError::NotFound(ref cause) => cause,
+            ListAliasesError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::InvalidMarker(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAliasesError {}
 /// Errors returned by ListGrants
 #[derive(Debug, PartialEq)]
 pub enum ListGrantsError {
@@ -3518,21 +3446,17 @@ impl ListGrantsError {
 }
 impl fmt::Display for ListGrantsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGrantsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGrantsError::DependencyTimeout(ref cause) => cause,
-            ListGrantsError::InvalidArn(ref cause) => cause,
-            ListGrantsError::InvalidMarker(ref cause) => cause,
-            ListGrantsError::KMSInternal(ref cause) => cause,
-            ListGrantsError::KMSInvalidState(ref cause) => cause,
-            ListGrantsError::NotFound(ref cause) => cause,
+            ListGrantsError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ListGrantsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListGrantsError::InvalidMarker(ref cause) => write!(f, "{}", cause),
+            ListGrantsError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ListGrantsError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            ListGrantsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGrantsError {}
 /// Errors returned by ListKeyPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListKeyPoliciesError {
@@ -3576,20 +3500,16 @@ impl ListKeyPoliciesError {
 }
 impl fmt::Display for ListKeyPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListKeyPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListKeyPoliciesError::DependencyTimeout(ref cause) => cause,
-            ListKeyPoliciesError::InvalidArn(ref cause) => cause,
-            ListKeyPoliciesError::KMSInternal(ref cause) => cause,
-            ListKeyPoliciesError::KMSInvalidState(ref cause) => cause,
-            ListKeyPoliciesError::NotFound(ref cause) => cause,
+            ListKeyPoliciesError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ListKeyPoliciesError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListKeyPoliciesError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ListKeyPoliciesError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            ListKeyPoliciesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListKeyPoliciesError {}
 /// Errors returned by ListKeys
 #[derive(Debug, PartialEq)]
 pub enum ListKeysError {
@@ -3623,18 +3543,14 @@ impl ListKeysError {
 }
 impl fmt::Display for ListKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListKeysError {
-    fn description(&self) -> &str {
         match *self {
-            ListKeysError::DependencyTimeout(ref cause) => cause,
-            ListKeysError::InvalidMarker(ref cause) => cause,
-            ListKeysError::KMSInternal(ref cause) => cause,
+            ListKeysError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ListKeysError::InvalidMarker(ref cause) => write!(f, "{}", cause),
+            ListKeysError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListKeysError {}
 /// Errors returned by ListResourceTags
 #[derive(Debug, PartialEq)]
 pub enum ListResourceTagsError {
@@ -3673,19 +3589,15 @@ impl ListResourceTagsError {
 }
 impl fmt::Display for ListResourceTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceTagsError::InvalidArn(ref cause) => cause,
-            ListResourceTagsError::InvalidMarker(ref cause) => cause,
-            ListResourceTagsError::KMSInternal(ref cause) => cause,
-            ListResourceTagsError::NotFound(ref cause) => cause,
+            ListResourceTagsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListResourceTagsError::InvalidMarker(ref cause) => write!(f, "{}", cause),
+            ListResourceTagsError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ListResourceTagsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourceTagsError {}
 /// Errors returned by ListRetirableGrants
 #[derive(Debug, PartialEq)]
 pub enum ListRetirableGrantsError {
@@ -3731,20 +3643,16 @@ impl ListRetirableGrantsError {
 }
 impl fmt::Display for ListRetirableGrantsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRetirableGrantsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRetirableGrantsError::DependencyTimeout(ref cause) => cause,
-            ListRetirableGrantsError::InvalidArn(ref cause) => cause,
-            ListRetirableGrantsError::InvalidMarker(ref cause) => cause,
-            ListRetirableGrantsError::KMSInternal(ref cause) => cause,
-            ListRetirableGrantsError::NotFound(ref cause) => cause,
+            ListRetirableGrantsError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ListRetirableGrantsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListRetirableGrantsError::InvalidMarker(ref cause) => write!(f, "{}", cause),
+            ListRetirableGrantsError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ListRetirableGrantsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRetirableGrantsError {}
 /// Errors returned by PutKeyPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutKeyPolicyError {
@@ -3805,23 +3713,19 @@ impl PutKeyPolicyError {
 }
 impl fmt::Display for PutKeyPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutKeyPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutKeyPolicyError::DependencyTimeout(ref cause) => cause,
-            PutKeyPolicyError::InvalidArn(ref cause) => cause,
-            PutKeyPolicyError::KMSInternal(ref cause) => cause,
-            PutKeyPolicyError::KMSInvalidState(ref cause) => cause,
-            PutKeyPolicyError::LimitExceeded(ref cause) => cause,
-            PutKeyPolicyError::MalformedPolicyDocument(ref cause) => cause,
-            PutKeyPolicyError::NotFound(ref cause) => cause,
-            PutKeyPolicyError::UnsupportedOperation(ref cause) => cause,
+            PutKeyPolicyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            PutKeyPolicyError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            PutKeyPolicyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            PutKeyPolicyError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            PutKeyPolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutKeyPolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            PutKeyPolicyError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutKeyPolicyError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutKeyPolicyError {}
 /// Errors returned by ReEncrypt
 #[derive(Debug, PartialEq)]
 pub enum ReEncryptError {
@@ -3890,25 +3794,21 @@ impl ReEncryptError {
 }
 impl fmt::Display for ReEncryptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReEncryptError {
-    fn description(&self) -> &str {
         match *self {
-            ReEncryptError::DependencyTimeout(ref cause) => cause,
-            ReEncryptError::Disabled(ref cause) => cause,
-            ReEncryptError::IncorrectKey(ref cause) => cause,
-            ReEncryptError::InvalidCiphertext(ref cause) => cause,
-            ReEncryptError::InvalidGrantToken(ref cause) => cause,
-            ReEncryptError::InvalidKeyUsage(ref cause) => cause,
-            ReEncryptError::KMSInternal(ref cause) => cause,
-            ReEncryptError::KMSInvalidState(ref cause) => cause,
-            ReEncryptError::KeyUnavailable(ref cause) => cause,
-            ReEncryptError::NotFound(ref cause) => cause,
+            ReEncryptError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::Disabled(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::IncorrectKey(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::InvalidCiphertext(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            ReEncryptError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReEncryptError {}
 /// Errors returned by RetireGrant
 #[derive(Debug, PartialEq)]
 pub enum RetireGrantError {
@@ -3962,22 +3862,18 @@ impl RetireGrantError {
 }
 impl fmt::Display for RetireGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RetireGrantError {
-    fn description(&self) -> &str {
         match *self {
-            RetireGrantError::DependencyTimeout(ref cause) => cause,
-            RetireGrantError::InvalidArn(ref cause) => cause,
-            RetireGrantError::InvalidGrantId(ref cause) => cause,
-            RetireGrantError::InvalidGrantToken(ref cause) => cause,
-            RetireGrantError::KMSInternal(ref cause) => cause,
-            RetireGrantError::KMSInvalidState(ref cause) => cause,
-            RetireGrantError::NotFound(ref cause) => cause,
+            RetireGrantError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            RetireGrantError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RetireGrantError::InvalidGrantId(ref cause) => write!(f, "{}", cause),
+            RetireGrantError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            RetireGrantError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            RetireGrantError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            RetireGrantError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RetireGrantError {}
 /// Errors returned by RevokeGrant
 #[derive(Debug, PartialEq)]
 pub enum RevokeGrantError {
@@ -4026,21 +3922,17 @@ impl RevokeGrantError {
 }
 impl fmt::Display for RevokeGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeGrantError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeGrantError::DependencyTimeout(ref cause) => cause,
-            RevokeGrantError::InvalidArn(ref cause) => cause,
-            RevokeGrantError::InvalidGrantId(ref cause) => cause,
-            RevokeGrantError::KMSInternal(ref cause) => cause,
-            RevokeGrantError::KMSInvalidState(ref cause) => cause,
-            RevokeGrantError::NotFound(ref cause) => cause,
+            RevokeGrantError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            RevokeGrantError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            RevokeGrantError::InvalidGrantId(ref cause) => write!(f, "{}", cause),
+            RevokeGrantError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            RevokeGrantError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            RevokeGrantError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RevokeGrantError {}
 /// Errors returned by ScheduleKeyDeletion
 #[derive(Debug, PartialEq)]
 pub enum ScheduleKeyDeletionError {
@@ -4086,20 +3978,16 @@ impl ScheduleKeyDeletionError {
 }
 impl fmt::Display for ScheduleKeyDeletionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ScheduleKeyDeletionError {
-    fn description(&self) -> &str {
         match *self {
-            ScheduleKeyDeletionError::DependencyTimeout(ref cause) => cause,
-            ScheduleKeyDeletionError::InvalidArn(ref cause) => cause,
-            ScheduleKeyDeletionError::KMSInternal(ref cause) => cause,
-            ScheduleKeyDeletionError::KMSInvalidState(ref cause) => cause,
-            ScheduleKeyDeletionError::NotFound(ref cause) => cause,
+            ScheduleKeyDeletionError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            ScheduleKeyDeletionError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ScheduleKeyDeletionError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            ScheduleKeyDeletionError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            ScheduleKeyDeletionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ScheduleKeyDeletionError {}
 /// Errors returned by Sign
 #[derive(Debug, PartialEq)]
 pub enum SignError {
@@ -4149,22 +4037,18 @@ impl SignError {
 }
 impl fmt::Display for SignError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SignError {
-    fn description(&self) -> &str {
         match *self {
-            SignError::DependencyTimeout(ref cause) => cause,
-            SignError::Disabled(ref cause) => cause,
-            SignError::InvalidGrantToken(ref cause) => cause,
-            SignError::InvalidKeyUsage(ref cause) => cause,
-            SignError::KMSInternal(ref cause) => cause,
-            SignError::KeyUnavailable(ref cause) => cause,
-            SignError::NotFound(ref cause) => cause,
+            SignError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            SignError::Disabled(ref cause) => write!(f, "{}", cause),
+            SignError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            SignError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            SignError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            SignError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            SignError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SignError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -4211,21 +4095,17 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidArn(ref cause) => cause,
-            TagResourceError::KMSInternal(ref cause) => cause,
-            TagResourceError::KMSInvalidState(ref cause) => cause,
-            TagResourceError::LimitExceeded(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::Tag(ref cause) => cause,
+            TagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            TagResourceError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            TagResourceError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            TagResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Tag(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -4267,20 +4147,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InvalidArn(ref cause) => cause,
-            UntagResourceError::KMSInternal(ref cause) => cause,
-            UntagResourceError::KMSInvalidState(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::Tag(ref cause) => cause,
+            UntagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Tag(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateAlias
 #[derive(Debug, PartialEq)]
 pub enum UpdateAliasError {
@@ -4319,19 +4195,15 @@ impl UpdateAliasError {
 }
 impl fmt::Display for UpdateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAliasError::DependencyTimeout(ref cause) => cause,
-            UpdateAliasError::KMSInternal(ref cause) => cause,
-            UpdateAliasError::KMSInvalidState(ref cause) => cause,
-            UpdateAliasError::NotFound(ref cause) => cause,
+            UpdateAliasError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAliasError {}
 /// Errors returned by UpdateCustomKeyStore
 #[derive(Debug, PartialEq)]
 pub enum UpdateCustomKeyStoreError {
@@ -4404,23 +4276,27 @@ impl UpdateCustomKeyStoreError {
 }
 impl fmt::Display for UpdateCustomKeyStoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCustomKeyStoreError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCustomKeyStoreError::CloudHsmClusterInvalidConfiguration(ref cause) => cause,
-            UpdateCustomKeyStoreError::CloudHsmClusterNotActive(ref cause) => cause,
-            UpdateCustomKeyStoreError::CloudHsmClusterNotFound(ref cause) => cause,
-            UpdateCustomKeyStoreError::CloudHsmClusterNotRelated(ref cause) => cause,
-            UpdateCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => cause,
-            UpdateCustomKeyStoreError::CustomKeyStoreNameInUse(ref cause) => cause,
-            UpdateCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => cause,
-            UpdateCustomKeyStoreError::KMSInternal(ref cause) => cause,
+            UpdateCustomKeyStoreError::CloudHsmClusterInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCustomKeyStoreError::CloudHsmClusterNotActive(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCustomKeyStoreError::CloudHsmClusterNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateCustomKeyStoreError::CloudHsmClusterNotRelated(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCustomKeyStoreError::CustomKeyStoreInvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCustomKeyStoreError::CustomKeyStoreNameInUse(ref cause) => write!(f, "{}", cause),
+            UpdateCustomKeyStoreError::CustomKeyStoreNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateCustomKeyStoreError::KMSInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateCustomKeyStoreError {}
 /// Errors returned by UpdateKeyDescription
 #[derive(Debug, PartialEq)]
 pub enum UpdateKeyDescriptionError {
@@ -4468,20 +4344,16 @@ impl UpdateKeyDescriptionError {
 }
 impl fmt::Display for UpdateKeyDescriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateKeyDescriptionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateKeyDescriptionError::DependencyTimeout(ref cause) => cause,
-            UpdateKeyDescriptionError::InvalidArn(ref cause) => cause,
-            UpdateKeyDescriptionError::KMSInternal(ref cause) => cause,
-            UpdateKeyDescriptionError::KMSInvalidState(ref cause) => cause,
-            UpdateKeyDescriptionError::NotFound(ref cause) => cause,
+            UpdateKeyDescriptionError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateKeyDescriptionError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateKeyDescriptionError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            UpdateKeyDescriptionError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            UpdateKeyDescriptionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateKeyDescriptionError {}
 /// Errors returned by Verify
 #[derive(Debug, PartialEq)]
 pub enum VerifyError {
@@ -4531,22 +4403,18 @@ impl VerifyError {
 }
 impl fmt::Display for VerifyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifyError {
-    fn description(&self) -> &str {
         match *self {
-            VerifyError::DependencyTimeout(ref cause) => cause,
-            VerifyError::Disabled(ref cause) => cause,
-            VerifyError::InvalidGrantToken(ref cause) => cause,
-            VerifyError::InvalidKeyUsage(ref cause) => cause,
-            VerifyError::KMSInternal(ref cause) => cause,
-            VerifyError::KeyUnavailable(ref cause) => cause,
-            VerifyError::NotFound(ref cause) => cause,
+            VerifyError::DependencyTimeout(ref cause) => write!(f, "{}", cause),
+            VerifyError::Disabled(ref cause) => write!(f, "{}", cause),
+            VerifyError::InvalidGrantToken(ref cause) => write!(f, "{}", cause),
+            VerifyError::InvalidKeyUsage(ref cause) => write!(f, "{}", cause),
+            VerifyError::KMSInternal(ref cause) => write!(f, "{}", cause),
+            VerifyError::KeyUnavailable(ref cause) => write!(f, "{}", cause),
+            VerifyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for VerifyError {}
 /// Trait representing the capabilities of the KMS API. KMS clients implement this trait.
 pub trait Kms {
     /// <p>Cancels the deletion of a customer master key (CMK). When this operation succeeds, the key state of the CMK is <code>Disabled</code>. To enable the CMK, use <a>EnableKey</a>. You cannot perform this operation on a CMK in a different AWS account.</p> <p>For more information about scheduling and canceling deletion of a CMK, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html">Deleting Customer Master Keys</a> in the <i>AWS Key Management Service Developer Guide</i>.</p> <p>The CMK that you use for this operation must be in a compatible key state. For details, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -1939,22 +1939,22 @@ impl AddLayerVersionPermissionError {
 }
 impl fmt::Display for AddLayerVersionPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddLayerVersionPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            AddLayerVersionPermissionError::InvalidParameterValue(ref cause) => cause,
-            AddLayerVersionPermissionError::PolicyLengthExceeded(ref cause) => cause,
-            AddLayerVersionPermissionError::PreconditionFailed(ref cause) => cause,
-            AddLayerVersionPermissionError::ResourceConflict(ref cause) => cause,
-            AddLayerVersionPermissionError::ResourceNotFound(ref cause) => cause,
-            AddLayerVersionPermissionError::Service(ref cause) => cause,
-            AddLayerVersionPermissionError::TooManyRequests(ref cause) => cause,
+            AddLayerVersionPermissionError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddLayerVersionPermissionError::PolicyLengthExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddLayerVersionPermissionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            AddLayerVersionPermissionError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            AddLayerVersionPermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddLayerVersionPermissionError::Service(ref cause) => write!(f, "{}", cause),
+            AddLayerVersionPermissionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddLayerVersionPermissionError {}
 /// Errors returned by AddPermission
 #[derive(Debug, PartialEq)]
 pub enum AddPermissionError {
@@ -2008,22 +2008,18 @@ impl AddPermissionError {
 }
 impl fmt::Display for AddPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            AddPermissionError::InvalidParameterValue(ref cause) => cause,
-            AddPermissionError::PolicyLengthExceeded(ref cause) => cause,
-            AddPermissionError::PreconditionFailed(ref cause) => cause,
-            AddPermissionError::ResourceConflict(ref cause) => cause,
-            AddPermissionError::ResourceNotFound(ref cause) => cause,
-            AddPermissionError::Service(ref cause) => cause,
-            AddPermissionError::TooManyRequests(ref cause) => cause,
+            AddPermissionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::PolicyLengthExceeded(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::Service(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddPermissionError {}
 /// Errors returned by CreateAlias
 #[derive(Debug, PartialEq)]
 pub enum CreateAliasError {
@@ -2067,20 +2063,16 @@ impl CreateAliasError {
 }
 impl fmt::Display for CreateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAliasError::InvalidParameterValue(ref cause) => cause,
-            CreateAliasError::ResourceConflict(ref cause) => cause,
-            CreateAliasError::ResourceNotFound(ref cause) => cause,
-            CreateAliasError::Service(ref cause) => cause,
-            CreateAliasError::TooManyRequests(ref cause) => cause,
+            CreateAliasError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::Service(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAliasError {}
 /// Errors returned by CreateEventSourceMapping
 #[derive(Debug, PartialEq)]
 pub enum CreateEventSourceMappingError {
@@ -2132,20 +2124,18 @@ impl CreateEventSourceMappingError {
 }
 impl fmt::Display for CreateEventSourceMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEventSourceMappingError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEventSourceMappingError::InvalidParameterValue(ref cause) => cause,
-            CreateEventSourceMappingError::ResourceConflict(ref cause) => cause,
-            CreateEventSourceMappingError::ResourceNotFound(ref cause) => cause,
-            CreateEventSourceMappingError::Service(ref cause) => cause,
-            CreateEventSourceMappingError::TooManyRequests(ref cause) => cause,
+            CreateEventSourceMappingError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSourceMappingError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            CreateEventSourceMappingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateEventSourceMappingError::Service(ref cause) => write!(f, "{}", cause),
+            CreateEventSourceMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEventSourceMappingError {}
 /// Errors returned by CreateFunction
 #[derive(Debug, PartialEq)]
 pub enum CreateFunctionError {
@@ -2196,21 +2186,17 @@ impl CreateFunctionError {
 }
 impl fmt::Display for CreateFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFunctionError::CodeStorageExceeded(ref cause) => cause,
-            CreateFunctionError::InvalidParameterValue(ref cause) => cause,
-            CreateFunctionError::ResourceConflict(ref cause) => cause,
-            CreateFunctionError::ResourceNotFound(ref cause) => cause,
-            CreateFunctionError::Service(ref cause) => cause,
-            CreateFunctionError::TooManyRequests(ref cause) => cause,
+            CreateFunctionError::CodeStorageExceeded(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::Service(ref cause) => write!(f, "{}", cause),
+            CreateFunctionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFunctionError {}
 /// Errors returned by DeleteAlias
 #[derive(Debug, PartialEq)]
 pub enum DeleteAliasError {
@@ -2249,19 +2235,15 @@ impl DeleteAliasError {
 }
 impl fmt::Display for DeleteAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAliasError::InvalidParameterValue(ref cause) => cause,
-            DeleteAliasError::ResourceConflict(ref cause) => cause,
-            DeleteAliasError::Service(ref cause) => cause,
-            DeleteAliasError::TooManyRequests(ref cause) => cause,
+            DeleteAliasError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAliasError {}
 /// Errors returned by DeleteEventSourceMapping
 #[derive(Debug, PartialEq)]
 pub enum DeleteEventSourceMappingError {
@@ -2313,20 +2295,18 @@ impl DeleteEventSourceMappingError {
 }
 impl fmt::Display for DeleteEventSourceMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEventSourceMappingError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEventSourceMappingError::InvalidParameterValue(ref cause) => cause,
-            DeleteEventSourceMappingError::ResourceInUse(ref cause) => cause,
-            DeleteEventSourceMappingError::ResourceNotFound(ref cause) => cause,
-            DeleteEventSourceMappingError::Service(ref cause) => cause,
-            DeleteEventSourceMappingError::TooManyRequests(ref cause) => cause,
+            DeleteEventSourceMappingError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteEventSourceMappingError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteEventSourceMappingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteEventSourceMappingError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteEventSourceMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEventSourceMappingError {}
 /// Errors returned by DeleteFunction
 #[derive(Debug, PartialEq)]
 pub enum DeleteFunctionError {
@@ -2372,20 +2352,16 @@ impl DeleteFunctionError {
 }
 impl fmt::Display for DeleteFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFunctionError::InvalidParameterValue(ref cause) => cause,
-            DeleteFunctionError::ResourceConflict(ref cause) => cause,
-            DeleteFunctionError::ResourceNotFound(ref cause) => cause,
-            DeleteFunctionError::Service(ref cause) => cause,
-            DeleteFunctionError::TooManyRequests(ref cause) => cause,
+            DeleteFunctionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFunctionError {}
 /// Errors returned by DeleteFunctionConcurrency
 #[derive(Debug, PartialEq)]
 pub enum DeleteFunctionConcurrencyError {
@@ -2437,20 +2413,18 @@ impl DeleteFunctionConcurrencyError {
 }
 impl fmt::Display for DeleteFunctionConcurrencyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFunctionConcurrencyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFunctionConcurrencyError::InvalidParameterValue(ref cause) => cause,
-            DeleteFunctionConcurrencyError::ResourceConflict(ref cause) => cause,
-            DeleteFunctionConcurrencyError::ResourceNotFound(ref cause) => cause,
-            DeleteFunctionConcurrencyError::Service(ref cause) => cause,
-            DeleteFunctionConcurrencyError::TooManyRequests(ref cause) => cause,
+            DeleteFunctionConcurrencyError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteFunctionConcurrencyError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionConcurrencyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionConcurrencyError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionConcurrencyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFunctionConcurrencyError {}
 /// Errors returned by DeleteFunctionEventInvokeConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteFunctionEventInvokeConfigError {
@@ -2499,19 +2473,21 @@ impl DeleteFunctionEventInvokeConfigError {
 }
 impl fmt::Display for DeleteFunctionEventInvokeConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFunctionEventInvokeConfigError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => cause,
-            DeleteFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => cause,
-            DeleteFunctionEventInvokeConfigError::Service(ref cause) => cause,
-            DeleteFunctionEventInvokeConfigError::TooManyRequests(ref cause) => cause,
+            DeleteFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteFunctionEventInvokeConfigError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteFunctionEventInvokeConfigError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteFunctionEventInvokeConfigError {}
 /// Errors returned by DeleteLayerVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteLayerVersionError {
@@ -2540,17 +2516,13 @@ impl DeleteLayerVersionError {
 }
 impl fmt::Display for DeleteLayerVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLayerVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLayerVersionError::Service(ref cause) => cause,
-            DeleteLayerVersionError::TooManyRequests(ref cause) => cause,
+            DeleteLayerVersionError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteLayerVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLayerVersionError {}
 /// Errors returned by DeleteProvisionedConcurrencyConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteProvisionedConcurrencyConfigError {
@@ -2606,20 +2578,24 @@ impl DeleteProvisionedConcurrencyConfigError {
 }
 impl fmt::Display for DeleteProvisionedConcurrencyConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProvisionedConcurrencyConfigError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProvisionedConcurrencyConfigError::InvalidParameterValue(ref cause) => cause,
-            DeleteProvisionedConcurrencyConfigError::ResourceConflict(ref cause) => cause,
-            DeleteProvisionedConcurrencyConfigError::ResourceNotFound(ref cause) => cause,
-            DeleteProvisionedConcurrencyConfigError::Service(ref cause) => cause,
-            DeleteProvisionedConcurrencyConfigError::TooManyRequests(ref cause) => cause,
+            DeleteProvisionedConcurrencyConfigError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisionedConcurrencyConfigError::ResourceConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisionedConcurrencyConfigError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisionedConcurrencyConfigError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteProvisionedConcurrencyConfigError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteProvisionedConcurrencyConfigError {}
 /// Errors returned by GetAccountSettings
 #[derive(Debug, PartialEq)]
 pub enum GetAccountSettingsError {
@@ -2648,17 +2624,13 @@ impl GetAccountSettingsError {
 }
 impl fmt::Display for GetAccountSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountSettingsError::Service(ref cause) => cause,
-            GetAccountSettingsError::TooManyRequests(ref cause) => cause,
+            GetAccountSettingsError::Service(ref cause) => write!(f, "{}", cause),
+            GetAccountSettingsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountSettingsError {}
 /// Errors returned by GetAlias
 #[derive(Debug, PartialEq)]
 pub enum GetAliasError {
@@ -2695,19 +2667,15 @@ impl GetAliasError {
 }
 impl fmt::Display for GetAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAliasError {
-    fn description(&self) -> &str {
         match *self {
-            GetAliasError::InvalidParameterValue(ref cause) => cause,
-            GetAliasError::ResourceNotFound(ref cause) => cause,
-            GetAliasError::Service(ref cause) => cause,
-            GetAliasError::TooManyRequests(ref cause) => cause,
+            GetAliasError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetAliasError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetAliasError::Service(ref cause) => write!(f, "{}", cause),
+            GetAliasError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAliasError {}
 /// Errors returned by GetEventSourceMapping
 #[derive(Debug, PartialEq)]
 pub enum GetEventSourceMappingError {
@@ -2752,19 +2720,15 @@ impl GetEventSourceMappingError {
 }
 impl fmt::Display for GetEventSourceMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEventSourceMappingError {
-    fn description(&self) -> &str {
         match *self {
-            GetEventSourceMappingError::InvalidParameterValue(ref cause) => cause,
-            GetEventSourceMappingError::ResourceNotFound(ref cause) => cause,
-            GetEventSourceMappingError::Service(ref cause) => cause,
-            GetEventSourceMappingError::TooManyRequests(ref cause) => cause,
+            GetEventSourceMappingError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetEventSourceMappingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetEventSourceMappingError::Service(ref cause) => write!(f, "{}", cause),
+            GetEventSourceMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEventSourceMappingError {}
 /// Errors returned by GetFunction
 #[derive(Debug, PartialEq)]
 pub enum GetFunctionError {
@@ -2803,19 +2767,15 @@ impl GetFunctionError {
 }
 impl fmt::Display for GetFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            GetFunctionError::InvalidParameterValue(ref cause) => cause,
-            GetFunctionError::ResourceNotFound(ref cause) => cause,
-            GetFunctionError::Service(ref cause) => cause,
-            GetFunctionError::TooManyRequests(ref cause) => cause,
+            GetFunctionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetFunctionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetFunctionError::Service(ref cause) => write!(f, "{}", cause),
+            GetFunctionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFunctionError {}
 /// Errors returned by GetFunctionConcurrency
 #[derive(Debug, PartialEq)]
 pub enum GetFunctionConcurrencyError {
@@ -2860,19 +2820,15 @@ impl GetFunctionConcurrencyError {
 }
 impl fmt::Display for GetFunctionConcurrencyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFunctionConcurrencyError {
-    fn description(&self) -> &str {
         match *self {
-            GetFunctionConcurrencyError::InvalidParameterValue(ref cause) => cause,
-            GetFunctionConcurrencyError::ResourceNotFound(ref cause) => cause,
-            GetFunctionConcurrencyError::Service(ref cause) => cause,
-            GetFunctionConcurrencyError::TooManyRequests(ref cause) => cause,
+            GetFunctionConcurrencyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetFunctionConcurrencyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetFunctionConcurrencyError::Service(ref cause) => write!(f, "{}", cause),
+            GetFunctionConcurrencyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFunctionConcurrencyError {}
 /// Errors returned by GetFunctionConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetFunctionConfigurationError {
@@ -2917,19 +2873,17 @@ impl GetFunctionConfigurationError {
 }
 impl fmt::Display for GetFunctionConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFunctionConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetFunctionConfigurationError::InvalidParameterValue(ref cause) => cause,
-            GetFunctionConfigurationError::ResourceNotFound(ref cause) => cause,
-            GetFunctionConfigurationError::Service(ref cause) => cause,
-            GetFunctionConfigurationError::TooManyRequests(ref cause) => cause,
+            GetFunctionConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetFunctionConfigurationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetFunctionConfigurationError::Service(ref cause) => write!(f, "{}", cause),
+            GetFunctionConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFunctionConfigurationError {}
 /// Errors returned by GetFunctionEventInvokeConfig
 #[derive(Debug, PartialEq)]
 pub enum GetFunctionEventInvokeConfigError {
@@ -2978,19 +2932,19 @@ impl GetFunctionEventInvokeConfigError {
 }
 impl fmt::Display for GetFunctionEventInvokeConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFunctionEventInvokeConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => cause,
-            GetFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => cause,
-            GetFunctionEventInvokeConfigError::Service(ref cause) => cause,
-            GetFunctionEventInvokeConfigError::TooManyRequests(ref cause) => cause,
+            GetFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetFunctionEventInvokeConfigError::Service(ref cause) => write!(f, "{}", cause),
+            GetFunctionEventInvokeConfigError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFunctionEventInvokeConfigError {}
 /// Errors returned by GetLayerVersion
 #[derive(Debug, PartialEq)]
 pub enum GetLayerVersionError {
@@ -3031,19 +2985,15 @@ impl GetLayerVersionError {
 }
 impl fmt::Display for GetLayerVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLayerVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetLayerVersionError::InvalidParameterValue(ref cause) => cause,
-            GetLayerVersionError::ResourceNotFound(ref cause) => cause,
-            GetLayerVersionError::Service(ref cause) => cause,
-            GetLayerVersionError::TooManyRequests(ref cause) => cause,
+            GetLayerVersionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionError::Service(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLayerVersionError {}
 /// Errors returned by GetLayerVersionByArn
 #[derive(Debug, PartialEq)]
 pub enum GetLayerVersionByArnError {
@@ -3088,19 +3038,15 @@ impl GetLayerVersionByArnError {
 }
 impl fmt::Display for GetLayerVersionByArnError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLayerVersionByArnError {
-    fn description(&self) -> &str {
         match *self {
-            GetLayerVersionByArnError::InvalidParameterValue(ref cause) => cause,
-            GetLayerVersionByArnError::ResourceNotFound(ref cause) => cause,
-            GetLayerVersionByArnError::Service(ref cause) => cause,
-            GetLayerVersionByArnError::TooManyRequests(ref cause) => cause,
+            GetLayerVersionByArnError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionByArnError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionByArnError::Service(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionByArnError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLayerVersionByArnError {}
 /// Errors returned by GetLayerVersionPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetLayerVersionPolicyError {
@@ -3145,19 +3091,15 @@ impl GetLayerVersionPolicyError {
 }
 impl fmt::Display for GetLayerVersionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLayerVersionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetLayerVersionPolicyError::InvalidParameterValue(ref cause) => cause,
-            GetLayerVersionPolicyError::ResourceNotFound(ref cause) => cause,
-            GetLayerVersionPolicyError::Service(ref cause) => cause,
-            GetLayerVersionPolicyError::TooManyRequests(ref cause) => cause,
+            GetLayerVersionPolicyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionPolicyError::Service(ref cause) => write!(f, "{}", cause),
+            GetLayerVersionPolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLayerVersionPolicyError {}
 /// Errors returned by GetPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetPolicyError {
@@ -3196,19 +3138,15 @@ impl GetPolicyError {
 }
 impl fmt::Display for GetPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPolicyError::InvalidParameterValue(ref cause) => cause,
-            GetPolicyError::ResourceNotFound(ref cause) => cause,
-            GetPolicyError::Service(ref cause) => cause,
-            GetPolicyError::TooManyRequests(ref cause) => cause,
+            GetPolicyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::Service(ref cause) => write!(f, "{}", cause),
+            GetPolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPolicyError {}
 /// Errors returned by GetProvisionedConcurrencyConfig
 #[derive(Debug, PartialEq)]
 pub enum GetProvisionedConcurrencyConfigError {
@@ -3266,22 +3204,24 @@ impl GetProvisionedConcurrencyConfigError {
 }
 impl fmt::Display for GetProvisionedConcurrencyConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetProvisionedConcurrencyConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetProvisionedConcurrencyConfigError::InvalidParameterValue(ref cause) => cause,
+            GetProvisionedConcurrencyConfigError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetProvisionedConcurrencyConfigError::ProvisionedConcurrencyConfigNotFound(
                 ref cause,
-            ) => cause,
-            GetProvisionedConcurrencyConfigError::ResourceNotFound(ref cause) => cause,
-            GetProvisionedConcurrencyConfigError::Service(ref cause) => cause,
-            GetProvisionedConcurrencyConfigError::TooManyRequests(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            GetProvisionedConcurrencyConfigError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetProvisionedConcurrencyConfigError::Service(ref cause) => write!(f, "{}", cause),
+            GetProvisionedConcurrencyConfigError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetProvisionedConcurrencyConfigError {}
 /// Errors returned by Invoke
 #[derive(Debug, PartialEq)]
 pub enum InvokeError {
@@ -3408,37 +3348,33 @@ impl InvokeError {
 }
 impl fmt::Display for InvokeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InvokeError {
-    fn description(&self) -> &str {
         match *self {
-            InvokeError::EC2AccessDenied(ref cause) => cause,
-            InvokeError::EC2Throttled(ref cause) => cause,
-            InvokeError::EC2Unexpected(ref cause) => cause,
-            InvokeError::ENILimitReached(ref cause) => cause,
-            InvokeError::InvalidParameterValue(ref cause) => cause,
-            InvokeError::InvalidRequestContent(ref cause) => cause,
-            InvokeError::InvalidRuntime(ref cause) => cause,
-            InvokeError::InvalidSecurityGroupID(ref cause) => cause,
-            InvokeError::InvalidSubnetID(ref cause) => cause,
-            InvokeError::InvalidZipFile(ref cause) => cause,
-            InvokeError::KMSAccessDenied(ref cause) => cause,
-            InvokeError::KMSDisabled(ref cause) => cause,
-            InvokeError::KMSInvalidState(ref cause) => cause,
-            InvokeError::KMSNotFound(ref cause) => cause,
-            InvokeError::RequestTooLarge(ref cause) => cause,
-            InvokeError::ResourceConflict(ref cause) => cause,
-            InvokeError::ResourceNotFound(ref cause) => cause,
-            InvokeError::ResourceNotReady(ref cause) => cause,
-            InvokeError::Service(ref cause) => cause,
-            InvokeError::SubnetIPAddressLimitReached(ref cause) => cause,
-            InvokeError::TooManyRequests(ref cause) => cause,
-            InvokeError::UnsupportedMediaType(ref cause) => cause,
+            InvokeError::EC2AccessDenied(ref cause) => write!(f, "{}", cause),
+            InvokeError::EC2Throttled(ref cause) => write!(f, "{}", cause),
+            InvokeError::EC2Unexpected(ref cause) => write!(f, "{}", cause),
+            InvokeError::ENILimitReached(ref cause) => write!(f, "{}", cause),
+            InvokeError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            InvokeError::InvalidRequestContent(ref cause) => write!(f, "{}", cause),
+            InvokeError::InvalidRuntime(ref cause) => write!(f, "{}", cause),
+            InvokeError::InvalidSecurityGroupID(ref cause) => write!(f, "{}", cause),
+            InvokeError::InvalidSubnetID(ref cause) => write!(f, "{}", cause),
+            InvokeError::InvalidZipFile(ref cause) => write!(f, "{}", cause),
+            InvokeError::KMSAccessDenied(ref cause) => write!(f, "{}", cause),
+            InvokeError::KMSDisabled(ref cause) => write!(f, "{}", cause),
+            InvokeError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            InvokeError::KMSNotFound(ref cause) => write!(f, "{}", cause),
+            InvokeError::RequestTooLarge(ref cause) => write!(f, "{}", cause),
+            InvokeError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            InvokeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            InvokeError::ResourceNotReady(ref cause) => write!(f, "{}", cause),
+            InvokeError::Service(ref cause) => write!(f, "{}", cause),
+            InvokeError::SubnetIPAddressLimitReached(ref cause) => write!(f, "{}", cause),
+            InvokeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            InvokeError::UnsupportedMediaType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InvokeError {}
 /// Errors returned by InvokeAsync
 #[derive(Debug, PartialEq)]
 pub enum InvokeAsyncError {
@@ -3482,20 +3418,16 @@ impl InvokeAsyncError {
 }
 impl fmt::Display for InvokeAsyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InvokeAsyncError {
-    fn description(&self) -> &str {
         match *self {
-            InvokeAsyncError::InvalidRequestContent(ref cause) => cause,
-            InvokeAsyncError::InvalidRuntime(ref cause) => cause,
-            InvokeAsyncError::ResourceConflict(ref cause) => cause,
-            InvokeAsyncError::ResourceNotFound(ref cause) => cause,
-            InvokeAsyncError::Service(ref cause) => cause,
+            InvokeAsyncError::InvalidRequestContent(ref cause) => write!(f, "{}", cause),
+            InvokeAsyncError::InvalidRuntime(ref cause) => write!(f, "{}", cause),
+            InvokeAsyncError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            InvokeAsyncError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            InvokeAsyncError::Service(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InvokeAsyncError {}
 /// Errors returned by ListAliases
 #[derive(Debug, PartialEq)]
 pub enum ListAliasesError {
@@ -3534,19 +3466,15 @@ impl ListAliasesError {
 }
 impl fmt::Display for ListAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAliasesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAliasesError::InvalidParameterValue(ref cause) => cause,
-            ListAliasesError::ResourceNotFound(ref cause) => cause,
-            ListAliasesError::Service(ref cause) => cause,
-            ListAliasesError::TooManyRequests(ref cause) => cause,
+            ListAliasesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::Service(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAliasesError {}
 /// Errors returned by ListEventSourceMappings
 #[derive(Debug, PartialEq)]
 pub enum ListEventSourceMappingsError {
@@ -3591,19 +3519,17 @@ impl ListEventSourceMappingsError {
 }
 impl fmt::Display for ListEventSourceMappingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEventSourceMappingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListEventSourceMappingsError::InvalidParameterValue(ref cause) => cause,
-            ListEventSourceMappingsError::ResourceNotFound(ref cause) => cause,
-            ListEventSourceMappingsError::Service(ref cause) => cause,
-            ListEventSourceMappingsError::TooManyRequests(ref cause) => cause,
+            ListEventSourceMappingsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListEventSourceMappingsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListEventSourceMappingsError::Service(ref cause) => write!(f, "{}", cause),
+            ListEventSourceMappingsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEventSourceMappingsError {}
 /// Errors returned by ListFunctionEventInvokeConfigs
 #[derive(Debug, PartialEq)]
 pub enum ListFunctionEventInvokeConfigsError {
@@ -3652,19 +3578,21 @@ impl ListFunctionEventInvokeConfigsError {
 }
 impl fmt::Display for ListFunctionEventInvokeConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFunctionEventInvokeConfigsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFunctionEventInvokeConfigsError::InvalidParameterValue(ref cause) => cause,
-            ListFunctionEventInvokeConfigsError::ResourceNotFound(ref cause) => cause,
-            ListFunctionEventInvokeConfigsError::Service(ref cause) => cause,
-            ListFunctionEventInvokeConfigsError::TooManyRequests(ref cause) => cause,
+            ListFunctionEventInvokeConfigsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListFunctionEventInvokeConfigsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListFunctionEventInvokeConfigsError::Service(ref cause) => write!(f, "{}", cause),
+            ListFunctionEventInvokeConfigsError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListFunctionEventInvokeConfigsError {}
 /// Errors returned by ListFunctions
 #[derive(Debug, PartialEq)]
 pub enum ListFunctionsError {
@@ -3698,18 +3626,14 @@ impl ListFunctionsError {
 }
 impl fmt::Display for ListFunctionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFunctionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFunctionsError::InvalidParameterValue(ref cause) => cause,
-            ListFunctionsError::Service(ref cause) => cause,
-            ListFunctionsError::TooManyRequests(ref cause) => cause,
+            ListFunctionsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListFunctionsError::Service(ref cause) => write!(f, "{}", cause),
+            ListFunctionsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFunctionsError {}
 /// Errors returned by ListLayerVersions
 #[derive(Debug, PartialEq)]
 pub enum ListLayerVersionsError {
@@ -3750,19 +3674,15 @@ impl ListLayerVersionsError {
 }
 impl fmt::Display for ListLayerVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLayerVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLayerVersionsError::InvalidParameterValue(ref cause) => cause,
-            ListLayerVersionsError::ResourceNotFound(ref cause) => cause,
-            ListLayerVersionsError::Service(ref cause) => cause,
-            ListLayerVersionsError::TooManyRequests(ref cause) => cause,
+            ListLayerVersionsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListLayerVersionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListLayerVersionsError::Service(ref cause) => write!(f, "{}", cause),
+            ListLayerVersionsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLayerVersionsError {}
 /// Errors returned by ListLayers
 #[derive(Debug, PartialEq)]
 pub enum ListLayersError {
@@ -3796,18 +3716,14 @@ impl ListLayersError {
 }
 impl fmt::Display for ListLayersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLayersError {
-    fn description(&self) -> &str {
         match *self {
-            ListLayersError::InvalidParameterValue(ref cause) => cause,
-            ListLayersError::Service(ref cause) => cause,
-            ListLayersError::TooManyRequests(ref cause) => cause,
+            ListLayersError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListLayersError::Service(ref cause) => write!(f, "{}", cause),
+            ListLayersError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLayersError {}
 /// Errors returned by ListProvisionedConcurrencyConfigs
 #[derive(Debug, PartialEq)]
 pub enum ListProvisionedConcurrencyConfigsError {
@@ -3856,19 +3772,21 @@ impl ListProvisionedConcurrencyConfigsError {
 }
 impl fmt::Display for ListProvisionedConcurrencyConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProvisionedConcurrencyConfigsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProvisionedConcurrencyConfigsError::InvalidParameterValue(ref cause) => cause,
-            ListProvisionedConcurrencyConfigsError::ResourceNotFound(ref cause) => cause,
-            ListProvisionedConcurrencyConfigsError::Service(ref cause) => cause,
-            ListProvisionedConcurrencyConfigsError::TooManyRequests(ref cause) => cause,
+            ListProvisionedConcurrencyConfigsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisionedConcurrencyConfigsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisionedConcurrencyConfigsError::Service(ref cause) => write!(f, "{}", cause),
+            ListProvisionedConcurrencyConfigsError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListProvisionedConcurrencyConfigsError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -3905,19 +3823,15 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::InvalidParameterValue(ref cause) => cause,
-            ListTagsError::ResourceNotFound(ref cause) => cause,
-            ListTagsError::Service(ref cause) => cause,
-            ListTagsError::TooManyRequests(ref cause) => cause,
+            ListTagsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsError::Service(ref cause) => write!(f, "{}", cause),
+            ListTagsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by ListVersionsByFunction
 #[derive(Debug, PartialEq)]
 pub enum ListVersionsByFunctionError {
@@ -3962,19 +3876,15 @@ impl ListVersionsByFunctionError {
 }
 impl fmt::Display for ListVersionsByFunctionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVersionsByFunctionError {
-    fn description(&self) -> &str {
         match *self {
-            ListVersionsByFunctionError::InvalidParameterValue(ref cause) => cause,
-            ListVersionsByFunctionError::ResourceNotFound(ref cause) => cause,
-            ListVersionsByFunctionError::Service(ref cause) => cause,
-            ListVersionsByFunctionError::TooManyRequests(ref cause) => cause,
+            ListVersionsByFunctionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListVersionsByFunctionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListVersionsByFunctionError::Service(ref cause) => write!(f, "{}", cause),
+            ListVersionsByFunctionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVersionsByFunctionError {}
 /// Errors returned by PublishLayerVersion
 #[derive(Debug, PartialEq)]
 pub enum PublishLayerVersionError {
@@ -4024,20 +3934,16 @@ impl PublishLayerVersionError {
 }
 impl fmt::Display for PublishLayerVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PublishLayerVersionError {
-    fn description(&self) -> &str {
         match *self {
-            PublishLayerVersionError::CodeStorageExceeded(ref cause) => cause,
-            PublishLayerVersionError::InvalidParameterValue(ref cause) => cause,
-            PublishLayerVersionError::ResourceNotFound(ref cause) => cause,
-            PublishLayerVersionError::Service(ref cause) => cause,
-            PublishLayerVersionError::TooManyRequests(ref cause) => cause,
+            PublishLayerVersionError::CodeStorageExceeded(ref cause) => write!(f, "{}", cause),
+            PublishLayerVersionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PublishLayerVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PublishLayerVersionError::Service(ref cause) => write!(f, "{}", cause),
+            PublishLayerVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PublishLayerVersionError {}
 /// Errors returned by PublishVersion
 #[derive(Debug, PartialEq)]
 pub enum PublishVersionError {
@@ -4093,22 +3999,18 @@ impl PublishVersionError {
 }
 impl fmt::Display for PublishVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PublishVersionError {
-    fn description(&self) -> &str {
         match *self {
-            PublishVersionError::CodeStorageExceeded(ref cause) => cause,
-            PublishVersionError::InvalidParameterValue(ref cause) => cause,
-            PublishVersionError::PreconditionFailed(ref cause) => cause,
-            PublishVersionError::ResourceConflict(ref cause) => cause,
-            PublishVersionError::ResourceNotFound(ref cause) => cause,
-            PublishVersionError::Service(ref cause) => cause,
-            PublishVersionError::TooManyRequests(ref cause) => cause,
+            PublishVersionError::CodeStorageExceeded(ref cause) => write!(f, "{}", cause),
+            PublishVersionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PublishVersionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            PublishVersionError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            PublishVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PublishVersionError::Service(ref cause) => write!(f, "{}", cause),
+            PublishVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PublishVersionError {}
 /// Errors returned by PutFunctionConcurrency
 #[derive(Debug, PartialEq)]
 pub enum PutFunctionConcurrencyError {
@@ -4160,20 +4062,16 @@ impl PutFunctionConcurrencyError {
 }
 impl fmt::Display for PutFunctionConcurrencyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutFunctionConcurrencyError {
-    fn description(&self) -> &str {
         match *self {
-            PutFunctionConcurrencyError::InvalidParameterValue(ref cause) => cause,
-            PutFunctionConcurrencyError::ResourceConflict(ref cause) => cause,
-            PutFunctionConcurrencyError::ResourceNotFound(ref cause) => cause,
-            PutFunctionConcurrencyError::Service(ref cause) => cause,
-            PutFunctionConcurrencyError::TooManyRequests(ref cause) => cause,
+            PutFunctionConcurrencyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutFunctionConcurrencyError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            PutFunctionConcurrencyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutFunctionConcurrencyError::Service(ref cause) => write!(f, "{}", cause),
+            PutFunctionConcurrencyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutFunctionConcurrencyError {}
 /// Errors returned by PutFunctionEventInvokeConfig
 #[derive(Debug, PartialEq)]
 pub enum PutFunctionEventInvokeConfigError {
@@ -4222,19 +4120,19 @@ impl PutFunctionEventInvokeConfigError {
 }
 impl fmt::Display for PutFunctionEventInvokeConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutFunctionEventInvokeConfigError {
-    fn description(&self) -> &str {
         match *self {
-            PutFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => cause,
-            PutFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => cause,
-            PutFunctionEventInvokeConfigError::Service(ref cause) => cause,
-            PutFunctionEventInvokeConfigError::TooManyRequests(ref cause) => cause,
+            PutFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutFunctionEventInvokeConfigError::Service(ref cause) => write!(f, "{}", cause),
+            PutFunctionEventInvokeConfigError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutFunctionEventInvokeConfigError {}
 /// Errors returned by PutProvisionedConcurrencyConfig
 #[derive(Debug, PartialEq)]
 pub enum PutProvisionedConcurrencyConfigError {
@@ -4290,20 +4188,24 @@ impl PutProvisionedConcurrencyConfigError {
 }
 impl fmt::Display for PutProvisionedConcurrencyConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutProvisionedConcurrencyConfigError {
-    fn description(&self) -> &str {
         match *self {
-            PutProvisionedConcurrencyConfigError::InvalidParameterValue(ref cause) => cause,
-            PutProvisionedConcurrencyConfigError::ResourceConflict(ref cause) => cause,
-            PutProvisionedConcurrencyConfigError::ResourceNotFound(ref cause) => cause,
-            PutProvisionedConcurrencyConfigError::Service(ref cause) => cause,
-            PutProvisionedConcurrencyConfigError::TooManyRequests(ref cause) => cause,
+            PutProvisionedConcurrencyConfigError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutProvisionedConcurrencyConfigError::ResourceConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutProvisionedConcurrencyConfigError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutProvisionedConcurrencyConfigError::Service(ref cause) => write!(f, "{}", cause),
+            PutProvisionedConcurrencyConfigError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutProvisionedConcurrencyConfigError {}
 /// Errors returned by RemoveLayerVersionPermission
 #[derive(Debug, PartialEq)]
 pub enum RemoveLayerVersionPermissionError {
@@ -4359,20 +4261,22 @@ impl RemoveLayerVersionPermissionError {
 }
 impl fmt::Display for RemoveLayerVersionPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveLayerVersionPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveLayerVersionPermissionError::InvalidParameterValue(ref cause) => cause,
-            RemoveLayerVersionPermissionError::PreconditionFailed(ref cause) => cause,
-            RemoveLayerVersionPermissionError::ResourceNotFound(ref cause) => cause,
-            RemoveLayerVersionPermissionError::Service(ref cause) => cause,
-            RemoveLayerVersionPermissionError::TooManyRequests(ref cause) => cause,
+            RemoveLayerVersionPermissionError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveLayerVersionPermissionError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveLayerVersionPermissionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveLayerVersionPermissionError::Service(ref cause) => write!(f, "{}", cause),
+            RemoveLayerVersionPermissionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveLayerVersionPermissionError {}
 /// Errors returned by RemovePermission
 #[derive(Debug, PartialEq)]
 pub enum RemovePermissionError {
@@ -4418,20 +4322,16 @@ impl RemovePermissionError {
 }
 impl fmt::Display for RemovePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemovePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            RemovePermissionError::InvalidParameterValue(ref cause) => cause,
-            RemovePermissionError::PreconditionFailed(ref cause) => cause,
-            RemovePermissionError::ResourceNotFound(ref cause) => cause,
-            RemovePermissionError::Service(ref cause) => cause,
-            RemovePermissionError::TooManyRequests(ref cause) => cause,
+            RemovePermissionError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::Service(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemovePermissionError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -4470,19 +4370,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidParameterValue(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::Service(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
+            TagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Service(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -4521,19 +4417,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InvalidParameterValue(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::Service(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
+            UntagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Service(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateAlias
 #[derive(Debug, PartialEq)]
 pub enum UpdateAliasError {
@@ -4582,21 +4474,17 @@ impl UpdateAliasError {
 }
 impl fmt::Display for UpdateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAliasError::InvalidParameterValue(ref cause) => cause,
-            UpdateAliasError::PreconditionFailed(ref cause) => cause,
-            UpdateAliasError::ResourceConflict(ref cause) => cause,
-            UpdateAliasError::ResourceNotFound(ref cause) => cause,
-            UpdateAliasError::Service(ref cause) => cause,
-            UpdateAliasError::TooManyRequests(ref cause) => cause,
+            UpdateAliasError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateAliasError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAliasError {}
 /// Errors returned by UpdateEventSourceMapping
 #[derive(Debug, PartialEq)]
 pub enum UpdateEventSourceMappingError {
@@ -4655,21 +4543,19 @@ impl UpdateEventSourceMappingError {
 }
 impl fmt::Display for UpdateEventSourceMappingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEventSourceMappingError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEventSourceMappingError::InvalidParameterValue(ref cause) => cause,
-            UpdateEventSourceMappingError::ResourceConflict(ref cause) => cause,
-            UpdateEventSourceMappingError::ResourceInUse(ref cause) => cause,
-            UpdateEventSourceMappingError::ResourceNotFound(ref cause) => cause,
-            UpdateEventSourceMappingError::Service(ref cause) => cause,
-            UpdateEventSourceMappingError::TooManyRequests(ref cause) => cause,
+            UpdateEventSourceMappingError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateEventSourceMappingError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UpdateEventSourceMappingError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateEventSourceMappingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateEventSourceMappingError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateEventSourceMappingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEventSourceMappingError {}
 /// Errors returned by UpdateFunctionCode
 #[derive(Debug, PartialEq)]
 pub enum UpdateFunctionCodeError {
@@ -4729,22 +4615,18 @@ impl UpdateFunctionCodeError {
 }
 impl fmt::Display for UpdateFunctionCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFunctionCodeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFunctionCodeError::CodeStorageExceeded(ref cause) => cause,
-            UpdateFunctionCodeError::InvalidParameterValue(ref cause) => cause,
-            UpdateFunctionCodeError::PreconditionFailed(ref cause) => cause,
-            UpdateFunctionCodeError::ResourceConflict(ref cause) => cause,
-            UpdateFunctionCodeError::ResourceNotFound(ref cause) => cause,
-            UpdateFunctionCodeError::Service(ref cause) => cause,
-            UpdateFunctionCodeError::TooManyRequests(ref cause) => cause,
+            UpdateFunctionCodeError::CodeStorageExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionCodeError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionCodeError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionCodeError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionCodeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionCodeError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionCodeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFunctionCodeError {}
 /// Errors returned by UpdateFunctionConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateFunctionConfigurationError {
@@ -4805,21 +4687,21 @@ impl UpdateFunctionConfigurationError {
 }
 impl fmt::Display for UpdateFunctionConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFunctionConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFunctionConfigurationError::InvalidParameterValue(ref cause) => cause,
-            UpdateFunctionConfigurationError::PreconditionFailed(ref cause) => cause,
-            UpdateFunctionConfigurationError::ResourceConflict(ref cause) => cause,
-            UpdateFunctionConfigurationError::ResourceNotFound(ref cause) => cause,
-            UpdateFunctionConfigurationError::Service(ref cause) => cause,
-            UpdateFunctionConfigurationError::TooManyRequests(ref cause) => cause,
+            UpdateFunctionConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateFunctionConfigurationError::PreconditionFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateFunctionConfigurationError::ResourceConflict(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionConfigurationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionConfigurationError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionConfigurationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFunctionConfigurationError {}
 /// Errors returned by UpdateFunctionEventInvokeConfig
 #[derive(Debug, PartialEq)]
 pub enum UpdateFunctionEventInvokeConfigError {
@@ -4868,19 +4750,21 @@ impl UpdateFunctionEventInvokeConfigError {
 }
 impl fmt::Display for UpdateFunctionEventInvokeConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFunctionEventInvokeConfigError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => cause,
-            UpdateFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => cause,
-            UpdateFunctionEventInvokeConfigError::Service(ref cause) => cause,
-            UpdateFunctionEventInvokeConfigError::TooManyRequests(ref cause) => cause,
+            UpdateFunctionEventInvokeConfigError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateFunctionEventInvokeConfigError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateFunctionEventInvokeConfigError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateFunctionEventInvokeConfigError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateFunctionEventInvokeConfigError {}
 /// Trait representing the capabilities of the AWS Lambda API. AWS Lambda clients implement this trait.
 pub trait Lambda {
     /// <p>Adds permissions to the resource-based policy of a version of an <a href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html">AWS Lambda layer</a>. Use this action to grant layer usage permission to other accounts. You can grant permission to a single account, all AWS accounts, or all accounts in an organization.</p> <p>To revoke permission, call <a>RemoveLayerVersionPermission</a> with the statement ID that you specified when you added it.</p>

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -1903,21 +1903,17 @@ impl CreateBotVersionError {
 }
 impl fmt::Display for CreateBotVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBotVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBotVersionError::BadRequest(ref cause) => cause,
-            CreateBotVersionError::Conflict(ref cause) => cause,
-            CreateBotVersionError::InternalFailure(ref cause) => cause,
-            CreateBotVersionError::LimitExceeded(ref cause) => cause,
-            CreateBotVersionError::NotFound(ref cause) => cause,
-            CreateBotVersionError::PreconditionFailed(ref cause) => cause,
+            CreateBotVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateBotVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateBotVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateBotVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBotVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateBotVersionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBotVersionError {}
 /// Errors returned by CreateIntentVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateIntentVersionError {
@@ -1968,21 +1964,17 @@ impl CreateIntentVersionError {
 }
 impl fmt::Display for CreateIntentVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIntentVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIntentVersionError::BadRequest(ref cause) => cause,
-            CreateIntentVersionError::Conflict(ref cause) => cause,
-            CreateIntentVersionError::InternalFailure(ref cause) => cause,
-            CreateIntentVersionError::LimitExceeded(ref cause) => cause,
-            CreateIntentVersionError::NotFound(ref cause) => cause,
-            CreateIntentVersionError::PreconditionFailed(ref cause) => cause,
+            CreateIntentVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateIntentVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateIntentVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateIntentVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateIntentVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateIntentVersionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIntentVersionError {}
 /// Errors returned by CreateSlotTypeVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateSlotTypeVersionError {
@@ -2035,21 +2027,17 @@ impl CreateSlotTypeVersionError {
 }
 impl fmt::Display for CreateSlotTypeVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSlotTypeVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSlotTypeVersionError::BadRequest(ref cause) => cause,
-            CreateSlotTypeVersionError::Conflict(ref cause) => cause,
-            CreateSlotTypeVersionError::InternalFailure(ref cause) => cause,
-            CreateSlotTypeVersionError::LimitExceeded(ref cause) => cause,
-            CreateSlotTypeVersionError::NotFound(ref cause) => cause,
-            CreateSlotTypeVersionError::PreconditionFailed(ref cause) => cause,
+            CreateSlotTypeVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateSlotTypeVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateSlotTypeVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateSlotTypeVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSlotTypeVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateSlotTypeVersionError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSlotTypeVersionError {}
 /// Errors returned by DeleteBot
 #[derive(Debug, PartialEq)]
 pub enum DeleteBotError {
@@ -2098,21 +2086,17 @@ impl DeleteBotError {
 }
 impl fmt::Display for DeleteBotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBotError::BadRequest(ref cause) => cause,
-            DeleteBotError::Conflict(ref cause) => cause,
-            DeleteBotError::InternalFailure(ref cause) => cause,
-            DeleteBotError::LimitExceeded(ref cause) => cause,
-            DeleteBotError::NotFound(ref cause) => cause,
-            DeleteBotError::ResourceInUse(ref cause) => cause,
+            DeleteBotError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBotError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteBotError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBotError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteBotError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBotError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBotError {}
 /// Errors returned by DeleteBotAlias
 #[derive(Debug, PartialEq)]
 pub enum DeleteBotAliasError {
@@ -2161,21 +2145,17 @@ impl DeleteBotAliasError {
 }
 impl fmt::Display for DeleteBotAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBotAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBotAliasError::BadRequest(ref cause) => cause,
-            DeleteBotAliasError::Conflict(ref cause) => cause,
-            DeleteBotAliasError::InternalFailure(ref cause) => cause,
-            DeleteBotAliasError::LimitExceeded(ref cause) => cause,
-            DeleteBotAliasError::NotFound(ref cause) => cause,
-            DeleteBotAliasError::ResourceInUse(ref cause) => cause,
+            DeleteBotAliasError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBotAliasError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteBotAliasError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBotAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteBotAliasError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBotAliasError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBotAliasError {}
 /// Errors returned by DeleteBotChannelAssociation
 #[derive(Debug, PartialEq)]
 pub enum DeleteBotChannelAssociationError {
@@ -2231,20 +2211,16 @@ impl DeleteBotChannelAssociationError {
 }
 impl fmt::Display for DeleteBotChannelAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBotChannelAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBotChannelAssociationError::BadRequest(ref cause) => cause,
-            DeleteBotChannelAssociationError::Conflict(ref cause) => cause,
-            DeleteBotChannelAssociationError::InternalFailure(ref cause) => cause,
-            DeleteBotChannelAssociationError::LimitExceeded(ref cause) => cause,
-            DeleteBotChannelAssociationError::NotFound(ref cause) => cause,
+            DeleteBotChannelAssociationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBotChannelAssociationError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteBotChannelAssociationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBotChannelAssociationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteBotChannelAssociationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBotChannelAssociationError {}
 /// Errors returned by DeleteBotVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteBotVersionError {
@@ -2293,21 +2269,17 @@ impl DeleteBotVersionError {
 }
 impl fmt::Display for DeleteBotVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBotVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBotVersionError::BadRequest(ref cause) => cause,
-            DeleteBotVersionError::Conflict(ref cause) => cause,
-            DeleteBotVersionError::InternalFailure(ref cause) => cause,
-            DeleteBotVersionError::LimitExceeded(ref cause) => cause,
-            DeleteBotVersionError::NotFound(ref cause) => cause,
-            DeleteBotVersionError::ResourceInUse(ref cause) => cause,
+            DeleteBotVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBotVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteBotVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteBotVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteBotVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteBotVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBotVersionError {}
 /// Errors returned by DeleteIntent
 #[derive(Debug, PartialEq)]
 pub enum DeleteIntentError {
@@ -2356,21 +2328,17 @@ impl DeleteIntentError {
 }
 impl fmt::Display for DeleteIntentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIntentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIntentError::BadRequest(ref cause) => cause,
-            DeleteIntentError::Conflict(ref cause) => cause,
-            DeleteIntentError::InternalFailure(ref cause) => cause,
-            DeleteIntentError::LimitExceeded(ref cause) => cause,
-            DeleteIntentError::NotFound(ref cause) => cause,
-            DeleteIntentError::ResourceInUse(ref cause) => cause,
+            DeleteIntentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteIntentError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteIntentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteIntentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteIntentError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIntentError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIntentError {}
 /// Errors returned by DeleteIntentVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteIntentVersionError {
@@ -2419,21 +2387,17 @@ impl DeleteIntentVersionError {
 }
 impl fmt::Display for DeleteIntentVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIntentVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIntentVersionError::BadRequest(ref cause) => cause,
-            DeleteIntentVersionError::Conflict(ref cause) => cause,
-            DeleteIntentVersionError::InternalFailure(ref cause) => cause,
-            DeleteIntentVersionError::LimitExceeded(ref cause) => cause,
-            DeleteIntentVersionError::NotFound(ref cause) => cause,
-            DeleteIntentVersionError::ResourceInUse(ref cause) => cause,
+            DeleteIntentVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteIntentVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteIntentVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteIntentVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteIntentVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteIntentVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIntentVersionError {}
 /// Errors returned by DeleteSlotType
 #[derive(Debug, PartialEq)]
 pub enum DeleteSlotTypeError {
@@ -2482,21 +2446,17 @@ impl DeleteSlotTypeError {
 }
 impl fmt::Display for DeleteSlotTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSlotTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSlotTypeError::BadRequest(ref cause) => cause,
-            DeleteSlotTypeError::Conflict(ref cause) => cause,
-            DeleteSlotTypeError::InternalFailure(ref cause) => cause,
-            DeleteSlotTypeError::LimitExceeded(ref cause) => cause,
-            DeleteSlotTypeError::NotFound(ref cause) => cause,
-            DeleteSlotTypeError::ResourceInUse(ref cause) => cause,
+            DeleteSlotTypeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSlotTypeError {}
 /// Errors returned by DeleteSlotTypeVersion
 #[derive(Debug, PartialEq)]
 pub enum DeleteSlotTypeVersionError {
@@ -2547,21 +2507,17 @@ impl DeleteSlotTypeVersionError {
 }
 impl fmt::Display for DeleteSlotTypeVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSlotTypeVersionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSlotTypeVersionError::BadRequest(ref cause) => cause,
-            DeleteSlotTypeVersionError::Conflict(ref cause) => cause,
-            DeleteSlotTypeVersionError::InternalFailure(ref cause) => cause,
-            DeleteSlotTypeVersionError::LimitExceeded(ref cause) => cause,
-            DeleteSlotTypeVersionError::NotFound(ref cause) => cause,
-            DeleteSlotTypeVersionError::ResourceInUse(ref cause) => cause,
+            DeleteSlotTypeVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeVersionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeVersionError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteSlotTypeVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSlotTypeVersionError {}
 /// Errors returned by DeleteUtterances
 #[derive(Debug, PartialEq)]
 pub enum DeleteUtterancesError {
@@ -2600,19 +2556,15 @@ impl DeleteUtterancesError {
 }
 impl fmt::Display for DeleteUtterancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUtterancesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUtterancesError::BadRequest(ref cause) => cause,
-            DeleteUtterancesError::InternalFailure(ref cause) => cause,
-            DeleteUtterancesError::LimitExceeded(ref cause) => cause,
-            DeleteUtterancesError::NotFound(ref cause) => cause,
+            DeleteUtterancesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteUtterancesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteUtterancesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteUtterancesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUtterancesError {}
 /// Errors returned by GetBot
 #[derive(Debug, PartialEq)]
 pub enum GetBotError {
@@ -2649,19 +2601,15 @@ impl GetBotError {
 }
 impl fmt::Display for GetBotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotError::BadRequest(ref cause) => cause,
-            GetBotError::InternalFailure(ref cause) => cause,
-            GetBotError::LimitExceeded(ref cause) => cause,
-            GetBotError::NotFound(ref cause) => cause,
+            GetBotError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBotError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetBotError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotError {}
 /// Errors returned by GetBotAlias
 #[derive(Debug, PartialEq)]
 pub enum GetBotAliasError {
@@ -2700,19 +2648,15 @@ impl GetBotAliasError {
 }
 impl fmt::Display for GetBotAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotAliasError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotAliasError::BadRequest(ref cause) => cause,
-            GetBotAliasError::InternalFailure(ref cause) => cause,
-            GetBotAliasError::LimitExceeded(ref cause) => cause,
-            GetBotAliasError::NotFound(ref cause) => cause,
+            GetBotAliasError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotAliasError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBotAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetBotAliasError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotAliasError {}
 /// Errors returned by GetBotAliases
 #[derive(Debug, PartialEq)]
 pub enum GetBotAliasesError {
@@ -2746,18 +2690,14 @@ impl GetBotAliasesError {
 }
 impl fmt::Display for GetBotAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotAliasesError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotAliasesError::BadRequest(ref cause) => cause,
-            GetBotAliasesError::InternalFailure(ref cause) => cause,
-            GetBotAliasesError::LimitExceeded(ref cause) => cause,
+            GetBotAliasesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotAliasesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBotAliasesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotAliasesError {}
 /// Errors returned by GetBotChannelAssociation
 #[derive(Debug, PartialEq)]
 pub enum GetBotChannelAssociationError {
@@ -2800,19 +2740,15 @@ impl GetBotChannelAssociationError {
 }
 impl fmt::Display for GetBotChannelAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotChannelAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotChannelAssociationError::BadRequest(ref cause) => cause,
-            GetBotChannelAssociationError::InternalFailure(ref cause) => cause,
-            GetBotChannelAssociationError::LimitExceeded(ref cause) => cause,
-            GetBotChannelAssociationError::NotFound(ref cause) => cause,
+            GetBotChannelAssociationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotChannelAssociationError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBotChannelAssociationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetBotChannelAssociationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotChannelAssociationError {}
 /// Errors returned by GetBotChannelAssociations
 #[derive(Debug, PartialEq)]
 pub enum GetBotChannelAssociationsError {
@@ -2852,18 +2788,14 @@ impl GetBotChannelAssociationsError {
 }
 impl fmt::Display for GetBotChannelAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotChannelAssociationsError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotChannelAssociationsError::BadRequest(ref cause) => cause,
-            GetBotChannelAssociationsError::InternalFailure(ref cause) => cause,
-            GetBotChannelAssociationsError::LimitExceeded(ref cause) => cause,
+            GetBotChannelAssociationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotChannelAssociationsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBotChannelAssociationsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotChannelAssociationsError {}
 /// Errors returned by GetBotVersions
 #[derive(Debug, PartialEq)]
 pub enum GetBotVersionsError {
@@ -2902,19 +2834,15 @@ impl GetBotVersionsError {
 }
 impl fmt::Display for GetBotVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotVersionsError::BadRequest(ref cause) => cause,
-            GetBotVersionsError::InternalFailure(ref cause) => cause,
-            GetBotVersionsError::LimitExceeded(ref cause) => cause,
-            GetBotVersionsError::NotFound(ref cause) => cause,
+            GetBotVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotVersionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBotVersionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetBotVersionsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotVersionsError {}
 /// Errors returned by GetBots
 #[derive(Debug, PartialEq)]
 pub enum GetBotsError {
@@ -2953,19 +2881,15 @@ impl GetBotsError {
 }
 impl fmt::Display for GetBotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBotsError {
-    fn description(&self) -> &str {
         match *self {
-            GetBotsError::BadRequest(ref cause) => cause,
-            GetBotsError::InternalFailure(ref cause) => cause,
-            GetBotsError::LimitExceeded(ref cause) => cause,
-            GetBotsError::NotFound(ref cause) => cause,
+            GetBotsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBotsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBotsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetBotsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBotsError {}
 /// Errors returned by GetBuiltinIntent
 #[derive(Debug, PartialEq)]
 pub enum GetBuiltinIntentError {
@@ -3004,19 +2928,15 @@ impl GetBuiltinIntentError {
 }
 impl fmt::Display for GetBuiltinIntentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBuiltinIntentError {
-    fn description(&self) -> &str {
         match *self {
-            GetBuiltinIntentError::BadRequest(ref cause) => cause,
-            GetBuiltinIntentError::InternalFailure(ref cause) => cause,
-            GetBuiltinIntentError::LimitExceeded(ref cause) => cause,
-            GetBuiltinIntentError::NotFound(ref cause) => cause,
+            GetBuiltinIntentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBuiltinIntentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBuiltinIntentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetBuiltinIntentError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBuiltinIntentError {}
 /// Errors returned by GetBuiltinIntents
 #[derive(Debug, PartialEq)]
 pub enum GetBuiltinIntentsError {
@@ -3050,18 +2970,14 @@ impl GetBuiltinIntentsError {
 }
 impl fmt::Display for GetBuiltinIntentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBuiltinIntentsError {
-    fn description(&self) -> &str {
         match *self {
-            GetBuiltinIntentsError::BadRequest(ref cause) => cause,
-            GetBuiltinIntentsError::InternalFailure(ref cause) => cause,
-            GetBuiltinIntentsError::LimitExceeded(ref cause) => cause,
+            GetBuiltinIntentsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBuiltinIntentsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBuiltinIntentsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBuiltinIntentsError {}
 /// Errors returned by GetBuiltinSlotTypes
 #[derive(Debug, PartialEq)]
 pub enum GetBuiltinSlotTypesError {
@@ -3095,18 +3011,14 @@ impl GetBuiltinSlotTypesError {
 }
 impl fmt::Display for GetBuiltinSlotTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBuiltinSlotTypesError {
-    fn description(&self) -> &str {
         match *self {
-            GetBuiltinSlotTypesError::BadRequest(ref cause) => cause,
-            GetBuiltinSlotTypesError::InternalFailure(ref cause) => cause,
-            GetBuiltinSlotTypesError::LimitExceeded(ref cause) => cause,
+            GetBuiltinSlotTypesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetBuiltinSlotTypesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetBuiltinSlotTypesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBuiltinSlotTypesError {}
 /// Errors returned by GetExport
 #[derive(Debug, PartialEq)]
 pub enum GetExportError {
@@ -3145,19 +3057,15 @@ impl GetExportError {
 }
 impl fmt::Display for GetExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetExportError {
-    fn description(&self) -> &str {
         match *self {
-            GetExportError::BadRequest(ref cause) => cause,
-            GetExportError::InternalFailure(ref cause) => cause,
-            GetExportError::LimitExceeded(ref cause) => cause,
-            GetExportError::NotFound(ref cause) => cause,
+            GetExportError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetExportError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetExportError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetExportError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetExportError {}
 /// Errors returned by GetImport
 #[derive(Debug, PartialEq)]
 pub enum GetImportError {
@@ -3196,19 +3104,15 @@ impl GetImportError {
 }
 impl fmt::Display for GetImportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetImportError {
-    fn description(&self) -> &str {
         match *self {
-            GetImportError::BadRequest(ref cause) => cause,
-            GetImportError::InternalFailure(ref cause) => cause,
-            GetImportError::LimitExceeded(ref cause) => cause,
-            GetImportError::NotFound(ref cause) => cause,
+            GetImportError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetImportError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetImportError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetImportError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetImportError {}
 /// Errors returned by GetIntent
 #[derive(Debug, PartialEq)]
 pub enum GetIntentError {
@@ -3247,19 +3151,15 @@ impl GetIntentError {
 }
 impl fmt::Display for GetIntentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntentError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntentError::BadRequest(ref cause) => cause,
-            GetIntentError::InternalFailure(ref cause) => cause,
-            GetIntentError::LimitExceeded(ref cause) => cause,
-            GetIntentError::NotFound(ref cause) => cause,
+            GetIntentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetIntentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetIntentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetIntentError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntentError {}
 /// Errors returned by GetIntentVersions
 #[derive(Debug, PartialEq)]
 pub enum GetIntentVersionsError {
@@ -3298,19 +3198,15 @@ impl GetIntentVersionsError {
 }
 impl fmt::Display for GetIntentVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntentVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntentVersionsError::BadRequest(ref cause) => cause,
-            GetIntentVersionsError::InternalFailure(ref cause) => cause,
-            GetIntentVersionsError::LimitExceeded(ref cause) => cause,
-            GetIntentVersionsError::NotFound(ref cause) => cause,
+            GetIntentVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetIntentVersionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetIntentVersionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetIntentVersionsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntentVersionsError {}
 /// Errors returned by GetIntents
 #[derive(Debug, PartialEq)]
 pub enum GetIntentsError {
@@ -3349,19 +3245,15 @@ impl GetIntentsError {
 }
 impl fmt::Display for GetIntentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIntentsError {
-    fn description(&self) -> &str {
         match *self {
-            GetIntentsError::BadRequest(ref cause) => cause,
-            GetIntentsError::InternalFailure(ref cause) => cause,
-            GetIntentsError::LimitExceeded(ref cause) => cause,
-            GetIntentsError::NotFound(ref cause) => cause,
+            GetIntentsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetIntentsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetIntentsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetIntentsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIntentsError {}
 /// Errors returned by GetSlotType
 #[derive(Debug, PartialEq)]
 pub enum GetSlotTypeError {
@@ -3400,19 +3292,15 @@ impl GetSlotTypeError {
 }
 impl fmt::Display for GetSlotTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSlotTypeError {
-    fn description(&self) -> &str {
         match *self {
-            GetSlotTypeError::BadRequest(ref cause) => cause,
-            GetSlotTypeError::InternalFailure(ref cause) => cause,
-            GetSlotTypeError::LimitExceeded(ref cause) => cause,
-            GetSlotTypeError::NotFound(ref cause) => cause,
+            GetSlotTypeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetSlotTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetSlotTypeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetSlotTypeError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSlotTypeError {}
 /// Errors returned by GetSlotTypeVersions
 #[derive(Debug, PartialEq)]
 pub enum GetSlotTypeVersionsError {
@@ -3451,19 +3339,15 @@ impl GetSlotTypeVersionsError {
 }
 impl fmt::Display for GetSlotTypeVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSlotTypeVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetSlotTypeVersionsError::BadRequest(ref cause) => cause,
-            GetSlotTypeVersionsError::InternalFailure(ref cause) => cause,
-            GetSlotTypeVersionsError::LimitExceeded(ref cause) => cause,
-            GetSlotTypeVersionsError::NotFound(ref cause) => cause,
+            GetSlotTypeVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetSlotTypeVersionsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetSlotTypeVersionsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetSlotTypeVersionsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSlotTypeVersionsError {}
 /// Errors returned by GetSlotTypes
 #[derive(Debug, PartialEq)]
 pub enum GetSlotTypesError {
@@ -3502,19 +3386,15 @@ impl GetSlotTypesError {
 }
 impl fmt::Display for GetSlotTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSlotTypesError {
-    fn description(&self) -> &str {
         match *self {
-            GetSlotTypesError::BadRequest(ref cause) => cause,
-            GetSlotTypesError::InternalFailure(ref cause) => cause,
-            GetSlotTypesError::LimitExceeded(ref cause) => cause,
-            GetSlotTypesError::NotFound(ref cause) => cause,
+            GetSlotTypesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetSlotTypesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetSlotTypesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetSlotTypesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSlotTypesError {}
 /// Errors returned by GetUtterancesView
 #[derive(Debug, PartialEq)]
 pub enum GetUtterancesViewError {
@@ -3548,18 +3428,14 @@ impl GetUtterancesViewError {
 }
 impl fmt::Display for GetUtterancesViewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetUtterancesViewError {
-    fn description(&self) -> &str {
         match *self {
-            GetUtterancesViewError::BadRequest(ref cause) => cause,
-            GetUtterancesViewError::InternalFailure(ref cause) => cause,
-            GetUtterancesViewError::LimitExceeded(ref cause) => cause,
+            GetUtterancesViewError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetUtterancesViewError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetUtterancesViewError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetUtterancesViewError {}
 /// Errors returned by PutBot
 #[derive(Debug, PartialEq)]
 pub enum PutBotError {
@@ -3601,20 +3477,16 @@ impl PutBotError {
 }
 impl fmt::Display for PutBotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBotError {
-    fn description(&self) -> &str {
         match *self {
-            PutBotError::BadRequest(ref cause) => cause,
-            PutBotError::Conflict(ref cause) => cause,
-            PutBotError::InternalFailure(ref cause) => cause,
-            PutBotError::LimitExceeded(ref cause) => cause,
-            PutBotError::PreconditionFailed(ref cause) => cause,
+            PutBotError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutBotError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutBotError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PutBotError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutBotError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutBotError {}
 /// Errors returned by PutBotAlias
 #[derive(Debug, PartialEq)]
 pub enum PutBotAliasError {
@@ -3658,20 +3530,16 @@ impl PutBotAliasError {
 }
 impl fmt::Display for PutBotAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBotAliasError {
-    fn description(&self) -> &str {
         match *self {
-            PutBotAliasError::BadRequest(ref cause) => cause,
-            PutBotAliasError::Conflict(ref cause) => cause,
-            PutBotAliasError::InternalFailure(ref cause) => cause,
-            PutBotAliasError::LimitExceeded(ref cause) => cause,
-            PutBotAliasError::PreconditionFailed(ref cause) => cause,
+            PutBotAliasError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutBotAliasError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutBotAliasError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PutBotAliasError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutBotAliasError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutBotAliasError {}
 /// Errors returned by PutIntent
 #[derive(Debug, PartialEq)]
 pub enum PutIntentError {
@@ -3715,20 +3583,16 @@ impl PutIntentError {
 }
 impl fmt::Display for PutIntentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutIntentError {
-    fn description(&self) -> &str {
         match *self {
-            PutIntentError::BadRequest(ref cause) => cause,
-            PutIntentError::Conflict(ref cause) => cause,
-            PutIntentError::InternalFailure(ref cause) => cause,
-            PutIntentError::LimitExceeded(ref cause) => cause,
-            PutIntentError::PreconditionFailed(ref cause) => cause,
+            PutIntentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutIntentError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutIntentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PutIntentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutIntentError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutIntentError {}
 /// Errors returned by PutSlotType
 #[derive(Debug, PartialEq)]
 pub enum PutSlotTypeError {
@@ -3772,20 +3636,16 @@ impl PutSlotTypeError {
 }
 impl fmt::Display for PutSlotTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutSlotTypeError {
-    fn description(&self) -> &str {
         match *self {
-            PutSlotTypeError::BadRequest(ref cause) => cause,
-            PutSlotTypeError::Conflict(ref cause) => cause,
-            PutSlotTypeError::InternalFailure(ref cause) => cause,
-            PutSlotTypeError::LimitExceeded(ref cause) => cause,
-            PutSlotTypeError::PreconditionFailed(ref cause) => cause,
+            PutSlotTypeError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutSlotTypeError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutSlotTypeError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PutSlotTypeError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutSlotTypeError::PreconditionFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutSlotTypeError {}
 /// Errors returned by StartImport
 #[derive(Debug, PartialEq)]
 pub enum StartImportError {
@@ -3819,18 +3679,14 @@ impl StartImportError {
 }
 impl fmt::Display for StartImportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartImportError {
-    fn description(&self) -> &str {
         match *self {
-            StartImportError::BadRequest(ref cause) => cause,
-            StartImportError::InternalFailure(ref cause) => cause,
-            StartImportError::LimitExceeded(ref cause) => cause,
+            StartImportError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartImportError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartImportError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartImportError {}
 /// Trait representing the capabilities of the Amazon Lex Model Building Service API. Amazon Lex Model Building Service clients implement this trait.
 pub trait LexModels {
     /// <p>Creates a new version of the bot based on the <code>$LATEST</code> version. If the <code>$LATEST</code> version of this resource hasn't changed since you created the last version, Amazon Lex doesn't create a new version. It returns the last created version.</p> <note> <p>You can update only the <code>$LATEST</code> version of the bot. You can't update the numbered versions that you create with the <code>CreateBotVersion</code> operation.</p> </note> <p> When you create the first version of a bot, Amazon Lex sets the version to 1. Subsequent versions increment by 1. For more information, see <a>versioning-intro</a>. </p> <p> This operation requires permission for the <code>lex:CreateBotVersion</code> action. </p>

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -459,20 +459,16 @@ impl DeleteSessionError {
 }
 impl fmt::Display for DeleteSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSessionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSessionError::BadRequest(ref cause) => cause,
-            DeleteSessionError::Conflict(ref cause) => cause,
-            DeleteSessionError::InternalFailure(ref cause) => cause,
-            DeleteSessionError::LimitExceeded(ref cause) => cause,
-            DeleteSessionError::NotFound(ref cause) => cause,
+            DeleteSessionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteSessionError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteSessionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteSessionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSessionError {}
 /// Errors returned by GetSession
 #[derive(Debug, PartialEq)]
 pub enum GetSessionError {
@@ -511,19 +507,15 @@ impl GetSessionError {
 }
 impl fmt::Display for GetSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSessionError {
-    fn description(&self) -> &str {
         match *self {
-            GetSessionError::BadRequest(ref cause) => cause,
-            GetSessionError::InternalFailure(ref cause) => cause,
-            GetSessionError::LimitExceeded(ref cause) => cause,
-            GetSessionError::NotFound(ref cause) => cause,
+            GetSessionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetSessionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetSessionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSessionError {}
 /// Errors returned by PostContent
 #[derive(Debug, PartialEq)]
 pub enum PostContentError {
@@ -597,26 +589,22 @@ impl PostContentError {
 }
 impl fmt::Display for PostContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PostContentError {
-    fn description(&self) -> &str {
         match *self {
-            PostContentError::BadGateway(ref cause) => cause,
-            PostContentError::BadRequest(ref cause) => cause,
-            PostContentError::Conflict(ref cause) => cause,
-            PostContentError::DependencyFailed(ref cause) => cause,
-            PostContentError::InternalFailure(ref cause) => cause,
-            PostContentError::LimitExceeded(ref cause) => cause,
-            PostContentError::LoopDetected(ref cause) => cause,
-            PostContentError::NotAcceptable(ref cause) => cause,
-            PostContentError::NotFound(ref cause) => cause,
-            PostContentError::RequestTimeout(ref cause) => cause,
-            PostContentError::UnsupportedMediaType(ref cause) => cause,
+            PostContentError::BadGateway(ref cause) => write!(f, "{}", cause),
+            PostContentError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PostContentError::Conflict(ref cause) => write!(f, "{}", cause),
+            PostContentError::DependencyFailed(ref cause) => write!(f, "{}", cause),
+            PostContentError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PostContentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PostContentError::LoopDetected(ref cause) => write!(f, "{}", cause),
+            PostContentError::NotAcceptable(ref cause) => write!(f, "{}", cause),
+            PostContentError::NotFound(ref cause) => write!(f, "{}", cause),
+            PostContentError::RequestTimeout(ref cause) => write!(f, "{}", cause),
+            PostContentError::UnsupportedMediaType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PostContentError {}
 /// Errors returned by PostText
 #[derive(Debug, PartialEq)]
 pub enum PostTextError {
@@ -675,23 +663,19 @@ impl PostTextError {
 }
 impl fmt::Display for PostTextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PostTextError {
-    fn description(&self) -> &str {
         match *self {
-            PostTextError::BadGateway(ref cause) => cause,
-            PostTextError::BadRequest(ref cause) => cause,
-            PostTextError::Conflict(ref cause) => cause,
-            PostTextError::DependencyFailed(ref cause) => cause,
-            PostTextError::InternalFailure(ref cause) => cause,
-            PostTextError::LimitExceeded(ref cause) => cause,
-            PostTextError::LoopDetected(ref cause) => cause,
-            PostTextError::NotFound(ref cause) => cause,
+            PostTextError::BadGateway(ref cause) => write!(f, "{}", cause),
+            PostTextError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PostTextError::Conflict(ref cause) => write!(f, "{}", cause),
+            PostTextError::DependencyFailed(ref cause) => write!(f, "{}", cause),
+            PostTextError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PostTextError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PostTextError::LoopDetected(ref cause) => write!(f, "{}", cause),
+            PostTextError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PostTextError {}
 /// Errors returned by PutSession
 #[derive(Debug, PartialEq)]
 pub enum PutSessionError {
@@ -750,23 +734,19 @@ impl PutSessionError {
 }
 impl fmt::Display for PutSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutSessionError {
-    fn description(&self) -> &str {
         match *self {
-            PutSessionError::BadGateway(ref cause) => cause,
-            PutSessionError::BadRequest(ref cause) => cause,
-            PutSessionError::Conflict(ref cause) => cause,
-            PutSessionError::DependencyFailed(ref cause) => cause,
-            PutSessionError::InternalFailure(ref cause) => cause,
-            PutSessionError::LimitExceeded(ref cause) => cause,
-            PutSessionError::NotAcceptable(ref cause) => cause,
-            PutSessionError::NotFound(ref cause) => cause,
+            PutSessionError::BadGateway(ref cause) => write!(f, "{}", cause),
+            PutSessionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutSessionError::Conflict(ref cause) => write!(f, "{}", cause),
+            PutSessionError::DependencyFailed(ref cause) => write!(f, "{}", cause),
+            PutSessionError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            PutSessionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutSessionError::NotAcceptable(ref cause) => write!(f, "{}", cause),
+            PutSessionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutSessionError {}
 /// Trait representing the capabilities of the Amazon Lex Runtime Service API. Amazon Lex Runtime Service clients implement this trait.
 pub trait LexRuntime {
     /// <p>Removes session information for a specified bot, alias, and user ID. </p>

--- a/rusoto/services/license-manager/src/generated.rs
+++ b/rusoto/services/license-manager/src/generated.rs
@@ -867,21 +867,21 @@ impl CreateLicenseConfigurationError {
 }
 impl fmt::Display for CreateLicenseConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLicenseConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLicenseConfigurationError::AccessDenied(ref cause) => cause,
-            CreateLicenseConfigurationError::Authorization(ref cause) => cause,
-            CreateLicenseConfigurationError::InvalidParameterValue(ref cause) => cause,
-            CreateLicenseConfigurationError::RateLimitExceeded(ref cause) => cause,
-            CreateLicenseConfigurationError::ResourceLimitExceeded(ref cause) => cause,
-            CreateLicenseConfigurationError::ServerInternal(ref cause) => cause,
+            CreateLicenseConfigurationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateLicenseConfigurationError::Authorization(ref cause) => write!(f, "{}", cause),
+            CreateLicenseConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLicenseConfigurationError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateLicenseConfigurationError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLicenseConfigurationError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLicenseConfigurationError {}
 /// Errors returned by DeleteLicenseConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteLicenseConfigurationError {
@@ -937,20 +937,18 @@ impl DeleteLicenseConfigurationError {
 }
 impl fmt::Display for DeleteLicenseConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLicenseConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLicenseConfigurationError::AccessDenied(ref cause) => cause,
-            DeleteLicenseConfigurationError::Authorization(ref cause) => cause,
-            DeleteLicenseConfigurationError::InvalidParameterValue(ref cause) => cause,
-            DeleteLicenseConfigurationError::RateLimitExceeded(ref cause) => cause,
-            DeleteLicenseConfigurationError::ServerInternal(ref cause) => cause,
+            DeleteLicenseConfigurationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteLicenseConfigurationError::Authorization(ref cause) => write!(f, "{}", cause),
+            DeleteLicenseConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLicenseConfigurationError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteLicenseConfigurationError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLicenseConfigurationError {}
 /// Errors returned by GetLicenseConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetLicenseConfigurationError {
@@ -1004,20 +1002,18 @@ impl GetLicenseConfigurationError {
 }
 impl fmt::Display for GetLicenseConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLicenseConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetLicenseConfigurationError::AccessDenied(ref cause) => cause,
-            GetLicenseConfigurationError::Authorization(ref cause) => cause,
-            GetLicenseConfigurationError::InvalidParameterValue(ref cause) => cause,
-            GetLicenseConfigurationError::RateLimitExceeded(ref cause) => cause,
-            GetLicenseConfigurationError::ServerInternal(ref cause) => cause,
+            GetLicenseConfigurationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetLicenseConfigurationError::Authorization(ref cause) => write!(f, "{}", cause),
+            GetLicenseConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetLicenseConfigurationError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetLicenseConfigurationError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLicenseConfigurationError {}
 /// Errors returned by GetServiceSettings
 #[derive(Debug, PartialEq)]
 pub enum GetServiceSettingsError {
@@ -1058,19 +1054,15 @@ impl GetServiceSettingsError {
 }
 impl fmt::Display for GetServiceSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceSettingsError::AccessDenied(ref cause) => cause,
-            GetServiceSettingsError::Authorization(ref cause) => cause,
-            GetServiceSettingsError::RateLimitExceeded(ref cause) => cause,
-            GetServiceSettingsError::ServerInternal(ref cause) => cause,
+            GetServiceSettingsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetServiceSettingsError::Authorization(ref cause) => write!(f, "{}", cause),
+            GetServiceSettingsError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetServiceSettingsError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServiceSettingsError {}
 /// Errors returned by ListAssociationsForLicenseConfiguration
 #[derive(Debug, PartialEq)]
 pub enum ListAssociationsForLicenseConfigurationError {
@@ -1135,21 +1127,29 @@ impl ListAssociationsForLicenseConfigurationError {
 }
 impl fmt::Display for ListAssociationsForLicenseConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssociationsForLicenseConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssociationsForLicenseConfigurationError::AccessDenied(ref cause) => cause,
-            ListAssociationsForLicenseConfigurationError::Authorization(ref cause) => cause,
-            ListAssociationsForLicenseConfigurationError::FilterLimitExceeded(ref cause) => cause,
-            ListAssociationsForLicenseConfigurationError::InvalidParameterValue(ref cause) => cause,
-            ListAssociationsForLicenseConfigurationError::RateLimitExceeded(ref cause) => cause,
-            ListAssociationsForLicenseConfigurationError::ServerInternal(ref cause) => cause,
+            ListAssociationsForLicenseConfigurationError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAssociationsForLicenseConfigurationError::Authorization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAssociationsForLicenseConfigurationError::FilterLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAssociationsForLicenseConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAssociationsForLicenseConfigurationError::RateLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAssociationsForLicenseConfigurationError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListAssociationsForLicenseConfigurationError {}
 /// Errors returned by ListFailuresForLicenseConfigurationOperations
 #[derive(Debug, PartialEq)]
 pub enum ListFailuresForLicenseConfigurationOperationsError {
@@ -1209,24 +1209,26 @@ impl ListFailuresForLicenseConfigurationOperationsError {
 }
 impl fmt::Display for ListFailuresForLicenseConfigurationOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFailuresForLicenseConfigurationOperationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFailuresForLicenseConfigurationOperationsError::AccessDenied(ref cause) => cause,
-            ListFailuresForLicenseConfigurationOperationsError::Authorization(ref cause) => cause,
+            ListFailuresForLicenseConfigurationOperationsError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListFailuresForLicenseConfigurationOperationsError::Authorization(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ListFailuresForLicenseConfigurationOperationsError::InvalidParameterValue(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ListFailuresForLicenseConfigurationOperationsError::RateLimitExceeded(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            ListFailuresForLicenseConfigurationOperationsError::ServerInternal(ref cause) => cause,
+            ListFailuresForLicenseConfigurationOperationsError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListFailuresForLicenseConfigurationOperationsError {}
 /// Errors returned by ListLicenseConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListLicenseConfigurationsError {
@@ -1287,21 +1289,21 @@ impl ListLicenseConfigurationsError {
 }
 impl fmt::Display for ListLicenseConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLicenseConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLicenseConfigurationsError::AccessDenied(ref cause) => cause,
-            ListLicenseConfigurationsError::Authorization(ref cause) => cause,
-            ListLicenseConfigurationsError::FilterLimitExceeded(ref cause) => cause,
-            ListLicenseConfigurationsError::InvalidParameterValue(ref cause) => cause,
-            ListLicenseConfigurationsError::RateLimitExceeded(ref cause) => cause,
-            ListLicenseConfigurationsError::ServerInternal(ref cause) => cause,
+            ListLicenseConfigurationsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListLicenseConfigurationsError::Authorization(ref cause) => write!(f, "{}", cause),
+            ListLicenseConfigurationsError::FilterLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLicenseConfigurationsError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLicenseConfigurationsError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListLicenseConfigurationsError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLicenseConfigurationsError {}
 /// Errors returned by ListLicenseSpecificationsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListLicenseSpecificationsForResourceError {
@@ -1357,20 +1359,26 @@ impl ListLicenseSpecificationsForResourceError {
 }
 impl fmt::Display for ListLicenseSpecificationsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLicenseSpecificationsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListLicenseSpecificationsForResourceError::AccessDenied(ref cause) => cause,
-            ListLicenseSpecificationsForResourceError::Authorization(ref cause) => cause,
-            ListLicenseSpecificationsForResourceError::InvalidParameterValue(ref cause) => cause,
-            ListLicenseSpecificationsForResourceError::RateLimitExceeded(ref cause) => cause,
-            ListLicenseSpecificationsForResourceError::ServerInternal(ref cause) => cause,
+            ListLicenseSpecificationsForResourceError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLicenseSpecificationsForResourceError::Authorization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLicenseSpecificationsForResourceError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLicenseSpecificationsForResourceError::RateLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLicenseSpecificationsForResourceError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListLicenseSpecificationsForResourceError {}
 /// Errors returned by ListResourceInventory
 #[derive(Debug, PartialEq)]
 pub enum ListResourceInventoryError {
@@ -1434,22 +1442,18 @@ impl ListResourceInventoryError {
 }
 impl fmt::Display for ListResourceInventoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceInventoryError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceInventoryError::AccessDenied(ref cause) => cause,
-            ListResourceInventoryError::Authorization(ref cause) => cause,
-            ListResourceInventoryError::FailedDependency(ref cause) => cause,
-            ListResourceInventoryError::FilterLimitExceeded(ref cause) => cause,
-            ListResourceInventoryError::InvalidParameterValue(ref cause) => cause,
-            ListResourceInventoryError::RateLimitExceeded(ref cause) => cause,
-            ListResourceInventoryError::ServerInternal(ref cause) => cause,
+            ListResourceInventoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListResourceInventoryError::Authorization(ref cause) => write!(f, "{}", cause),
+            ListResourceInventoryError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            ListResourceInventoryError::FilterLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListResourceInventoryError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListResourceInventoryError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListResourceInventoryError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourceInventoryError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1497,20 +1501,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AccessDenied(ref cause) => cause,
-            ListTagsForResourceError::Authorization(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameterValue(ref cause) => cause,
-            ListTagsForResourceError::RateLimitExceeded(ref cause) => cause,
-            ListTagsForResourceError::ServerInternal(ref cause) => cause,
+            ListTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Authorization(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListUsageForLicenseConfiguration
 #[derive(Debug, PartialEq)]
 pub enum ListUsageForLicenseConfigurationError {
@@ -1573,21 +1573,29 @@ impl ListUsageForLicenseConfigurationError {
 }
 impl fmt::Display for ListUsageForLicenseConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsageForLicenseConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsageForLicenseConfigurationError::AccessDenied(ref cause) => cause,
-            ListUsageForLicenseConfigurationError::Authorization(ref cause) => cause,
-            ListUsageForLicenseConfigurationError::FilterLimitExceeded(ref cause) => cause,
-            ListUsageForLicenseConfigurationError::InvalidParameterValue(ref cause) => cause,
-            ListUsageForLicenseConfigurationError::RateLimitExceeded(ref cause) => cause,
-            ListUsageForLicenseConfigurationError::ServerInternal(ref cause) => cause,
+            ListUsageForLicenseConfigurationError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListUsageForLicenseConfigurationError::Authorization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListUsageForLicenseConfigurationError::FilterLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListUsageForLicenseConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListUsageForLicenseConfigurationError::RateLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListUsageForLicenseConfigurationError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListUsageForLicenseConfigurationError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1631,20 +1639,16 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AccessDenied(ref cause) => cause,
-            TagResourceError::Authorization(ref cause) => cause,
-            TagResourceError::InvalidParameterValue(ref cause) => cause,
-            TagResourceError::RateLimitExceeded(ref cause) => cause,
-            TagResourceError::ServerInternal(ref cause) => cause,
+            TagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Authorization(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            TagResourceError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1688,20 +1692,16 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AccessDenied(ref cause) => cause,
-            UntagResourceError::Authorization(ref cause) => cause,
-            UntagResourceError::InvalidParameterValue(ref cause) => cause,
-            UntagResourceError::RateLimitExceeded(ref cause) => cause,
-            UntagResourceError::ServerInternal(ref cause) => cause,
+            UntagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Authorization(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateLicenseConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateLicenseConfigurationError {
@@ -1757,20 +1757,18 @@ impl UpdateLicenseConfigurationError {
 }
 impl fmt::Display for UpdateLicenseConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLicenseConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLicenseConfigurationError::AccessDenied(ref cause) => cause,
-            UpdateLicenseConfigurationError::Authorization(ref cause) => cause,
-            UpdateLicenseConfigurationError::InvalidParameterValue(ref cause) => cause,
-            UpdateLicenseConfigurationError::RateLimitExceeded(ref cause) => cause,
-            UpdateLicenseConfigurationError::ServerInternal(ref cause) => cause,
+            UpdateLicenseConfigurationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateLicenseConfigurationError::Authorization(ref cause) => write!(f, "{}", cause),
+            UpdateLicenseConfigurationError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLicenseConfigurationError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateLicenseConfigurationError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLicenseConfigurationError {}
 /// Errors returned by UpdateLicenseSpecificationsForResource
 #[derive(Debug, PartialEq)]
 pub enum UpdateLicenseSpecificationsForResourceError {
@@ -1840,22 +1838,32 @@ impl UpdateLicenseSpecificationsForResourceError {
 }
 impl fmt::Display for UpdateLicenseSpecificationsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLicenseSpecificationsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLicenseSpecificationsForResourceError::AccessDenied(ref cause) => cause,
-            UpdateLicenseSpecificationsForResourceError::Authorization(ref cause) => cause,
-            UpdateLicenseSpecificationsForResourceError::InvalidParameterValue(ref cause) => cause,
-            UpdateLicenseSpecificationsForResourceError::InvalidResourceState(ref cause) => cause,
-            UpdateLicenseSpecificationsForResourceError::LicenseUsage(ref cause) => cause,
-            UpdateLicenseSpecificationsForResourceError::RateLimitExceeded(ref cause) => cause,
-            UpdateLicenseSpecificationsForResourceError::ServerInternal(ref cause) => cause,
+            UpdateLicenseSpecificationsForResourceError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLicenseSpecificationsForResourceError::Authorization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLicenseSpecificationsForResourceError::InvalidParameterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLicenseSpecificationsForResourceError::InvalidResourceState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLicenseSpecificationsForResourceError::LicenseUsage(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLicenseSpecificationsForResourceError::RateLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLicenseSpecificationsForResourceError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateLicenseSpecificationsForResourceError {}
 /// Errors returned by UpdateServiceSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateServiceSettingsError {
@@ -1905,20 +1913,16 @@ impl UpdateServiceSettingsError {
 }
 impl fmt::Display for UpdateServiceSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServiceSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServiceSettingsError::AccessDenied(ref cause) => cause,
-            UpdateServiceSettingsError::Authorization(ref cause) => cause,
-            UpdateServiceSettingsError::InvalidParameterValue(ref cause) => cause,
-            UpdateServiceSettingsError::RateLimitExceeded(ref cause) => cause,
-            UpdateServiceSettingsError::ServerInternal(ref cause) => cause,
+            UpdateServiceSettingsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateServiceSettingsError::Authorization(ref cause) => write!(f, "{}", cause),
+            UpdateServiceSettingsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            UpdateServiceSettingsError::RateLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateServiceSettingsError::ServerInternal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServiceSettingsError {}
 /// Trait representing the capabilities of the AWS License Manager API. AWS License Manager clients implement this trait.
 pub trait LicenseManager {
     /// <p>Creates a license configuration.</p> <p>A license configuration is an abstraction of a customer license agreement that can be consumed and enforced by License Manager. Components include specifications for the license type (licensing by instance, socket, CPU, or vCPU), allowed tenancy (shared tenancy, Dedicated Instance, Dedicated Host, or all of these), host affinity (how long a VM must be associated with a host), and the number of licenses purchased and used.</p>

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -4278,22 +4278,18 @@ impl AllocateStaticIpError {
 }
 impl fmt::Display for AllocateStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AllocateStaticIpError {
-    fn description(&self) -> &str {
         match *self {
-            AllocateStaticIpError::AccessDenied(ref cause) => cause,
-            AllocateStaticIpError::AccountSetupInProgress(ref cause) => cause,
-            AllocateStaticIpError::InvalidInput(ref cause) => cause,
-            AllocateStaticIpError::NotFound(ref cause) => cause,
-            AllocateStaticIpError::OperationFailure(ref cause) => cause,
-            AllocateStaticIpError::Service(ref cause) => cause,
-            AllocateStaticIpError::Unauthenticated(ref cause) => cause,
+            AllocateStaticIpError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AllocateStaticIpError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            AllocateStaticIpError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AllocateStaticIpError::NotFound(ref cause) => write!(f, "{}", cause),
+            AllocateStaticIpError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            AllocateStaticIpError::Service(ref cause) => write!(f, "{}", cause),
+            AllocateStaticIpError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AllocateStaticIpError {}
 /// Errors returned by AttachDisk
 #[derive(Debug, PartialEq)]
 pub enum AttachDiskError {
@@ -4347,22 +4343,18 @@ impl AttachDiskError {
 }
 impl fmt::Display for AttachDiskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachDiskError {
-    fn description(&self) -> &str {
         match *self {
-            AttachDiskError::AccessDenied(ref cause) => cause,
-            AttachDiskError::AccountSetupInProgress(ref cause) => cause,
-            AttachDiskError::InvalidInput(ref cause) => cause,
-            AttachDiskError::NotFound(ref cause) => cause,
-            AttachDiskError::OperationFailure(ref cause) => cause,
-            AttachDiskError::Service(ref cause) => cause,
-            AttachDiskError::Unauthenticated(ref cause) => cause,
+            AttachDiskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachDiskError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            AttachDiskError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AttachDiskError::NotFound(ref cause) => write!(f, "{}", cause),
+            AttachDiskError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            AttachDiskError::Service(ref cause) => write!(f, "{}", cause),
+            AttachDiskError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachDiskError {}
 /// Errors returned by AttachInstancesToLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum AttachInstancesToLoadBalancerError {
@@ -4432,22 +4424,24 @@ impl AttachInstancesToLoadBalancerError {
 }
 impl fmt::Display for AttachInstancesToLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachInstancesToLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            AttachInstancesToLoadBalancerError::AccessDenied(ref cause) => cause,
-            AttachInstancesToLoadBalancerError::AccountSetupInProgress(ref cause) => cause,
-            AttachInstancesToLoadBalancerError::InvalidInput(ref cause) => cause,
-            AttachInstancesToLoadBalancerError::NotFound(ref cause) => cause,
-            AttachInstancesToLoadBalancerError::OperationFailure(ref cause) => cause,
-            AttachInstancesToLoadBalancerError::Service(ref cause) => cause,
-            AttachInstancesToLoadBalancerError::Unauthenticated(ref cause) => cause,
+            AttachInstancesToLoadBalancerError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachInstancesToLoadBalancerError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachInstancesToLoadBalancerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AttachInstancesToLoadBalancerError::NotFound(ref cause) => write!(f, "{}", cause),
+            AttachInstancesToLoadBalancerError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachInstancesToLoadBalancerError::Service(ref cause) => write!(f, "{}", cause),
+            AttachInstancesToLoadBalancerError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AttachInstancesToLoadBalancerError {}
 /// Errors returned by AttachLoadBalancerTlsCertificate
 #[derive(Debug, PartialEq)]
 pub enum AttachLoadBalancerTlsCertificateError {
@@ -4517,22 +4511,28 @@ impl AttachLoadBalancerTlsCertificateError {
 }
 impl fmt::Display for AttachLoadBalancerTlsCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachLoadBalancerTlsCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            AttachLoadBalancerTlsCertificateError::AccessDenied(ref cause) => cause,
-            AttachLoadBalancerTlsCertificateError::AccountSetupInProgress(ref cause) => cause,
-            AttachLoadBalancerTlsCertificateError::InvalidInput(ref cause) => cause,
-            AttachLoadBalancerTlsCertificateError::NotFound(ref cause) => cause,
-            AttachLoadBalancerTlsCertificateError::OperationFailure(ref cause) => cause,
-            AttachLoadBalancerTlsCertificateError::Service(ref cause) => cause,
-            AttachLoadBalancerTlsCertificateError::Unauthenticated(ref cause) => cause,
+            AttachLoadBalancerTlsCertificateError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachLoadBalancerTlsCertificateError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachLoadBalancerTlsCertificateError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachLoadBalancerTlsCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            AttachLoadBalancerTlsCertificateError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AttachLoadBalancerTlsCertificateError::Service(ref cause) => write!(f, "{}", cause),
+            AttachLoadBalancerTlsCertificateError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AttachLoadBalancerTlsCertificateError {}
 /// Errors returned by AttachStaticIp
 #[derive(Debug, PartialEq)]
 pub enum AttachStaticIpError {
@@ -4588,22 +4588,18 @@ impl AttachStaticIpError {
 }
 impl fmt::Display for AttachStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachStaticIpError {
-    fn description(&self) -> &str {
         match *self {
-            AttachStaticIpError::AccessDenied(ref cause) => cause,
-            AttachStaticIpError::AccountSetupInProgress(ref cause) => cause,
-            AttachStaticIpError::InvalidInput(ref cause) => cause,
-            AttachStaticIpError::NotFound(ref cause) => cause,
-            AttachStaticIpError::OperationFailure(ref cause) => cause,
-            AttachStaticIpError::Service(ref cause) => cause,
-            AttachStaticIpError::Unauthenticated(ref cause) => cause,
+            AttachStaticIpError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachStaticIpError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            AttachStaticIpError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AttachStaticIpError::NotFound(ref cause) => write!(f, "{}", cause),
+            AttachStaticIpError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            AttachStaticIpError::Service(ref cause) => write!(f, "{}", cause),
+            AttachStaticIpError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachStaticIpError {}
 /// Errors returned by CloseInstancePublicPorts
 #[derive(Debug, PartialEq)]
 pub enum CloseInstancePublicPortsError {
@@ -4667,22 +4663,20 @@ impl CloseInstancePublicPortsError {
 }
 impl fmt::Display for CloseInstancePublicPortsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CloseInstancePublicPortsError {
-    fn description(&self) -> &str {
         match *self {
-            CloseInstancePublicPortsError::AccessDenied(ref cause) => cause,
-            CloseInstancePublicPortsError::AccountSetupInProgress(ref cause) => cause,
-            CloseInstancePublicPortsError::InvalidInput(ref cause) => cause,
-            CloseInstancePublicPortsError::NotFound(ref cause) => cause,
-            CloseInstancePublicPortsError::OperationFailure(ref cause) => cause,
-            CloseInstancePublicPortsError::Service(ref cause) => cause,
-            CloseInstancePublicPortsError::Unauthenticated(ref cause) => cause,
+            CloseInstancePublicPortsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CloseInstancePublicPortsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CloseInstancePublicPortsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CloseInstancePublicPortsError::NotFound(ref cause) => write!(f, "{}", cause),
+            CloseInstancePublicPortsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CloseInstancePublicPortsError::Service(ref cause) => write!(f, "{}", cause),
+            CloseInstancePublicPortsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CloseInstancePublicPortsError {}
 /// Errors returned by CopySnapshot
 #[derive(Debug, PartialEq)]
 pub enum CopySnapshotError {
@@ -4736,22 +4730,18 @@ impl CopySnapshotError {
 }
 impl fmt::Display for CopySnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopySnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CopySnapshotError::AccessDenied(ref cause) => cause,
-            CopySnapshotError::AccountSetupInProgress(ref cause) => cause,
-            CopySnapshotError::InvalidInput(ref cause) => cause,
-            CopySnapshotError::NotFound(ref cause) => cause,
-            CopySnapshotError::OperationFailure(ref cause) => cause,
-            CopySnapshotError::Service(ref cause) => cause,
-            CopySnapshotError::Unauthenticated(ref cause) => cause,
+            CopySnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CopySnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopySnapshotError {}
 /// Errors returned by CreateCloudFormationStack
 #[derive(Debug, PartialEq)]
 pub enum CreateCloudFormationStackError {
@@ -4815,22 +4805,20 @@ impl CreateCloudFormationStackError {
 }
 impl fmt::Display for CreateCloudFormationStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCloudFormationStackError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCloudFormationStackError::AccessDenied(ref cause) => cause,
-            CreateCloudFormationStackError::AccountSetupInProgress(ref cause) => cause,
-            CreateCloudFormationStackError::InvalidInput(ref cause) => cause,
-            CreateCloudFormationStackError::NotFound(ref cause) => cause,
-            CreateCloudFormationStackError::OperationFailure(ref cause) => cause,
-            CreateCloudFormationStackError::Service(ref cause) => cause,
-            CreateCloudFormationStackError::Unauthenticated(ref cause) => cause,
+            CreateCloudFormationStackError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationStackError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCloudFormationStackError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationStackError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationStackError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationStackError::Service(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationStackError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCloudFormationStackError {}
 /// Errors returned by CreateDisk
 #[derive(Debug, PartialEq)]
 pub enum CreateDiskError {
@@ -4884,22 +4872,18 @@ impl CreateDiskError {
 }
 impl fmt::Display for CreateDiskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDiskError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDiskError::AccessDenied(ref cause) => cause,
-            CreateDiskError::AccountSetupInProgress(ref cause) => cause,
-            CreateDiskError::InvalidInput(ref cause) => cause,
-            CreateDiskError::NotFound(ref cause) => cause,
-            CreateDiskError::OperationFailure(ref cause) => cause,
-            CreateDiskError::Service(ref cause) => cause,
-            CreateDiskError::Unauthenticated(ref cause) => cause,
+            CreateDiskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDiskError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateDiskError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDiskError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDiskError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateDiskError::Service(ref cause) => write!(f, "{}", cause),
+            CreateDiskError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDiskError {}
 /// Errors returned by CreateDiskFromSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateDiskFromSnapshotError {
@@ -4959,22 +4943,20 @@ impl CreateDiskFromSnapshotError {
 }
 impl fmt::Display for CreateDiskFromSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDiskFromSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDiskFromSnapshotError::AccessDenied(ref cause) => cause,
-            CreateDiskFromSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            CreateDiskFromSnapshotError::InvalidInput(ref cause) => cause,
-            CreateDiskFromSnapshotError::NotFound(ref cause) => cause,
-            CreateDiskFromSnapshotError::OperationFailure(ref cause) => cause,
-            CreateDiskFromSnapshotError::Service(ref cause) => cause,
-            CreateDiskFromSnapshotError::Unauthenticated(ref cause) => cause,
+            CreateDiskFromSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDiskFromSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDiskFromSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDiskFromSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDiskFromSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateDiskFromSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CreateDiskFromSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDiskFromSnapshotError {}
 /// Errors returned by CreateDiskSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateDiskSnapshotError {
@@ -5030,22 +5012,18 @@ impl CreateDiskSnapshotError {
 }
 impl fmt::Display for CreateDiskSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDiskSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDiskSnapshotError::AccessDenied(ref cause) => cause,
-            CreateDiskSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            CreateDiskSnapshotError::InvalidInput(ref cause) => cause,
-            CreateDiskSnapshotError::NotFound(ref cause) => cause,
-            CreateDiskSnapshotError::OperationFailure(ref cause) => cause,
-            CreateDiskSnapshotError::Service(ref cause) => cause,
-            CreateDiskSnapshotError::Unauthenticated(ref cause) => cause,
+            CreateDiskSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDiskSnapshotError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateDiskSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDiskSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDiskSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateDiskSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CreateDiskSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDiskSnapshotError {}
 /// Errors returned by CreateDomain
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainError {
@@ -5099,22 +5077,18 @@ impl CreateDomainError {
 }
 impl fmt::Display for CreateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainError::AccessDenied(ref cause) => cause,
-            CreateDomainError::AccountSetupInProgress(ref cause) => cause,
-            CreateDomainError::InvalidInput(ref cause) => cause,
-            CreateDomainError::NotFound(ref cause) => cause,
-            CreateDomainError::OperationFailure(ref cause) => cause,
-            CreateDomainError::Service(ref cause) => cause,
-            CreateDomainError::Unauthenticated(ref cause) => cause,
+            CreateDomainError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::Service(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainError {}
 /// Errors returned by CreateDomainEntry
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainEntryError {
@@ -5170,22 +5144,18 @@ impl CreateDomainEntryError {
 }
 impl fmt::Display for CreateDomainEntryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainEntryError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainEntryError::AccessDenied(ref cause) => cause,
-            CreateDomainEntryError::AccountSetupInProgress(ref cause) => cause,
-            CreateDomainEntryError::InvalidInput(ref cause) => cause,
-            CreateDomainEntryError::NotFound(ref cause) => cause,
-            CreateDomainEntryError::OperationFailure(ref cause) => cause,
-            CreateDomainEntryError::Service(ref cause) => cause,
-            CreateDomainEntryError::Unauthenticated(ref cause) => cause,
+            CreateDomainEntryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateDomainEntryError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateDomainEntryError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateDomainEntryError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateDomainEntryError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateDomainEntryError::Service(ref cause) => write!(f, "{}", cause),
+            CreateDomainEntryError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainEntryError {}
 /// Errors returned by CreateInstanceSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateInstanceSnapshotError {
@@ -5245,22 +5215,20 @@ impl CreateInstanceSnapshotError {
 }
 impl fmt::Display for CreateInstanceSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInstanceSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInstanceSnapshotError::AccessDenied(ref cause) => cause,
-            CreateInstanceSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            CreateInstanceSnapshotError::InvalidInput(ref cause) => cause,
-            CreateInstanceSnapshotError::NotFound(ref cause) => cause,
-            CreateInstanceSnapshotError::OperationFailure(ref cause) => cause,
-            CreateInstanceSnapshotError::Service(ref cause) => cause,
-            CreateInstanceSnapshotError::Unauthenticated(ref cause) => cause,
+            CreateInstanceSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateInstanceSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateInstanceSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateInstanceSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateInstanceSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateInstanceSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CreateInstanceSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInstanceSnapshotError {}
 /// Errors returned by CreateInstances
 #[derive(Debug, PartialEq)]
 pub enum CreateInstancesError {
@@ -5316,22 +5284,18 @@ impl CreateInstancesError {
 }
 impl fmt::Display for CreateInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInstancesError::AccessDenied(ref cause) => cause,
-            CreateInstancesError::AccountSetupInProgress(ref cause) => cause,
-            CreateInstancesError::InvalidInput(ref cause) => cause,
-            CreateInstancesError::NotFound(ref cause) => cause,
-            CreateInstancesError::OperationFailure(ref cause) => cause,
-            CreateInstancesError::Service(ref cause) => cause,
-            CreateInstancesError::Unauthenticated(ref cause) => cause,
+            CreateInstancesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateInstancesError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateInstancesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateInstancesError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateInstancesError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateInstancesError::Service(ref cause) => write!(f, "{}", cause),
+            CreateInstancesError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInstancesError {}
 /// Errors returned by CreateInstancesFromSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateInstancesFromSnapshotError {
@@ -5399,22 +5363,20 @@ impl CreateInstancesFromSnapshotError {
 }
 impl fmt::Display for CreateInstancesFromSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInstancesFromSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInstancesFromSnapshotError::AccessDenied(ref cause) => cause,
-            CreateInstancesFromSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            CreateInstancesFromSnapshotError::InvalidInput(ref cause) => cause,
-            CreateInstancesFromSnapshotError::NotFound(ref cause) => cause,
-            CreateInstancesFromSnapshotError::OperationFailure(ref cause) => cause,
-            CreateInstancesFromSnapshotError::Service(ref cause) => cause,
-            CreateInstancesFromSnapshotError::Unauthenticated(ref cause) => cause,
+            CreateInstancesFromSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateInstancesFromSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateInstancesFromSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateInstancesFromSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateInstancesFromSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateInstancesFromSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CreateInstancesFromSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInstancesFromSnapshotError {}
 /// Errors returned by CreateKeyPair
 #[derive(Debug, PartialEq)]
 pub enum CreateKeyPairError {
@@ -5470,22 +5432,18 @@ impl CreateKeyPairError {
 }
 impl fmt::Display for CreateKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateKeyPairError {
-    fn description(&self) -> &str {
         match *self {
-            CreateKeyPairError::AccessDenied(ref cause) => cause,
-            CreateKeyPairError::AccountSetupInProgress(ref cause) => cause,
-            CreateKeyPairError::InvalidInput(ref cause) => cause,
-            CreateKeyPairError::NotFound(ref cause) => cause,
-            CreateKeyPairError::OperationFailure(ref cause) => cause,
-            CreateKeyPairError::Service(ref cause) => cause,
-            CreateKeyPairError::Unauthenticated(ref cause) => cause,
+            CreateKeyPairError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateKeyPairError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateKeyPairError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateKeyPairError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateKeyPairError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateKeyPairError::Service(ref cause) => write!(f, "{}", cause),
+            CreateKeyPairError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateKeyPairError {}
 /// Errors returned by CreateLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum CreateLoadBalancerError {
@@ -5541,22 +5499,18 @@ impl CreateLoadBalancerError {
 }
 impl fmt::Display for CreateLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoadBalancerError::AccessDenied(ref cause) => cause,
-            CreateLoadBalancerError::AccountSetupInProgress(ref cause) => cause,
-            CreateLoadBalancerError::InvalidInput(ref cause) => cause,
-            CreateLoadBalancerError::NotFound(ref cause) => cause,
-            CreateLoadBalancerError::OperationFailure(ref cause) => cause,
-            CreateLoadBalancerError::Service(ref cause) => cause,
-            CreateLoadBalancerError::Unauthenticated(ref cause) => cause,
+            CreateLoadBalancerError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::Service(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLoadBalancerError {}
 /// Errors returned by CreateLoadBalancerTlsCertificate
 #[derive(Debug, PartialEq)]
 pub enum CreateLoadBalancerTlsCertificateError {
@@ -5626,22 +5580,28 @@ impl CreateLoadBalancerTlsCertificateError {
 }
 impl fmt::Display for CreateLoadBalancerTlsCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLoadBalancerTlsCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLoadBalancerTlsCertificateError::AccessDenied(ref cause) => cause,
-            CreateLoadBalancerTlsCertificateError::AccountSetupInProgress(ref cause) => cause,
-            CreateLoadBalancerTlsCertificateError::InvalidInput(ref cause) => cause,
-            CreateLoadBalancerTlsCertificateError::NotFound(ref cause) => cause,
-            CreateLoadBalancerTlsCertificateError::OperationFailure(ref cause) => cause,
-            CreateLoadBalancerTlsCertificateError::Service(ref cause) => cause,
-            CreateLoadBalancerTlsCertificateError::Unauthenticated(ref cause) => cause,
+            CreateLoadBalancerTlsCertificateError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerTlsCertificateError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerTlsCertificateError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerTlsCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerTlsCertificateError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateLoadBalancerTlsCertificateError::Service(ref cause) => write!(f, "{}", cause),
+            CreateLoadBalancerTlsCertificateError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateLoadBalancerTlsCertificateError {}
 /// Errors returned by CreateRelationalDatabase
 #[derive(Debug, PartialEq)]
 pub enum CreateRelationalDatabaseError {
@@ -5705,22 +5665,20 @@ impl CreateRelationalDatabaseError {
 }
 impl fmt::Display for CreateRelationalDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRelationalDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRelationalDatabaseError::AccessDenied(ref cause) => cause,
-            CreateRelationalDatabaseError::AccountSetupInProgress(ref cause) => cause,
-            CreateRelationalDatabaseError::InvalidInput(ref cause) => cause,
-            CreateRelationalDatabaseError::NotFound(ref cause) => cause,
-            CreateRelationalDatabaseError::OperationFailure(ref cause) => cause,
-            CreateRelationalDatabaseError::Service(ref cause) => cause,
-            CreateRelationalDatabaseError::Unauthenticated(ref cause) => cause,
+            CreateRelationalDatabaseError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseError::Service(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRelationalDatabaseError {}
 /// Errors returned by CreateRelationalDatabaseFromSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateRelationalDatabaseFromSnapshotError {
@@ -5790,22 +5748,30 @@ impl CreateRelationalDatabaseFromSnapshotError {
 }
 impl fmt::Display for CreateRelationalDatabaseFromSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRelationalDatabaseFromSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRelationalDatabaseFromSnapshotError::AccessDenied(ref cause) => cause,
-            CreateRelationalDatabaseFromSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            CreateRelationalDatabaseFromSnapshotError::InvalidInput(ref cause) => cause,
-            CreateRelationalDatabaseFromSnapshotError::NotFound(ref cause) => cause,
-            CreateRelationalDatabaseFromSnapshotError::OperationFailure(ref cause) => cause,
-            CreateRelationalDatabaseFromSnapshotError::Service(ref cause) => cause,
-            CreateRelationalDatabaseFromSnapshotError::Unauthenticated(ref cause) => cause,
+            CreateRelationalDatabaseFromSnapshotError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseFromSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseFromSnapshotError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseFromSnapshotError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseFromSnapshotError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseFromSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseFromSnapshotError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateRelationalDatabaseFromSnapshotError {}
 /// Errors returned by CreateRelationalDatabaseSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateRelationalDatabaseSnapshotError {
@@ -5875,22 +5841,28 @@ impl CreateRelationalDatabaseSnapshotError {
 }
 impl fmt::Display for CreateRelationalDatabaseSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRelationalDatabaseSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRelationalDatabaseSnapshotError::AccessDenied(ref cause) => cause,
-            CreateRelationalDatabaseSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            CreateRelationalDatabaseSnapshotError::InvalidInput(ref cause) => cause,
-            CreateRelationalDatabaseSnapshotError::NotFound(ref cause) => cause,
-            CreateRelationalDatabaseSnapshotError::OperationFailure(ref cause) => cause,
-            CreateRelationalDatabaseSnapshotError::Service(ref cause) => cause,
-            CreateRelationalDatabaseSnapshotError::Unauthenticated(ref cause) => cause,
+            CreateRelationalDatabaseSnapshotError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseSnapshotError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseSnapshotError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateRelationalDatabaseSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            CreateRelationalDatabaseSnapshotError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateRelationalDatabaseSnapshotError {}
 /// Errors returned by DeleteAutoSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteAutoSnapshotError {
@@ -5939,21 +5911,17 @@ impl DeleteAutoSnapshotError {
 }
 impl fmt::Display for DeleteAutoSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAutoSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAutoSnapshotError::AccessDenied(ref cause) => cause,
-            DeleteAutoSnapshotError::InvalidInput(ref cause) => cause,
-            DeleteAutoSnapshotError::NotFound(ref cause) => cause,
-            DeleteAutoSnapshotError::OperationFailure(ref cause) => cause,
-            DeleteAutoSnapshotError::Service(ref cause) => cause,
-            DeleteAutoSnapshotError::Unauthenticated(ref cause) => cause,
+            DeleteAutoSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteAutoSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteAutoSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAutoSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteAutoSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteAutoSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAutoSnapshotError {}
 /// Errors returned by DeleteDisk
 #[derive(Debug, PartialEq)]
 pub enum DeleteDiskError {
@@ -6007,22 +5975,18 @@ impl DeleteDiskError {
 }
 impl fmt::Display for DeleteDiskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDiskError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDiskError::AccessDenied(ref cause) => cause,
-            DeleteDiskError::AccountSetupInProgress(ref cause) => cause,
-            DeleteDiskError::InvalidInput(ref cause) => cause,
-            DeleteDiskError::NotFound(ref cause) => cause,
-            DeleteDiskError::OperationFailure(ref cause) => cause,
-            DeleteDiskError::Service(ref cause) => cause,
-            DeleteDiskError::Unauthenticated(ref cause) => cause,
+            DeleteDiskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteDiskError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteDiskError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteDiskError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDiskError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDiskError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteDiskError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDiskError {}
 /// Errors returned by DeleteDiskSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteDiskSnapshotError {
@@ -6078,22 +6042,18 @@ impl DeleteDiskSnapshotError {
 }
 impl fmt::Display for DeleteDiskSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDiskSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDiskSnapshotError::AccessDenied(ref cause) => cause,
-            DeleteDiskSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            DeleteDiskSnapshotError::InvalidInput(ref cause) => cause,
-            DeleteDiskSnapshotError::NotFound(ref cause) => cause,
-            DeleteDiskSnapshotError::OperationFailure(ref cause) => cause,
-            DeleteDiskSnapshotError::Service(ref cause) => cause,
-            DeleteDiskSnapshotError::Unauthenticated(ref cause) => cause,
+            DeleteDiskSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteDiskSnapshotError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteDiskSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteDiskSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDiskSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDiskSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteDiskSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDiskSnapshotError {}
 /// Errors returned by DeleteDomain
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainError {
@@ -6147,22 +6107,18 @@ impl DeleteDomainError {
 }
 impl fmt::Display for DeleteDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainError::AccessDenied(ref cause) => cause,
-            DeleteDomainError::AccountSetupInProgress(ref cause) => cause,
-            DeleteDomainError::InvalidInput(ref cause) => cause,
-            DeleteDomainError::NotFound(ref cause) => cause,
-            DeleteDomainError::OperationFailure(ref cause) => cause,
-            DeleteDomainError::Service(ref cause) => cause,
-            DeleteDomainError::Unauthenticated(ref cause) => cause,
+            DeleteDomainError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainError {}
 /// Errors returned by DeleteDomainEntry
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainEntryError {
@@ -6218,22 +6174,18 @@ impl DeleteDomainEntryError {
 }
 impl fmt::Display for DeleteDomainEntryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainEntryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainEntryError::AccessDenied(ref cause) => cause,
-            DeleteDomainEntryError::AccountSetupInProgress(ref cause) => cause,
-            DeleteDomainEntryError::InvalidInput(ref cause) => cause,
-            DeleteDomainEntryError::NotFound(ref cause) => cause,
-            DeleteDomainEntryError::OperationFailure(ref cause) => cause,
-            DeleteDomainEntryError::Service(ref cause) => cause,
-            DeleteDomainEntryError::Unauthenticated(ref cause) => cause,
+            DeleteDomainEntryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteDomainEntryError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteDomainEntryError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteDomainEntryError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDomainEntryError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteDomainEntryError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteDomainEntryError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainEntryError {}
 /// Errors returned by DeleteInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteInstanceError {
@@ -6289,22 +6241,18 @@ impl DeleteInstanceError {
 }
 impl fmt::Display for DeleteInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInstanceError::AccessDenied(ref cause) => cause,
-            DeleteInstanceError::AccountSetupInProgress(ref cause) => cause,
-            DeleteInstanceError::InvalidInput(ref cause) => cause,
-            DeleteInstanceError::NotFound(ref cause) => cause,
-            DeleteInstanceError::OperationFailure(ref cause) => cause,
-            DeleteInstanceError::Service(ref cause) => cause,
-            DeleteInstanceError::Unauthenticated(ref cause) => cause,
+            DeleteInstanceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInstanceError {}
 /// Errors returned by DeleteInstanceSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteInstanceSnapshotError {
@@ -6364,22 +6312,20 @@ impl DeleteInstanceSnapshotError {
 }
 impl fmt::Display for DeleteInstanceSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInstanceSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInstanceSnapshotError::AccessDenied(ref cause) => cause,
-            DeleteInstanceSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            DeleteInstanceSnapshotError::InvalidInput(ref cause) => cause,
-            DeleteInstanceSnapshotError::NotFound(ref cause) => cause,
-            DeleteInstanceSnapshotError::OperationFailure(ref cause) => cause,
-            DeleteInstanceSnapshotError::Service(ref cause) => cause,
-            DeleteInstanceSnapshotError::Unauthenticated(ref cause) => cause,
+            DeleteInstanceSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteInstanceSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteInstanceSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInstanceSnapshotError {}
 /// Errors returned by DeleteKeyPair
 #[derive(Debug, PartialEq)]
 pub enum DeleteKeyPairError {
@@ -6435,22 +6381,18 @@ impl DeleteKeyPairError {
 }
 impl fmt::Display for DeleteKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteKeyPairError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteKeyPairError::AccessDenied(ref cause) => cause,
-            DeleteKeyPairError::AccountSetupInProgress(ref cause) => cause,
-            DeleteKeyPairError::InvalidInput(ref cause) => cause,
-            DeleteKeyPairError::NotFound(ref cause) => cause,
-            DeleteKeyPairError::OperationFailure(ref cause) => cause,
-            DeleteKeyPairError::Service(ref cause) => cause,
-            DeleteKeyPairError::Unauthenticated(ref cause) => cause,
+            DeleteKeyPairError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteKeyPairError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteKeyPairError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteKeyPairError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteKeyPairError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteKeyPairError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteKeyPairError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteKeyPairError {}
 /// Errors returned by DeleteKnownHostKeys
 #[derive(Debug, PartialEq)]
 pub enum DeleteKnownHostKeysError {
@@ -6508,22 +6450,18 @@ impl DeleteKnownHostKeysError {
 }
 impl fmt::Display for DeleteKnownHostKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteKnownHostKeysError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteKnownHostKeysError::AccessDenied(ref cause) => cause,
-            DeleteKnownHostKeysError::AccountSetupInProgress(ref cause) => cause,
-            DeleteKnownHostKeysError::InvalidInput(ref cause) => cause,
-            DeleteKnownHostKeysError::NotFound(ref cause) => cause,
-            DeleteKnownHostKeysError::OperationFailure(ref cause) => cause,
-            DeleteKnownHostKeysError::Service(ref cause) => cause,
-            DeleteKnownHostKeysError::Unauthenticated(ref cause) => cause,
+            DeleteKnownHostKeysError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteKnownHostKeysError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteKnownHostKeysError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteKnownHostKeysError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteKnownHostKeysError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteKnownHostKeysError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteKnownHostKeysError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteKnownHostKeysError {}
 /// Errors returned by DeleteLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoadBalancerError {
@@ -6579,22 +6517,18 @@ impl DeleteLoadBalancerError {
 }
 impl fmt::Display for DeleteLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoadBalancerError::AccessDenied(ref cause) => cause,
-            DeleteLoadBalancerError::AccountSetupInProgress(ref cause) => cause,
-            DeleteLoadBalancerError::InvalidInput(ref cause) => cause,
-            DeleteLoadBalancerError::NotFound(ref cause) => cause,
-            DeleteLoadBalancerError::OperationFailure(ref cause) => cause,
-            DeleteLoadBalancerError::Service(ref cause) => cause,
-            DeleteLoadBalancerError::Unauthenticated(ref cause) => cause,
+            DeleteLoadBalancerError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLoadBalancerError {}
 /// Errors returned by DeleteLoadBalancerTlsCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoadBalancerTlsCertificateError {
@@ -6664,22 +6598,28 @@ impl DeleteLoadBalancerTlsCertificateError {
 }
 impl fmt::Display for DeleteLoadBalancerTlsCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoadBalancerTlsCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoadBalancerTlsCertificateError::AccessDenied(ref cause) => cause,
-            DeleteLoadBalancerTlsCertificateError::AccountSetupInProgress(ref cause) => cause,
-            DeleteLoadBalancerTlsCertificateError::InvalidInput(ref cause) => cause,
-            DeleteLoadBalancerTlsCertificateError::NotFound(ref cause) => cause,
-            DeleteLoadBalancerTlsCertificateError::OperationFailure(ref cause) => cause,
-            DeleteLoadBalancerTlsCertificateError::Service(ref cause) => cause,
-            DeleteLoadBalancerTlsCertificateError::Unauthenticated(ref cause) => cause,
+            DeleteLoadBalancerTlsCertificateError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLoadBalancerTlsCertificateError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLoadBalancerTlsCertificateError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLoadBalancerTlsCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerTlsCertificateError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLoadBalancerTlsCertificateError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteLoadBalancerTlsCertificateError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteLoadBalancerTlsCertificateError {}
 /// Errors returned by DeleteRelationalDatabase
 #[derive(Debug, PartialEq)]
 pub enum DeleteRelationalDatabaseError {
@@ -6743,22 +6683,20 @@ impl DeleteRelationalDatabaseError {
 }
 impl fmt::Display for DeleteRelationalDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRelationalDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRelationalDatabaseError::AccessDenied(ref cause) => cause,
-            DeleteRelationalDatabaseError::AccountSetupInProgress(ref cause) => cause,
-            DeleteRelationalDatabaseError::InvalidInput(ref cause) => cause,
-            DeleteRelationalDatabaseError::NotFound(ref cause) => cause,
-            DeleteRelationalDatabaseError::OperationFailure(ref cause) => cause,
-            DeleteRelationalDatabaseError::Service(ref cause) => cause,
-            DeleteRelationalDatabaseError::Unauthenticated(ref cause) => cause,
+            DeleteRelationalDatabaseError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteRelationalDatabaseError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRelationalDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteRelationalDatabaseError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRelationalDatabaseError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DeleteRelationalDatabaseError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteRelationalDatabaseError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRelationalDatabaseError {}
 /// Errors returned by DeleteRelationalDatabaseSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteRelationalDatabaseSnapshotError {
@@ -6828,22 +6766,28 @@ impl DeleteRelationalDatabaseSnapshotError {
 }
 impl fmt::Display for DeleteRelationalDatabaseSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRelationalDatabaseSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRelationalDatabaseSnapshotError::AccessDenied(ref cause) => cause,
-            DeleteRelationalDatabaseSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            DeleteRelationalDatabaseSnapshotError::InvalidInput(ref cause) => cause,
-            DeleteRelationalDatabaseSnapshotError::NotFound(ref cause) => cause,
-            DeleteRelationalDatabaseSnapshotError::OperationFailure(ref cause) => cause,
-            DeleteRelationalDatabaseSnapshotError::Service(ref cause) => cause,
-            DeleteRelationalDatabaseSnapshotError::Unauthenticated(ref cause) => cause,
+            DeleteRelationalDatabaseSnapshotError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRelationalDatabaseSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRelationalDatabaseSnapshotError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRelationalDatabaseSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRelationalDatabaseSnapshotError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteRelationalDatabaseSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteRelationalDatabaseSnapshotError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRelationalDatabaseSnapshotError {}
 /// Errors returned by DetachDisk
 #[derive(Debug, PartialEq)]
 pub enum DetachDiskError {
@@ -6897,22 +6841,18 @@ impl DetachDiskError {
 }
 impl fmt::Display for DetachDiskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachDiskError {
-    fn description(&self) -> &str {
         match *self {
-            DetachDiskError::AccessDenied(ref cause) => cause,
-            DetachDiskError::AccountSetupInProgress(ref cause) => cause,
-            DetachDiskError::InvalidInput(ref cause) => cause,
-            DetachDiskError::NotFound(ref cause) => cause,
-            DetachDiskError::OperationFailure(ref cause) => cause,
-            DetachDiskError::Service(ref cause) => cause,
-            DetachDiskError::Unauthenticated(ref cause) => cause,
+            DetachDiskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachDiskError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DetachDiskError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DetachDiskError::NotFound(ref cause) => write!(f, "{}", cause),
+            DetachDiskError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DetachDiskError::Service(ref cause) => write!(f, "{}", cause),
+            DetachDiskError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachDiskError {}
 /// Errors returned by DetachInstancesFromLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum DetachInstancesFromLoadBalancerError {
@@ -6982,22 +6922,24 @@ impl DetachInstancesFromLoadBalancerError {
 }
 impl fmt::Display for DetachInstancesFromLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachInstancesFromLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            DetachInstancesFromLoadBalancerError::AccessDenied(ref cause) => cause,
-            DetachInstancesFromLoadBalancerError::AccountSetupInProgress(ref cause) => cause,
-            DetachInstancesFromLoadBalancerError::InvalidInput(ref cause) => cause,
-            DetachInstancesFromLoadBalancerError::NotFound(ref cause) => cause,
-            DetachInstancesFromLoadBalancerError::OperationFailure(ref cause) => cause,
-            DetachInstancesFromLoadBalancerError::Service(ref cause) => cause,
-            DetachInstancesFromLoadBalancerError::Unauthenticated(ref cause) => cause,
+            DetachInstancesFromLoadBalancerError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachInstancesFromLoadBalancerError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DetachInstancesFromLoadBalancerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DetachInstancesFromLoadBalancerError::NotFound(ref cause) => write!(f, "{}", cause),
+            DetachInstancesFromLoadBalancerError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DetachInstancesFromLoadBalancerError::Service(ref cause) => write!(f, "{}", cause),
+            DetachInstancesFromLoadBalancerError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DetachInstancesFromLoadBalancerError {}
 /// Errors returned by DetachStaticIp
 #[derive(Debug, PartialEq)]
 pub enum DetachStaticIpError {
@@ -7053,22 +6995,18 @@ impl DetachStaticIpError {
 }
 impl fmt::Display for DetachStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachStaticIpError {
-    fn description(&self) -> &str {
         match *self {
-            DetachStaticIpError::AccessDenied(ref cause) => cause,
-            DetachStaticIpError::AccountSetupInProgress(ref cause) => cause,
-            DetachStaticIpError::InvalidInput(ref cause) => cause,
-            DetachStaticIpError::NotFound(ref cause) => cause,
-            DetachStaticIpError::OperationFailure(ref cause) => cause,
-            DetachStaticIpError::Service(ref cause) => cause,
-            DetachStaticIpError::Unauthenticated(ref cause) => cause,
+            DetachStaticIpError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachStaticIpError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            DetachStaticIpError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DetachStaticIpError::NotFound(ref cause) => write!(f, "{}", cause),
+            DetachStaticIpError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DetachStaticIpError::Service(ref cause) => write!(f, "{}", cause),
+            DetachStaticIpError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachStaticIpError {}
 /// Errors returned by DisableAddOn
 #[derive(Debug, PartialEq)]
 pub enum DisableAddOnError {
@@ -7117,21 +7055,17 @@ impl DisableAddOnError {
 }
 impl fmt::Display for DisableAddOnError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableAddOnError {
-    fn description(&self) -> &str {
         match *self {
-            DisableAddOnError::AccessDenied(ref cause) => cause,
-            DisableAddOnError::InvalidInput(ref cause) => cause,
-            DisableAddOnError::NotFound(ref cause) => cause,
-            DisableAddOnError::OperationFailure(ref cause) => cause,
-            DisableAddOnError::Service(ref cause) => cause,
-            DisableAddOnError::Unauthenticated(ref cause) => cause,
+            DisableAddOnError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisableAddOnError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisableAddOnError::NotFound(ref cause) => write!(f, "{}", cause),
+            DisableAddOnError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DisableAddOnError::Service(ref cause) => write!(f, "{}", cause),
+            DisableAddOnError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableAddOnError {}
 /// Errors returned by DownloadDefaultKeyPair
 #[derive(Debug, PartialEq)]
 pub enum DownloadDefaultKeyPairError {
@@ -7191,22 +7125,20 @@ impl DownloadDefaultKeyPairError {
 }
 impl fmt::Display for DownloadDefaultKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DownloadDefaultKeyPairError {
-    fn description(&self) -> &str {
         match *self {
-            DownloadDefaultKeyPairError::AccessDenied(ref cause) => cause,
-            DownloadDefaultKeyPairError::AccountSetupInProgress(ref cause) => cause,
-            DownloadDefaultKeyPairError::InvalidInput(ref cause) => cause,
-            DownloadDefaultKeyPairError::NotFound(ref cause) => cause,
-            DownloadDefaultKeyPairError::OperationFailure(ref cause) => cause,
-            DownloadDefaultKeyPairError::Service(ref cause) => cause,
-            DownloadDefaultKeyPairError::Unauthenticated(ref cause) => cause,
+            DownloadDefaultKeyPairError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DownloadDefaultKeyPairError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DownloadDefaultKeyPairError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DownloadDefaultKeyPairError::NotFound(ref cause) => write!(f, "{}", cause),
+            DownloadDefaultKeyPairError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            DownloadDefaultKeyPairError::Service(ref cause) => write!(f, "{}", cause),
+            DownloadDefaultKeyPairError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DownloadDefaultKeyPairError {}
 /// Errors returned by EnableAddOn
 #[derive(Debug, PartialEq)]
 pub enum EnableAddOnError {
@@ -7255,21 +7187,17 @@ impl EnableAddOnError {
 }
 impl fmt::Display for EnableAddOnError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableAddOnError {
-    fn description(&self) -> &str {
         match *self {
-            EnableAddOnError::AccessDenied(ref cause) => cause,
-            EnableAddOnError::InvalidInput(ref cause) => cause,
-            EnableAddOnError::NotFound(ref cause) => cause,
-            EnableAddOnError::OperationFailure(ref cause) => cause,
-            EnableAddOnError::Service(ref cause) => cause,
-            EnableAddOnError::Unauthenticated(ref cause) => cause,
+            EnableAddOnError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            EnableAddOnError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            EnableAddOnError::NotFound(ref cause) => write!(f, "{}", cause),
+            EnableAddOnError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            EnableAddOnError::Service(ref cause) => write!(f, "{}", cause),
+            EnableAddOnError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableAddOnError {}
 /// Errors returned by ExportSnapshot
 #[derive(Debug, PartialEq)]
 pub enum ExportSnapshotError {
@@ -7325,22 +7253,18 @@ impl ExportSnapshotError {
 }
 impl fmt::Display for ExportSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExportSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            ExportSnapshotError::AccessDenied(ref cause) => cause,
-            ExportSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            ExportSnapshotError::InvalidInput(ref cause) => cause,
-            ExportSnapshotError::NotFound(ref cause) => cause,
-            ExportSnapshotError::OperationFailure(ref cause) => cause,
-            ExportSnapshotError::Service(ref cause) => cause,
-            ExportSnapshotError::Unauthenticated(ref cause) => cause,
+            ExportSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ExportSnapshotError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            ExportSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ExportSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            ExportSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            ExportSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            ExportSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExportSnapshotError {}
 /// Errors returned by GetActiveNames
 #[derive(Debug, PartialEq)]
 pub enum GetActiveNamesError {
@@ -7396,22 +7320,18 @@ impl GetActiveNamesError {
 }
 impl fmt::Display for GetActiveNamesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetActiveNamesError {
-    fn description(&self) -> &str {
         match *self {
-            GetActiveNamesError::AccessDenied(ref cause) => cause,
-            GetActiveNamesError::AccountSetupInProgress(ref cause) => cause,
-            GetActiveNamesError::InvalidInput(ref cause) => cause,
-            GetActiveNamesError::NotFound(ref cause) => cause,
-            GetActiveNamesError::OperationFailure(ref cause) => cause,
-            GetActiveNamesError::Service(ref cause) => cause,
-            GetActiveNamesError::Unauthenticated(ref cause) => cause,
+            GetActiveNamesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetActiveNamesError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetActiveNamesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetActiveNamesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetActiveNamesError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetActiveNamesError::Service(ref cause) => write!(f, "{}", cause),
+            GetActiveNamesError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetActiveNamesError {}
 /// Errors returned by GetAutoSnapshots
 #[derive(Debug, PartialEq)]
 pub enum GetAutoSnapshotsError {
@@ -7460,21 +7380,17 @@ impl GetAutoSnapshotsError {
 }
 impl fmt::Display for GetAutoSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAutoSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            GetAutoSnapshotsError::AccessDenied(ref cause) => cause,
-            GetAutoSnapshotsError::InvalidInput(ref cause) => cause,
-            GetAutoSnapshotsError::NotFound(ref cause) => cause,
-            GetAutoSnapshotsError::OperationFailure(ref cause) => cause,
-            GetAutoSnapshotsError::Service(ref cause) => cause,
-            GetAutoSnapshotsError::Unauthenticated(ref cause) => cause,
+            GetAutoSnapshotsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetAutoSnapshotsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetAutoSnapshotsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetAutoSnapshotsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetAutoSnapshotsError::Service(ref cause) => write!(f, "{}", cause),
+            GetAutoSnapshotsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAutoSnapshotsError {}
 /// Errors returned by GetBlueprints
 #[derive(Debug, PartialEq)]
 pub enum GetBlueprintsError {
@@ -7530,22 +7446,18 @@ impl GetBlueprintsError {
 }
 impl fmt::Display for GetBlueprintsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBlueprintsError {
-    fn description(&self) -> &str {
         match *self {
-            GetBlueprintsError::AccessDenied(ref cause) => cause,
-            GetBlueprintsError::AccountSetupInProgress(ref cause) => cause,
-            GetBlueprintsError::InvalidInput(ref cause) => cause,
-            GetBlueprintsError::NotFound(ref cause) => cause,
-            GetBlueprintsError::OperationFailure(ref cause) => cause,
-            GetBlueprintsError::Service(ref cause) => cause,
-            GetBlueprintsError::Unauthenticated(ref cause) => cause,
+            GetBlueprintsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetBlueprintsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetBlueprintsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetBlueprintsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetBlueprintsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetBlueprintsError::Service(ref cause) => write!(f, "{}", cause),
+            GetBlueprintsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBlueprintsError {}
 /// Errors returned by GetBundles
 #[derive(Debug, PartialEq)]
 pub enum GetBundlesError {
@@ -7599,22 +7511,18 @@ impl GetBundlesError {
 }
 impl fmt::Display for GetBundlesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBundlesError {
-    fn description(&self) -> &str {
         match *self {
-            GetBundlesError::AccessDenied(ref cause) => cause,
-            GetBundlesError::AccountSetupInProgress(ref cause) => cause,
-            GetBundlesError::InvalidInput(ref cause) => cause,
-            GetBundlesError::NotFound(ref cause) => cause,
-            GetBundlesError::OperationFailure(ref cause) => cause,
-            GetBundlesError::Service(ref cause) => cause,
-            GetBundlesError::Unauthenticated(ref cause) => cause,
+            GetBundlesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetBundlesError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetBundlesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetBundlesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetBundlesError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetBundlesError::Service(ref cause) => write!(f, "{}", cause),
+            GetBundlesError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBundlesError {}
 /// Errors returned by GetCloudFormationStackRecords
 #[derive(Debug, PartialEq)]
 pub enum GetCloudFormationStackRecordsError {
@@ -7684,22 +7592,24 @@ impl GetCloudFormationStackRecordsError {
 }
 impl fmt::Display for GetCloudFormationStackRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCloudFormationStackRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            GetCloudFormationStackRecordsError::AccessDenied(ref cause) => cause,
-            GetCloudFormationStackRecordsError::AccountSetupInProgress(ref cause) => cause,
-            GetCloudFormationStackRecordsError::InvalidInput(ref cause) => cause,
-            GetCloudFormationStackRecordsError::NotFound(ref cause) => cause,
-            GetCloudFormationStackRecordsError::OperationFailure(ref cause) => cause,
-            GetCloudFormationStackRecordsError::Service(ref cause) => cause,
-            GetCloudFormationStackRecordsError::Unauthenticated(ref cause) => cause,
+            GetCloudFormationStackRecordsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetCloudFormationStackRecordsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCloudFormationStackRecordsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetCloudFormationStackRecordsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetCloudFormationStackRecordsError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCloudFormationStackRecordsError::Service(ref cause) => write!(f, "{}", cause),
+            GetCloudFormationStackRecordsError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetCloudFormationStackRecordsError {}
 /// Errors returned by GetDisk
 #[derive(Debug, PartialEq)]
 pub enum GetDiskError {
@@ -7751,22 +7661,18 @@ impl GetDiskError {
 }
 impl fmt::Display for GetDiskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDiskError {
-    fn description(&self) -> &str {
         match *self {
-            GetDiskError::AccessDenied(ref cause) => cause,
-            GetDiskError::AccountSetupInProgress(ref cause) => cause,
-            GetDiskError::InvalidInput(ref cause) => cause,
-            GetDiskError::NotFound(ref cause) => cause,
-            GetDiskError::OperationFailure(ref cause) => cause,
-            GetDiskError::Service(ref cause) => cause,
-            GetDiskError::Unauthenticated(ref cause) => cause,
+            GetDiskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDiskError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetDiskError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDiskError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDiskError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetDiskError::Service(ref cause) => write!(f, "{}", cause),
+            GetDiskError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDiskError {}
 /// Errors returned by GetDiskSnapshot
 #[derive(Debug, PartialEq)]
 pub enum GetDiskSnapshotError {
@@ -7822,22 +7728,18 @@ impl GetDiskSnapshotError {
 }
 impl fmt::Display for GetDiskSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDiskSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            GetDiskSnapshotError::AccessDenied(ref cause) => cause,
-            GetDiskSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            GetDiskSnapshotError::InvalidInput(ref cause) => cause,
-            GetDiskSnapshotError::NotFound(ref cause) => cause,
-            GetDiskSnapshotError::OperationFailure(ref cause) => cause,
-            GetDiskSnapshotError::Service(ref cause) => cause,
-            GetDiskSnapshotError::Unauthenticated(ref cause) => cause,
+            GetDiskSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDiskSnapshotError {}
 /// Errors returned by GetDiskSnapshots
 #[derive(Debug, PartialEq)]
 pub enum GetDiskSnapshotsError {
@@ -7893,22 +7795,18 @@ impl GetDiskSnapshotsError {
 }
 impl fmt::Display for GetDiskSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDiskSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDiskSnapshotsError::AccessDenied(ref cause) => cause,
-            GetDiskSnapshotsError::AccountSetupInProgress(ref cause) => cause,
-            GetDiskSnapshotsError::InvalidInput(ref cause) => cause,
-            GetDiskSnapshotsError::NotFound(ref cause) => cause,
-            GetDiskSnapshotsError::OperationFailure(ref cause) => cause,
-            GetDiskSnapshotsError::Service(ref cause) => cause,
-            GetDiskSnapshotsError::Unauthenticated(ref cause) => cause,
+            GetDiskSnapshotsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotsError::Service(ref cause) => write!(f, "{}", cause),
+            GetDiskSnapshotsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDiskSnapshotsError {}
 /// Errors returned by GetDisks
 #[derive(Debug, PartialEq)]
 pub enum GetDisksError {
@@ -7960,22 +7858,18 @@ impl GetDisksError {
 }
 impl fmt::Display for GetDisksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDisksError {
-    fn description(&self) -> &str {
         match *self {
-            GetDisksError::AccessDenied(ref cause) => cause,
-            GetDisksError::AccountSetupInProgress(ref cause) => cause,
-            GetDisksError::InvalidInput(ref cause) => cause,
-            GetDisksError::NotFound(ref cause) => cause,
-            GetDisksError::OperationFailure(ref cause) => cause,
-            GetDisksError::Service(ref cause) => cause,
-            GetDisksError::Unauthenticated(ref cause) => cause,
+            GetDisksError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDisksError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetDisksError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDisksError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDisksError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetDisksError::Service(ref cause) => write!(f, "{}", cause),
+            GetDisksError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDisksError {}
 /// Errors returned by GetDomain
 #[derive(Debug, PartialEq)]
 pub enum GetDomainError {
@@ -8029,22 +7923,18 @@ impl GetDomainError {
 }
 impl fmt::Display for GetDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainError::AccessDenied(ref cause) => cause,
-            GetDomainError::AccountSetupInProgress(ref cause) => cause,
-            GetDomainError::InvalidInput(ref cause) => cause,
-            GetDomainError::NotFound(ref cause) => cause,
-            GetDomainError::OperationFailure(ref cause) => cause,
-            GetDomainError::Service(ref cause) => cause,
-            GetDomainError::Unauthenticated(ref cause) => cause,
+            GetDomainError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDomainError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDomainError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDomainError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetDomainError::Service(ref cause) => write!(f, "{}", cause),
+            GetDomainError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainError {}
 /// Errors returned by GetDomains
 #[derive(Debug, PartialEq)]
 pub enum GetDomainsError {
@@ -8098,22 +7988,18 @@ impl GetDomainsError {
 }
 impl fmt::Display for GetDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainsError::AccessDenied(ref cause) => cause,
-            GetDomainsError::AccountSetupInProgress(ref cause) => cause,
-            GetDomainsError::InvalidInput(ref cause) => cause,
-            GetDomainsError::NotFound(ref cause) => cause,
-            GetDomainsError::OperationFailure(ref cause) => cause,
-            GetDomainsError::Service(ref cause) => cause,
-            GetDomainsError::Unauthenticated(ref cause) => cause,
+            GetDomainsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDomainsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetDomainsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDomainsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetDomainsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetDomainsError::Service(ref cause) => write!(f, "{}", cause),
+            GetDomainsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainsError {}
 /// Errors returned by GetExportSnapshotRecords
 #[derive(Debug, PartialEq)]
 pub enum GetExportSnapshotRecordsError {
@@ -8177,22 +8063,20 @@ impl GetExportSnapshotRecordsError {
 }
 impl fmt::Display for GetExportSnapshotRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetExportSnapshotRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            GetExportSnapshotRecordsError::AccessDenied(ref cause) => cause,
-            GetExportSnapshotRecordsError::AccountSetupInProgress(ref cause) => cause,
-            GetExportSnapshotRecordsError::InvalidInput(ref cause) => cause,
-            GetExportSnapshotRecordsError::NotFound(ref cause) => cause,
-            GetExportSnapshotRecordsError::OperationFailure(ref cause) => cause,
-            GetExportSnapshotRecordsError::Service(ref cause) => cause,
-            GetExportSnapshotRecordsError::Unauthenticated(ref cause) => cause,
+            GetExportSnapshotRecordsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetExportSnapshotRecordsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetExportSnapshotRecordsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetExportSnapshotRecordsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetExportSnapshotRecordsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetExportSnapshotRecordsError::Service(ref cause) => write!(f, "{}", cause),
+            GetExportSnapshotRecordsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetExportSnapshotRecordsError {}
 /// Errors returned by GetInstance
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceError {
@@ -8246,22 +8130,18 @@ impl GetInstanceError {
 }
 impl fmt::Display for GetInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceError::AccessDenied(ref cause) => cause,
-            GetInstanceError::AccountSetupInProgress(ref cause) => cause,
-            GetInstanceError::InvalidInput(ref cause) => cause,
-            GetInstanceError::NotFound(ref cause) => cause,
-            GetInstanceError::OperationFailure(ref cause) => cause,
-            GetInstanceError::Service(ref cause) => cause,
-            GetInstanceError::Unauthenticated(ref cause) => cause,
+            GetInstanceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceError {}
 /// Errors returned by GetInstanceAccessDetails
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceAccessDetailsError {
@@ -8325,22 +8205,20 @@ impl GetInstanceAccessDetailsError {
 }
 impl fmt::Display for GetInstanceAccessDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceAccessDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceAccessDetailsError::AccessDenied(ref cause) => cause,
-            GetInstanceAccessDetailsError::AccountSetupInProgress(ref cause) => cause,
-            GetInstanceAccessDetailsError::InvalidInput(ref cause) => cause,
-            GetInstanceAccessDetailsError::NotFound(ref cause) => cause,
-            GetInstanceAccessDetailsError::OperationFailure(ref cause) => cause,
-            GetInstanceAccessDetailsError::Service(ref cause) => cause,
-            GetInstanceAccessDetailsError::Unauthenticated(ref cause) => cause,
+            GetInstanceAccessDetailsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessDetailsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetInstanceAccessDetailsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessDetailsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessDetailsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessDetailsError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstanceAccessDetailsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceAccessDetailsError {}
 /// Errors returned by GetInstanceMetricData
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceMetricDataError {
@@ -8400,22 +8278,18 @@ impl GetInstanceMetricDataError {
 }
 impl fmt::Display for GetInstanceMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceMetricDataError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceMetricDataError::AccessDenied(ref cause) => cause,
-            GetInstanceMetricDataError::AccountSetupInProgress(ref cause) => cause,
-            GetInstanceMetricDataError::InvalidInput(ref cause) => cause,
-            GetInstanceMetricDataError::NotFound(ref cause) => cause,
-            GetInstanceMetricDataError::OperationFailure(ref cause) => cause,
-            GetInstanceMetricDataError::Service(ref cause) => cause,
-            GetInstanceMetricDataError::Unauthenticated(ref cause) => cause,
+            GetInstanceMetricDataError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstanceMetricDataError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetInstanceMetricDataError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstanceMetricDataError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceMetricDataError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstanceMetricDataError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstanceMetricDataError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceMetricDataError {}
 /// Errors returned by GetInstancePortStates
 #[derive(Debug, PartialEq)]
 pub enum GetInstancePortStatesError {
@@ -8475,22 +8349,18 @@ impl GetInstancePortStatesError {
 }
 impl fmt::Display for GetInstancePortStatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstancePortStatesError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstancePortStatesError::AccessDenied(ref cause) => cause,
-            GetInstancePortStatesError::AccountSetupInProgress(ref cause) => cause,
-            GetInstancePortStatesError::InvalidInput(ref cause) => cause,
-            GetInstancePortStatesError::NotFound(ref cause) => cause,
-            GetInstancePortStatesError::OperationFailure(ref cause) => cause,
-            GetInstancePortStatesError::Service(ref cause) => cause,
-            GetInstancePortStatesError::Unauthenticated(ref cause) => cause,
+            GetInstancePortStatesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstancePortStatesError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetInstancePortStatesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstancePortStatesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstancePortStatesError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstancePortStatesError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstancePortStatesError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstancePortStatesError {}
 /// Errors returned by GetInstanceSnapshot
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceSnapshotError {
@@ -8548,22 +8418,18 @@ impl GetInstanceSnapshotError {
 }
 impl fmt::Display for GetInstanceSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceSnapshotError::AccessDenied(ref cause) => cause,
-            GetInstanceSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            GetInstanceSnapshotError::InvalidInput(ref cause) => cause,
-            GetInstanceSnapshotError::NotFound(ref cause) => cause,
-            GetInstanceSnapshotError::OperationFailure(ref cause) => cause,
-            GetInstanceSnapshotError::Service(ref cause) => cause,
-            GetInstanceSnapshotError::Unauthenticated(ref cause) => cause,
+            GetInstanceSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceSnapshotError {}
 /// Errors returned by GetInstanceSnapshots
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceSnapshotsError {
@@ -8623,22 +8489,18 @@ impl GetInstanceSnapshotsError {
 }
 impl fmt::Display for GetInstanceSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceSnapshotsError::AccessDenied(ref cause) => cause,
-            GetInstanceSnapshotsError::AccountSetupInProgress(ref cause) => cause,
-            GetInstanceSnapshotsError::InvalidInput(ref cause) => cause,
-            GetInstanceSnapshotsError::NotFound(ref cause) => cause,
-            GetInstanceSnapshotsError::OperationFailure(ref cause) => cause,
-            GetInstanceSnapshotsError::Service(ref cause) => cause,
-            GetInstanceSnapshotsError::Unauthenticated(ref cause) => cause,
+            GetInstanceSnapshotsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotsError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstanceSnapshotsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceSnapshotsError {}
 /// Errors returned by GetInstanceState
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceStateError {
@@ -8694,22 +8556,18 @@ impl GetInstanceStateError {
 }
 impl fmt::Display for GetInstanceStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceStateError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceStateError::AccessDenied(ref cause) => cause,
-            GetInstanceStateError::AccountSetupInProgress(ref cause) => cause,
-            GetInstanceStateError::InvalidInput(ref cause) => cause,
-            GetInstanceStateError::NotFound(ref cause) => cause,
-            GetInstanceStateError::OperationFailure(ref cause) => cause,
-            GetInstanceStateError::Service(ref cause) => cause,
-            GetInstanceStateError::Unauthenticated(ref cause) => cause,
+            GetInstanceStateError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstanceStateError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetInstanceStateError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstanceStateError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceStateError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstanceStateError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstanceStateError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceStateError {}
 /// Errors returned by GetInstances
 #[derive(Debug, PartialEq)]
 pub enum GetInstancesError {
@@ -8763,22 +8621,18 @@ impl GetInstancesError {
 }
 impl fmt::Display for GetInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstancesError::AccessDenied(ref cause) => cause,
-            GetInstancesError::AccountSetupInProgress(ref cause) => cause,
-            GetInstancesError::InvalidInput(ref cause) => cause,
-            GetInstancesError::NotFound(ref cause) => cause,
-            GetInstancesError::OperationFailure(ref cause) => cause,
-            GetInstancesError::Service(ref cause) => cause,
-            GetInstancesError::Unauthenticated(ref cause) => cause,
+            GetInstancesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetInstancesError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetInstancesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstancesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetInstancesError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetInstancesError::Service(ref cause) => write!(f, "{}", cause),
+            GetInstancesError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstancesError {}
 /// Errors returned by GetKeyPair
 #[derive(Debug, PartialEq)]
 pub enum GetKeyPairError {
@@ -8832,22 +8686,18 @@ impl GetKeyPairError {
 }
 impl fmt::Display for GetKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetKeyPairError {
-    fn description(&self) -> &str {
         match *self {
-            GetKeyPairError::AccessDenied(ref cause) => cause,
-            GetKeyPairError::AccountSetupInProgress(ref cause) => cause,
-            GetKeyPairError::InvalidInput(ref cause) => cause,
-            GetKeyPairError::NotFound(ref cause) => cause,
-            GetKeyPairError::OperationFailure(ref cause) => cause,
-            GetKeyPairError::Service(ref cause) => cause,
-            GetKeyPairError::Unauthenticated(ref cause) => cause,
+            GetKeyPairError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetKeyPairError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetKeyPairError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetKeyPairError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetKeyPairError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetKeyPairError::Service(ref cause) => write!(f, "{}", cause),
+            GetKeyPairError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetKeyPairError {}
 /// Errors returned by GetKeyPairs
 #[derive(Debug, PartialEq)]
 pub enum GetKeyPairsError {
@@ -8901,22 +8751,18 @@ impl GetKeyPairsError {
 }
 impl fmt::Display for GetKeyPairsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetKeyPairsError {
-    fn description(&self) -> &str {
         match *self {
-            GetKeyPairsError::AccessDenied(ref cause) => cause,
-            GetKeyPairsError::AccountSetupInProgress(ref cause) => cause,
-            GetKeyPairsError::InvalidInput(ref cause) => cause,
-            GetKeyPairsError::NotFound(ref cause) => cause,
-            GetKeyPairsError::OperationFailure(ref cause) => cause,
-            GetKeyPairsError::Service(ref cause) => cause,
-            GetKeyPairsError::Unauthenticated(ref cause) => cause,
+            GetKeyPairsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetKeyPairsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetKeyPairsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetKeyPairsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetKeyPairsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetKeyPairsError::Service(ref cause) => write!(f, "{}", cause),
+            GetKeyPairsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetKeyPairsError {}
 /// Errors returned by GetLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum GetLoadBalancerError {
@@ -8972,22 +8818,18 @@ impl GetLoadBalancerError {
 }
 impl fmt::Display for GetLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoadBalancerError::AccessDenied(ref cause) => cause,
-            GetLoadBalancerError::AccountSetupInProgress(ref cause) => cause,
-            GetLoadBalancerError::InvalidInput(ref cause) => cause,
-            GetLoadBalancerError::NotFound(ref cause) => cause,
-            GetLoadBalancerError::OperationFailure(ref cause) => cause,
-            GetLoadBalancerError::Service(ref cause) => cause,
-            GetLoadBalancerError::Unauthenticated(ref cause) => cause,
+            GetLoadBalancerError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerError::Service(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoadBalancerError {}
 /// Errors returned by GetLoadBalancerMetricData
 #[derive(Debug, PartialEq)]
 pub enum GetLoadBalancerMetricDataError {
@@ -9051,22 +8893,20 @@ impl GetLoadBalancerMetricDataError {
 }
 impl fmt::Display for GetLoadBalancerMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoadBalancerMetricDataError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoadBalancerMetricDataError::AccessDenied(ref cause) => cause,
-            GetLoadBalancerMetricDataError::AccountSetupInProgress(ref cause) => cause,
-            GetLoadBalancerMetricDataError::InvalidInput(ref cause) => cause,
-            GetLoadBalancerMetricDataError::NotFound(ref cause) => cause,
-            GetLoadBalancerMetricDataError::OperationFailure(ref cause) => cause,
-            GetLoadBalancerMetricDataError::Service(ref cause) => cause,
-            GetLoadBalancerMetricDataError::Unauthenticated(ref cause) => cause,
+            GetLoadBalancerMetricDataError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerMetricDataError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetLoadBalancerMetricDataError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerMetricDataError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerMetricDataError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerMetricDataError::Service(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerMetricDataError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoadBalancerMetricDataError {}
 /// Errors returned by GetLoadBalancerTlsCertificates
 #[derive(Debug, PartialEq)]
 pub enum GetLoadBalancerTlsCertificatesError {
@@ -9136,22 +8976,24 @@ impl GetLoadBalancerTlsCertificatesError {
 }
 impl fmt::Display for GetLoadBalancerTlsCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoadBalancerTlsCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoadBalancerTlsCertificatesError::AccessDenied(ref cause) => cause,
-            GetLoadBalancerTlsCertificatesError::AccountSetupInProgress(ref cause) => cause,
-            GetLoadBalancerTlsCertificatesError::InvalidInput(ref cause) => cause,
-            GetLoadBalancerTlsCertificatesError::NotFound(ref cause) => cause,
-            GetLoadBalancerTlsCertificatesError::OperationFailure(ref cause) => cause,
-            GetLoadBalancerTlsCertificatesError::Service(ref cause) => cause,
-            GetLoadBalancerTlsCertificatesError::Unauthenticated(ref cause) => cause,
+            GetLoadBalancerTlsCertificatesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerTlsCertificatesError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetLoadBalancerTlsCertificatesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerTlsCertificatesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerTlsCertificatesError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetLoadBalancerTlsCertificatesError::Service(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancerTlsCertificatesError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetLoadBalancerTlsCertificatesError {}
 /// Errors returned by GetLoadBalancers
 #[derive(Debug, PartialEq)]
 pub enum GetLoadBalancersError {
@@ -9207,22 +9049,18 @@ impl GetLoadBalancersError {
 }
 impl fmt::Display for GetLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoadBalancersError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoadBalancersError::AccessDenied(ref cause) => cause,
-            GetLoadBalancersError::AccountSetupInProgress(ref cause) => cause,
-            GetLoadBalancersError::InvalidInput(ref cause) => cause,
-            GetLoadBalancersError::NotFound(ref cause) => cause,
-            GetLoadBalancersError::OperationFailure(ref cause) => cause,
-            GetLoadBalancersError::Service(ref cause) => cause,
-            GetLoadBalancersError::Unauthenticated(ref cause) => cause,
+            GetLoadBalancersError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancersError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancersError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancersError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancersError::Service(ref cause) => write!(f, "{}", cause),
+            GetLoadBalancersError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoadBalancersError {}
 /// Errors returned by GetOperation
 #[derive(Debug, PartialEq)]
 pub enum GetOperationError {
@@ -9276,22 +9114,18 @@ impl GetOperationError {
 }
 impl fmt::Display for GetOperationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOperationError {
-    fn description(&self) -> &str {
         match *self {
-            GetOperationError::AccessDenied(ref cause) => cause,
-            GetOperationError::AccountSetupInProgress(ref cause) => cause,
-            GetOperationError::InvalidInput(ref cause) => cause,
-            GetOperationError::NotFound(ref cause) => cause,
-            GetOperationError::OperationFailure(ref cause) => cause,
-            GetOperationError::Service(ref cause) => cause,
-            GetOperationError::Unauthenticated(ref cause) => cause,
+            GetOperationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetOperationError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetOperationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetOperationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetOperationError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetOperationError::Service(ref cause) => write!(f, "{}", cause),
+            GetOperationError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOperationError {}
 /// Errors returned by GetOperations
 #[derive(Debug, PartialEq)]
 pub enum GetOperationsError {
@@ -9347,22 +9181,18 @@ impl GetOperationsError {
 }
 impl fmt::Display for GetOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOperationsError {
-    fn description(&self) -> &str {
         match *self {
-            GetOperationsError::AccessDenied(ref cause) => cause,
-            GetOperationsError::AccountSetupInProgress(ref cause) => cause,
-            GetOperationsError::InvalidInput(ref cause) => cause,
-            GetOperationsError::NotFound(ref cause) => cause,
-            GetOperationsError::OperationFailure(ref cause) => cause,
-            GetOperationsError::Service(ref cause) => cause,
-            GetOperationsError::Unauthenticated(ref cause) => cause,
+            GetOperationsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetOperationsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetOperationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetOperationsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetOperationsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetOperationsError::Service(ref cause) => write!(f, "{}", cause),
+            GetOperationsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOperationsError {}
 /// Errors returned by GetOperationsForResource
 #[derive(Debug, PartialEq)]
 pub enum GetOperationsForResourceError {
@@ -9426,22 +9256,20 @@ impl GetOperationsForResourceError {
 }
 impl fmt::Display for GetOperationsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOperationsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            GetOperationsForResourceError::AccessDenied(ref cause) => cause,
-            GetOperationsForResourceError::AccountSetupInProgress(ref cause) => cause,
-            GetOperationsForResourceError::InvalidInput(ref cause) => cause,
-            GetOperationsForResourceError::NotFound(ref cause) => cause,
-            GetOperationsForResourceError::OperationFailure(ref cause) => cause,
-            GetOperationsForResourceError::Service(ref cause) => cause,
-            GetOperationsForResourceError::Unauthenticated(ref cause) => cause,
+            GetOperationsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetOperationsForResourceError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetOperationsForResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetOperationsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetOperationsForResourceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetOperationsForResourceError::Service(ref cause) => write!(f, "{}", cause),
+            GetOperationsForResourceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOperationsForResourceError {}
 /// Errors returned by GetRegions
 #[derive(Debug, PartialEq)]
 pub enum GetRegionsError {
@@ -9495,22 +9323,18 @@ impl GetRegionsError {
 }
 impl fmt::Display for GetRegionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRegionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRegionsError::AccessDenied(ref cause) => cause,
-            GetRegionsError::AccountSetupInProgress(ref cause) => cause,
-            GetRegionsError::InvalidInput(ref cause) => cause,
-            GetRegionsError::NotFound(ref cause) => cause,
-            GetRegionsError::OperationFailure(ref cause) => cause,
-            GetRegionsError::Service(ref cause) => cause,
-            GetRegionsError::Unauthenticated(ref cause) => cause,
+            GetRegionsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRegionsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetRegionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRegionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRegionsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetRegionsError::Service(ref cause) => write!(f, "{}", cause),
+            GetRegionsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRegionsError {}
 /// Errors returned by GetRelationalDatabase
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseError {
@@ -9570,22 +9394,18 @@ impl GetRelationalDatabaseError {
 }
 impl fmt::Display for GetRelationalDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseError::Service(ref cause) => cause,
-            GetRelationalDatabaseError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRelationalDatabaseError {}
 /// Errors returned by GetRelationalDatabaseBlueprints
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseBlueprintsError {
@@ -9655,22 +9475,24 @@ impl GetRelationalDatabaseBlueprintsError {
 }
 impl fmt::Display for GetRelationalDatabaseBlueprintsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseBlueprintsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseBlueprintsError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseBlueprintsError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseBlueprintsError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseBlueprintsError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseBlueprintsError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseBlueprintsError::Service(ref cause) => cause,
-            GetRelationalDatabaseBlueprintsError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseBlueprintsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBlueprintsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseBlueprintsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBlueprintsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBlueprintsError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseBlueprintsError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBlueprintsError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseBlueprintsError {}
 /// Errors returned by GetRelationalDatabaseBundles
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseBundlesError {
@@ -9740,22 +9562,22 @@ impl GetRelationalDatabaseBundlesError {
 }
 impl fmt::Display for GetRelationalDatabaseBundlesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseBundlesError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseBundlesError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseBundlesError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseBundlesError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseBundlesError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseBundlesError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseBundlesError::Service(ref cause) => cause,
-            GetRelationalDatabaseBundlesError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseBundlesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBundlesError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseBundlesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBundlesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBundlesError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseBundlesError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseBundlesError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRelationalDatabaseBundlesError {}
 /// Errors returned by GetRelationalDatabaseEvents
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseEventsError {
@@ -9823,22 +9645,20 @@ impl GetRelationalDatabaseEventsError {
 }
 impl fmt::Display for GetRelationalDatabaseEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseEventsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseEventsError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseEventsError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseEventsError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseEventsError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseEventsError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseEventsError::Service(ref cause) => cause,
-            GetRelationalDatabaseEventsError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseEventsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseEventsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseEventsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseEventsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseEventsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseEventsError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseEventsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRelationalDatabaseEventsError {}
 /// Errors returned by GetRelationalDatabaseLogEvents
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseLogEventsError {
@@ -9908,22 +9728,24 @@ impl GetRelationalDatabaseLogEventsError {
 }
 impl fmt::Display for GetRelationalDatabaseLogEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseLogEventsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseLogEventsError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseLogEventsError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseLogEventsError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseLogEventsError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseLogEventsError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseLogEventsError::Service(ref cause) => cause,
-            GetRelationalDatabaseLogEventsError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseLogEventsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogEventsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseLogEventsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogEventsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogEventsError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseLogEventsError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogEventsError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseLogEventsError {}
 /// Errors returned by GetRelationalDatabaseLogStreams
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseLogStreamsError {
@@ -9993,22 +9815,24 @@ impl GetRelationalDatabaseLogStreamsError {
 }
 impl fmt::Display for GetRelationalDatabaseLogStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseLogStreamsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseLogStreamsError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseLogStreamsError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseLogStreamsError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseLogStreamsError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseLogStreamsError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseLogStreamsError::Service(ref cause) => cause,
-            GetRelationalDatabaseLogStreamsError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseLogStreamsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogStreamsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseLogStreamsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogStreamsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogStreamsError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseLogStreamsError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseLogStreamsError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseLogStreamsError {}
 /// Errors returned by GetRelationalDatabaseMasterUserPassword
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseMasterUserPasswordError {
@@ -10080,24 +9904,32 @@ impl GetRelationalDatabaseMasterUserPasswordError {
 }
 impl fmt::Display for GetRelationalDatabaseMasterUserPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseMasterUserPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseMasterUserPasswordError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseMasterUserPasswordError::AccountSetupInProgress(ref cause) => {
-                cause
+            GetRelationalDatabaseMasterUserPasswordError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
             }
-            GetRelationalDatabaseMasterUserPasswordError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseMasterUserPasswordError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseMasterUserPasswordError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseMasterUserPasswordError::Service(ref cause) => cause,
-            GetRelationalDatabaseMasterUserPasswordError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseMasterUserPasswordError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseMasterUserPasswordError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseMasterUserPasswordError::NotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseMasterUserPasswordError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseMasterUserPasswordError::Service(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseMasterUserPasswordError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseMasterUserPasswordError {}
 /// Errors returned by GetRelationalDatabaseMetricData
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseMetricDataError {
@@ -10167,22 +9999,24 @@ impl GetRelationalDatabaseMetricDataError {
 }
 impl fmt::Display for GetRelationalDatabaseMetricDataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseMetricDataError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseMetricDataError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseMetricDataError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseMetricDataError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseMetricDataError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseMetricDataError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseMetricDataError::Service(ref cause) => cause,
-            GetRelationalDatabaseMetricDataError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseMetricDataError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseMetricDataError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseMetricDataError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseMetricDataError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseMetricDataError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseMetricDataError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseMetricDataError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseMetricDataError {}
 /// Errors returned by GetRelationalDatabaseParameters
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseParametersError {
@@ -10252,22 +10086,24 @@ impl GetRelationalDatabaseParametersError {
 }
 impl fmt::Display for GetRelationalDatabaseParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseParametersError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseParametersError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseParametersError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseParametersError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseParametersError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseParametersError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseParametersError::Service(ref cause) => cause,
-            GetRelationalDatabaseParametersError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseParametersError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseParametersError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseParametersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseParametersError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseParametersError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseParametersError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseParametersError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseParametersError {}
 /// Errors returned by GetRelationalDatabaseSnapshot
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseSnapshotError {
@@ -10337,22 +10173,24 @@ impl GetRelationalDatabaseSnapshotError {
 }
 impl fmt::Display for GetRelationalDatabaseSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseSnapshotError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseSnapshotError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseSnapshotError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseSnapshotError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseSnapshotError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseSnapshotError::Service(ref cause) => cause,
-            GetRelationalDatabaseSnapshotError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseSnapshotError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseSnapshotError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseSnapshotError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseSnapshotError {}
 /// Errors returned by GetRelationalDatabaseSnapshots
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabaseSnapshotsError {
@@ -10422,22 +10260,24 @@ impl GetRelationalDatabaseSnapshotsError {
 }
 impl fmt::Display for GetRelationalDatabaseSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabaseSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabaseSnapshotsError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabaseSnapshotsError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabaseSnapshotsError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabaseSnapshotsError::NotFound(ref cause) => cause,
-            GetRelationalDatabaseSnapshotsError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabaseSnapshotsError::Service(ref cause) => cause,
-            GetRelationalDatabaseSnapshotsError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabaseSnapshotsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseSnapshotsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotsError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabaseSnapshotsError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabaseSnapshotsError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRelationalDatabaseSnapshotsError {}
 /// Errors returned by GetRelationalDatabases
 #[derive(Debug, PartialEq)]
 pub enum GetRelationalDatabasesError {
@@ -10497,22 +10337,20 @@ impl GetRelationalDatabasesError {
 }
 impl fmt::Display for GetRelationalDatabasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRelationalDatabasesError {
-    fn description(&self) -> &str {
         match *self {
-            GetRelationalDatabasesError::AccessDenied(ref cause) => cause,
-            GetRelationalDatabasesError::AccountSetupInProgress(ref cause) => cause,
-            GetRelationalDatabasesError::InvalidInput(ref cause) => cause,
-            GetRelationalDatabasesError::NotFound(ref cause) => cause,
-            GetRelationalDatabasesError::OperationFailure(ref cause) => cause,
-            GetRelationalDatabasesError::Service(ref cause) => cause,
-            GetRelationalDatabasesError::Unauthenticated(ref cause) => cause,
+            GetRelationalDatabasesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabasesError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRelationalDatabasesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabasesError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabasesError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabasesError::Service(ref cause) => write!(f, "{}", cause),
+            GetRelationalDatabasesError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRelationalDatabasesError {}
 /// Errors returned by GetStaticIp
 #[derive(Debug, PartialEq)]
 pub enum GetStaticIpError {
@@ -10566,22 +10404,18 @@ impl GetStaticIpError {
 }
 impl fmt::Display for GetStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStaticIpError {
-    fn description(&self) -> &str {
         match *self {
-            GetStaticIpError::AccessDenied(ref cause) => cause,
-            GetStaticIpError::AccountSetupInProgress(ref cause) => cause,
-            GetStaticIpError::InvalidInput(ref cause) => cause,
-            GetStaticIpError::NotFound(ref cause) => cause,
-            GetStaticIpError::OperationFailure(ref cause) => cause,
-            GetStaticIpError::Service(ref cause) => cause,
-            GetStaticIpError::Unauthenticated(ref cause) => cause,
+            GetStaticIpError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetStaticIpError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetStaticIpError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetStaticIpError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetStaticIpError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetStaticIpError::Service(ref cause) => write!(f, "{}", cause),
+            GetStaticIpError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStaticIpError {}
 /// Errors returned by GetStaticIps
 #[derive(Debug, PartialEq)]
 pub enum GetStaticIpsError {
@@ -10635,22 +10469,18 @@ impl GetStaticIpsError {
 }
 impl fmt::Display for GetStaticIpsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetStaticIpsError {
-    fn description(&self) -> &str {
         match *self {
-            GetStaticIpsError::AccessDenied(ref cause) => cause,
-            GetStaticIpsError::AccountSetupInProgress(ref cause) => cause,
-            GetStaticIpsError::InvalidInput(ref cause) => cause,
-            GetStaticIpsError::NotFound(ref cause) => cause,
-            GetStaticIpsError::OperationFailure(ref cause) => cause,
-            GetStaticIpsError::Service(ref cause) => cause,
-            GetStaticIpsError::Unauthenticated(ref cause) => cause,
+            GetStaticIpsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetStaticIpsError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            GetStaticIpsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetStaticIpsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetStaticIpsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            GetStaticIpsError::Service(ref cause) => write!(f, "{}", cause),
+            GetStaticIpsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetStaticIpsError {}
 /// Errors returned by ImportKeyPair
 #[derive(Debug, PartialEq)]
 pub enum ImportKeyPairError {
@@ -10706,22 +10536,18 @@ impl ImportKeyPairError {
 }
 impl fmt::Display for ImportKeyPairError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportKeyPairError {
-    fn description(&self) -> &str {
         match *self {
-            ImportKeyPairError::AccessDenied(ref cause) => cause,
-            ImportKeyPairError::AccountSetupInProgress(ref cause) => cause,
-            ImportKeyPairError::InvalidInput(ref cause) => cause,
-            ImportKeyPairError::NotFound(ref cause) => cause,
-            ImportKeyPairError::OperationFailure(ref cause) => cause,
-            ImportKeyPairError::Service(ref cause) => cause,
-            ImportKeyPairError::Unauthenticated(ref cause) => cause,
+            ImportKeyPairError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ImportKeyPairError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            ImportKeyPairError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ImportKeyPairError::NotFound(ref cause) => write!(f, "{}", cause),
+            ImportKeyPairError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            ImportKeyPairError::Service(ref cause) => write!(f, "{}", cause),
+            ImportKeyPairError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportKeyPairError {}
 /// Errors returned by IsVpcPeered
 #[derive(Debug, PartialEq)]
 pub enum IsVpcPeeredError {
@@ -10775,22 +10601,18 @@ impl IsVpcPeeredError {
 }
 impl fmt::Display for IsVpcPeeredError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for IsVpcPeeredError {
-    fn description(&self) -> &str {
         match *self {
-            IsVpcPeeredError::AccessDenied(ref cause) => cause,
-            IsVpcPeeredError::AccountSetupInProgress(ref cause) => cause,
-            IsVpcPeeredError::InvalidInput(ref cause) => cause,
-            IsVpcPeeredError::NotFound(ref cause) => cause,
-            IsVpcPeeredError::OperationFailure(ref cause) => cause,
-            IsVpcPeeredError::Service(ref cause) => cause,
-            IsVpcPeeredError::Unauthenticated(ref cause) => cause,
+            IsVpcPeeredError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            IsVpcPeeredError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            IsVpcPeeredError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            IsVpcPeeredError::NotFound(ref cause) => write!(f, "{}", cause),
+            IsVpcPeeredError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            IsVpcPeeredError::Service(ref cause) => write!(f, "{}", cause),
+            IsVpcPeeredError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for IsVpcPeeredError {}
 /// Errors returned by OpenInstancePublicPorts
 #[derive(Debug, PartialEq)]
 pub enum OpenInstancePublicPortsError {
@@ -10854,22 +10676,20 @@ impl OpenInstancePublicPortsError {
 }
 impl fmt::Display for OpenInstancePublicPortsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for OpenInstancePublicPortsError {
-    fn description(&self) -> &str {
         match *self {
-            OpenInstancePublicPortsError::AccessDenied(ref cause) => cause,
-            OpenInstancePublicPortsError::AccountSetupInProgress(ref cause) => cause,
-            OpenInstancePublicPortsError::InvalidInput(ref cause) => cause,
-            OpenInstancePublicPortsError::NotFound(ref cause) => cause,
-            OpenInstancePublicPortsError::OperationFailure(ref cause) => cause,
-            OpenInstancePublicPortsError::Service(ref cause) => cause,
-            OpenInstancePublicPortsError::Unauthenticated(ref cause) => cause,
+            OpenInstancePublicPortsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            OpenInstancePublicPortsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            OpenInstancePublicPortsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            OpenInstancePublicPortsError::NotFound(ref cause) => write!(f, "{}", cause),
+            OpenInstancePublicPortsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            OpenInstancePublicPortsError::Service(ref cause) => write!(f, "{}", cause),
+            OpenInstancePublicPortsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for OpenInstancePublicPortsError {}
 /// Errors returned by PeerVpc
 #[derive(Debug, PartialEq)]
 pub enum PeerVpcError {
@@ -10921,22 +10741,18 @@ impl PeerVpcError {
 }
 impl fmt::Display for PeerVpcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PeerVpcError {
-    fn description(&self) -> &str {
         match *self {
-            PeerVpcError::AccessDenied(ref cause) => cause,
-            PeerVpcError::AccountSetupInProgress(ref cause) => cause,
-            PeerVpcError::InvalidInput(ref cause) => cause,
-            PeerVpcError::NotFound(ref cause) => cause,
-            PeerVpcError::OperationFailure(ref cause) => cause,
-            PeerVpcError::Service(ref cause) => cause,
-            PeerVpcError::Unauthenticated(ref cause) => cause,
+            PeerVpcError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            PeerVpcError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            PeerVpcError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PeerVpcError::NotFound(ref cause) => write!(f, "{}", cause),
+            PeerVpcError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            PeerVpcError::Service(ref cause) => write!(f, "{}", cause),
+            PeerVpcError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PeerVpcError {}
 /// Errors returned by PutInstancePublicPorts
 #[derive(Debug, PartialEq)]
 pub enum PutInstancePublicPortsError {
@@ -10996,22 +10812,20 @@ impl PutInstancePublicPortsError {
 }
 impl fmt::Display for PutInstancePublicPortsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutInstancePublicPortsError {
-    fn description(&self) -> &str {
         match *self {
-            PutInstancePublicPortsError::AccessDenied(ref cause) => cause,
-            PutInstancePublicPortsError::AccountSetupInProgress(ref cause) => cause,
-            PutInstancePublicPortsError::InvalidInput(ref cause) => cause,
-            PutInstancePublicPortsError::NotFound(ref cause) => cause,
-            PutInstancePublicPortsError::OperationFailure(ref cause) => cause,
-            PutInstancePublicPortsError::Service(ref cause) => cause,
-            PutInstancePublicPortsError::Unauthenticated(ref cause) => cause,
+            PutInstancePublicPortsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            PutInstancePublicPortsError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutInstancePublicPortsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PutInstancePublicPortsError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutInstancePublicPortsError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            PutInstancePublicPortsError::Service(ref cause) => write!(f, "{}", cause),
+            PutInstancePublicPortsError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutInstancePublicPortsError {}
 /// Errors returned by RebootInstance
 #[derive(Debug, PartialEq)]
 pub enum RebootInstanceError {
@@ -11067,22 +10881,18 @@ impl RebootInstanceError {
 }
 impl fmt::Display for RebootInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RebootInstanceError::AccessDenied(ref cause) => cause,
-            RebootInstanceError::AccountSetupInProgress(ref cause) => cause,
-            RebootInstanceError::InvalidInput(ref cause) => cause,
-            RebootInstanceError::NotFound(ref cause) => cause,
-            RebootInstanceError::OperationFailure(ref cause) => cause,
-            RebootInstanceError::Service(ref cause) => cause,
-            RebootInstanceError::Unauthenticated(ref cause) => cause,
+            RebootInstanceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RebootInstanceError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            RebootInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RebootInstanceError::NotFound(ref cause) => write!(f, "{}", cause),
+            RebootInstanceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            RebootInstanceError::Service(ref cause) => write!(f, "{}", cause),
+            RebootInstanceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootInstanceError {}
 /// Errors returned by RebootRelationalDatabase
 #[derive(Debug, PartialEq)]
 pub enum RebootRelationalDatabaseError {
@@ -11146,22 +10956,20 @@ impl RebootRelationalDatabaseError {
 }
 impl fmt::Display for RebootRelationalDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootRelationalDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            RebootRelationalDatabaseError::AccessDenied(ref cause) => cause,
-            RebootRelationalDatabaseError::AccountSetupInProgress(ref cause) => cause,
-            RebootRelationalDatabaseError::InvalidInput(ref cause) => cause,
-            RebootRelationalDatabaseError::NotFound(ref cause) => cause,
-            RebootRelationalDatabaseError::OperationFailure(ref cause) => cause,
-            RebootRelationalDatabaseError::Service(ref cause) => cause,
-            RebootRelationalDatabaseError::Unauthenticated(ref cause) => cause,
+            RebootRelationalDatabaseError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RebootRelationalDatabaseError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RebootRelationalDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RebootRelationalDatabaseError::NotFound(ref cause) => write!(f, "{}", cause),
+            RebootRelationalDatabaseError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            RebootRelationalDatabaseError::Service(ref cause) => write!(f, "{}", cause),
+            RebootRelationalDatabaseError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootRelationalDatabaseError {}
 /// Errors returned by ReleaseStaticIp
 #[derive(Debug, PartialEq)]
 pub enum ReleaseStaticIpError {
@@ -11217,22 +11025,18 @@ impl ReleaseStaticIpError {
 }
 impl fmt::Display for ReleaseStaticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReleaseStaticIpError {
-    fn description(&self) -> &str {
         match *self {
-            ReleaseStaticIpError::AccessDenied(ref cause) => cause,
-            ReleaseStaticIpError::AccountSetupInProgress(ref cause) => cause,
-            ReleaseStaticIpError::InvalidInput(ref cause) => cause,
-            ReleaseStaticIpError::NotFound(ref cause) => cause,
-            ReleaseStaticIpError::OperationFailure(ref cause) => cause,
-            ReleaseStaticIpError::Service(ref cause) => cause,
-            ReleaseStaticIpError::Unauthenticated(ref cause) => cause,
+            ReleaseStaticIpError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ReleaseStaticIpError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            ReleaseStaticIpError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ReleaseStaticIpError::NotFound(ref cause) => write!(f, "{}", cause),
+            ReleaseStaticIpError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            ReleaseStaticIpError::Service(ref cause) => write!(f, "{}", cause),
+            ReleaseStaticIpError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReleaseStaticIpError {}
 /// Errors returned by StartInstance
 #[derive(Debug, PartialEq)]
 pub enum StartInstanceError {
@@ -11288,22 +11092,18 @@ impl StartInstanceError {
 }
 impl fmt::Display for StartInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            StartInstanceError::AccessDenied(ref cause) => cause,
-            StartInstanceError::AccountSetupInProgress(ref cause) => cause,
-            StartInstanceError::InvalidInput(ref cause) => cause,
-            StartInstanceError::NotFound(ref cause) => cause,
-            StartInstanceError::OperationFailure(ref cause) => cause,
-            StartInstanceError::Service(ref cause) => cause,
-            StartInstanceError::Unauthenticated(ref cause) => cause,
+            StartInstanceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartInstanceError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            StartInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartInstanceError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartInstanceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            StartInstanceError::Service(ref cause) => write!(f, "{}", cause),
+            StartInstanceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartInstanceError {}
 /// Errors returned by StartRelationalDatabase
 #[derive(Debug, PartialEq)]
 pub enum StartRelationalDatabaseError {
@@ -11367,22 +11167,20 @@ impl StartRelationalDatabaseError {
 }
 impl fmt::Display for StartRelationalDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartRelationalDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            StartRelationalDatabaseError::AccessDenied(ref cause) => cause,
-            StartRelationalDatabaseError::AccountSetupInProgress(ref cause) => cause,
-            StartRelationalDatabaseError::InvalidInput(ref cause) => cause,
-            StartRelationalDatabaseError::NotFound(ref cause) => cause,
-            StartRelationalDatabaseError::OperationFailure(ref cause) => cause,
-            StartRelationalDatabaseError::Service(ref cause) => cause,
-            StartRelationalDatabaseError::Unauthenticated(ref cause) => cause,
+            StartRelationalDatabaseError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartRelationalDatabaseError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartRelationalDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StartRelationalDatabaseError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartRelationalDatabaseError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            StartRelationalDatabaseError::Service(ref cause) => write!(f, "{}", cause),
+            StartRelationalDatabaseError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartRelationalDatabaseError {}
 /// Errors returned by StopInstance
 #[derive(Debug, PartialEq)]
 pub enum StopInstanceError {
@@ -11436,22 +11234,18 @@ impl StopInstanceError {
 }
 impl fmt::Display for StopInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            StopInstanceError::AccessDenied(ref cause) => cause,
-            StopInstanceError::AccountSetupInProgress(ref cause) => cause,
-            StopInstanceError::InvalidInput(ref cause) => cause,
-            StopInstanceError::NotFound(ref cause) => cause,
-            StopInstanceError::OperationFailure(ref cause) => cause,
-            StopInstanceError::Service(ref cause) => cause,
-            StopInstanceError::Unauthenticated(ref cause) => cause,
+            StopInstanceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StopInstanceError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            StopInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StopInstanceError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopInstanceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            StopInstanceError::Service(ref cause) => write!(f, "{}", cause),
+            StopInstanceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopInstanceError {}
 /// Errors returned by StopRelationalDatabase
 #[derive(Debug, PartialEq)]
 pub enum StopRelationalDatabaseError {
@@ -11511,22 +11305,20 @@ impl StopRelationalDatabaseError {
 }
 impl fmt::Display for StopRelationalDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopRelationalDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            StopRelationalDatabaseError::AccessDenied(ref cause) => cause,
-            StopRelationalDatabaseError::AccountSetupInProgress(ref cause) => cause,
-            StopRelationalDatabaseError::InvalidInput(ref cause) => cause,
-            StopRelationalDatabaseError::NotFound(ref cause) => cause,
-            StopRelationalDatabaseError::OperationFailure(ref cause) => cause,
-            StopRelationalDatabaseError::Service(ref cause) => cause,
-            StopRelationalDatabaseError::Unauthenticated(ref cause) => cause,
+            StopRelationalDatabaseError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StopRelationalDatabaseError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopRelationalDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            StopRelationalDatabaseError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopRelationalDatabaseError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            StopRelationalDatabaseError::Service(ref cause) => write!(f, "{}", cause),
+            StopRelationalDatabaseError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopRelationalDatabaseError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -11580,22 +11372,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AccessDenied(ref cause) => cause,
-            TagResourceError::AccountSetupInProgress(ref cause) => cause,
-            TagResourceError::InvalidInput(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::OperationFailure(ref cause) => cause,
-            TagResourceError::Service(ref cause) => cause,
-            TagResourceError::Unauthenticated(ref cause) => cause,
+            TagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Service(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UnpeerVpc
 #[derive(Debug, PartialEq)]
 pub enum UnpeerVpcError {
@@ -11649,22 +11437,18 @@ impl UnpeerVpcError {
 }
 impl fmt::Display for UnpeerVpcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnpeerVpcError {
-    fn description(&self) -> &str {
         match *self {
-            UnpeerVpcError::AccessDenied(ref cause) => cause,
-            UnpeerVpcError::AccountSetupInProgress(ref cause) => cause,
-            UnpeerVpcError::InvalidInput(ref cause) => cause,
-            UnpeerVpcError::NotFound(ref cause) => cause,
-            UnpeerVpcError::OperationFailure(ref cause) => cause,
-            UnpeerVpcError::Service(ref cause) => cause,
-            UnpeerVpcError::Unauthenticated(ref cause) => cause,
+            UnpeerVpcError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UnpeerVpcError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            UnpeerVpcError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UnpeerVpcError::NotFound(ref cause) => write!(f, "{}", cause),
+            UnpeerVpcError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            UnpeerVpcError::Service(ref cause) => write!(f, "{}", cause),
+            UnpeerVpcError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnpeerVpcError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -11720,22 +11504,18 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AccessDenied(ref cause) => cause,
-            UntagResourceError::AccountSetupInProgress(ref cause) => cause,
-            UntagResourceError::InvalidInput(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::OperationFailure(ref cause) => cause,
-            UntagResourceError::Service(ref cause) => cause,
-            UntagResourceError::Unauthenticated(ref cause) => cause,
+            UntagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Service(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateDomainEntry
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainEntryError {
@@ -11791,22 +11571,18 @@ impl UpdateDomainEntryError {
 }
 impl fmt::Display for UpdateDomainEntryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainEntryError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainEntryError::AccessDenied(ref cause) => cause,
-            UpdateDomainEntryError::AccountSetupInProgress(ref cause) => cause,
-            UpdateDomainEntryError::InvalidInput(ref cause) => cause,
-            UpdateDomainEntryError::NotFound(ref cause) => cause,
-            UpdateDomainEntryError::OperationFailure(ref cause) => cause,
-            UpdateDomainEntryError::Service(ref cause) => cause,
-            UpdateDomainEntryError::Unauthenticated(ref cause) => cause,
+            UpdateDomainEntryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEntryError::AccountSetupInProgress(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEntryError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEntryError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEntryError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEntryError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateDomainEntryError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainEntryError {}
 /// Errors returned by UpdateLoadBalancerAttribute
 #[derive(Debug, PartialEq)]
 pub enum UpdateLoadBalancerAttributeError {
@@ -11874,22 +11650,20 @@ impl UpdateLoadBalancerAttributeError {
 }
 impl fmt::Display for UpdateLoadBalancerAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLoadBalancerAttributeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLoadBalancerAttributeError::AccessDenied(ref cause) => cause,
-            UpdateLoadBalancerAttributeError::AccountSetupInProgress(ref cause) => cause,
-            UpdateLoadBalancerAttributeError::InvalidInput(ref cause) => cause,
-            UpdateLoadBalancerAttributeError::NotFound(ref cause) => cause,
-            UpdateLoadBalancerAttributeError::OperationFailure(ref cause) => cause,
-            UpdateLoadBalancerAttributeError::Service(ref cause) => cause,
-            UpdateLoadBalancerAttributeError::Unauthenticated(ref cause) => cause,
+            UpdateLoadBalancerAttributeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateLoadBalancerAttributeError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateLoadBalancerAttributeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateLoadBalancerAttributeError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateLoadBalancerAttributeError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            UpdateLoadBalancerAttributeError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateLoadBalancerAttributeError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLoadBalancerAttributeError {}
 /// Errors returned by UpdateRelationalDatabase
 #[derive(Debug, PartialEq)]
 pub enum UpdateRelationalDatabaseError {
@@ -11953,22 +11727,20 @@ impl UpdateRelationalDatabaseError {
 }
 impl fmt::Display for UpdateRelationalDatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRelationalDatabaseError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRelationalDatabaseError::AccessDenied(ref cause) => cause,
-            UpdateRelationalDatabaseError::AccountSetupInProgress(ref cause) => cause,
-            UpdateRelationalDatabaseError::InvalidInput(ref cause) => cause,
-            UpdateRelationalDatabaseError::NotFound(ref cause) => cause,
-            UpdateRelationalDatabaseError::OperationFailure(ref cause) => cause,
-            UpdateRelationalDatabaseError::Service(ref cause) => cause,
-            UpdateRelationalDatabaseError::Unauthenticated(ref cause) => cause,
+            UpdateRelationalDatabaseError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateRelationalDatabaseError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRelationalDatabaseError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateRelationalDatabaseError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRelationalDatabaseError::OperationFailure(ref cause) => write!(f, "{}", cause),
+            UpdateRelationalDatabaseError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateRelationalDatabaseError::Unauthenticated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRelationalDatabaseError {}
 /// Errors returned by UpdateRelationalDatabaseParameters
 #[derive(Debug, PartialEq)]
 pub enum UpdateRelationalDatabaseParametersError {
@@ -12038,22 +11810,28 @@ impl UpdateRelationalDatabaseParametersError {
 }
 impl fmt::Display for UpdateRelationalDatabaseParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRelationalDatabaseParametersError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRelationalDatabaseParametersError::AccessDenied(ref cause) => cause,
-            UpdateRelationalDatabaseParametersError::AccountSetupInProgress(ref cause) => cause,
-            UpdateRelationalDatabaseParametersError::InvalidInput(ref cause) => cause,
-            UpdateRelationalDatabaseParametersError::NotFound(ref cause) => cause,
-            UpdateRelationalDatabaseParametersError::OperationFailure(ref cause) => cause,
-            UpdateRelationalDatabaseParametersError::Service(ref cause) => cause,
-            UpdateRelationalDatabaseParametersError::Unauthenticated(ref cause) => cause,
+            UpdateRelationalDatabaseParametersError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRelationalDatabaseParametersError::AccountSetupInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRelationalDatabaseParametersError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRelationalDatabaseParametersError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateRelationalDatabaseParametersError::OperationFailure(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRelationalDatabaseParametersError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateRelationalDatabaseParametersError::Unauthenticated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateRelationalDatabaseParametersError {}
 /// Trait representing the capabilities of the Amazon Lightsail API. Amazon Lightsail clients implement this trait.
 pub trait Lightsail {
     /// <p>Allocates a static IP address.</p>

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -1308,19 +1308,15 @@ impl AssociateKmsKeyError {
 }
 impl fmt::Display for AssociateKmsKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateKmsKeyError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateKmsKeyError::InvalidParameter(ref cause) => cause,
-            AssociateKmsKeyError::OperationAborted(ref cause) => cause,
-            AssociateKmsKeyError::ResourceNotFound(ref cause) => cause,
-            AssociateKmsKeyError::ServiceUnavailable(ref cause) => cause,
+            AssociateKmsKeyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateKmsKeyError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            AssociateKmsKeyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateKmsKeyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateKmsKeyError {}
 /// Errors returned by CancelExportTask
 #[derive(Debug, PartialEq)]
 pub enum CancelExportTaskError {
@@ -1359,19 +1355,15 @@ impl CancelExportTaskError {
 }
 impl fmt::Display for CancelExportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelExportTaskError {
-    fn description(&self) -> &str {
         match *self {
-            CancelExportTaskError::InvalidOperation(ref cause) => cause,
-            CancelExportTaskError::InvalidParameter(ref cause) => cause,
-            CancelExportTaskError::ResourceNotFound(ref cause) => cause,
-            CancelExportTaskError::ServiceUnavailable(ref cause) => cause,
+            CancelExportTaskError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            CancelExportTaskError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CancelExportTaskError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CancelExportTaskError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelExportTaskError {}
 /// Errors returned by CreateExportTask
 #[derive(Debug, PartialEq)]
 pub enum CreateExportTaskError {
@@ -1422,21 +1414,17 @@ impl CreateExportTaskError {
 }
 impl fmt::Display for CreateExportTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateExportTaskError {
-    fn description(&self) -> &str {
         match *self {
-            CreateExportTaskError::InvalidParameter(ref cause) => cause,
-            CreateExportTaskError::LimitExceeded(ref cause) => cause,
-            CreateExportTaskError::OperationAborted(ref cause) => cause,
-            CreateExportTaskError::ResourceAlreadyExists(ref cause) => cause,
-            CreateExportTaskError::ResourceNotFound(ref cause) => cause,
-            CreateExportTaskError::ServiceUnavailable(ref cause) => cause,
+            CreateExportTaskError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateExportTaskError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateExportTaskError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            CreateExportTaskError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateExportTaskError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateExportTaskError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateExportTaskError {}
 /// Errors returned by CreateLogGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateLogGroupError {
@@ -1482,20 +1470,16 @@ impl CreateLogGroupError {
 }
 impl fmt::Display for CreateLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLogGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLogGroupError::InvalidParameter(ref cause) => cause,
-            CreateLogGroupError::LimitExceeded(ref cause) => cause,
-            CreateLogGroupError::OperationAborted(ref cause) => cause,
-            CreateLogGroupError::ResourceAlreadyExists(ref cause) => cause,
-            CreateLogGroupError::ServiceUnavailable(ref cause) => cause,
+            CreateLogGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateLogGroupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateLogGroupError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            CreateLogGroupError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateLogGroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLogGroupError {}
 /// Errors returned by CreateLogStream
 #[derive(Debug, PartialEq)]
 pub enum CreateLogStreamError {
@@ -1536,19 +1520,15 @@ impl CreateLogStreamError {
 }
 impl fmt::Display for CreateLogStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLogStreamError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLogStreamError::InvalidParameter(ref cause) => cause,
-            CreateLogStreamError::ResourceAlreadyExists(ref cause) => cause,
-            CreateLogStreamError::ResourceNotFound(ref cause) => cause,
-            CreateLogStreamError::ServiceUnavailable(ref cause) => cause,
+            CreateLogStreamError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateLogStreamError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateLogStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateLogStreamError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLogStreamError {}
 /// Errors returned by DeleteDestination
 #[derive(Debug, PartialEq)]
 pub enum DeleteDestinationError {
@@ -1589,19 +1569,15 @@ impl DeleteDestinationError {
 }
 impl fmt::Display for DeleteDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDestinationError::InvalidParameter(ref cause) => cause,
-            DeleteDestinationError::OperationAborted(ref cause) => cause,
-            DeleteDestinationError::ResourceNotFound(ref cause) => cause,
-            DeleteDestinationError::ServiceUnavailable(ref cause) => cause,
+            DeleteDestinationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteDestinationError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            DeleteDestinationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteDestinationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDestinationError {}
 /// Errors returned by DeleteLogGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteLogGroupError {
@@ -1640,19 +1616,15 @@ impl DeleteLogGroupError {
 }
 impl fmt::Display for DeleteLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLogGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLogGroupError::InvalidParameter(ref cause) => cause,
-            DeleteLogGroupError::OperationAborted(ref cause) => cause,
-            DeleteLogGroupError::ResourceNotFound(ref cause) => cause,
-            DeleteLogGroupError::ServiceUnavailable(ref cause) => cause,
+            DeleteLogGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteLogGroupError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            DeleteLogGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLogGroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLogGroupError {}
 /// Errors returned by DeleteLogStream
 #[derive(Debug, PartialEq)]
 pub enum DeleteLogStreamError {
@@ -1691,19 +1663,15 @@ impl DeleteLogStreamError {
 }
 impl fmt::Display for DeleteLogStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLogStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLogStreamError::InvalidParameter(ref cause) => cause,
-            DeleteLogStreamError::OperationAborted(ref cause) => cause,
-            DeleteLogStreamError::ResourceNotFound(ref cause) => cause,
-            DeleteLogStreamError::ServiceUnavailable(ref cause) => cause,
+            DeleteLogStreamError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteLogStreamError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            DeleteLogStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLogStreamError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLogStreamError {}
 /// Errors returned by DeleteMetricFilter
 #[derive(Debug, PartialEq)]
 pub enum DeleteMetricFilterError {
@@ -1744,19 +1712,15 @@ impl DeleteMetricFilterError {
 }
 impl fmt::Display for DeleteMetricFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMetricFilterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMetricFilterError::InvalidParameter(ref cause) => cause,
-            DeleteMetricFilterError::OperationAborted(ref cause) => cause,
-            DeleteMetricFilterError::ResourceNotFound(ref cause) => cause,
-            DeleteMetricFilterError::ServiceUnavailable(ref cause) => cause,
+            DeleteMetricFilterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteMetricFilterError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            DeleteMetricFilterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMetricFilterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMetricFilterError {}
 /// Errors returned by DeleteResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourcePolicyError {
@@ -1796,18 +1760,14 @@ impl DeleteResourcePolicyError {
 }
 impl fmt::Display for DeleteResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourcePolicyError::InvalidParameter(ref cause) => cause,
-            DeleteResourcePolicyError::ResourceNotFound(ref cause) => cause,
-            DeleteResourcePolicyError::ServiceUnavailable(ref cause) => cause,
+            DeleteResourcePolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourcePolicyError {}
 /// Errors returned by DeleteRetentionPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteRetentionPolicyError {
@@ -1854,19 +1814,15 @@ impl DeleteRetentionPolicyError {
 }
 impl fmt::Display for DeleteRetentionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRetentionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRetentionPolicyError::InvalidParameter(ref cause) => cause,
-            DeleteRetentionPolicyError::OperationAborted(ref cause) => cause,
-            DeleteRetentionPolicyError::ResourceNotFound(ref cause) => cause,
-            DeleteRetentionPolicyError::ServiceUnavailable(ref cause) => cause,
+            DeleteRetentionPolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteRetentionPolicyError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            DeleteRetentionPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteRetentionPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRetentionPolicyError {}
 /// Errors returned by DeleteSubscriptionFilter
 #[derive(Debug, PartialEq)]
 pub enum DeleteSubscriptionFilterError {
@@ -1913,19 +1869,15 @@ impl DeleteSubscriptionFilterError {
 }
 impl fmt::Display for DeleteSubscriptionFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSubscriptionFilterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSubscriptionFilterError::InvalidParameter(ref cause) => cause,
-            DeleteSubscriptionFilterError::OperationAborted(ref cause) => cause,
-            DeleteSubscriptionFilterError::ResourceNotFound(ref cause) => cause,
-            DeleteSubscriptionFilterError::ServiceUnavailable(ref cause) => cause,
+            DeleteSubscriptionFilterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriptionFilterError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriptionFilterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriptionFilterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSubscriptionFilterError {}
 /// Errors returned by DescribeDestinations
 #[derive(Debug, PartialEq)]
 pub enum DescribeDestinationsError {
@@ -1958,17 +1910,13 @@ impl DescribeDestinationsError {
 }
 impl fmt::Display for DescribeDestinationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDestinationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDestinationsError::InvalidParameter(ref cause) => cause,
-            DescribeDestinationsError::ServiceUnavailable(ref cause) => cause,
+            DescribeDestinationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeDestinationsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDestinationsError {}
 /// Errors returned by DescribeExportTasks
 #[derive(Debug, PartialEq)]
 pub enum DescribeExportTasksError {
@@ -2001,17 +1949,13 @@ impl DescribeExportTasksError {
 }
 impl fmt::Display for DescribeExportTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeExportTasksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeExportTasksError::InvalidParameter(ref cause) => cause,
-            DescribeExportTasksError::ServiceUnavailable(ref cause) => cause,
+            DescribeExportTasksError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeExportTasksError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeExportTasksError {}
 /// Errors returned by DescribeLogGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeLogGroupsError {
@@ -2042,17 +1986,13 @@ impl DescribeLogGroupsError {
 }
 impl fmt::Display for DescribeLogGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLogGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLogGroupsError::InvalidParameter(ref cause) => cause,
-            DescribeLogGroupsError::ServiceUnavailable(ref cause) => cause,
+            DescribeLogGroupsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeLogGroupsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLogGroupsError {}
 /// Errors returned by DescribeLogStreams
 #[derive(Debug, PartialEq)]
 pub enum DescribeLogStreamsError {
@@ -2088,18 +2028,14 @@ impl DescribeLogStreamsError {
 }
 impl fmt::Display for DescribeLogStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLogStreamsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLogStreamsError::InvalidParameter(ref cause) => cause,
-            DescribeLogStreamsError::ResourceNotFound(ref cause) => cause,
-            DescribeLogStreamsError::ServiceUnavailable(ref cause) => cause,
+            DescribeLogStreamsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeLogStreamsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeLogStreamsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLogStreamsError {}
 /// Errors returned by DescribeMetricFilters
 #[derive(Debug, PartialEq)]
 pub enum DescribeMetricFiltersError {
@@ -2139,18 +2075,14 @@ impl DescribeMetricFiltersError {
 }
 impl fmt::Display for DescribeMetricFiltersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMetricFiltersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMetricFiltersError::InvalidParameter(ref cause) => cause,
-            DescribeMetricFiltersError::ResourceNotFound(ref cause) => cause,
-            DescribeMetricFiltersError::ServiceUnavailable(ref cause) => cause,
+            DescribeMetricFiltersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeMetricFiltersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMetricFiltersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMetricFiltersError {}
 /// Errors returned by DescribeQueries
 #[derive(Debug, PartialEq)]
 pub enum DescribeQueriesError {
@@ -2184,18 +2116,14 @@ impl DescribeQueriesError {
 }
 impl fmt::Display for DescribeQueriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeQueriesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeQueriesError::InvalidParameter(ref cause) => cause,
-            DescribeQueriesError::ResourceNotFound(ref cause) => cause,
-            DescribeQueriesError::ServiceUnavailable(ref cause) => cause,
+            DescribeQueriesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeQueriesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeQueriesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeQueriesError {}
 /// Errors returned by DescribeResourcePolicies
 #[derive(Debug, PartialEq)]
 pub enum DescribeResourcePoliciesError {
@@ -2228,17 +2156,13 @@ impl DescribeResourcePoliciesError {
 }
 impl fmt::Display for DescribeResourcePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeResourcePoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeResourcePoliciesError::InvalidParameter(ref cause) => cause,
-            DescribeResourcePoliciesError::ServiceUnavailable(ref cause) => cause,
+            DescribeResourcePoliciesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeResourcePoliciesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeResourcePoliciesError {}
 /// Errors returned by DescribeSubscriptionFilters
 #[derive(Debug, PartialEq)]
 pub enum DescribeSubscriptionFiltersError {
@@ -2280,18 +2204,16 @@ impl DescribeSubscriptionFiltersError {
 }
 impl fmt::Display for DescribeSubscriptionFiltersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSubscriptionFiltersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSubscriptionFiltersError::InvalidParameter(ref cause) => cause,
-            DescribeSubscriptionFiltersError::ResourceNotFound(ref cause) => cause,
-            DescribeSubscriptionFiltersError::ServiceUnavailable(ref cause) => cause,
+            DescribeSubscriptionFiltersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeSubscriptionFiltersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeSubscriptionFiltersError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeSubscriptionFiltersError {}
 /// Errors returned by DisassociateKmsKey
 #[derive(Debug, PartialEq)]
 pub enum DisassociateKmsKeyError {
@@ -2332,19 +2254,15 @@ impl DisassociateKmsKeyError {
 }
 impl fmt::Display for DisassociateKmsKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateKmsKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateKmsKeyError::InvalidParameter(ref cause) => cause,
-            DisassociateKmsKeyError::OperationAborted(ref cause) => cause,
-            DisassociateKmsKeyError::ResourceNotFound(ref cause) => cause,
-            DisassociateKmsKeyError::ServiceUnavailable(ref cause) => cause,
+            DisassociateKmsKeyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DisassociateKmsKeyError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            DisassociateKmsKeyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DisassociateKmsKeyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateKmsKeyError {}
 /// Errors returned by FilterLogEvents
 #[derive(Debug, PartialEq)]
 pub enum FilterLogEventsError {
@@ -2378,18 +2296,14 @@ impl FilterLogEventsError {
 }
 impl fmt::Display for FilterLogEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FilterLogEventsError {
-    fn description(&self) -> &str {
         match *self {
-            FilterLogEventsError::InvalidParameter(ref cause) => cause,
-            FilterLogEventsError::ResourceNotFound(ref cause) => cause,
-            FilterLogEventsError::ServiceUnavailable(ref cause) => cause,
+            FilterLogEventsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            FilterLogEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            FilterLogEventsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for FilterLogEventsError {}
 /// Errors returned by GetLogEvents
 #[derive(Debug, PartialEq)]
 pub enum GetLogEventsError {
@@ -2423,18 +2337,14 @@ impl GetLogEventsError {
 }
 impl fmt::Display for GetLogEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLogEventsError {
-    fn description(&self) -> &str {
         match *self {
-            GetLogEventsError::InvalidParameter(ref cause) => cause,
-            GetLogEventsError::ResourceNotFound(ref cause) => cause,
-            GetLogEventsError::ServiceUnavailable(ref cause) => cause,
+            GetLogEventsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetLogEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLogEventsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLogEventsError {}
 /// Errors returned by GetLogGroupFields
 #[derive(Debug, PartialEq)]
 pub enum GetLogGroupFieldsError {
@@ -2475,19 +2385,15 @@ impl GetLogGroupFieldsError {
 }
 impl fmt::Display for GetLogGroupFieldsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLogGroupFieldsError {
-    fn description(&self) -> &str {
         match *self {
-            GetLogGroupFieldsError::InvalidParameter(ref cause) => cause,
-            GetLogGroupFieldsError::LimitExceeded(ref cause) => cause,
-            GetLogGroupFieldsError::ResourceNotFound(ref cause) => cause,
-            GetLogGroupFieldsError::ServiceUnavailable(ref cause) => cause,
+            GetLogGroupFieldsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetLogGroupFieldsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetLogGroupFieldsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLogGroupFieldsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLogGroupFieldsError {}
 /// Errors returned by GetLogRecord
 #[derive(Debug, PartialEq)]
 pub enum GetLogRecordError {
@@ -2526,19 +2432,15 @@ impl GetLogRecordError {
 }
 impl fmt::Display for GetLogRecordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLogRecordError {
-    fn description(&self) -> &str {
         match *self {
-            GetLogRecordError::InvalidParameter(ref cause) => cause,
-            GetLogRecordError::LimitExceeded(ref cause) => cause,
-            GetLogRecordError::ResourceNotFound(ref cause) => cause,
-            GetLogRecordError::ServiceUnavailable(ref cause) => cause,
+            GetLogRecordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetLogRecordError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetLogRecordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLogRecordError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLogRecordError {}
 /// Errors returned by GetQueryResults
 #[derive(Debug, PartialEq)]
 pub enum GetQueryResultsError {
@@ -2572,18 +2474,14 @@ impl GetQueryResultsError {
 }
 impl fmt::Display for GetQueryResultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQueryResultsError {
-    fn description(&self) -> &str {
         match *self {
-            GetQueryResultsError::InvalidParameter(ref cause) => cause,
-            GetQueryResultsError::ResourceNotFound(ref cause) => cause,
-            GetQueryResultsError::ServiceUnavailable(ref cause) => cause,
+            GetQueryResultsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetQueryResultsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetQueryResultsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQueryResultsError {}
 /// Errors returned by ListTagsLogGroup
 #[derive(Debug, PartialEq)]
 pub enum ListTagsLogGroupError {
@@ -2612,17 +2510,13 @@ impl ListTagsLogGroupError {
 }
 impl fmt::Display for ListTagsLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsLogGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsLogGroupError::ResourceNotFound(ref cause) => cause,
-            ListTagsLogGroupError::ServiceUnavailable(ref cause) => cause,
+            ListTagsLogGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsLogGroupError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsLogGroupError {}
 /// Errors returned by PutDestination
 #[derive(Debug, PartialEq)]
 pub enum PutDestinationError {
@@ -2656,18 +2550,14 @@ impl PutDestinationError {
 }
 impl fmt::Display for PutDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutDestinationError {
-    fn description(&self) -> &str {
         match *self {
-            PutDestinationError::InvalidParameter(ref cause) => cause,
-            PutDestinationError::OperationAborted(ref cause) => cause,
-            PutDestinationError::ServiceUnavailable(ref cause) => cause,
+            PutDestinationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutDestinationError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            PutDestinationError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutDestinationError {}
 /// Errors returned by PutDestinationPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutDestinationPolicyError {
@@ -2707,18 +2597,14 @@ impl PutDestinationPolicyError {
 }
 impl fmt::Display for PutDestinationPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutDestinationPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutDestinationPolicyError::InvalidParameter(ref cause) => cause,
-            PutDestinationPolicyError::OperationAborted(ref cause) => cause,
-            PutDestinationPolicyError::ServiceUnavailable(ref cause) => cause,
+            PutDestinationPolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutDestinationPolicyError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            PutDestinationPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutDestinationPolicyError {}
 /// Errors returned by PutLogEvents
 #[derive(Debug, PartialEq)]
 pub enum PutLogEventsError {
@@ -2767,21 +2653,17 @@ impl PutLogEventsError {
 }
 impl fmt::Display for PutLogEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLogEventsError {
-    fn description(&self) -> &str {
         match *self {
-            PutLogEventsError::DataAlreadyAccepted(ref cause) => cause,
-            PutLogEventsError::InvalidParameter(ref cause) => cause,
-            PutLogEventsError::InvalidSequenceToken(ref cause) => cause,
-            PutLogEventsError::ResourceNotFound(ref cause) => cause,
-            PutLogEventsError::ServiceUnavailable(ref cause) => cause,
-            PutLogEventsError::UnrecognizedClient(ref cause) => cause,
+            PutLogEventsError::DataAlreadyAccepted(ref cause) => write!(f, "{}", cause),
+            PutLogEventsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutLogEventsError::InvalidSequenceToken(ref cause) => write!(f, "{}", cause),
+            PutLogEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutLogEventsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            PutLogEventsError::UnrecognizedClient(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLogEventsError {}
 /// Errors returned by PutMetricFilter
 #[derive(Debug, PartialEq)]
 pub enum PutMetricFilterError {
@@ -2825,20 +2707,16 @@ impl PutMetricFilterError {
 }
 impl fmt::Display for PutMetricFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutMetricFilterError {
-    fn description(&self) -> &str {
         match *self {
-            PutMetricFilterError::InvalidParameter(ref cause) => cause,
-            PutMetricFilterError::LimitExceeded(ref cause) => cause,
-            PutMetricFilterError::OperationAborted(ref cause) => cause,
-            PutMetricFilterError::ResourceNotFound(ref cause) => cause,
-            PutMetricFilterError::ServiceUnavailable(ref cause) => cause,
+            PutMetricFilterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutMetricFilterError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutMetricFilterError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            PutMetricFilterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutMetricFilterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutMetricFilterError {}
 /// Errors returned by PutResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum PutResourcePolicyError {
@@ -2874,18 +2752,14 @@ impl PutResourcePolicyError {
 }
 impl fmt::Display for PutResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutResourcePolicyError::InvalidParameter(ref cause) => cause,
-            PutResourcePolicyError::LimitExceeded(ref cause) => cause,
-            PutResourcePolicyError::ServiceUnavailable(ref cause) => cause,
+            PutResourcePolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutResourcePolicyError {}
 /// Errors returned by PutRetentionPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutRetentionPolicyError {
@@ -2926,19 +2800,15 @@ impl PutRetentionPolicyError {
 }
 impl fmt::Display for PutRetentionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutRetentionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutRetentionPolicyError::InvalidParameter(ref cause) => cause,
-            PutRetentionPolicyError::OperationAborted(ref cause) => cause,
-            PutRetentionPolicyError::ResourceNotFound(ref cause) => cause,
-            PutRetentionPolicyError::ServiceUnavailable(ref cause) => cause,
+            PutRetentionPolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutRetentionPolicyError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            PutRetentionPolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutRetentionPolicyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutRetentionPolicyError {}
 /// Errors returned by PutSubscriptionFilter
 #[derive(Debug, PartialEq)]
 pub enum PutSubscriptionFilterError {
@@ -2990,20 +2860,16 @@ impl PutSubscriptionFilterError {
 }
 impl fmt::Display for PutSubscriptionFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutSubscriptionFilterError {
-    fn description(&self) -> &str {
         match *self {
-            PutSubscriptionFilterError::InvalidParameter(ref cause) => cause,
-            PutSubscriptionFilterError::LimitExceeded(ref cause) => cause,
-            PutSubscriptionFilterError::OperationAborted(ref cause) => cause,
-            PutSubscriptionFilterError::ResourceNotFound(ref cause) => cause,
-            PutSubscriptionFilterError::ServiceUnavailable(ref cause) => cause,
+            PutSubscriptionFilterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutSubscriptionFilterError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutSubscriptionFilterError::OperationAborted(ref cause) => write!(f, "{}", cause),
+            PutSubscriptionFilterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutSubscriptionFilterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutSubscriptionFilterError {}
 /// Errors returned by StartQuery
 #[derive(Debug, PartialEq)]
 pub enum StartQueryError {
@@ -3047,20 +2913,16 @@ impl StartQueryError {
 }
 impl fmt::Display for StartQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartQueryError {
-    fn description(&self) -> &str {
         match *self {
-            StartQueryError::InvalidParameter(ref cause) => cause,
-            StartQueryError::LimitExceeded(ref cause) => cause,
-            StartQueryError::MalformedQuery(ref cause) => cause,
-            StartQueryError::ResourceNotFound(ref cause) => cause,
-            StartQueryError::ServiceUnavailable(ref cause) => cause,
+            StartQueryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartQueryError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartQueryError::MalformedQuery(ref cause) => write!(f, "{}", cause),
+            StartQueryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartQueryError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartQueryError {}
 /// Errors returned by StopQuery
 #[derive(Debug, PartialEq)]
 pub enum StopQueryError {
@@ -3094,18 +2956,14 @@ impl StopQueryError {
 }
 impl fmt::Display for StopQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopQueryError {
-    fn description(&self) -> &str {
         match *self {
-            StopQueryError::InvalidParameter(ref cause) => cause,
-            StopQueryError::ResourceNotFound(ref cause) => cause,
-            StopQueryError::ServiceUnavailable(ref cause) => cause,
+            StopQueryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopQueryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopQueryError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopQueryError {}
 /// Errors returned by TagLogGroup
 #[derive(Debug, PartialEq)]
 pub enum TagLogGroupError {
@@ -3134,17 +2992,13 @@ impl TagLogGroupError {
 }
 impl fmt::Display for TagLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagLogGroupError {
-    fn description(&self) -> &str {
         match *self {
-            TagLogGroupError::InvalidParameter(ref cause) => cause,
-            TagLogGroupError::ResourceNotFound(ref cause) => cause,
+            TagLogGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagLogGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagLogGroupError {}
 /// Errors returned by TestMetricFilter
 #[derive(Debug, PartialEq)]
 pub enum TestMetricFilterError {
@@ -3173,17 +3027,13 @@ impl TestMetricFilterError {
 }
 impl fmt::Display for TestMetricFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestMetricFilterError {
-    fn description(&self) -> &str {
         match *self {
-            TestMetricFilterError::InvalidParameter(ref cause) => cause,
-            TestMetricFilterError::ServiceUnavailable(ref cause) => cause,
+            TestMetricFilterError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TestMetricFilterError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestMetricFilterError {}
 /// Errors returned by UntagLogGroup
 #[derive(Debug, PartialEq)]
 pub enum UntagLogGroupError {
@@ -3207,16 +3057,12 @@ impl UntagLogGroupError {
 }
 impl fmt::Display for UntagLogGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagLogGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UntagLogGroupError::ResourceNotFound(ref cause) => cause,
+            UntagLogGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagLogGroupError {}
 /// Trait representing the capabilities of the Amazon CloudWatch Logs API. Amazon CloudWatch Logs clients implement this trait.
 pub trait CloudWatchLogs {
     /// <p>Associates the specified AWS Key Management Service (AWS KMS) customer master key (CMK) with the specified log group.</p> <p>Associating an AWS KMS CMK with a log group overrides any existing associations between the log group and a CMK. After a CMK is associated with a log group, all newly ingested data for the log group is encrypted using the CMK. This association is stored as long as the data encrypted with the CMK is still within Amazon CloudWatch Logs. This enables Amazon CloudWatch Logs to decrypt this data whenever it is requested.</p> <p>Note that it can take up to 5 minutes for this operation to take effect.</p> <p>If you attempt to associate a CMK with a log group but the CMK does not exist or the CMK is disabled, you will receive an <code>InvalidParameterException</code> error. </p>

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -1653,20 +1653,16 @@ impl AddTagsError {
 }
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsError::InternalServer(ref cause) => cause,
-            AddTagsError::InvalidInput(ref cause) => cause,
-            AddTagsError::InvalidTag(ref cause) => cause,
-            AddTagsError::ResourceNotFound(ref cause) => cause,
-            AddTagsError::TagLimitExceeded(ref cause) => cause,
+            AddTagsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            AddTagsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AddTagsError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            AddTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AddTagsError::TagLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsError {}
 /// Errors returned by CreateBatchPrediction
 #[derive(Debug, PartialEq)]
 pub enum CreateBatchPredictionError {
@@ -1704,18 +1700,16 @@ impl CreateBatchPredictionError {
 }
 impl fmt::Display for CreateBatchPredictionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBatchPredictionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBatchPredictionError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateBatchPredictionError::InternalServer(ref cause) => cause,
-            CreateBatchPredictionError::InvalidInput(ref cause) => cause,
+            CreateBatchPredictionError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateBatchPredictionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateBatchPredictionError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBatchPredictionError {}
 /// Errors returned by CreateDataSourceFromRDS
 #[derive(Debug, PartialEq)]
 pub enum CreateDataSourceFromRDSError {
@@ -1755,18 +1749,16 @@ impl CreateDataSourceFromRDSError {
 }
 impl fmt::Display for CreateDataSourceFromRDSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDataSourceFromRDSError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDataSourceFromRDSError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateDataSourceFromRDSError::InternalServer(ref cause) => cause,
-            CreateDataSourceFromRDSError::InvalidInput(ref cause) => cause,
+            CreateDataSourceFromRDSError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDataSourceFromRDSError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateDataSourceFromRDSError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDataSourceFromRDSError {}
 /// Errors returned by CreateDataSourceFromRedshift
 #[derive(Debug, PartialEq)]
 pub enum CreateDataSourceFromRedshiftError {
@@ -1808,18 +1800,16 @@ impl CreateDataSourceFromRedshiftError {
 }
 impl fmt::Display for CreateDataSourceFromRedshiftError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDataSourceFromRedshiftError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDataSourceFromRedshiftError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateDataSourceFromRedshiftError::InternalServer(ref cause) => cause,
-            CreateDataSourceFromRedshiftError::InvalidInput(ref cause) => cause,
+            CreateDataSourceFromRedshiftError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDataSourceFromRedshiftError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateDataSourceFromRedshiftError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDataSourceFromRedshiftError {}
 /// Errors returned by CreateDataSourceFromS3
 #[derive(Debug, PartialEq)]
 pub enum CreateDataSourceFromS3Error {
@@ -1857,18 +1847,16 @@ impl CreateDataSourceFromS3Error {
 }
 impl fmt::Display for CreateDataSourceFromS3Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDataSourceFromS3Error {
-    fn description(&self) -> &str {
         match *self {
-            CreateDataSourceFromS3Error::IdempotentParameterMismatch(ref cause) => cause,
-            CreateDataSourceFromS3Error::InternalServer(ref cause) => cause,
-            CreateDataSourceFromS3Error::InvalidInput(ref cause) => cause,
+            CreateDataSourceFromS3Error::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDataSourceFromS3Error::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateDataSourceFromS3Error::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDataSourceFromS3Error {}
 /// Errors returned by CreateEvaluation
 #[derive(Debug, PartialEq)]
 pub enum CreateEvaluationError {
@@ -1904,18 +1892,14 @@ impl CreateEvaluationError {
 }
 impl fmt::Display for CreateEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEvaluationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEvaluationError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateEvaluationError::InternalServer(ref cause) => cause,
-            CreateEvaluationError::InvalidInput(ref cause) => cause,
+            CreateEvaluationError::IdempotentParameterMismatch(ref cause) => write!(f, "{}", cause),
+            CreateEvaluationError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateEvaluationError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEvaluationError {}
 /// Errors returned by CreateMLModel
 #[derive(Debug, PartialEq)]
 pub enum CreateMLModelError {
@@ -1951,18 +1935,14 @@ impl CreateMLModelError {
 }
 impl fmt::Display for CreateMLModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMLModelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMLModelError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateMLModelError::InternalServer(ref cause) => cause,
-            CreateMLModelError::InvalidInput(ref cause) => cause,
+            CreateMLModelError::IdempotentParameterMismatch(ref cause) => write!(f, "{}", cause),
+            CreateMLModelError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateMLModelError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMLModelError {}
 /// Errors returned by CreateRealtimeEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateRealtimeEndpointError {
@@ -2000,18 +1980,14 @@ impl CreateRealtimeEndpointError {
 }
 impl fmt::Display for CreateRealtimeEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRealtimeEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRealtimeEndpointError::InternalServer(ref cause) => cause,
-            CreateRealtimeEndpointError::InvalidInput(ref cause) => cause,
-            CreateRealtimeEndpointError::ResourceNotFound(ref cause) => cause,
+            CreateRealtimeEndpointError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CreateRealtimeEndpointError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateRealtimeEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRealtimeEndpointError {}
 /// Errors returned by DeleteBatchPrediction
 #[derive(Debug, PartialEq)]
 pub enum DeleteBatchPredictionError {
@@ -2049,18 +2025,14 @@ impl DeleteBatchPredictionError {
 }
 impl fmt::Display for DeleteBatchPredictionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBatchPredictionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBatchPredictionError::InternalServer(ref cause) => cause,
-            DeleteBatchPredictionError::InvalidInput(ref cause) => cause,
-            DeleteBatchPredictionError::ResourceNotFound(ref cause) => cause,
+            DeleteBatchPredictionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteBatchPredictionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteBatchPredictionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBatchPredictionError {}
 /// Errors returned by DeleteDataSource
 #[derive(Debug, PartialEq)]
 pub enum DeleteDataSourceError {
@@ -2094,18 +2066,14 @@ impl DeleteDataSourceError {
 }
 impl fmt::Display for DeleteDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDataSourceError::InternalServer(ref cause) => cause,
-            DeleteDataSourceError::InvalidInput(ref cause) => cause,
-            DeleteDataSourceError::ResourceNotFound(ref cause) => cause,
+            DeleteDataSourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteDataSourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteDataSourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDataSourceError {}
 /// Errors returned by DeleteEvaluation
 #[derive(Debug, PartialEq)]
 pub enum DeleteEvaluationError {
@@ -2139,18 +2107,14 @@ impl DeleteEvaluationError {
 }
 impl fmt::Display for DeleteEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEvaluationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEvaluationError::InternalServer(ref cause) => cause,
-            DeleteEvaluationError::InvalidInput(ref cause) => cause,
-            DeleteEvaluationError::ResourceNotFound(ref cause) => cause,
+            DeleteEvaluationError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteEvaluationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteEvaluationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEvaluationError {}
 /// Errors returned by DeleteMLModel
 #[derive(Debug, PartialEq)]
 pub enum DeleteMLModelError {
@@ -2184,18 +2148,14 @@ impl DeleteMLModelError {
 }
 impl fmt::Display for DeleteMLModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMLModelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMLModelError::InternalServer(ref cause) => cause,
-            DeleteMLModelError::InvalidInput(ref cause) => cause,
-            DeleteMLModelError::ResourceNotFound(ref cause) => cause,
+            DeleteMLModelError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteMLModelError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteMLModelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMLModelError {}
 /// Errors returned by DeleteRealtimeEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteRealtimeEndpointError {
@@ -2233,18 +2193,14 @@ impl DeleteRealtimeEndpointError {
 }
 impl fmt::Display for DeleteRealtimeEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRealtimeEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRealtimeEndpointError::InternalServer(ref cause) => cause,
-            DeleteRealtimeEndpointError::InvalidInput(ref cause) => cause,
-            DeleteRealtimeEndpointError::ResourceNotFound(ref cause) => cause,
+            DeleteRealtimeEndpointError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteRealtimeEndpointError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteRealtimeEndpointError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRealtimeEndpointError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -2283,19 +2239,15 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::InternalServer(ref cause) => cause,
-            DeleteTagsError::InvalidInput(ref cause) => cause,
-            DeleteTagsError::InvalidTag(ref cause) => cause,
-            DeleteTagsError::ResourceNotFound(ref cause) => cause,
+            DeleteTagsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::InvalidTag(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DescribeBatchPredictions
 #[derive(Debug, PartialEq)]
 pub enum DescribeBatchPredictionsError {
@@ -2328,17 +2280,13 @@ impl DescribeBatchPredictionsError {
 }
 impl fmt::Display for DescribeBatchPredictionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBatchPredictionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBatchPredictionsError::InternalServer(ref cause) => cause,
-            DescribeBatchPredictionsError::InvalidInput(ref cause) => cause,
+            DescribeBatchPredictionsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeBatchPredictionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBatchPredictionsError {}
 /// Errors returned by DescribeDataSources
 #[derive(Debug, PartialEq)]
 pub enum DescribeDataSourcesError {
@@ -2367,17 +2315,13 @@ impl DescribeDataSourcesError {
 }
 impl fmt::Display for DescribeDataSourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDataSourcesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDataSourcesError::InternalServer(ref cause) => cause,
-            DescribeDataSourcesError::InvalidInput(ref cause) => cause,
+            DescribeDataSourcesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeDataSourcesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDataSourcesError {}
 /// Errors returned by DescribeEvaluations
 #[derive(Debug, PartialEq)]
 pub enum DescribeEvaluationsError {
@@ -2406,17 +2350,13 @@ impl DescribeEvaluationsError {
 }
 impl fmt::Display for DescribeEvaluationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEvaluationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEvaluationsError::InternalServer(ref cause) => cause,
-            DescribeEvaluationsError::InvalidInput(ref cause) => cause,
+            DescribeEvaluationsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeEvaluationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEvaluationsError {}
 /// Errors returned by DescribeMLModels
 #[derive(Debug, PartialEq)]
 pub enum DescribeMLModelsError {
@@ -2445,17 +2385,13 @@ impl DescribeMLModelsError {
 }
 impl fmt::Display for DescribeMLModelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMLModelsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMLModelsError::InternalServer(ref cause) => cause,
-            DescribeMLModelsError::InvalidInput(ref cause) => cause,
+            DescribeMLModelsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeMLModelsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMLModelsError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -2489,18 +2425,14 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::InternalServer(ref cause) => cause,
-            DescribeTagsError::InvalidInput(ref cause) => cause,
-            DescribeTagsError::ResourceNotFound(ref cause) => cause,
+            DescribeTagsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by GetBatchPrediction
 #[derive(Debug, PartialEq)]
 pub enum GetBatchPredictionError {
@@ -2534,18 +2466,14 @@ impl GetBatchPredictionError {
 }
 impl fmt::Display for GetBatchPredictionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBatchPredictionError {
-    fn description(&self) -> &str {
         match *self {
-            GetBatchPredictionError::InternalServer(ref cause) => cause,
-            GetBatchPredictionError::InvalidInput(ref cause) => cause,
-            GetBatchPredictionError::ResourceNotFound(ref cause) => cause,
+            GetBatchPredictionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetBatchPredictionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetBatchPredictionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBatchPredictionError {}
 /// Errors returned by GetDataSource
 #[derive(Debug, PartialEq)]
 pub enum GetDataSourceError {
@@ -2579,18 +2507,14 @@ impl GetDataSourceError {
 }
 impl fmt::Display for GetDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDataSourceError::InternalServer(ref cause) => cause,
-            GetDataSourceError::InvalidInput(ref cause) => cause,
-            GetDataSourceError::ResourceNotFound(ref cause) => cause,
+            GetDataSourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetDataSourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDataSourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDataSourceError {}
 /// Errors returned by GetEvaluation
 #[derive(Debug, PartialEq)]
 pub enum GetEvaluationError {
@@ -2624,18 +2548,14 @@ impl GetEvaluationError {
 }
 impl fmt::Display for GetEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEvaluationError {
-    fn description(&self) -> &str {
         match *self {
-            GetEvaluationError::InternalServer(ref cause) => cause,
-            GetEvaluationError::InvalidInput(ref cause) => cause,
-            GetEvaluationError::ResourceNotFound(ref cause) => cause,
+            GetEvaluationError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetEvaluationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetEvaluationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEvaluationError {}
 /// Errors returned by GetMLModel
 #[derive(Debug, PartialEq)]
 pub enum GetMLModelError {
@@ -2669,18 +2589,14 @@ impl GetMLModelError {
 }
 impl fmt::Display for GetMLModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMLModelError {
-    fn description(&self) -> &str {
         match *self {
-            GetMLModelError::InternalServer(ref cause) => cause,
-            GetMLModelError::InvalidInput(ref cause) => cause,
-            GetMLModelError::ResourceNotFound(ref cause) => cause,
+            GetMLModelError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetMLModelError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMLModelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMLModelError {}
 /// Errors returned by Predict
 #[derive(Debug, PartialEq)]
 pub enum PredictError {
@@ -2724,20 +2640,16 @@ impl PredictError {
 }
 impl fmt::Display for PredictError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PredictError {
-    fn description(&self) -> &str {
         match *self {
-            PredictError::InternalServer(ref cause) => cause,
-            PredictError::InvalidInput(ref cause) => cause,
-            PredictError::LimitExceeded(ref cause) => cause,
-            PredictError::PredictorNotMounted(ref cause) => cause,
-            PredictError::ResourceNotFound(ref cause) => cause,
+            PredictError::InternalServer(ref cause) => write!(f, "{}", cause),
+            PredictError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PredictError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PredictError::PredictorNotMounted(ref cause) => write!(f, "{}", cause),
+            PredictError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PredictError {}
 /// Errors returned by UpdateBatchPrediction
 #[derive(Debug, PartialEq)]
 pub enum UpdateBatchPredictionError {
@@ -2775,18 +2687,14 @@ impl UpdateBatchPredictionError {
 }
 impl fmt::Display for UpdateBatchPredictionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBatchPredictionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBatchPredictionError::InternalServer(ref cause) => cause,
-            UpdateBatchPredictionError::InvalidInput(ref cause) => cause,
-            UpdateBatchPredictionError::ResourceNotFound(ref cause) => cause,
+            UpdateBatchPredictionError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UpdateBatchPredictionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateBatchPredictionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBatchPredictionError {}
 /// Errors returned by UpdateDataSource
 #[derive(Debug, PartialEq)]
 pub enum UpdateDataSourceError {
@@ -2820,18 +2728,14 @@ impl UpdateDataSourceError {
 }
 impl fmt::Display for UpdateDataSourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDataSourceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDataSourceError::InternalServer(ref cause) => cause,
-            UpdateDataSourceError::InvalidInput(ref cause) => cause,
-            UpdateDataSourceError::ResourceNotFound(ref cause) => cause,
+            UpdateDataSourceError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UpdateDataSourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDataSourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDataSourceError {}
 /// Errors returned by UpdateEvaluation
 #[derive(Debug, PartialEq)]
 pub enum UpdateEvaluationError {
@@ -2865,18 +2769,14 @@ impl UpdateEvaluationError {
 }
 impl fmt::Display for UpdateEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEvaluationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEvaluationError::InternalServer(ref cause) => cause,
-            UpdateEvaluationError::InvalidInput(ref cause) => cause,
-            UpdateEvaluationError::ResourceNotFound(ref cause) => cause,
+            UpdateEvaluationError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UpdateEvaluationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateEvaluationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEvaluationError {}
 /// Errors returned by UpdateMLModel
 #[derive(Debug, PartialEq)]
 pub enum UpdateMLModelError {
@@ -2910,18 +2810,14 @@ impl UpdateMLModelError {
 }
 impl fmt::Display for UpdateMLModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMLModelError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMLModelError::InternalServer(ref cause) => cause,
-            UpdateMLModelError::InvalidInput(ref cause) => cause,
-            UpdateMLModelError::ResourceNotFound(ref cause) => cause,
+            UpdateMLModelError::InternalServer(ref cause) => write!(f, "{}", cause),
+            UpdateMLModelError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateMLModelError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMLModelError {}
 /// Trait representing the capabilities of the Amazon Machine Learning API. Amazon Machine Learning clients implement this trait.
 pub trait MachineLearning {
     /// <p>Adds one or more tags to an object, up to a limit of 10. Each tag consists of a key and an optional value. If you add a tag using a key that is already associated with the ML object, <code>AddTags</code> updates the tag's value.</p>

--- a/rusoto/services/macie/src/generated.rs
+++ b/rusoto/services/macie/src/generated.rs
@@ -280,18 +280,14 @@ impl AssociateMemberAccountError {
 }
 impl fmt::Display for AssociateMemberAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateMemberAccountError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateMemberAccountError::Internal(ref cause) => cause,
-            AssociateMemberAccountError::InvalidInput(ref cause) => cause,
-            AssociateMemberAccountError::LimitExceeded(ref cause) => cause,
+            AssociateMemberAccountError::Internal(ref cause) => write!(f, "{}", cause),
+            AssociateMemberAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AssociateMemberAccountError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateMemberAccountError {}
 /// Errors returned by AssociateS3Resources
 #[derive(Debug, PartialEq)]
 pub enum AssociateS3ResourcesError {
@@ -330,19 +326,15 @@ impl AssociateS3ResourcesError {
 }
 impl fmt::Display for AssociateS3ResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateS3ResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateS3ResourcesError::AccessDenied(ref cause) => cause,
-            AssociateS3ResourcesError::Internal(ref cause) => cause,
-            AssociateS3ResourcesError::InvalidInput(ref cause) => cause,
-            AssociateS3ResourcesError::LimitExceeded(ref cause) => cause,
+            AssociateS3ResourcesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AssociateS3ResourcesError::Internal(ref cause) => write!(f, "{}", cause),
+            AssociateS3ResourcesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AssociateS3ResourcesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateS3ResourcesError {}
 /// Errors returned by DisassociateMemberAccount
 #[derive(Debug, PartialEq)]
 pub enum DisassociateMemberAccountError {
@@ -373,17 +365,13 @@ impl DisassociateMemberAccountError {
 }
 impl fmt::Display for DisassociateMemberAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateMemberAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateMemberAccountError::Internal(ref cause) => cause,
-            DisassociateMemberAccountError::InvalidInput(ref cause) => cause,
+            DisassociateMemberAccountError::Internal(ref cause) => write!(f, "{}", cause),
+            DisassociateMemberAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateMemberAccountError {}
 /// Errors returned by DisassociateS3Resources
 #[derive(Debug, PartialEq)]
 pub enum DisassociateS3ResourcesError {
@@ -421,18 +409,14 @@ impl DisassociateS3ResourcesError {
 }
 impl fmt::Display for DisassociateS3ResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateS3ResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateS3ResourcesError::AccessDenied(ref cause) => cause,
-            DisassociateS3ResourcesError::Internal(ref cause) => cause,
-            DisassociateS3ResourcesError::InvalidInput(ref cause) => cause,
+            DisassociateS3ResourcesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisassociateS3ResourcesError::Internal(ref cause) => write!(f, "{}", cause),
+            DisassociateS3ResourcesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateS3ResourcesError {}
 /// Errors returned by ListMemberAccounts
 #[derive(Debug, PartialEq)]
 pub enum ListMemberAccountsError {
@@ -461,17 +445,13 @@ impl ListMemberAccountsError {
 }
 impl fmt::Display for ListMemberAccountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMemberAccountsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMemberAccountsError::Internal(ref cause) => cause,
-            ListMemberAccountsError::InvalidInput(ref cause) => cause,
+            ListMemberAccountsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListMemberAccountsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMemberAccountsError {}
 /// Errors returned by ListS3Resources
 #[derive(Debug, PartialEq)]
 pub enum ListS3ResourcesError {
@@ -505,18 +485,14 @@ impl ListS3ResourcesError {
 }
 impl fmt::Display for ListS3ResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListS3ResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListS3ResourcesError::AccessDenied(ref cause) => cause,
-            ListS3ResourcesError::Internal(ref cause) => cause,
-            ListS3ResourcesError::InvalidInput(ref cause) => cause,
+            ListS3ResourcesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListS3ResourcesError::Internal(ref cause) => write!(f, "{}", cause),
+            ListS3ResourcesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListS3ResourcesError {}
 /// Errors returned by UpdateS3Resources
 #[derive(Debug, PartialEq)]
 pub enum UpdateS3ResourcesError {
@@ -550,18 +526,14 @@ impl UpdateS3ResourcesError {
 }
 impl fmt::Display for UpdateS3ResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateS3ResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateS3ResourcesError::AccessDenied(ref cause) => cause,
-            UpdateS3ResourcesError::Internal(ref cause) => cause,
-            UpdateS3ResourcesError::InvalidInput(ref cause) => cause,
+            UpdateS3ResourcesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateS3ResourcesError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateS3ResourcesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateS3ResourcesError {}
 /// Trait representing the capabilities of the Amazon Macie API. Amazon Macie clients implement this trait.
 pub trait Macie {
     /// <p>Associates a specified AWS account with Amazon Macie as a member account.</p>

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -140,18 +140,14 @@ impl GetEntitlementsError {
 }
 impl fmt::Display for GetEntitlementsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEntitlementsError {
-    fn description(&self) -> &str {
         match *self {
-            GetEntitlementsError::InternalServiceError(ref cause) => cause,
-            GetEntitlementsError::InvalidParameter(ref cause) => cause,
-            GetEntitlementsError::Throttling(ref cause) => cause,
+            GetEntitlementsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            GetEntitlementsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetEntitlementsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEntitlementsError {}
 /// Trait representing the capabilities of the AWS Marketplace Entitlement Service API. AWS Marketplace Entitlement Service clients implement this trait.
 pub trait MarketplaceEntitlement {
     /// <p>GetEntitlements retrieves entitlement values for a given product. The results can be filtered based on customer identifier or product dimensions.</p>

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -124,16 +124,12 @@ impl GenerateDataSetError {
 }
 impl fmt::Display for GenerateDataSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateDataSetError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateDataSetError::MarketplaceCommerceAnalytics(ref cause) => cause,
+            GenerateDataSetError::MarketplaceCommerceAnalytics(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateDataSetError {}
 /// Errors returned by StartSupportDataExport
 #[derive(Debug, PartialEq)]
 pub enum StartSupportDataExportError {
@@ -159,16 +155,14 @@ impl StartSupportDataExportError {
 }
 impl fmt::Display for StartSupportDataExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartSupportDataExportError {
-    fn description(&self) -> &str {
         match *self {
-            StartSupportDataExportError::MarketplaceCommerceAnalytics(ref cause) => cause,
+            StartSupportDataExportError::MarketplaceCommerceAnalytics(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartSupportDataExportError {}
 /// Trait representing the capabilities of the AWS Marketplace Commerce Analytics API. AWS Marketplace Commerce Analytics clients implement this trait.
 pub trait MarketplaceCommerceAnalytics {
     /// <p>Given a data set type and data set publication date, asynchronously publishes the requested data set to the specified S3 bucket and notifies the specified SNS topic once the data is available. Returns a unique request identifier that can be used to correlate requests with notifications from the SNS topic. Data sets will be published in comma-separated values (CSV) format with the file name {data<em>set</em>type}_YYYY-MM-DD.csv. If a file with the same name already exists (e.g. if the same data set is requested twice), the original file will be overwritten by the new file. Requires a Role with an attached permissions policy providing Allow permissions for the following actions: s3:PutObject, s3:GetBucketLocation, sns:GetTopicAttributes, sns:Publish, iam:GetRolePolicy.</p>

--- a/rusoto/services/mediaconvert/src/generated.rs
+++ b/rusoto/services/mediaconvert/src/generated.rs
@@ -4490,21 +4490,17 @@ impl AssociateCertificateError {
 }
 impl fmt::Display for AssociateCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateCertificateError::BadRequest(ref cause) => cause,
-            AssociateCertificateError::Conflict(ref cause) => cause,
-            AssociateCertificateError::Forbidden(ref cause) => cause,
-            AssociateCertificateError::InternalServerError(ref cause) => cause,
-            AssociateCertificateError::NotFound(ref cause) => cause,
-            AssociateCertificateError::TooManyRequests(ref cause) => cause,
+            AssociateCertificateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            AssociateCertificateError::Conflict(ref cause) => write!(f, "{}", cause),
+            AssociateCertificateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            AssociateCertificateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AssociateCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            AssociateCertificateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateCertificateError {}
 /// Errors returned by CancelJob
 #[derive(Debug, PartialEq)]
 pub enum CancelJobError {
@@ -4553,21 +4549,17 @@ impl CancelJobError {
 }
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelJobError {
-    fn description(&self) -> &str {
         match *self {
-            CancelJobError::BadRequest(ref cause) => cause,
-            CancelJobError::Conflict(ref cause) => cause,
-            CancelJobError::Forbidden(ref cause) => cause,
-            CancelJobError::InternalServerError(ref cause) => cause,
-            CancelJobError::NotFound(ref cause) => cause,
-            CancelJobError::TooManyRequests(ref cause) => cause,
+            CancelJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CancelJobError::Conflict(ref cause) => write!(f, "{}", cause),
+            CancelJobError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CancelJobError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CancelJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            CancelJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelJobError {}
 /// Errors returned by CreateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateJobError {
@@ -4616,21 +4608,17 @@ impl CreateJobError {
 }
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobError::BadRequest(ref cause) => cause,
-            CreateJobError::Conflict(ref cause) => cause,
-            CreateJobError::Forbidden(ref cause) => cause,
-            CreateJobError::InternalServerError(ref cause) => cause,
-            CreateJobError::NotFound(ref cause) => cause,
-            CreateJobError::TooManyRequests(ref cause) => cause,
+            CreateJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateJobError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateJobError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobError {}
 /// Errors returned by CreateJobTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateJobTemplateError {
@@ -4681,21 +4669,17 @@ impl CreateJobTemplateError {
 }
 impl fmt::Display for CreateJobTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobTemplateError::BadRequest(ref cause) => cause,
-            CreateJobTemplateError::Conflict(ref cause) => cause,
-            CreateJobTemplateError::Forbidden(ref cause) => cause,
-            CreateJobTemplateError::InternalServerError(ref cause) => cause,
-            CreateJobTemplateError::NotFound(ref cause) => cause,
-            CreateJobTemplateError::TooManyRequests(ref cause) => cause,
+            CreateJobTemplateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateJobTemplateError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateJobTemplateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateJobTemplateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateJobTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateJobTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobTemplateError {}
 /// Errors returned by CreatePreset
 #[derive(Debug, PartialEq)]
 pub enum CreatePresetError {
@@ -4744,21 +4728,17 @@ impl CreatePresetError {
 }
 impl fmt::Display for CreatePresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePresetError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePresetError::BadRequest(ref cause) => cause,
-            CreatePresetError::Conflict(ref cause) => cause,
-            CreatePresetError::Forbidden(ref cause) => cause,
-            CreatePresetError::InternalServerError(ref cause) => cause,
-            CreatePresetError::NotFound(ref cause) => cause,
-            CreatePresetError::TooManyRequests(ref cause) => cause,
+            CreatePresetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreatePresetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePresetError {}
 /// Errors returned by CreateQueue
 #[derive(Debug, PartialEq)]
 pub enum CreateQueueError {
@@ -4807,21 +4787,17 @@ impl CreateQueueError {
 }
 impl fmt::Display for CreateQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateQueueError {
-    fn description(&self) -> &str {
         match *self {
-            CreateQueueError::BadRequest(ref cause) => cause,
-            CreateQueueError::Conflict(ref cause) => cause,
-            CreateQueueError::Forbidden(ref cause) => cause,
-            CreateQueueError::InternalServerError(ref cause) => cause,
-            CreateQueueError::NotFound(ref cause) => cause,
-            CreateQueueError::TooManyRequests(ref cause) => cause,
+            CreateQueueError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateQueueError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateQueueError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateQueueError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateQueueError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateQueueError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateQueueError {}
 /// Errors returned by DeleteJobTemplate
 #[derive(Debug, PartialEq)]
 pub enum DeleteJobTemplateError {
@@ -4872,21 +4848,17 @@ impl DeleteJobTemplateError {
 }
 impl fmt::Display for DeleteJobTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteJobTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteJobTemplateError::BadRequest(ref cause) => cause,
-            DeleteJobTemplateError::Conflict(ref cause) => cause,
-            DeleteJobTemplateError::Forbidden(ref cause) => cause,
-            DeleteJobTemplateError::InternalServerError(ref cause) => cause,
-            DeleteJobTemplateError::NotFound(ref cause) => cause,
-            DeleteJobTemplateError::TooManyRequests(ref cause) => cause,
+            DeleteJobTemplateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteJobTemplateError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteJobTemplateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteJobTemplateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteJobTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteJobTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteJobTemplateError {}
 /// Errors returned by DeletePreset
 #[derive(Debug, PartialEq)]
 pub enum DeletePresetError {
@@ -4935,21 +4907,17 @@ impl DeletePresetError {
 }
 impl fmt::Display for DeletePresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePresetError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePresetError::BadRequest(ref cause) => cause,
-            DeletePresetError::Conflict(ref cause) => cause,
-            DeletePresetError::Forbidden(ref cause) => cause,
-            DeletePresetError::InternalServerError(ref cause) => cause,
-            DeletePresetError::NotFound(ref cause) => cause,
-            DeletePresetError::TooManyRequests(ref cause) => cause,
+            DeletePresetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeletePresetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePresetError {}
 /// Errors returned by DeleteQueue
 #[derive(Debug, PartialEq)]
 pub enum DeleteQueueError {
@@ -4998,21 +4966,17 @@ impl DeleteQueueError {
 }
 impl fmt::Display for DeleteQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteQueueError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteQueueError::BadRequest(ref cause) => cause,
-            DeleteQueueError::Conflict(ref cause) => cause,
-            DeleteQueueError::Forbidden(ref cause) => cause,
-            DeleteQueueError::InternalServerError(ref cause) => cause,
-            DeleteQueueError::NotFound(ref cause) => cause,
-            DeleteQueueError::TooManyRequests(ref cause) => cause,
+            DeleteQueueError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteQueueError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteQueueError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteQueueError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteQueueError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteQueueError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteQueueError {}
 /// Errors returned by DescribeEndpoints
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointsError {
@@ -5063,21 +5027,17 @@ impl DescribeEndpointsError {
 }
 impl fmt::Display for DescribeEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEndpointsError::BadRequest(ref cause) => cause,
-            DescribeEndpointsError::Conflict(ref cause) => cause,
-            DescribeEndpointsError::Forbidden(ref cause) => cause,
-            DescribeEndpointsError::InternalServerError(ref cause) => cause,
-            DescribeEndpointsError::NotFound(ref cause) => cause,
-            DescribeEndpointsError::TooManyRequests(ref cause) => cause,
+            DescribeEndpointsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointsError::Conflict(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointsError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEndpointsError {}
 /// Errors returned by DisassociateCertificate
 #[derive(Debug, PartialEq)]
 pub enum DisassociateCertificateError {
@@ -5130,21 +5090,17 @@ impl DisassociateCertificateError {
 }
 impl fmt::Display for DisassociateCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateCertificateError::BadRequest(ref cause) => cause,
-            DisassociateCertificateError::Conflict(ref cause) => cause,
-            DisassociateCertificateError::Forbidden(ref cause) => cause,
-            DisassociateCertificateError::InternalServerError(ref cause) => cause,
-            DisassociateCertificateError::NotFound(ref cause) => cause,
-            DisassociateCertificateError::TooManyRequests(ref cause) => cause,
+            DisassociateCertificateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DisassociateCertificateError::Conflict(ref cause) => write!(f, "{}", cause),
+            DisassociateCertificateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DisassociateCertificateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DisassociateCertificateError::NotFound(ref cause) => write!(f, "{}", cause),
+            DisassociateCertificateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateCertificateError {}
 /// Errors returned by GetJob
 #[derive(Debug, PartialEq)]
 pub enum GetJobError {
@@ -5189,21 +5145,17 @@ impl GetJobError {
 }
 impl fmt::Display for GetJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobError::BadRequest(ref cause) => cause,
-            GetJobError::Conflict(ref cause) => cause,
-            GetJobError::Forbidden(ref cause) => cause,
-            GetJobError::InternalServerError(ref cause) => cause,
-            GetJobError::NotFound(ref cause) => cause,
-            GetJobError::TooManyRequests(ref cause) => cause,
+            GetJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetJobError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetJobError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetJobError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobError {}
 /// Errors returned by GetJobTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetJobTemplateError {
@@ -5252,21 +5204,17 @@ impl GetJobTemplateError {
 }
 impl fmt::Display for GetJobTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobTemplateError::BadRequest(ref cause) => cause,
-            GetJobTemplateError::Conflict(ref cause) => cause,
-            GetJobTemplateError::Forbidden(ref cause) => cause,
-            GetJobTemplateError::InternalServerError(ref cause) => cause,
-            GetJobTemplateError::NotFound(ref cause) => cause,
-            GetJobTemplateError::TooManyRequests(ref cause) => cause,
+            GetJobTemplateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetJobTemplateError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetJobTemplateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetJobTemplateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetJobTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetJobTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobTemplateError {}
 /// Errors returned by GetPreset
 #[derive(Debug, PartialEq)]
 pub enum GetPresetError {
@@ -5315,21 +5263,17 @@ impl GetPresetError {
 }
 impl fmt::Display for GetPresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPresetError {
-    fn description(&self) -> &str {
         match *self {
-            GetPresetError::BadRequest(ref cause) => cause,
-            GetPresetError::Conflict(ref cause) => cause,
-            GetPresetError::Forbidden(ref cause) => cause,
-            GetPresetError::InternalServerError(ref cause) => cause,
-            GetPresetError::NotFound(ref cause) => cause,
-            GetPresetError::TooManyRequests(ref cause) => cause,
+            GetPresetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetPresetError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetPresetError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetPresetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetPresetError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetPresetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPresetError {}
 /// Errors returned by GetQueue
 #[derive(Debug, PartialEq)]
 pub enum GetQueueError {
@@ -5378,21 +5322,17 @@ impl GetQueueError {
 }
 impl fmt::Display for GetQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQueueError {
-    fn description(&self) -> &str {
         match *self {
-            GetQueueError::BadRequest(ref cause) => cause,
-            GetQueueError::Conflict(ref cause) => cause,
-            GetQueueError::Forbidden(ref cause) => cause,
-            GetQueueError::InternalServerError(ref cause) => cause,
-            GetQueueError::NotFound(ref cause) => cause,
-            GetQueueError::TooManyRequests(ref cause) => cause,
+            GetQueueError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetQueueError::Conflict(ref cause) => write!(f, "{}", cause),
+            GetQueueError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetQueueError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetQueueError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetQueueError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQueueError {}
 /// Errors returned by ListJobTemplates
 #[derive(Debug, PartialEq)]
 pub enum ListJobTemplatesError {
@@ -5443,21 +5383,17 @@ impl ListJobTemplatesError {
 }
 impl fmt::Display for ListJobTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobTemplatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobTemplatesError::BadRequest(ref cause) => cause,
-            ListJobTemplatesError::Conflict(ref cause) => cause,
-            ListJobTemplatesError::Forbidden(ref cause) => cause,
-            ListJobTemplatesError::InternalServerError(ref cause) => cause,
-            ListJobTemplatesError::NotFound(ref cause) => cause,
-            ListJobTemplatesError::TooManyRequests(ref cause) => cause,
+            ListJobTemplatesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListJobTemplatesError::Conflict(ref cause) => write!(f, "{}", cause),
+            ListJobTemplatesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListJobTemplatesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListJobTemplatesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListJobTemplatesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobTemplatesError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -5506,21 +5442,17 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::BadRequest(ref cause) => cause,
-            ListJobsError::Conflict(ref cause) => cause,
-            ListJobsError::Forbidden(ref cause) => cause,
-            ListJobsError::InternalServerError(ref cause) => cause,
-            ListJobsError::NotFound(ref cause) => cause,
-            ListJobsError::TooManyRequests(ref cause) => cause,
+            ListJobsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListJobsError::Conflict(ref cause) => write!(f, "{}", cause),
+            ListJobsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListJobsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListJobsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by ListPresets
 #[derive(Debug, PartialEq)]
 pub enum ListPresetsError {
@@ -5569,21 +5501,17 @@ impl ListPresetsError {
 }
 impl fmt::Display for ListPresetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPresetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPresetsError::BadRequest(ref cause) => cause,
-            ListPresetsError::Conflict(ref cause) => cause,
-            ListPresetsError::Forbidden(ref cause) => cause,
-            ListPresetsError::InternalServerError(ref cause) => cause,
-            ListPresetsError::NotFound(ref cause) => cause,
-            ListPresetsError::TooManyRequests(ref cause) => cause,
+            ListPresetsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListPresetsError::Conflict(ref cause) => write!(f, "{}", cause),
+            ListPresetsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListPresetsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListPresetsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListPresetsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPresetsError {}
 /// Errors returned by ListQueues
 #[derive(Debug, PartialEq)]
 pub enum ListQueuesError {
@@ -5632,21 +5560,17 @@ impl ListQueuesError {
 }
 impl fmt::Display for ListQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQueuesError {
-    fn description(&self) -> &str {
         match *self {
-            ListQueuesError::BadRequest(ref cause) => cause,
-            ListQueuesError::Conflict(ref cause) => cause,
-            ListQueuesError::Forbidden(ref cause) => cause,
-            ListQueuesError::InternalServerError(ref cause) => cause,
-            ListQueuesError::NotFound(ref cause) => cause,
-            ListQueuesError::TooManyRequests(ref cause) => cause,
+            ListQueuesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::Conflict(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListQueuesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListQueuesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -5697,21 +5621,17 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::Conflict(ref cause) => cause,
-            ListTagsForResourceError::Forbidden(ref cause) => cause,
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
-            ListTagsForResourceError::NotFound(ref cause) => cause,
-            ListTagsForResourceError::TooManyRequests(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5760,21 +5680,17 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
-            TagResourceError::Conflict(ref cause) => cause,
-            TagResourceError::Forbidden(ref cause) => cause,
-            TagResourceError::InternalServerError(ref cause) => cause,
-            TagResourceError::NotFound(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -5823,21 +5739,17 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
-            UntagResourceError::Conflict(ref cause) => cause,
-            UntagResourceError::Forbidden(ref cause) => cause,
-            UntagResourceError::InternalServerError(ref cause) => cause,
-            UntagResourceError::NotFound(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Conflict(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateJobTemplate
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobTemplateError {
@@ -5888,21 +5800,17 @@ impl UpdateJobTemplateError {
 }
 impl fmt::Display for UpdateJobTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateJobTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateJobTemplateError::BadRequest(ref cause) => cause,
-            UpdateJobTemplateError::Conflict(ref cause) => cause,
-            UpdateJobTemplateError::Forbidden(ref cause) => cause,
-            UpdateJobTemplateError::InternalServerError(ref cause) => cause,
-            UpdateJobTemplateError::NotFound(ref cause) => cause,
-            UpdateJobTemplateError::TooManyRequests(ref cause) => cause,
+            UpdateJobTemplateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateJobTemplateError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateJobTemplateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateJobTemplateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateJobTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateJobTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateJobTemplateError {}
 /// Errors returned by UpdatePreset
 #[derive(Debug, PartialEq)]
 pub enum UpdatePresetError {
@@ -5951,21 +5859,17 @@ impl UpdatePresetError {
 }
 impl fmt::Display for UpdatePresetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePresetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePresetError::BadRequest(ref cause) => cause,
-            UpdatePresetError::Conflict(ref cause) => cause,
-            UpdatePresetError::Forbidden(ref cause) => cause,
-            UpdatePresetError::InternalServerError(ref cause) => cause,
-            UpdatePresetError::NotFound(ref cause) => cause,
-            UpdatePresetError::TooManyRequests(ref cause) => cause,
+            UpdatePresetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdatePresetError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdatePresetError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdatePresetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdatePresetError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePresetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePresetError {}
 /// Errors returned by UpdateQueue
 #[derive(Debug, PartialEq)]
 pub enum UpdateQueueError {
@@ -6014,21 +5918,17 @@ impl UpdateQueueError {
 }
 impl fmt::Display for UpdateQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateQueueError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateQueueError::BadRequest(ref cause) => cause,
-            UpdateQueueError::Conflict(ref cause) => cause,
-            UpdateQueueError::Forbidden(ref cause) => cause,
-            UpdateQueueError::InternalServerError(ref cause) => cause,
-            UpdateQueueError::NotFound(ref cause) => cause,
-            UpdateQueueError::TooManyRequests(ref cause) => cause,
+            UpdateQueueError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateQueueError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateQueueError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateQueueError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateQueueError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateQueueError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateQueueError {}
 /// Trait representing the capabilities of the MediaConvert API. MediaConvert clients implement this trait.
 pub trait MediaConvert {
     /// <p>Associates an AWS Certificate Manager (ACM) Amazon Resource Name (ARN) with AWS Elemental MediaConvert.</p>

--- a/rusoto/services/medialive/src/generated.rs
+++ b/rusoto/services/medialive/src/generated.rs
@@ -5709,23 +5709,19 @@ impl BatchUpdateScheduleError {
 }
 impl fmt::Display for BatchUpdateScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchUpdateScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            BatchUpdateScheduleError::BadGateway(ref cause) => cause,
-            BatchUpdateScheduleError::BadRequest(ref cause) => cause,
-            BatchUpdateScheduleError::Forbidden(ref cause) => cause,
-            BatchUpdateScheduleError::GatewayTimeout(ref cause) => cause,
-            BatchUpdateScheduleError::InternalServerError(ref cause) => cause,
-            BatchUpdateScheduleError::NotFound(ref cause) => cause,
-            BatchUpdateScheduleError::TooManyRequests(ref cause) => cause,
-            BatchUpdateScheduleError::UnprocessableEntity(ref cause) => cause,
+            BatchUpdateScheduleError::BadGateway(ref cause) => write!(f, "{}", cause),
+            BatchUpdateScheduleError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchUpdateScheduleError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchUpdateScheduleError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            BatchUpdateScheduleError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            BatchUpdateScheduleError::NotFound(ref cause) => write!(f, "{}", cause),
+            BatchUpdateScheduleError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            BatchUpdateScheduleError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchUpdateScheduleError {}
 /// Errors returned by CreateChannel
 #[derive(Debug, PartialEq)]
 pub enum CreateChannelError {
@@ -5784,23 +5780,19 @@ impl CreateChannelError {
 }
 impl fmt::Display for CreateChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateChannelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateChannelError::BadGateway(ref cause) => cause,
-            CreateChannelError::BadRequest(ref cause) => cause,
-            CreateChannelError::Conflict(ref cause) => cause,
-            CreateChannelError::Forbidden(ref cause) => cause,
-            CreateChannelError::GatewayTimeout(ref cause) => cause,
-            CreateChannelError::InternalServerError(ref cause) => cause,
-            CreateChannelError::TooManyRequests(ref cause) => cause,
-            CreateChannelError::UnprocessableEntity(ref cause) => cause,
+            CreateChannelError::BadGateway(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateChannelError {}
 /// Errors returned by CreateInput
 #[derive(Debug, PartialEq)]
 pub enum CreateInputError {
@@ -5849,21 +5841,17 @@ impl CreateInputError {
 }
 impl fmt::Display for CreateInputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInputError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInputError::BadGateway(ref cause) => cause,
-            CreateInputError::BadRequest(ref cause) => cause,
-            CreateInputError::Forbidden(ref cause) => cause,
-            CreateInputError::GatewayTimeout(ref cause) => cause,
-            CreateInputError::InternalServerError(ref cause) => cause,
-            CreateInputError::TooManyRequests(ref cause) => cause,
+            CreateInputError::BadGateway(ref cause) => write!(f, "{}", cause),
+            CreateInputError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateInputError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateInputError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            CreateInputError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateInputError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInputError {}
 /// Errors returned by CreateInputSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateInputSecurityGroupError {
@@ -5918,21 +5906,17 @@ impl CreateInputSecurityGroupError {
 }
 impl fmt::Display for CreateInputSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInputSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInputSecurityGroupError::BadGateway(ref cause) => cause,
-            CreateInputSecurityGroupError::BadRequest(ref cause) => cause,
-            CreateInputSecurityGroupError::Forbidden(ref cause) => cause,
-            CreateInputSecurityGroupError::GatewayTimeout(ref cause) => cause,
-            CreateInputSecurityGroupError::InternalServerError(ref cause) => cause,
-            CreateInputSecurityGroupError::TooManyRequests(ref cause) => cause,
+            CreateInputSecurityGroupError::BadGateway(ref cause) => write!(f, "{}", cause),
+            CreateInputSecurityGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateInputSecurityGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateInputSecurityGroupError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            CreateInputSecurityGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateInputSecurityGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInputSecurityGroupError {}
 /// Errors returned by CreateMultiplex
 #[derive(Debug, PartialEq)]
 pub enum CreateMultiplexError {
@@ -5991,23 +5975,19 @@ impl CreateMultiplexError {
 }
 impl fmt::Display for CreateMultiplexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMultiplexError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMultiplexError::BadGateway(ref cause) => cause,
-            CreateMultiplexError::BadRequest(ref cause) => cause,
-            CreateMultiplexError::Conflict(ref cause) => cause,
-            CreateMultiplexError::Forbidden(ref cause) => cause,
-            CreateMultiplexError::GatewayTimeout(ref cause) => cause,
-            CreateMultiplexError::InternalServerError(ref cause) => cause,
-            CreateMultiplexError::TooManyRequests(ref cause) => cause,
-            CreateMultiplexError::UnprocessableEntity(ref cause) => cause,
+            CreateMultiplexError::BadGateway(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMultiplexError {}
 /// Errors returned by CreateMultiplexProgram
 #[derive(Debug, PartialEq)]
 pub enum CreateMultiplexProgramError {
@@ -6074,23 +6054,19 @@ impl CreateMultiplexProgramError {
 }
 impl fmt::Display for CreateMultiplexProgramError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMultiplexProgramError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMultiplexProgramError::BadGateway(ref cause) => cause,
-            CreateMultiplexProgramError::BadRequest(ref cause) => cause,
-            CreateMultiplexProgramError::Conflict(ref cause) => cause,
-            CreateMultiplexProgramError::Forbidden(ref cause) => cause,
-            CreateMultiplexProgramError::GatewayTimeout(ref cause) => cause,
-            CreateMultiplexProgramError::InternalServerError(ref cause) => cause,
-            CreateMultiplexProgramError::TooManyRequests(ref cause) => cause,
-            CreateMultiplexProgramError::UnprocessableEntity(ref cause) => cause,
+            CreateMultiplexProgramError::BadGateway(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexProgramError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexProgramError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexProgramError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexProgramError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexProgramError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexProgramError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateMultiplexProgramError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMultiplexProgramError {}
 /// Errors returned by CreateTags
 #[derive(Debug, PartialEq)]
 pub enum CreateTagsError {
@@ -6129,19 +6105,15 @@ impl CreateTagsError {
 }
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTagsError::BadRequest(ref cause) => cause,
-            CreateTagsError::Forbidden(ref cause) => cause,
-            CreateTagsError::InternalServerError(ref cause) => cause,
-            CreateTagsError::NotFound(ref cause) => cause,
+            CreateTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTagsError {}
 /// Errors returned by DeleteChannel
 #[derive(Debug, PartialEq)]
 pub enum DeleteChannelError {
@@ -6200,23 +6172,19 @@ impl DeleteChannelError {
 }
 impl fmt::Display for DeleteChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteChannelError::BadGateway(ref cause) => cause,
-            DeleteChannelError::BadRequest(ref cause) => cause,
-            DeleteChannelError::Conflict(ref cause) => cause,
-            DeleteChannelError::Forbidden(ref cause) => cause,
-            DeleteChannelError::GatewayTimeout(ref cause) => cause,
-            DeleteChannelError::InternalServerError(ref cause) => cause,
-            DeleteChannelError::NotFound(ref cause) => cause,
-            DeleteChannelError::TooManyRequests(ref cause) => cause,
+            DeleteChannelError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteChannelError {}
 /// Errors returned by DeleteInput
 #[derive(Debug, PartialEq)]
 pub enum DeleteInputError {
@@ -6275,23 +6243,19 @@ impl DeleteInputError {
 }
 impl fmt::Display for DeleteInputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInputError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInputError::BadGateway(ref cause) => cause,
-            DeleteInputError::BadRequest(ref cause) => cause,
-            DeleteInputError::Conflict(ref cause) => cause,
-            DeleteInputError::Forbidden(ref cause) => cause,
-            DeleteInputError::GatewayTimeout(ref cause) => cause,
-            DeleteInputError::InternalServerError(ref cause) => cause,
-            DeleteInputError::NotFound(ref cause) => cause,
-            DeleteInputError::TooManyRequests(ref cause) => cause,
+            DeleteInputError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DeleteInputError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteInputError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteInputError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteInputError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteInputError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteInputError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteInputError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInputError {}
 /// Errors returned by DeleteInputSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteInputSecurityGroupError {
@@ -6351,22 +6315,18 @@ impl DeleteInputSecurityGroupError {
 }
 impl fmt::Display for DeleteInputSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInputSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInputSecurityGroupError::BadGateway(ref cause) => cause,
-            DeleteInputSecurityGroupError::BadRequest(ref cause) => cause,
-            DeleteInputSecurityGroupError::Forbidden(ref cause) => cause,
-            DeleteInputSecurityGroupError::GatewayTimeout(ref cause) => cause,
-            DeleteInputSecurityGroupError::InternalServerError(ref cause) => cause,
-            DeleteInputSecurityGroupError::NotFound(ref cause) => cause,
-            DeleteInputSecurityGroupError::TooManyRequests(ref cause) => cause,
+            DeleteInputSecurityGroupError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DeleteInputSecurityGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteInputSecurityGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteInputSecurityGroupError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteInputSecurityGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteInputSecurityGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteInputSecurityGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInputSecurityGroupError {}
 /// Errors returned by DeleteMultiplex
 #[derive(Debug, PartialEq)]
 pub enum DeleteMultiplexError {
@@ -6425,23 +6385,19 @@ impl DeleteMultiplexError {
 }
 impl fmt::Display for DeleteMultiplexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMultiplexError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMultiplexError::BadGateway(ref cause) => cause,
-            DeleteMultiplexError::BadRequest(ref cause) => cause,
-            DeleteMultiplexError::Conflict(ref cause) => cause,
-            DeleteMultiplexError::Forbidden(ref cause) => cause,
-            DeleteMultiplexError::GatewayTimeout(ref cause) => cause,
-            DeleteMultiplexError::InternalServerError(ref cause) => cause,
-            DeleteMultiplexError::NotFound(ref cause) => cause,
-            DeleteMultiplexError::TooManyRequests(ref cause) => cause,
+            DeleteMultiplexError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMultiplexError {}
 /// Errors returned by DeleteMultiplexProgram
 #[derive(Debug, PartialEq)]
 pub enum DeleteMultiplexProgramError {
@@ -6506,23 +6462,19 @@ impl DeleteMultiplexProgramError {
 }
 impl fmt::Display for DeleteMultiplexProgramError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMultiplexProgramError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMultiplexProgramError::BadGateway(ref cause) => cause,
-            DeleteMultiplexProgramError::BadRequest(ref cause) => cause,
-            DeleteMultiplexProgramError::Conflict(ref cause) => cause,
-            DeleteMultiplexProgramError::Forbidden(ref cause) => cause,
-            DeleteMultiplexProgramError::GatewayTimeout(ref cause) => cause,
-            DeleteMultiplexProgramError::InternalServerError(ref cause) => cause,
-            DeleteMultiplexProgramError::NotFound(ref cause) => cause,
-            DeleteMultiplexProgramError::TooManyRequests(ref cause) => cause,
+            DeleteMultiplexProgramError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexProgramError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexProgramError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexProgramError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexProgramError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexProgramError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexProgramError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMultiplexProgramError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMultiplexProgramError {}
 /// Errors returned by DeleteReservation
 #[derive(Debug, PartialEq)]
 pub enum DeleteReservationError {
@@ -6583,23 +6535,19 @@ impl DeleteReservationError {
 }
 impl fmt::Display for DeleteReservationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReservationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReservationError::BadGateway(ref cause) => cause,
-            DeleteReservationError::BadRequest(ref cause) => cause,
-            DeleteReservationError::Conflict(ref cause) => cause,
-            DeleteReservationError::Forbidden(ref cause) => cause,
-            DeleteReservationError::GatewayTimeout(ref cause) => cause,
-            DeleteReservationError::InternalServerError(ref cause) => cause,
-            DeleteReservationError::NotFound(ref cause) => cause,
-            DeleteReservationError::TooManyRequests(ref cause) => cause,
+            DeleteReservationError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DeleteReservationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteReservationError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteReservationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteReservationError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteReservationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteReservationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteReservationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReservationError {}
 /// Errors returned by DeleteSchedule
 #[derive(Debug, PartialEq)]
 pub enum DeleteScheduleError {
@@ -6653,22 +6601,18 @@ impl DeleteScheduleError {
 }
 impl fmt::Display for DeleteScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScheduleError::BadGateway(ref cause) => cause,
-            DeleteScheduleError::BadRequest(ref cause) => cause,
-            DeleteScheduleError::Forbidden(ref cause) => cause,
-            DeleteScheduleError::GatewayTimeout(ref cause) => cause,
-            DeleteScheduleError::InternalServerError(ref cause) => cause,
-            DeleteScheduleError::NotFound(ref cause) => cause,
-            DeleteScheduleError::TooManyRequests(ref cause) => cause,
+            DeleteScheduleError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DeleteScheduleError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteScheduleError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteScheduleError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DeleteScheduleError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteScheduleError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteScheduleError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScheduleError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -6707,19 +6651,15 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::BadRequest(ref cause) => cause,
-            DeleteTagsError::Forbidden(ref cause) => cause,
-            DeleteTagsError::InternalServerError(ref cause) => cause,
-            DeleteTagsError::NotFound(ref cause) => cause,
+            DeleteTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DescribeChannel
 #[derive(Debug, PartialEq)]
 pub enum DescribeChannelError {
@@ -6773,22 +6713,18 @@ impl DescribeChannelError {
 }
 impl fmt::Display for DescribeChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeChannelError::BadGateway(ref cause) => cause,
-            DescribeChannelError::BadRequest(ref cause) => cause,
-            DescribeChannelError::Forbidden(ref cause) => cause,
-            DescribeChannelError::GatewayTimeout(ref cause) => cause,
-            DescribeChannelError::InternalServerError(ref cause) => cause,
-            DescribeChannelError::NotFound(ref cause) => cause,
-            DescribeChannelError::TooManyRequests(ref cause) => cause,
+            DescribeChannelError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeChannelError {}
 /// Errors returned by DescribeInput
 #[derive(Debug, PartialEq)]
 pub enum DescribeInputError {
@@ -6842,22 +6778,18 @@ impl DescribeInputError {
 }
 impl fmt::Display for DescribeInputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInputError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInputError::BadGateway(ref cause) => cause,
-            DescribeInputError::BadRequest(ref cause) => cause,
-            DescribeInputError::Forbidden(ref cause) => cause,
-            DescribeInputError::GatewayTimeout(ref cause) => cause,
-            DescribeInputError::InternalServerError(ref cause) => cause,
-            DescribeInputError::NotFound(ref cause) => cause,
-            DescribeInputError::TooManyRequests(ref cause) => cause,
+            DescribeInputError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeInputError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeInputError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeInputError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeInputError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeInputError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeInputError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInputError {}
 /// Errors returned by DescribeInputSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum DescribeInputSecurityGroupError {
@@ -6925,22 +6857,20 @@ impl DescribeInputSecurityGroupError {
 }
 impl fmt::Display for DescribeInputSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInputSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInputSecurityGroupError::BadGateway(ref cause) => cause,
-            DescribeInputSecurityGroupError::BadRequest(ref cause) => cause,
-            DescribeInputSecurityGroupError::Forbidden(ref cause) => cause,
-            DescribeInputSecurityGroupError::GatewayTimeout(ref cause) => cause,
-            DescribeInputSecurityGroupError::InternalServerError(ref cause) => cause,
-            DescribeInputSecurityGroupError::NotFound(ref cause) => cause,
-            DescribeInputSecurityGroupError::TooManyRequests(ref cause) => cause,
+            DescribeInputSecurityGroupError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeInputSecurityGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeInputSecurityGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeInputSecurityGroupError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeInputSecurityGroupError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInputSecurityGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeInputSecurityGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInputSecurityGroupError {}
 /// Errors returned by DescribeMultiplex
 #[derive(Debug, PartialEq)]
 pub enum DescribeMultiplexError {
@@ -6996,22 +6926,18 @@ impl DescribeMultiplexError {
 }
 impl fmt::Display for DescribeMultiplexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMultiplexError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMultiplexError::BadGateway(ref cause) => cause,
-            DescribeMultiplexError::BadRequest(ref cause) => cause,
-            DescribeMultiplexError::Forbidden(ref cause) => cause,
-            DescribeMultiplexError::GatewayTimeout(ref cause) => cause,
-            DescribeMultiplexError::InternalServerError(ref cause) => cause,
-            DescribeMultiplexError::NotFound(ref cause) => cause,
-            DescribeMultiplexError::TooManyRequests(ref cause) => cause,
+            DescribeMultiplexError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMultiplexError {}
 /// Errors returned by DescribeMultiplexProgram
 #[derive(Debug, PartialEq)]
 pub enum DescribeMultiplexProgramError {
@@ -7071,22 +6997,18 @@ impl DescribeMultiplexProgramError {
 }
 impl fmt::Display for DescribeMultiplexProgramError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMultiplexProgramError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMultiplexProgramError::BadGateway(ref cause) => cause,
-            DescribeMultiplexProgramError::BadRequest(ref cause) => cause,
-            DescribeMultiplexProgramError::Forbidden(ref cause) => cause,
-            DescribeMultiplexProgramError::GatewayTimeout(ref cause) => cause,
-            DescribeMultiplexProgramError::InternalServerError(ref cause) => cause,
-            DescribeMultiplexProgramError::NotFound(ref cause) => cause,
-            DescribeMultiplexProgramError::TooManyRequests(ref cause) => cause,
+            DescribeMultiplexProgramError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexProgramError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexProgramError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexProgramError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexProgramError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexProgramError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMultiplexProgramError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMultiplexProgramError {}
 /// Errors returned by DescribeOffering
 #[derive(Debug, PartialEq)]
 pub enum DescribeOfferingError {
@@ -7142,22 +7064,18 @@ impl DescribeOfferingError {
 }
 impl fmt::Display for DescribeOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOfferingError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOfferingError::BadGateway(ref cause) => cause,
-            DescribeOfferingError::BadRequest(ref cause) => cause,
-            DescribeOfferingError::Forbidden(ref cause) => cause,
-            DescribeOfferingError::GatewayTimeout(ref cause) => cause,
-            DescribeOfferingError::InternalServerError(ref cause) => cause,
-            DescribeOfferingError::NotFound(ref cause) => cause,
-            DescribeOfferingError::TooManyRequests(ref cause) => cause,
+            DescribeOfferingError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeOfferingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeOfferingError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeOfferingError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeOfferingError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeOfferingError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeOfferingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeOfferingError {}
 /// Errors returned by DescribeReservation
 #[derive(Debug, PartialEq)]
 pub enum DescribeReservationError {
@@ -7213,22 +7131,18 @@ impl DescribeReservationError {
 }
 impl fmt::Display for DescribeReservationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReservationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReservationError::BadGateway(ref cause) => cause,
-            DescribeReservationError::BadRequest(ref cause) => cause,
-            DescribeReservationError::Forbidden(ref cause) => cause,
-            DescribeReservationError::GatewayTimeout(ref cause) => cause,
-            DescribeReservationError::InternalServerError(ref cause) => cause,
-            DescribeReservationError::NotFound(ref cause) => cause,
-            DescribeReservationError::TooManyRequests(ref cause) => cause,
+            DescribeReservationError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeReservationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeReservationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeReservationError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeReservationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeReservationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeReservationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeReservationError {}
 /// Errors returned by DescribeSchedule
 #[derive(Debug, PartialEq)]
 pub enum DescribeScheduleError {
@@ -7284,22 +7198,18 @@ impl DescribeScheduleError {
 }
 impl fmt::Display for DescribeScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScheduleError::BadGateway(ref cause) => cause,
-            DescribeScheduleError::BadRequest(ref cause) => cause,
-            DescribeScheduleError::Forbidden(ref cause) => cause,
-            DescribeScheduleError::GatewayTimeout(ref cause) => cause,
-            DescribeScheduleError::InternalServerError(ref cause) => cause,
-            DescribeScheduleError::NotFound(ref cause) => cause,
-            DescribeScheduleError::TooManyRequests(ref cause) => cause,
+            DescribeScheduleError::BadGateway(ref cause) => write!(f, "{}", cause),
+            DescribeScheduleError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeScheduleError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeScheduleError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            DescribeScheduleError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeScheduleError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeScheduleError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeScheduleError {}
 /// Errors returned by ListChannels
 #[derive(Debug, PartialEq)]
 pub enum ListChannelsError {
@@ -7348,21 +7258,17 @@ impl ListChannelsError {
 }
 impl fmt::Display for ListChannelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListChannelsError {
-    fn description(&self) -> &str {
         match *self {
-            ListChannelsError::BadGateway(ref cause) => cause,
-            ListChannelsError::BadRequest(ref cause) => cause,
-            ListChannelsError::Forbidden(ref cause) => cause,
-            ListChannelsError::GatewayTimeout(ref cause) => cause,
-            ListChannelsError::InternalServerError(ref cause) => cause,
-            ListChannelsError::TooManyRequests(ref cause) => cause,
+            ListChannelsError::BadGateway(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListChannelsError {}
 /// Errors returned by ListInputSecurityGroups
 #[derive(Debug, PartialEq)]
 pub enum ListInputSecurityGroupsError {
@@ -7417,21 +7323,17 @@ impl ListInputSecurityGroupsError {
 }
 impl fmt::Display for ListInputSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInputSecurityGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListInputSecurityGroupsError::BadGateway(ref cause) => cause,
-            ListInputSecurityGroupsError::BadRequest(ref cause) => cause,
-            ListInputSecurityGroupsError::Forbidden(ref cause) => cause,
-            ListInputSecurityGroupsError::GatewayTimeout(ref cause) => cause,
-            ListInputSecurityGroupsError::InternalServerError(ref cause) => cause,
-            ListInputSecurityGroupsError::TooManyRequests(ref cause) => cause,
+            ListInputSecurityGroupsError::BadGateway(ref cause) => write!(f, "{}", cause),
+            ListInputSecurityGroupsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListInputSecurityGroupsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListInputSecurityGroupsError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            ListInputSecurityGroupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListInputSecurityGroupsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInputSecurityGroupsError {}
 /// Errors returned by ListInputs
 #[derive(Debug, PartialEq)]
 pub enum ListInputsError {
@@ -7480,21 +7382,17 @@ impl ListInputsError {
 }
 impl fmt::Display for ListInputsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInputsError {
-    fn description(&self) -> &str {
         match *self {
-            ListInputsError::BadGateway(ref cause) => cause,
-            ListInputsError::BadRequest(ref cause) => cause,
-            ListInputsError::Forbidden(ref cause) => cause,
-            ListInputsError::GatewayTimeout(ref cause) => cause,
-            ListInputsError::InternalServerError(ref cause) => cause,
-            ListInputsError::TooManyRequests(ref cause) => cause,
+            ListInputsError::BadGateway(ref cause) => write!(f, "{}", cause),
+            ListInputsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListInputsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListInputsError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            ListInputsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListInputsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInputsError {}
 /// Errors returned by ListMultiplexPrograms
 #[derive(Debug, PartialEq)]
 pub enum ListMultiplexProgramsError {
@@ -7554,22 +7452,18 @@ impl ListMultiplexProgramsError {
 }
 impl fmt::Display for ListMultiplexProgramsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMultiplexProgramsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMultiplexProgramsError::BadGateway(ref cause) => cause,
-            ListMultiplexProgramsError::BadRequest(ref cause) => cause,
-            ListMultiplexProgramsError::Forbidden(ref cause) => cause,
-            ListMultiplexProgramsError::GatewayTimeout(ref cause) => cause,
-            ListMultiplexProgramsError::InternalServerError(ref cause) => cause,
-            ListMultiplexProgramsError::NotFound(ref cause) => cause,
-            ListMultiplexProgramsError::TooManyRequests(ref cause) => cause,
+            ListMultiplexProgramsError::BadGateway(ref cause) => write!(f, "{}", cause),
+            ListMultiplexProgramsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListMultiplexProgramsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListMultiplexProgramsError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            ListMultiplexProgramsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListMultiplexProgramsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListMultiplexProgramsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMultiplexProgramsError {}
 /// Errors returned by ListMultiplexes
 #[derive(Debug, PartialEq)]
 pub enum ListMultiplexesError {
@@ -7618,21 +7512,17 @@ impl ListMultiplexesError {
 }
 impl fmt::Display for ListMultiplexesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMultiplexesError {
-    fn description(&self) -> &str {
         match *self {
-            ListMultiplexesError::BadGateway(ref cause) => cause,
-            ListMultiplexesError::BadRequest(ref cause) => cause,
-            ListMultiplexesError::Forbidden(ref cause) => cause,
-            ListMultiplexesError::GatewayTimeout(ref cause) => cause,
-            ListMultiplexesError::InternalServerError(ref cause) => cause,
-            ListMultiplexesError::TooManyRequests(ref cause) => cause,
+            ListMultiplexesError::BadGateway(ref cause) => write!(f, "{}", cause),
+            ListMultiplexesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListMultiplexesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListMultiplexesError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            ListMultiplexesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListMultiplexesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMultiplexesError {}
 /// Errors returned by ListOfferings
 #[derive(Debug, PartialEq)]
 pub enum ListOfferingsError {
@@ -7681,21 +7571,17 @@ impl ListOfferingsError {
 }
 impl fmt::Display for ListOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOfferingsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOfferingsError::BadGateway(ref cause) => cause,
-            ListOfferingsError::BadRequest(ref cause) => cause,
-            ListOfferingsError::Forbidden(ref cause) => cause,
-            ListOfferingsError::GatewayTimeout(ref cause) => cause,
-            ListOfferingsError::InternalServerError(ref cause) => cause,
-            ListOfferingsError::TooManyRequests(ref cause) => cause,
+            ListOfferingsError::BadGateway(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListOfferingsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOfferingsError {}
 /// Errors returned by ListReservations
 #[derive(Debug, PartialEq)]
 pub enum ListReservationsError {
@@ -7746,21 +7632,17 @@ impl ListReservationsError {
 }
 impl fmt::Display for ListReservationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReservationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListReservationsError::BadGateway(ref cause) => cause,
-            ListReservationsError::BadRequest(ref cause) => cause,
-            ListReservationsError::Forbidden(ref cause) => cause,
-            ListReservationsError::GatewayTimeout(ref cause) => cause,
-            ListReservationsError::InternalServerError(ref cause) => cause,
-            ListReservationsError::TooManyRequests(ref cause) => cause,
+            ListReservationsError::BadGateway(ref cause) => write!(f, "{}", cause),
+            ListReservationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListReservationsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListReservationsError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            ListReservationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListReservationsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListReservationsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -7801,19 +7683,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
-            ListTagsForResourceError::Forbidden(ref cause) => cause,
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
-            ListTagsForResourceError::NotFound(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PurchaseOffering
 #[derive(Debug, PartialEq)]
 pub enum PurchaseOfferingError {
@@ -7874,23 +7752,19 @@ impl PurchaseOfferingError {
 }
 impl fmt::Display for PurchaseOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PurchaseOfferingError {
-    fn description(&self) -> &str {
         match *self {
-            PurchaseOfferingError::BadGateway(ref cause) => cause,
-            PurchaseOfferingError::BadRequest(ref cause) => cause,
-            PurchaseOfferingError::Conflict(ref cause) => cause,
-            PurchaseOfferingError::Forbidden(ref cause) => cause,
-            PurchaseOfferingError::GatewayTimeout(ref cause) => cause,
-            PurchaseOfferingError::InternalServerError(ref cause) => cause,
-            PurchaseOfferingError::NotFound(ref cause) => cause,
-            PurchaseOfferingError::TooManyRequests(ref cause) => cause,
+            PurchaseOfferingError::BadGateway(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::Conflict(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::Forbidden(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::NotFound(ref cause) => write!(f, "{}", cause),
+            PurchaseOfferingError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PurchaseOfferingError {}
 /// Errors returned by StartChannel
 #[derive(Debug, PartialEq)]
 pub enum StartChannelError {
@@ -7949,23 +7823,19 @@ impl StartChannelError {
 }
 impl fmt::Display for StartChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartChannelError {
-    fn description(&self) -> &str {
         match *self {
-            StartChannelError::BadGateway(ref cause) => cause,
-            StartChannelError::BadRequest(ref cause) => cause,
-            StartChannelError::Conflict(ref cause) => cause,
-            StartChannelError::Forbidden(ref cause) => cause,
-            StartChannelError::GatewayTimeout(ref cause) => cause,
-            StartChannelError::InternalServerError(ref cause) => cause,
-            StartChannelError::NotFound(ref cause) => cause,
-            StartChannelError::TooManyRequests(ref cause) => cause,
+            StartChannelError::BadGateway(ref cause) => write!(f, "{}", cause),
+            StartChannelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartChannelError::Conflict(ref cause) => write!(f, "{}", cause),
+            StartChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            StartChannelError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            StartChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartChannelError {}
 /// Errors returned by StartMultiplex
 #[derive(Debug, PartialEq)]
 pub enum StartMultiplexError {
@@ -8024,23 +7894,19 @@ impl StartMultiplexError {
 }
 impl fmt::Display for StartMultiplexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMultiplexError {
-    fn description(&self) -> &str {
         match *self {
-            StartMultiplexError::BadGateway(ref cause) => cause,
-            StartMultiplexError::BadRequest(ref cause) => cause,
-            StartMultiplexError::Conflict(ref cause) => cause,
-            StartMultiplexError::Forbidden(ref cause) => cause,
-            StartMultiplexError::GatewayTimeout(ref cause) => cause,
-            StartMultiplexError::InternalServerError(ref cause) => cause,
-            StartMultiplexError::NotFound(ref cause) => cause,
-            StartMultiplexError::TooManyRequests(ref cause) => cause,
+            StartMultiplexError::BadGateway(ref cause) => write!(f, "{}", cause),
+            StartMultiplexError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartMultiplexError::Conflict(ref cause) => write!(f, "{}", cause),
+            StartMultiplexError::Forbidden(ref cause) => write!(f, "{}", cause),
+            StartMultiplexError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            StartMultiplexError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartMultiplexError::NotFound(ref cause) => write!(f, "{}", cause),
+            StartMultiplexError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMultiplexError {}
 /// Errors returned by StopChannel
 #[derive(Debug, PartialEq)]
 pub enum StopChannelError {
@@ -8099,23 +7965,19 @@ impl StopChannelError {
 }
 impl fmt::Display for StopChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopChannelError {
-    fn description(&self) -> &str {
         match *self {
-            StopChannelError::BadGateway(ref cause) => cause,
-            StopChannelError::BadRequest(ref cause) => cause,
-            StopChannelError::Conflict(ref cause) => cause,
-            StopChannelError::Forbidden(ref cause) => cause,
-            StopChannelError::GatewayTimeout(ref cause) => cause,
-            StopChannelError::InternalServerError(ref cause) => cause,
-            StopChannelError::NotFound(ref cause) => cause,
-            StopChannelError::TooManyRequests(ref cause) => cause,
+            StopChannelError::BadGateway(ref cause) => write!(f, "{}", cause),
+            StopChannelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StopChannelError::Conflict(ref cause) => write!(f, "{}", cause),
+            StopChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            StopChannelError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            StopChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StopChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopChannelError {}
 /// Errors returned by StopMultiplex
 #[derive(Debug, PartialEq)]
 pub enum StopMultiplexError {
@@ -8174,23 +8036,19 @@ impl StopMultiplexError {
 }
 impl fmt::Display for StopMultiplexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopMultiplexError {
-    fn description(&self) -> &str {
         match *self {
-            StopMultiplexError::BadGateway(ref cause) => cause,
-            StopMultiplexError::BadRequest(ref cause) => cause,
-            StopMultiplexError::Conflict(ref cause) => cause,
-            StopMultiplexError::Forbidden(ref cause) => cause,
-            StopMultiplexError::GatewayTimeout(ref cause) => cause,
-            StopMultiplexError::InternalServerError(ref cause) => cause,
-            StopMultiplexError::NotFound(ref cause) => cause,
-            StopMultiplexError::TooManyRequests(ref cause) => cause,
+            StopMultiplexError::BadGateway(ref cause) => write!(f, "{}", cause),
+            StopMultiplexError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StopMultiplexError::Conflict(ref cause) => write!(f, "{}", cause),
+            StopMultiplexError::Forbidden(ref cause) => write!(f, "{}", cause),
+            StopMultiplexError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            StopMultiplexError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StopMultiplexError::NotFound(ref cause) => write!(f, "{}", cause),
+            StopMultiplexError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopMultiplexError {}
 /// Errors returned by UpdateChannel
 #[derive(Debug, PartialEq)]
 pub enum UpdateChannelError {
@@ -8244,22 +8102,18 @@ impl UpdateChannelError {
 }
 impl fmt::Display for UpdateChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateChannelError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateChannelError::BadGateway(ref cause) => cause,
-            UpdateChannelError::BadRequest(ref cause) => cause,
-            UpdateChannelError::Conflict(ref cause) => cause,
-            UpdateChannelError::Forbidden(ref cause) => cause,
-            UpdateChannelError::GatewayTimeout(ref cause) => cause,
-            UpdateChannelError::InternalServerError(ref cause) => cause,
-            UpdateChannelError::UnprocessableEntity(ref cause) => cause,
+            UpdateChannelError::BadGateway(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateChannelError {}
 /// Errors returned by UpdateChannelClass
 #[derive(Debug, PartialEq)]
 pub enum UpdateChannelClassError {
@@ -8327,24 +8181,20 @@ impl UpdateChannelClassError {
 }
 impl fmt::Display for UpdateChannelClassError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateChannelClassError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateChannelClassError::BadGateway(ref cause) => cause,
-            UpdateChannelClassError::BadRequest(ref cause) => cause,
-            UpdateChannelClassError::Conflict(ref cause) => cause,
-            UpdateChannelClassError::Forbidden(ref cause) => cause,
-            UpdateChannelClassError::GatewayTimeout(ref cause) => cause,
-            UpdateChannelClassError::InternalServerError(ref cause) => cause,
-            UpdateChannelClassError::NotFound(ref cause) => cause,
-            UpdateChannelClassError::TooManyRequests(ref cause) => cause,
-            UpdateChannelClassError::UnprocessableEntity(ref cause) => cause,
+            UpdateChannelClassError::BadGateway(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateChannelClassError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateChannelClassError {}
 /// Errors returned by UpdateInput
 #[derive(Debug, PartialEq)]
 pub enum UpdateInputError {
@@ -8398,22 +8248,18 @@ impl UpdateInputError {
 }
 impl fmt::Display for UpdateInputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateInputError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateInputError::BadGateway(ref cause) => cause,
-            UpdateInputError::BadRequest(ref cause) => cause,
-            UpdateInputError::Conflict(ref cause) => cause,
-            UpdateInputError::Forbidden(ref cause) => cause,
-            UpdateInputError::GatewayTimeout(ref cause) => cause,
-            UpdateInputError::InternalServerError(ref cause) => cause,
-            UpdateInputError::NotFound(ref cause) => cause,
+            UpdateInputError::BadGateway(ref cause) => write!(f, "{}", cause),
+            UpdateInputError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateInputError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateInputError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateInputError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateInputError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateInputError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateInputError {}
 /// Errors returned by UpdateInputSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateInputSecurityGroupError {
@@ -8471,22 +8317,18 @@ impl UpdateInputSecurityGroupError {
 }
 impl fmt::Display for UpdateInputSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateInputSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateInputSecurityGroupError::BadGateway(ref cause) => cause,
-            UpdateInputSecurityGroupError::BadRequest(ref cause) => cause,
-            UpdateInputSecurityGroupError::Conflict(ref cause) => cause,
-            UpdateInputSecurityGroupError::Forbidden(ref cause) => cause,
-            UpdateInputSecurityGroupError::GatewayTimeout(ref cause) => cause,
-            UpdateInputSecurityGroupError::InternalServerError(ref cause) => cause,
-            UpdateInputSecurityGroupError::NotFound(ref cause) => cause,
+            UpdateInputSecurityGroupError::BadGateway(ref cause) => write!(f, "{}", cause),
+            UpdateInputSecurityGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateInputSecurityGroupError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateInputSecurityGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateInputSecurityGroupError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateInputSecurityGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateInputSecurityGroupError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateInputSecurityGroupError {}
 /// Errors returned by UpdateMultiplex
 #[derive(Debug, PartialEq)]
 pub enum UpdateMultiplexError {
@@ -8545,23 +8387,19 @@ impl UpdateMultiplexError {
 }
 impl fmt::Display for UpdateMultiplexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMultiplexError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMultiplexError::BadGateway(ref cause) => cause,
-            UpdateMultiplexError::BadRequest(ref cause) => cause,
-            UpdateMultiplexError::Conflict(ref cause) => cause,
-            UpdateMultiplexError::Forbidden(ref cause) => cause,
-            UpdateMultiplexError::GatewayTimeout(ref cause) => cause,
-            UpdateMultiplexError::InternalServerError(ref cause) => cause,
-            UpdateMultiplexError::NotFound(ref cause) => cause,
-            UpdateMultiplexError::UnprocessableEntity(ref cause) => cause,
+            UpdateMultiplexError::BadGateway(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMultiplexError {}
 /// Errors returned by UpdateMultiplexProgram
 #[derive(Debug, PartialEq)]
 pub enum UpdateMultiplexProgramError {
@@ -8626,23 +8464,19 @@ impl UpdateMultiplexProgramError {
 }
 impl fmt::Display for UpdateMultiplexProgramError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMultiplexProgramError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMultiplexProgramError::BadGateway(ref cause) => cause,
-            UpdateMultiplexProgramError::BadRequest(ref cause) => cause,
-            UpdateMultiplexProgramError::Conflict(ref cause) => cause,
-            UpdateMultiplexProgramError::Forbidden(ref cause) => cause,
-            UpdateMultiplexProgramError::GatewayTimeout(ref cause) => cause,
-            UpdateMultiplexProgramError::InternalServerError(ref cause) => cause,
-            UpdateMultiplexProgramError::NotFound(ref cause) => cause,
-            UpdateMultiplexProgramError::UnprocessableEntity(ref cause) => cause,
+            UpdateMultiplexProgramError::BadGateway(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexProgramError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexProgramError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexProgramError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexProgramError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexProgramError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexProgramError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMultiplexProgramError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMultiplexProgramError {}
 /// Errors returned by UpdateReservation
 #[derive(Debug, PartialEq)]
 pub enum UpdateReservationError {
@@ -8703,23 +8537,19 @@ impl UpdateReservationError {
 }
 impl fmt::Display for UpdateReservationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateReservationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateReservationError::BadGateway(ref cause) => cause,
-            UpdateReservationError::BadRequest(ref cause) => cause,
-            UpdateReservationError::Conflict(ref cause) => cause,
-            UpdateReservationError::Forbidden(ref cause) => cause,
-            UpdateReservationError::GatewayTimeout(ref cause) => cause,
-            UpdateReservationError::InternalServerError(ref cause) => cause,
-            UpdateReservationError::NotFound(ref cause) => cause,
-            UpdateReservationError::TooManyRequests(ref cause) => cause,
+            UpdateReservationError::BadGateway(ref cause) => write!(f, "{}", cause),
+            UpdateReservationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateReservationError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateReservationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateReservationError::GatewayTimeout(ref cause) => write!(f, "{}", cause),
+            UpdateReservationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateReservationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateReservationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateReservationError {}
 /// Trait representing the capabilities of the MediaLive API. MediaLive clients implement this trait.
 pub trait MediaLive {
     /// <p>Update a channel schedule</p>

--- a/rusoto/services/mediapackage/src/generated.rs
+++ b/rusoto/services/mediapackage/src/generated.rs
@@ -1363,21 +1363,17 @@ impl CreateChannelError {
 }
 impl fmt::Display for CreateChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateChannelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateChannelError::Forbidden(ref cause) => cause,
-            CreateChannelError::InternalServerError(ref cause) => cause,
-            CreateChannelError::NotFound(ref cause) => cause,
-            CreateChannelError::ServiceUnavailable(ref cause) => cause,
-            CreateChannelError::TooManyRequests(ref cause) => cause,
-            CreateChannelError::UnprocessableEntity(ref cause) => cause,
+            CreateChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateChannelError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateChannelError {}
 /// Errors returned by CreateHarvestJob
 #[derive(Debug, PartialEq)]
 pub enum CreateHarvestJobError {
@@ -1430,21 +1426,17 @@ impl CreateHarvestJobError {
 }
 impl fmt::Display for CreateHarvestJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHarvestJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHarvestJobError::Forbidden(ref cause) => cause,
-            CreateHarvestJobError::InternalServerError(ref cause) => cause,
-            CreateHarvestJobError::NotFound(ref cause) => cause,
-            CreateHarvestJobError::ServiceUnavailable(ref cause) => cause,
-            CreateHarvestJobError::TooManyRequests(ref cause) => cause,
-            CreateHarvestJobError::UnprocessableEntity(ref cause) => cause,
+            CreateHarvestJobError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateHarvestJobError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateHarvestJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateHarvestJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateHarvestJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateHarvestJobError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHarvestJobError {}
 /// Errors returned by CreateOriginEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateOriginEndpointError {
@@ -1501,21 +1493,17 @@ impl CreateOriginEndpointError {
 }
 impl fmt::Display for CreateOriginEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOriginEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOriginEndpointError::Forbidden(ref cause) => cause,
-            CreateOriginEndpointError::InternalServerError(ref cause) => cause,
-            CreateOriginEndpointError::NotFound(ref cause) => cause,
-            CreateOriginEndpointError::ServiceUnavailable(ref cause) => cause,
-            CreateOriginEndpointError::TooManyRequests(ref cause) => cause,
-            CreateOriginEndpointError::UnprocessableEntity(ref cause) => cause,
+            CreateOriginEndpointError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateOriginEndpointError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateOriginEndpointError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateOriginEndpointError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateOriginEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateOriginEndpointError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateOriginEndpointError {}
 /// Errors returned by DeleteChannel
 #[derive(Debug, PartialEq)]
 pub enum DeleteChannelError {
@@ -1564,21 +1552,17 @@ impl DeleteChannelError {
 }
 impl fmt::Display for DeleteChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteChannelError::Forbidden(ref cause) => cause,
-            DeleteChannelError::InternalServerError(ref cause) => cause,
-            DeleteChannelError::NotFound(ref cause) => cause,
-            DeleteChannelError::ServiceUnavailable(ref cause) => cause,
-            DeleteChannelError::TooManyRequests(ref cause) => cause,
-            DeleteChannelError::UnprocessableEntity(ref cause) => cause,
+            DeleteChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteChannelError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteChannelError {}
 /// Errors returned by DeleteOriginEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteOriginEndpointError {
@@ -1635,21 +1619,17 @@ impl DeleteOriginEndpointError {
 }
 impl fmt::Display for DeleteOriginEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOriginEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteOriginEndpointError::Forbidden(ref cause) => cause,
-            DeleteOriginEndpointError::InternalServerError(ref cause) => cause,
-            DeleteOriginEndpointError::NotFound(ref cause) => cause,
-            DeleteOriginEndpointError::ServiceUnavailable(ref cause) => cause,
-            DeleteOriginEndpointError::TooManyRequests(ref cause) => cause,
-            DeleteOriginEndpointError::UnprocessableEntity(ref cause) => cause,
+            DeleteOriginEndpointError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteOriginEndpointError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteOriginEndpointError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteOriginEndpointError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteOriginEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteOriginEndpointError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteOriginEndpointError {}
 /// Errors returned by DescribeChannel
 #[derive(Debug, PartialEq)]
 pub enum DescribeChannelError {
@@ -1698,21 +1678,17 @@ impl DescribeChannelError {
 }
 impl fmt::Display for DescribeChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeChannelError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeChannelError::Forbidden(ref cause) => cause,
-            DescribeChannelError::InternalServerError(ref cause) => cause,
-            DescribeChannelError::NotFound(ref cause) => cause,
-            DescribeChannelError::ServiceUnavailable(ref cause) => cause,
-            DescribeChannelError::TooManyRequests(ref cause) => cause,
-            DescribeChannelError::UnprocessableEntity(ref cause) => cause,
+            DescribeChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeChannelError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeChannelError {}
 /// Errors returned by DescribeHarvestJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeHarvestJobError {
@@ -1767,21 +1743,17 @@ impl DescribeHarvestJobError {
 }
 impl fmt::Display for DescribeHarvestJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHarvestJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHarvestJobError::Forbidden(ref cause) => cause,
-            DescribeHarvestJobError::InternalServerError(ref cause) => cause,
-            DescribeHarvestJobError::NotFound(ref cause) => cause,
-            DescribeHarvestJobError::ServiceUnavailable(ref cause) => cause,
-            DescribeHarvestJobError::TooManyRequests(ref cause) => cause,
-            DescribeHarvestJobError::UnprocessableEntity(ref cause) => cause,
+            DescribeHarvestJobError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeHarvestJobError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeHarvestJobError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeHarvestJobError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeHarvestJobError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeHarvestJobError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeHarvestJobError {}
 /// Errors returned by DescribeOriginEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DescribeOriginEndpointError {
@@ -1838,21 +1810,17 @@ impl DescribeOriginEndpointError {
 }
 impl fmt::Display for DescribeOriginEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOriginEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOriginEndpointError::Forbidden(ref cause) => cause,
-            DescribeOriginEndpointError::InternalServerError(ref cause) => cause,
-            DescribeOriginEndpointError::NotFound(ref cause) => cause,
-            DescribeOriginEndpointError::ServiceUnavailable(ref cause) => cause,
-            DescribeOriginEndpointError::TooManyRequests(ref cause) => cause,
-            DescribeOriginEndpointError::UnprocessableEntity(ref cause) => cause,
+            DescribeOriginEndpointError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeOriginEndpointError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeOriginEndpointError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeOriginEndpointError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeOriginEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeOriginEndpointError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeOriginEndpointError {}
 /// Errors returned by ListChannels
 #[derive(Debug, PartialEq)]
 pub enum ListChannelsError {
@@ -1901,21 +1869,17 @@ impl ListChannelsError {
 }
 impl fmt::Display for ListChannelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListChannelsError {
-    fn description(&self) -> &str {
         match *self {
-            ListChannelsError::Forbidden(ref cause) => cause,
-            ListChannelsError::InternalServerError(ref cause) => cause,
-            ListChannelsError::NotFound(ref cause) => cause,
-            ListChannelsError::ServiceUnavailable(ref cause) => cause,
-            ListChannelsError::TooManyRequests(ref cause) => cause,
-            ListChannelsError::UnprocessableEntity(ref cause) => cause,
+            ListChannelsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListChannelsError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListChannelsError {}
 /// Errors returned by ListHarvestJobs
 #[derive(Debug, PartialEq)]
 pub enum ListHarvestJobsError {
@@ -1964,21 +1928,17 @@ impl ListHarvestJobsError {
 }
 impl fmt::Display for ListHarvestJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHarvestJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListHarvestJobsError::Forbidden(ref cause) => cause,
-            ListHarvestJobsError::InternalServerError(ref cause) => cause,
-            ListHarvestJobsError::NotFound(ref cause) => cause,
-            ListHarvestJobsError::ServiceUnavailable(ref cause) => cause,
-            ListHarvestJobsError::TooManyRequests(ref cause) => cause,
-            ListHarvestJobsError::UnprocessableEntity(ref cause) => cause,
+            ListHarvestJobsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListHarvestJobsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListHarvestJobsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListHarvestJobsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListHarvestJobsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListHarvestJobsError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHarvestJobsError {}
 /// Errors returned by ListOriginEndpoints
 #[derive(Debug, PartialEq)]
 pub enum ListOriginEndpointsError {
@@ -2033,21 +1993,17 @@ impl ListOriginEndpointsError {
 }
 impl fmt::Display for ListOriginEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOriginEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOriginEndpointsError::Forbidden(ref cause) => cause,
-            ListOriginEndpointsError::InternalServerError(ref cause) => cause,
-            ListOriginEndpointsError::NotFound(ref cause) => cause,
-            ListOriginEndpointsError::ServiceUnavailable(ref cause) => cause,
-            ListOriginEndpointsError::TooManyRequests(ref cause) => cause,
-            ListOriginEndpointsError::UnprocessableEntity(ref cause) => cause,
+            ListOriginEndpointsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListOriginEndpointsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListOriginEndpointsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListOriginEndpointsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListOriginEndpointsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListOriginEndpointsError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOriginEndpointsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {}
@@ -2065,14 +2021,10 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by RotateChannelCredentials
 #[derive(Debug, PartialEq)]
 pub enum RotateChannelCredentialsError {
@@ -2129,21 +2081,17 @@ impl RotateChannelCredentialsError {
 }
 impl fmt::Display for RotateChannelCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RotateChannelCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            RotateChannelCredentialsError::Forbidden(ref cause) => cause,
-            RotateChannelCredentialsError::InternalServerError(ref cause) => cause,
-            RotateChannelCredentialsError::NotFound(ref cause) => cause,
-            RotateChannelCredentialsError::ServiceUnavailable(ref cause) => cause,
-            RotateChannelCredentialsError::TooManyRequests(ref cause) => cause,
-            RotateChannelCredentialsError::UnprocessableEntity(ref cause) => cause,
+            RotateChannelCredentialsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            RotateChannelCredentialsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RotateChannelCredentialsError::NotFound(ref cause) => write!(f, "{}", cause),
+            RotateChannelCredentialsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RotateChannelCredentialsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            RotateChannelCredentialsError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RotateChannelCredentialsError {}
 /// Errors returned by RotateIngestEndpointCredentials
 #[derive(Debug, PartialEq)]
 pub enum RotateIngestEndpointCredentialsError {
@@ -2206,21 +2154,25 @@ impl RotateIngestEndpointCredentialsError {
 }
 impl fmt::Display for RotateIngestEndpointCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RotateIngestEndpointCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            RotateIngestEndpointCredentialsError::Forbidden(ref cause) => cause,
-            RotateIngestEndpointCredentialsError::InternalServerError(ref cause) => cause,
-            RotateIngestEndpointCredentialsError::NotFound(ref cause) => cause,
-            RotateIngestEndpointCredentialsError::ServiceUnavailable(ref cause) => cause,
-            RotateIngestEndpointCredentialsError::TooManyRequests(ref cause) => cause,
-            RotateIngestEndpointCredentialsError::UnprocessableEntity(ref cause) => cause,
+            RotateIngestEndpointCredentialsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            RotateIngestEndpointCredentialsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RotateIngestEndpointCredentialsError::NotFound(ref cause) => write!(f, "{}", cause),
+            RotateIngestEndpointCredentialsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RotateIngestEndpointCredentialsError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RotateIngestEndpointCredentialsError::UnprocessableEntity(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RotateIngestEndpointCredentialsError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {}
@@ -2238,14 +2190,10 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {}
@@ -2263,14 +2211,10 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateChannel
 #[derive(Debug, PartialEq)]
 pub enum UpdateChannelError {
@@ -2319,21 +2263,17 @@ impl UpdateChannelError {
 }
 impl fmt::Display for UpdateChannelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateChannelError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateChannelError::Forbidden(ref cause) => cause,
-            UpdateChannelError::InternalServerError(ref cause) => cause,
-            UpdateChannelError::NotFound(ref cause) => cause,
-            UpdateChannelError::ServiceUnavailable(ref cause) => cause,
-            UpdateChannelError::TooManyRequests(ref cause) => cause,
-            UpdateChannelError::UnprocessableEntity(ref cause) => cause,
+            UpdateChannelError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateChannelError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateChannelError {}
 /// Errors returned by UpdateOriginEndpoint
 #[derive(Debug, PartialEq)]
 pub enum UpdateOriginEndpointError {
@@ -2390,21 +2330,17 @@ impl UpdateOriginEndpointError {
 }
 impl fmt::Display for UpdateOriginEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateOriginEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateOriginEndpointError::Forbidden(ref cause) => cause,
-            UpdateOriginEndpointError::InternalServerError(ref cause) => cause,
-            UpdateOriginEndpointError::NotFound(ref cause) => cause,
-            UpdateOriginEndpointError::ServiceUnavailable(ref cause) => cause,
-            UpdateOriginEndpointError::TooManyRequests(ref cause) => cause,
-            UpdateOriginEndpointError::UnprocessableEntity(ref cause) => cause,
+            UpdateOriginEndpointError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateOriginEndpointError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateOriginEndpointError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateOriginEndpointError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateOriginEndpointError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateOriginEndpointError::UnprocessableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateOriginEndpointError {}
 /// Trait representing the capabilities of the MediaPackage API. MediaPackage clients implement this trait.
 pub trait MediaPackage {
     /// <p>Creates a new Channel.</p>

--- a/rusoto/services/mediastore/src/generated.rs
+++ b/rusoto/services/mediastore/src/generated.rs
@@ -378,18 +378,14 @@ impl CreateContainerError {
 }
 impl fmt::Display for CreateContainerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateContainerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateContainerError::ContainerInUse(ref cause) => cause,
-            CreateContainerError::InternalServerError(ref cause) => cause,
-            CreateContainerError::LimitExceeded(ref cause) => cause,
+            CreateContainerError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            CreateContainerError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateContainerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateContainerError {}
 /// Errors returned by DeleteContainer
 #[derive(Debug, PartialEq)]
 pub enum DeleteContainerError {
@@ -423,18 +419,14 @@ impl DeleteContainerError {
 }
 impl fmt::Display for DeleteContainerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteContainerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteContainerError::ContainerInUse(ref cause) => cause,
-            DeleteContainerError::ContainerNotFound(ref cause) => cause,
-            DeleteContainerError::InternalServerError(ref cause) => cause,
+            DeleteContainerError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            DeleteContainerError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteContainerError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteContainerError {}
 /// Errors returned by DeleteContainerPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteContainerPolicyError {
@@ -481,19 +473,15 @@ impl DeleteContainerPolicyError {
 }
 impl fmt::Display for DeleteContainerPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteContainerPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteContainerPolicyError::ContainerInUse(ref cause) => cause,
-            DeleteContainerPolicyError::ContainerNotFound(ref cause) => cause,
-            DeleteContainerPolicyError::InternalServerError(ref cause) => cause,
-            DeleteContainerPolicyError::PolicyNotFound(ref cause) => cause,
+            DeleteContainerPolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            DeleteContainerPolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteContainerPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteContainerPolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteContainerPolicyError {}
 /// Errors returned by DeleteCorsPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteCorsPolicyError {
@@ -534,19 +522,15 @@ impl DeleteCorsPolicyError {
 }
 impl fmt::Display for DeleteCorsPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCorsPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCorsPolicyError::ContainerInUse(ref cause) => cause,
-            DeleteCorsPolicyError::ContainerNotFound(ref cause) => cause,
-            DeleteCorsPolicyError::CorsPolicyNotFound(ref cause) => cause,
-            DeleteCorsPolicyError::InternalServerError(ref cause) => cause,
+            DeleteCorsPolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            DeleteCorsPolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCorsPolicyError::CorsPolicyNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCorsPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCorsPolicyError {}
 /// Errors returned by DeleteLifecyclePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteLifecyclePolicyError {
@@ -593,19 +577,15 @@ impl DeleteLifecyclePolicyError {
 }
 impl fmt::Display for DeleteLifecyclePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLifecyclePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLifecyclePolicyError::ContainerInUse(ref cause) => cause,
-            DeleteLifecyclePolicyError::ContainerNotFound(ref cause) => cause,
-            DeleteLifecyclePolicyError::InternalServerError(ref cause) => cause,
-            DeleteLifecyclePolicyError::PolicyNotFound(ref cause) => cause,
+            DeleteLifecyclePolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            DeleteLifecyclePolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLifecyclePolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteLifecyclePolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLifecyclePolicyError {}
 /// Errors returned by DescribeContainer
 #[derive(Debug, PartialEq)]
 pub enum DescribeContainerError {
@@ -636,17 +616,13 @@ impl DescribeContainerError {
 }
 impl fmt::Display for DescribeContainerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeContainerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeContainerError::ContainerNotFound(ref cause) => cause,
-            DescribeContainerError::InternalServerError(ref cause) => cause,
+            DescribeContainerError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeContainerError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeContainerError {}
 /// Errors returned by GetContainerPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetContainerPolicyError {
@@ -689,19 +665,15 @@ impl GetContainerPolicyError {
 }
 impl fmt::Display for GetContainerPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetContainerPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetContainerPolicyError::ContainerInUse(ref cause) => cause,
-            GetContainerPolicyError::ContainerNotFound(ref cause) => cause,
-            GetContainerPolicyError::InternalServerError(ref cause) => cause,
-            GetContainerPolicyError::PolicyNotFound(ref cause) => cause,
+            GetContainerPolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            GetContainerPolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            GetContainerPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetContainerPolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetContainerPolicyError {}
 /// Errors returned by GetCorsPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetCorsPolicyError {
@@ -740,19 +712,15 @@ impl GetCorsPolicyError {
 }
 impl fmt::Display for GetCorsPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCorsPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetCorsPolicyError::ContainerInUse(ref cause) => cause,
-            GetCorsPolicyError::ContainerNotFound(ref cause) => cause,
-            GetCorsPolicyError::CorsPolicyNotFound(ref cause) => cause,
-            GetCorsPolicyError::InternalServerError(ref cause) => cause,
+            GetCorsPolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            GetCorsPolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            GetCorsPolicyError::CorsPolicyNotFound(ref cause) => write!(f, "{}", cause),
+            GetCorsPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCorsPolicyError {}
 /// Errors returned by GetLifecyclePolicy
 #[derive(Debug, PartialEq)]
 pub enum GetLifecyclePolicyError {
@@ -795,19 +763,15 @@ impl GetLifecyclePolicyError {
 }
 impl fmt::Display for GetLifecyclePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLifecyclePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetLifecyclePolicyError::ContainerInUse(ref cause) => cause,
-            GetLifecyclePolicyError::ContainerNotFound(ref cause) => cause,
-            GetLifecyclePolicyError::InternalServerError(ref cause) => cause,
-            GetLifecyclePolicyError::PolicyNotFound(ref cause) => cause,
+            GetLifecyclePolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetLifecyclePolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLifecyclePolicyError {}
 /// Errors returned by ListContainers
 #[derive(Debug, PartialEq)]
 pub enum ListContainersError {
@@ -831,16 +795,12 @@ impl ListContainersError {
 }
 impl fmt::Display for ListContainersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListContainersError {
-    fn description(&self) -> &str {
         match *self {
-            ListContainersError::InternalServerError(ref cause) => cause,
+            ListContainersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListContainersError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -878,18 +838,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::ContainerInUse(ref cause) => cause,
-            ListTagsForResourceError::ContainerNotFound(ref cause) => cause,
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
+            ListTagsForResourceError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PutContainerPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutContainerPolicyError {
@@ -927,18 +883,14 @@ impl PutContainerPolicyError {
 }
 impl fmt::Display for PutContainerPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutContainerPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutContainerPolicyError::ContainerInUse(ref cause) => cause,
-            PutContainerPolicyError::ContainerNotFound(ref cause) => cause,
-            PutContainerPolicyError::InternalServerError(ref cause) => cause,
+            PutContainerPolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            PutContainerPolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            PutContainerPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutContainerPolicyError {}
 /// Errors returned by PutCorsPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutCorsPolicyError {
@@ -972,18 +924,14 @@ impl PutCorsPolicyError {
 }
 impl fmt::Display for PutCorsPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutCorsPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutCorsPolicyError::ContainerInUse(ref cause) => cause,
-            PutCorsPolicyError::ContainerNotFound(ref cause) => cause,
-            PutCorsPolicyError::InternalServerError(ref cause) => cause,
+            PutCorsPolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            PutCorsPolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            PutCorsPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutCorsPolicyError {}
 /// Errors returned by PutLifecyclePolicy
 #[derive(Debug, PartialEq)]
 pub enum PutLifecyclePolicyError {
@@ -1021,18 +969,14 @@ impl PutLifecyclePolicyError {
 }
 impl fmt::Display for PutLifecyclePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLifecyclePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutLifecyclePolicyError::ContainerInUse(ref cause) => cause,
-            PutLifecyclePolicyError::ContainerNotFound(ref cause) => cause,
-            PutLifecyclePolicyError::InternalServerError(ref cause) => cause,
+            PutLifecyclePolicyError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            PutLifecyclePolicyError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            PutLifecyclePolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLifecyclePolicyError {}
 /// Errors returned by StartAccessLogging
 #[derive(Debug, PartialEq)]
 pub enum StartAccessLoggingError {
@@ -1070,18 +1014,14 @@ impl StartAccessLoggingError {
 }
 impl fmt::Display for StartAccessLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartAccessLoggingError {
-    fn description(&self) -> &str {
         match *self {
-            StartAccessLoggingError::ContainerInUse(ref cause) => cause,
-            StartAccessLoggingError::ContainerNotFound(ref cause) => cause,
-            StartAccessLoggingError::InternalServerError(ref cause) => cause,
+            StartAccessLoggingError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            StartAccessLoggingError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            StartAccessLoggingError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartAccessLoggingError {}
 /// Errors returned by StopAccessLogging
 #[derive(Debug, PartialEq)]
 pub enum StopAccessLoggingError {
@@ -1117,18 +1057,14 @@ impl StopAccessLoggingError {
 }
 impl fmt::Display for StopAccessLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopAccessLoggingError {
-    fn description(&self) -> &str {
         match *self {
-            StopAccessLoggingError::ContainerInUse(ref cause) => cause,
-            StopAccessLoggingError::ContainerNotFound(ref cause) => cause,
-            StopAccessLoggingError::InternalServerError(ref cause) => cause,
+            StopAccessLoggingError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            StopAccessLoggingError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            StopAccessLoggingError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopAccessLoggingError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1162,18 +1098,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ContainerInUse(ref cause) => cause,
-            TagResourceError::ContainerNotFound(ref cause) => cause,
-            TagResourceError::InternalServerError(ref cause) => cause,
+            TagResourceError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1207,18 +1139,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ContainerInUse(ref cause) => cause,
-            UntagResourceError::ContainerNotFound(ref cause) => cause,
-            UntagResourceError::InternalServerError(ref cause) => cause,
+            UntagResourceError::ContainerInUse(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ContainerNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the MediaStore API. MediaStore clients implement this trait.
 pub trait MediaStore {
     /// <p>Creates a storage container to hold objects. A container is similar to a bucket in the Amazon S3 service.</p>

--- a/rusoto/services/mediatailor/src/generated.rs
+++ b/rusoto/services/mediatailor/src/generated.rs
@@ -407,14 +407,10 @@ impl DeletePlaybackConfigurationError {
 }
 impl fmt::Display for DeletePlaybackConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePlaybackConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeletePlaybackConfigurationError {}
 /// Errors returned by GetPlaybackConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetPlaybackConfigurationError {}
@@ -432,14 +428,10 @@ impl GetPlaybackConfigurationError {
 }
 impl fmt::Display for GetPlaybackConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPlaybackConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetPlaybackConfigurationError {}
 /// Errors returned by ListPlaybackConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListPlaybackConfigurationsError {}
@@ -459,14 +451,10 @@ impl ListPlaybackConfigurationsError {
 }
 impl fmt::Display for ListPlaybackConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPlaybackConfigurationsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListPlaybackConfigurationsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -490,16 +478,12 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::BadRequest(ref cause) => cause,
+            ListTagsForResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by PutPlaybackConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutPlaybackConfigurationError {}
@@ -517,14 +501,10 @@ impl PutPlaybackConfigurationError {
 }
 impl fmt::Display for PutPlaybackConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPlaybackConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutPlaybackConfigurationError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -548,16 +528,12 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::BadRequest(ref cause) => cause,
+            TagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -581,16 +557,12 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::BadRequest(ref cause) => cause,
+            UntagResourceError::BadRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the MediaTailor API. MediaTailor clients implement this trait.
 pub trait MediaTailor {
     /// <p>Deletes the playback configuration for the specified name. </p>

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -224,22 +224,18 @@ impl BatchMeterUsageError {
 }
 impl fmt::Display for BatchMeterUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchMeterUsageError {
-    fn description(&self) -> &str {
         match *self {
-            BatchMeterUsageError::DisabledApi(ref cause) => cause,
-            BatchMeterUsageError::InternalServiceError(ref cause) => cause,
-            BatchMeterUsageError::InvalidCustomerIdentifier(ref cause) => cause,
-            BatchMeterUsageError::InvalidProductCode(ref cause) => cause,
-            BatchMeterUsageError::InvalidUsageDimension(ref cause) => cause,
-            BatchMeterUsageError::Throttling(ref cause) => cause,
-            BatchMeterUsageError::TimestampOutOfBounds(ref cause) => cause,
+            BatchMeterUsageError::DisabledApi(ref cause) => write!(f, "{}", cause),
+            BatchMeterUsageError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            BatchMeterUsageError::InvalidCustomerIdentifier(ref cause) => write!(f, "{}", cause),
+            BatchMeterUsageError::InvalidProductCode(ref cause) => write!(f, "{}", cause),
+            BatchMeterUsageError::InvalidUsageDimension(ref cause) => write!(f, "{}", cause),
+            BatchMeterUsageError::Throttling(ref cause) => write!(f, "{}", cause),
+            BatchMeterUsageError::TimestampOutOfBounds(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchMeterUsageError {}
 /// Errors returned by MeterUsage
 #[derive(Debug, PartialEq)]
 pub enum MeterUsageError {
@@ -298,23 +294,19 @@ impl MeterUsageError {
 }
 impl fmt::Display for MeterUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MeterUsageError {
-    fn description(&self) -> &str {
         match *self {
-            MeterUsageError::CustomerNotEntitled(ref cause) => cause,
-            MeterUsageError::DuplicateRequest(ref cause) => cause,
-            MeterUsageError::InternalServiceError(ref cause) => cause,
-            MeterUsageError::InvalidEndpointRegion(ref cause) => cause,
-            MeterUsageError::InvalidProductCode(ref cause) => cause,
-            MeterUsageError::InvalidUsageDimension(ref cause) => cause,
-            MeterUsageError::Throttling(ref cause) => cause,
-            MeterUsageError::TimestampOutOfBounds(ref cause) => cause,
+            MeterUsageError::CustomerNotEntitled(ref cause) => write!(f, "{}", cause),
+            MeterUsageError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            MeterUsageError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            MeterUsageError::InvalidEndpointRegion(ref cause) => write!(f, "{}", cause),
+            MeterUsageError::InvalidProductCode(ref cause) => write!(f, "{}", cause),
+            MeterUsageError::InvalidUsageDimension(ref cause) => write!(f, "{}", cause),
+            MeterUsageError::Throttling(ref cause) => write!(f, "{}", cause),
+            MeterUsageError::TimestampOutOfBounds(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for MeterUsageError {}
 /// Errors returned by RegisterUsage
 #[derive(Debug, PartialEq)]
 pub enum RegisterUsageError {
@@ -375,23 +367,19 @@ impl RegisterUsageError {
 }
 impl fmt::Display for RegisterUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterUsageError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterUsageError::CustomerNotEntitled(ref cause) => cause,
-            RegisterUsageError::DisabledApi(ref cause) => cause,
-            RegisterUsageError::InternalServiceError(ref cause) => cause,
-            RegisterUsageError::InvalidProductCode(ref cause) => cause,
-            RegisterUsageError::InvalidPublicKeyVersion(ref cause) => cause,
-            RegisterUsageError::InvalidRegion(ref cause) => cause,
-            RegisterUsageError::PlatformNotSupported(ref cause) => cause,
-            RegisterUsageError::Throttling(ref cause) => cause,
+            RegisterUsageError::CustomerNotEntitled(ref cause) => write!(f, "{}", cause),
+            RegisterUsageError::DisabledApi(ref cause) => write!(f, "{}", cause),
+            RegisterUsageError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            RegisterUsageError::InvalidProductCode(ref cause) => write!(f, "{}", cause),
+            RegisterUsageError::InvalidPublicKeyVersion(ref cause) => write!(f, "{}", cause),
+            RegisterUsageError::InvalidRegion(ref cause) => write!(f, "{}", cause),
+            RegisterUsageError::PlatformNotSupported(ref cause) => write!(f, "{}", cause),
+            RegisterUsageError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterUsageError {}
 /// Errors returned by ResolveCustomer
 #[derive(Debug, PartialEq)]
 pub enum ResolveCustomerError {
@@ -437,20 +425,16 @@ impl ResolveCustomerError {
 }
 impl fmt::Display for ResolveCustomerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResolveCustomerError {
-    fn description(&self) -> &str {
         match *self {
-            ResolveCustomerError::DisabledApi(ref cause) => cause,
-            ResolveCustomerError::ExpiredToken(ref cause) => cause,
-            ResolveCustomerError::InternalServiceError(ref cause) => cause,
-            ResolveCustomerError::InvalidToken(ref cause) => cause,
-            ResolveCustomerError::Throttling(ref cause) => cause,
+            ResolveCustomerError::DisabledApi(ref cause) => write!(f, "{}", cause),
+            ResolveCustomerError::ExpiredToken(ref cause) => write!(f, "{}", cause),
+            ResolveCustomerError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ResolveCustomerError::InvalidToken(ref cause) => write!(f, "{}", cause),
+            ResolveCustomerError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResolveCustomerError {}
 /// Trait representing the capabilities of the AWSMarketplace Metering API. AWSMarketplace Metering clients implement this trait.
 pub trait MarketplaceMetering {
     /// <p>BatchMeterUsage is called from a SaaS application listed on the AWS Marketplace to post metering records for a set of customers.</p> <p>For identical requests, the API is idempotent; requests can be retried with the same records or a subset of the input records.</p> <p>Every request to BatchMeterUsage is for one product. If you need to meter usage for multiple products, you must make multiple calls to BatchMeterUsage.</p> <p>BatchMeterUsage can process up to 25 UsageRecords at a time.</p>

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -571,23 +571,21 @@ impl AssociateCreatedArtifactError {
 }
 impl fmt::Display for AssociateCreatedArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateCreatedArtifactError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateCreatedArtifactError::AccessDenied(ref cause) => cause,
-            AssociateCreatedArtifactError::DryRunOperation(ref cause) => cause,
-            AssociateCreatedArtifactError::HomeRegionNotSet(ref cause) => cause,
-            AssociateCreatedArtifactError::InternalServerError(ref cause) => cause,
-            AssociateCreatedArtifactError::InvalidInput(ref cause) => cause,
-            AssociateCreatedArtifactError::ResourceNotFound(ref cause) => cause,
-            AssociateCreatedArtifactError::ServiceUnavailable(ref cause) => cause,
-            AssociateCreatedArtifactError::UnauthorizedOperation(ref cause) => cause,
+            AssociateCreatedArtifactError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AssociateCreatedArtifactError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            AssociateCreatedArtifactError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            AssociateCreatedArtifactError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AssociateCreatedArtifactError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AssociateCreatedArtifactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateCreatedArtifactError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AssociateCreatedArtifactError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateCreatedArtifactError {}
 /// Errors returned by AssociateDiscoveredResource
 #[derive(Debug, PartialEq)]
 pub enum AssociateDiscoveredResourceError {
@@ -671,24 +669,26 @@ impl AssociateDiscoveredResourceError {
 }
 impl fmt::Display for AssociateDiscoveredResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDiscoveredResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDiscoveredResourceError::AccessDenied(ref cause) => cause,
-            AssociateDiscoveredResourceError::DryRunOperation(ref cause) => cause,
-            AssociateDiscoveredResourceError::HomeRegionNotSet(ref cause) => cause,
-            AssociateDiscoveredResourceError::InternalServerError(ref cause) => cause,
-            AssociateDiscoveredResourceError::InvalidInput(ref cause) => cause,
-            AssociateDiscoveredResourceError::PolicyError(ref cause) => cause,
-            AssociateDiscoveredResourceError::ResourceNotFound(ref cause) => cause,
-            AssociateDiscoveredResourceError::ServiceUnavailable(ref cause) => cause,
-            AssociateDiscoveredResourceError::UnauthorizedOperation(ref cause) => cause,
+            AssociateDiscoveredResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AssociateDiscoveredResourceError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            AssociateDiscoveredResourceError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            AssociateDiscoveredResourceError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDiscoveredResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AssociateDiscoveredResourceError::PolicyError(ref cause) => write!(f, "{}", cause),
+            AssociateDiscoveredResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateDiscoveredResourceError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDiscoveredResourceError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateDiscoveredResourceError {}
 /// Errors returned by CreateProgressUpdateStream
 #[derive(Debug, PartialEq)]
 pub enum CreateProgressUpdateStreamError {
@@ -758,22 +758,24 @@ impl CreateProgressUpdateStreamError {
 }
 impl fmt::Display for CreateProgressUpdateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProgressUpdateStreamError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProgressUpdateStreamError::AccessDenied(ref cause) => cause,
-            CreateProgressUpdateStreamError::DryRunOperation(ref cause) => cause,
-            CreateProgressUpdateStreamError::HomeRegionNotSet(ref cause) => cause,
-            CreateProgressUpdateStreamError::InternalServerError(ref cause) => cause,
-            CreateProgressUpdateStreamError::InvalidInput(ref cause) => cause,
-            CreateProgressUpdateStreamError::ServiceUnavailable(ref cause) => cause,
-            CreateProgressUpdateStreamError::UnauthorizedOperation(ref cause) => cause,
+            CreateProgressUpdateStreamError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateProgressUpdateStreamError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            CreateProgressUpdateStreamError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            CreateProgressUpdateStreamError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProgressUpdateStreamError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateProgressUpdateStreamError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProgressUpdateStreamError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateProgressUpdateStreamError {}
 /// Errors returned by DeleteProgressUpdateStream
 #[derive(Debug, PartialEq)]
 pub enum DeleteProgressUpdateStreamError {
@@ -850,23 +852,25 @@ impl DeleteProgressUpdateStreamError {
 }
 impl fmt::Display for DeleteProgressUpdateStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProgressUpdateStreamError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProgressUpdateStreamError::AccessDenied(ref cause) => cause,
-            DeleteProgressUpdateStreamError::DryRunOperation(ref cause) => cause,
-            DeleteProgressUpdateStreamError::HomeRegionNotSet(ref cause) => cause,
-            DeleteProgressUpdateStreamError::InternalServerError(ref cause) => cause,
-            DeleteProgressUpdateStreamError::InvalidInput(ref cause) => cause,
-            DeleteProgressUpdateStreamError::ResourceNotFound(ref cause) => cause,
-            DeleteProgressUpdateStreamError::ServiceUnavailable(ref cause) => cause,
-            DeleteProgressUpdateStreamError::UnauthorizedOperation(ref cause) => cause,
+            DeleteProgressUpdateStreamError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteProgressUpdateStreamError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            DeleteProgressUpdateStreamError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DeleteProgressUpdateStreamError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProgressUpdateStreamError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteProgressUpdateStreamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteProgressUpdateStreamError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProgressUpdateStreamError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteProgressUpdateStreamError {}
 /// Errors returned by DescribeApplicationState
 #[derive(Debug, PartialEq)]
 pub enum DescribeApplicationStateError {
@@ -934,22 +938,18 @@ impl DescribeApplicationStateError {
 }
 impl fmt::Display for DescribeApplicationStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeApplicationStateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeApplicationStateError::AccessDenied(ref cause) => cause,
-            DescribeApplicationStateError::HomeRegionNotSet(ref cause) => cause,
-            DescribeApplicationStateError::InternalServerError(ref cause) => cause,
-            DescribeApplicationStateError::InvalidInput(ref cause) => cause,
-            DescribeApplicationStateError::PolicyError(ref cause) => cause,
-            DescribeApplicationStateError::ResourceNotFound(ref cause) => cause,
-            DescribeApplicationStateError::ServiceUnavailable(ref cause) => cause,
+            DescribeApplicationStateError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeApplicationStateError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeApplicationStateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeApplicationStateError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeApplicationStateError::PolicyError(ref cause) => write!(f, "{}", cause),
+            DescribeApplicationStateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeApplicationStateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeApplicationStateError {}
 /// Errors returned by DescribeMigrationTask
 #[derive(Debug, PartialEq)]
 pub enum DescribeMigrationTaskError {
@@ -1006,21 +1006,17 @@ impl DescribeMigrationTaskError {
 }
 impl fmt::Display for DescribeMigrationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMigrationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMigrationTaskError::AccessDenied(ref cause) => cause,
-            DescribeMigrationTaskError::HomeRegionNotSet(ref cause) => cause,
-            DescribeMigrationTaskError::InternalServerError(ref cause) => cause,
-            DescribeMigrationTaskError::InvalidInput(ref cause) => cause,
-            DescribeMigrationTaskError::ResourceNotFound(ref cause) => cause,
-            DescribeMigrationTaskError::ServiceUnavailable(ref cause) => cause,
+            DescribeMigrationTaskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeMigrationTaskError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DescribeMigrationTaskError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeMigrationTaskError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeMigrationTaskError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeMigrationTaskError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMigrationTaskError {}
 /// Errors returned by DisassociateCreatedArtifact
 #[derive(Debug, PartialEq)]
 pub enum DisassociateCreatedArtifactError {
@@ -1097,23 +1093,25 @@ impl DisassociateCreatedArtifactError {
 }
 impl fmt::Display for DisassociateCreatedArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateCreatedArtifactError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateCreatedArtifactError::AccessDenied(ref cause) => cause,
-            DisassociateCreatedArtifactError::DryRunOperation(ref cause) => cause,
-            DisassociateCreatedArtifactError::HomeRegionNotSet(ref cause) => cause,
-            DisassociateCreatedArtifactError::InternalServerError(ref cause) => cause,
-            DisassociateCreatedArtifactError::InvalidInput(ref cause) => cause,
-            DisassociateCreatedArtifactError::ResourceNotFound(ref cause) => cause,
-            DisassociateCreatedArtifactError::ServiceUnavailable(ref cause) => cause,
-            DisassociateCreatedArtifactError::UnauthorizedOperation(ref cause) => cause,
+            DisassociateCreatedArtifactError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisassociateCreatedArtifactError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            DisassociateCreatedArtifactError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            DisassociateCreatedArtifactError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateCreatedArtifactError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisassociateCreatedArtifactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DisassociateCreatedArtifactError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateCreatedArtifactError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateCreatedArtifactError {}
 /// Errors returned by DisassociateDiscoveredResource
 #[derive(Debug, PartialEq)]
 pub enum DisassociateDiscoveredResourceError {
@@ -1190,23 +1188,31 @@ impl DisassociateDiscoveredResourceError {
 }
 impl fmt::Display for DisassociateDiscoveredResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateDiscoveredResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateDiscoveredResourceError::AccessDenied(ref cause) => cause,
-            DisassociateDiscoveredResourceError::DryRunOperation(ref cause) => cause,
-            DisassociateDiscoveredResourceError::HomeRegionNotSet(ref cause) => cause,
-            DisassociateDiscoveredResourceError::InternalServerError(ref cause) => cause,
-            DisassociateDiscoveredResourceError::InvalidInput(ref cause) => cause,
-            DisassociateDiscoveredResourceError::ResourceNotFound(ref cause) => cause,
-            DisassociateDiscoveredResourceError::ServiceUnavailable(ref cause) => cause,
-            DisassociateDiscoveredResourceError::UnauthorizedOperation(ref cause) => cause,
+            DisassociateDiscoveredResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisassociateDiscoveredResourceError::DryRunOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDiscoveredResourceError::HomeRegionNotSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDiscoveredResourceError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDiscoveredResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisassociateDiscoveredResourceError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDiscoveredResourceError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDiscoveredResourceError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateDiscoveredResourceError {}
 /// Errors returned by ImportMigrationTask
 #[derive(Debug, PartialEq)]
 pub enum ImportMigrationTaskError {
@@ -1275,23 +1281,19 @@ impl ImportMigrationTaskError {
 }
 impl fmt::Display for ImportMigrationTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportMigrationTaskError {
-    fn description(&self) -> &str {
         match *self {
-            ImportMigrationTaskError::AccessDenied(ref cause) => cause,
-            ImportMigrationTaskError::DryRunOperation(ref cause) => cause,
-            ImportMigrationTaskError::HomeRegionNotSet(ref cause) => cause,
-            ImportMigrationTaskError::InternalServerError(ref cause) => cause,
-            ImportMigrationTaskError::InvalidInput(ref cause) => cause,
-            ImportMigrationTaskError::ResourceNotFound(ref cause) => cause,
-            ImportMigrationTaskError::ServiceUnavailable(ref cause) => cause,
-            ImportMigrationTaskError::UnauthorizedOperation(ref cause) => cause,
+            ImportMigrationTaskError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ImportMigrationTaskError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            ImportMigrationTaskError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ImportMigrationTaskError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ImportMigrationTaskError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ImportMigrationTaskError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ImportMigrationTaskError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ImportMigrationTaskError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportMigrationTaskError {}
 /// Errors returned by ListCreatedArtifacts
 #[derive(Debug, PartialEq)]
 pub enum ListCreatedArtifactsError {
@@ -1348,21 +1350,17 @@ impl ListCreatedArtifactsError {
 }
 impl fmt::Display for ListCreatedArtifactsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCreatedArtifactsError {
-    fn description(&self) -> &str {
         match *self {
-            ListCreatedArtifactsError::AccessDenied(ref cause) => cause,
-            ListCreatedArtifactsError::HomeRegionNotSet(ref cause) => cause,
-            ListCreatedArtifactsError::InternalServerError(ref cause) => cause,
-            ListCreatedArtifactsError::InvalidInput(ref cause) => cause,
-            ListCreatedArtifactsError::ResourceNotFound(ref cause) => cause,
-            ListCreatedArtifactsError::ServiceUnavailable(ref cause) => cause,
+            ListCreatedArtifactsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListCreatedArtifactsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ListCreatedArtifactsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListCreatedArtifactsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListCreatedArtifactsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListCreatedArtifactsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCreatedArtifactsError {}
 /// Errors returned by ListDiscoveredResources
 #[derive(Debug, PartialEq)]
 pub enum ListDiscoveredResourcesError {
@@ -1423,21 +1421,17 @@ impl ListDiscoveredResourcesError {
 }
 impl fmt::Display for ListDiscoveredResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDiscoveredResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDiscoveredResourcesError::AccessDenied(ref cause) => cause,
-            ListDiscoveredResourcesError::HomeRegionNotSet(ref cause) => cause,
-            ListDiscoveredResourcesError::InternalServerError(ref cause) => cause,
-            ListDiscoveredResourcesError::InvalidInput(ref cause) => cause,
-            ListDiscoveredResourcesError::ResourceNotFound(ref cause) => cause,
-            ListDiscoveredResourcesError::ServiceUnavailable(ref cause) => cause,
+            ListDiscoveredResourcesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListDiscoveredResourcesError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ListDiscoveredResourcesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListDiscoveredResourcesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListDiscoveredResourcesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListDiscoveredResourcesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDiscoveredResourcesError {}
 /// Errors returned by ListMigrationTasks
 #[derive(Debug, PartialEq)]
 pub enum ListMigrationTasksError {
@@ -1495,22 +1489,18 @@ impl ListMigrationTasksError {
 }
 impl fmt::Display for ListMigrationTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMigrationTasksError {
-    fn description(&self) -> &str {
         match *self {
-            ListMigrationTasksError::AccessDenied(ref cause) => cause,
-            ListMigrationTasksError::HomeRegionNotSet(ref cause) => cause,
-            ListMigrationTasksError::InternalServerError(ref cause) => cause,
-            ListMigrationTasksError::InvalidInput(ref cause) => cause,
-            ListMigrationTasksError::PolicyError(ref cause) => cause,
-            ListMigrationTasksError::ResourceNotFound(ref cause) => cause,
-            ListMigrationTasksError::ServiceUnavailable(ref cause) => cause,
+            ListMigrationTasksError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListMigrationTasksError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ListMigrationTasksError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListMigrationTasksError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListMigrationTasksError::PolicyError(ref cause) => write!(f, "{}", cause),
+            ListMigrationTasksError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListMigrationTasksError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMigrationTasksError {}
 /// Errors returned by ListProgressUpdateStreams
 #[derive(Debug, PartialEq)]
 pub enum ListProgressUpdateStreamsError {
@@ -1564,20 +1554,18 @@ impl ListProgressUpdateStreamsError {
 }
 impl fmt::Display for ListProgressUpdateStreamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProgressUpdateStreamsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProgressUpdateStreamsError::AccessDenied(ref cause) => cause,
-            ListProgressUpdateStreamsError::HomeRegionNotSet(ref cause) => cause,
-            ListProgressUpdateStreamsError::InternalServerError(ref cause) => cause,
-            ListProgressUpdateStreamsError::InvalidInput(ref cause) => cause,
-            ListProgressUpdateStreamsError::ServiceUnavailable(ref cause) => cause,
+            ListProgressUpdateStreamsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListProgressUpdateStreamsError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            ListProgressUpdateStreamsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProgressUpdateStreamsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListProgressUpdateStreamsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProgressUpdateStreamsError {}
 /// Errors returned by NotifyApplicationState
 #[derive(Debug, PartialEq)]
 pub enum NotifyApplicationStateError {
@@ -1653,24 +1641,20 @@ impl NotifyApplicationStateError {
 }
 impl fmt::Display for NotifyApplicationStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for NotifyApplicationStateError {
-    fn description(&self) -> &str {
         match *self {
-            NotifyApplicationStateError::AccessDenied(ref cause) => cause,
-            NotifyApplicationStateError::DryRunOperation(ref cause) => cause,
-            NotifyApplicationStateError::HomeRegionNotSet(ref cause) => cause,
-            NotifyApplicationStateError::InternalServerError(ref cause) => cause,
-            NotifyApplicationStateError::InvalidInput(ref cause) => cause,
-            NotifyApplicationStateError::PolicyError(ref cause) => cause,
-            NotifyApplicationStateError::ResourceNotFound(ref cause) => cause,
-            NotifyApplicationStateError::ServiceUnavailable(ref cause) => cause,
-            NotifyApplicationStateError::UnauthorizedOperation(ref cause) => cause,
+            NotifyApplicationStateError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::PolicyError(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            NotifyApplicationStateError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for NotifyApplicationStateError {}
 /// Errors returned by NotifyMigrationTaskState
 #[derive(Debug, PartialEq)]
 pub enum NotifyMigrationTaskStateError {
@@ -1745,23 +1729,21 @@ impl NotifyMigrationTaskStateError {
 }
 impl fmt::Display for NotifyMigrationTaskStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for NotifyMigrationTaskStateError {
-    fn description(&self) -> &str {
         match *self {
-            NotifyMigrationTaskStateError::AccessDenied(ref cause) => cause,
-            NotifyMigrationTaskStateError::DryRunOperation(ref cause) => cause,
-            NotifyMigrationTaskStateError::HomeRegionNotSet(ref cause) => cause,
-            NotifyMigrationTaskStateError::InternalServerError(ref cause) => cause,
-            NotifyMigrationTaskStateError::InvalidInput(ref cause) => cause,
-            NotifyMigrationTaskStateError::ResourceNotFound(ref cause) => cause,
-            NotifyMigrationTaskStateError::ServiceUnavailable(ref cause) => cause,
-            NotifyMigrationTaskStateError::UnauthorizedOperation(ref cause) => cause,
+            NotifyMigrationTaskStateError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            NotifyMigrationTaskStateError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            NotifyMigrationTaskStateError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            NotifyMigrationTaskStateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            NotifyMigrationTaskStateError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            NotifyMigrationTaskStateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            NotifyMigrationTaskStateError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            NotifyMigrationTaskStateError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for NotifyMigrationTaskStateError {}
 /// Errors returned by PutResourceAttributes
 #[derive(Debug, PartialEq)]
 pub enum PutResourceAttributesError {
@@ -1832,23 +1814,19 @@ impl PutResourceAttributesError {
 }
 impl fmt::Display for PutResourceAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutResourceAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            PutResourceAttributesError::AccessDenied(ref cause) => cause,
-            PutResourceAttributesError::DryRunOperation(ref cause) => cause,
-            PutResourceAttributesError::HomeRegionNotSet(ref cause) => cause,
-            PutResourceAttributesError::InternalServerError(ref cause) => cause,
-            PutResourceAttributesError::InvalidInput(ref cause) => cause,
-            PutResourceAttributesError::ResourceNotFound(ref cause) => cause,
-            PutResourceAttributesError::ServiceUnavailable(ref cause) => cause,
-            PutResourceAttributesError::UnauthorizedOperation(ref cause) => cause,
+            PutResourceAttributesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            PutResourceAttributesError::DryRunOperation(ref cause) => write!(f, "{}", cause),
+            PutResourceAttributesError::HomeRegionNotSet(ref cause) => write!(f, "{}", cause),
+            PutResourceAttributesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            PutResourceAttributesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            PutResourceAttributesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            PutResourceAttributesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            PutResourceAttributesError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutResourceAttributesError {}
 /// Trait representing the capabilities of the AWS Migration Hub API. AWS Migration Hub clients implement this trait.
 pub trait MigrationHub {
     /// <p><p>Associates a created artifact of an AWS cloud resource, the target receiving the migration, with the migration task performed by a migration tool. This API has the following traits:</p> <ul> <li> <p>Migration tools can call the <code>AssociateCreatedArtifact</code> operation to indicate which AWS artifact is associated with a migration task.</p> </li> <li> <p>The created artifact name must be provided in ARN (Amazon Resource Name) format which will contain information about type and region; for example: <code>arn:aws:ec2:us-east-1:488216288981:image/ami-6d0ba87b</code>.</p> </li> <li> <p>Examples of the AWS resource behind the created artifact are, AMI&#39;s, EC2 instance, or DMS endpoint, etc.</p> </li> </ul></p>

--- a/rusoto/services/mobile/src/generated.rs
+++ b/rusoto/services/mobile/src/generated.rs
@@ -396,22 +396,18 @@ impl CreateProjectError {
 }
 impl fmt::Display for CreateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProjectError::BadRequest(ref cause) => cause,
-            CreateProjectError::InternalFailure(ref cause) => cause,
-            CreateProjectError::LimitExceeded(ref cause) => cause,
-            CreateProjectError::NotFound(ref cause) => cause,
-            CreateProjectError::ServiceUnavailable(ref cause) => cause,
-            CreateProjectError::TooManyRequests(ref cause) => cause,
-            CreateProjectError::Unauthorized(ref cause) => cause,
+            CreateProjectError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProjectError {}
 /// Errors returned by DeleteProject
 #[derive(Debug, PartialEq)]
 pub enum DeleteProjectError {
@@ -455,20 +451,16 @@ impl DeleteProjectError {
 }
 impl fmt::Display for DeleteProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProjectError::InternalFailure(ref cause) => cause,
-            DeleteProjectError::NotFound(ref cause) => cause,
-            DeleteProjectError::ServiceUnavailable(ref cause) => cause,
-            DeleteProjectError::TooManyRequests(ref cause) => cause,
-            DeleteProjectError::Unauthorized(ref cause) => cause,
+            DeleteProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteProjectError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProjectError {}
 /// Errors returned by DescribeBundle
 #[derive(Debug, PartialEq)]
 pub enum DescribeBundleError {
@@ -517,21 +509,17 @@ impl DescribeBundleError {
 }
 impl fmt::Display for DescribeBundleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBundleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBundleError::BadRequest(ref cause) => cause,
-            DescribeBundleError::InternalFailure(ref cause) => cause,
-            DescribeBundleError::NotFound(ref cause) => cause,
-            DescribeBundleError::ServiceUnavailable(ref cause) => cause,
-            DescribeBundleError::TooManyRequests(ref cause) => cause,
-            DescribeBundleError::Unauthorized(ref cause) => cause,
+            DescribeBundleError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBundleError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeBundleError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeBundleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeBundleError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeBundleError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBundleError {}
 /// Errors returned by DescribeProject
 #[derive(Debug, PartialEq)]
 pub enum DescribeProjectError {
@@ -580,21 +568,17 @@ impl DescribeProjectError {
 }
 impl fmt::Display for DescribeProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProjectError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProjectError::BadRequest(ref cause) => cause,
-            DescribeProjectError::InternalFailure(ref cause) => cause,
-            DescribeProjectError::NotFound(ref cause) => cause,
-            DescribeProjectError::ServiceUnavailable(ref cause) => cause,
-            DescribeProjectError::TooManyRequests(ref cause) => cause,
-            DescribeProjectError::Unauthorized(ref cause) => cause,
+            DescribeProjectError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeProjectError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProjectError {}
 /// Errors returned by ExportBundle
 #[derive(Debug, PartialEq)]
 pub enum ExportBundleError {
@@ -643,21 +627,17 @@ impl ExportBundleError {
 }
 impl fmt::Display for ExportBundleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExportBundleError {
-    fn description(&self) -> &str {
         match *self {
-            ExportBundleError::BadRequest(ref cause) => cause,
-            ExportBundleError::InternalFailure(ref cause) => cause,
-            ExportBundleError::NotFound(ref cause) => cause,
-            ExportBundleError::ServiceUnavailable(ref cause) => cause,
-            ExportBundleError::TooManyRequests(ref cause) => cause,
-            ExportBundleError::Unauthorized(ref cause) => cause,
+            ExportBundleError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ExportBundleError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ExportBundleError::NotFound(ref cause) => write!(f, "{}", cause),
+            ExportBundleError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ExportBundleError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ExportBundleError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExportBundleError {}
 /// Errors returned by ExportProject
 #[derive(Debug, PartialEq)]
 pub enum ExportProjectError {
@@ -706,21 +686,17 @@ impl ExportProjectError {
 }
 impl fmt::Display for ExportProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExportProjectError {
-    fn description(&self) -> &str {
         match *self {
-            ExportProjectError::BadRequest(ref cause) => cause,
-            ExportProjectError::InternalFailure(ref cause) => cause,
-            ExportProjectError::NotFound(ref cause) => cause,
-            ExportProjectError::ServiceUnavailable(ref cause) => cause,
-            ExportProjectError::TooManyRequests(ref cause) => cause,
-            ExportProjectError::Unauthorized(ref cause) => cause,
+            ExportProjectError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ExportProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ExportProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            ExportProjectError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ExportProjectError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ExportProjectError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExportProjectError {}
 /// Errors returned by ListBundles
 #[derive(Debug, PartialEq)]
 pub enum ListBundlesError {
@@ -764,20 +740,16 @@ impl ListBundlesError {
 }
 impl fmt::Display for ListBundlesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBundlesError {
-    fn description(&self) -> &str {
         match *self {
-            ListBundlesError::BadRequest(ref cause) => cause,
-            ListBundlesError::InternalFailure(ref cause) => cause,
-            ListBundlesError::ServiceUnavailable(ref cause) => cause,
-            ListBundlesError::TooManyRequests(ref cause) => cause,
-            ListBundlesError::Unauthorized(ref cause) => cause,
+            ListBundlesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListBundlesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListBundlesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListBundlesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListBundlesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBundlesError {}
 /// Errors returned by ListProjects
 #[derive(Debug, PartialEq)]
 pub enum ListProjectsError {
@@ -821,20 +793,16 @@ impl ListProjectsError {
 }
 impl fmt::Display for ListProjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProjectsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProjectsError::BadRequest(ref cause) => cause,
-            ListProjectsError::InternalFailure(ref cause) => cause,
-            ListProjectsError::ServiceUnavailable(ref cause) => cause,
-            ListProjectsError::TooManyRequests(ref cause) => cause,
-            ListProjectsError::Unauthorized(ref cause) => cause,
+            ListProjectsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListProjectsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProjectsError {}
 /// Errors returned by UpdateProject
 #[derive(Debug, PartialEq)]
 pub enum UpdateProjectError {
@@ -893,23 +861,19 @@ impl UpdateProjectError {
 }
 impl fmt::Display for UpdateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProjectError::AccountActionRequired(ref cause) => cause,
-            UpdateProjectError::BadRequest(ref cause) => cause,
-            UpdateProjectError::InternalFailure(ref cause) => cause,
-            UpdateProjectError::LimitExceeded(ref cause) => cause,
-            UpdateProjectError::NotFound(ref cause) => cause,
-            UpdateProjectError::ServiceUnavailable(ref cause) => cause,
-            UpdateProjectError::TooManyRequests(ref cause) => cause,
-            UpdateProjectError::Unauthorized(ref cause) => cause,
+            UpdateProjectError::AccountActionRequired(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateProjectError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProjectError {}
 /// Trait representing the capabilities of the AWS Mobile API. AWS Mobile clients implement this trait.
 pub trait Mobile {
     /// <p> Creates an AWS Mobile Hub project. </p>

--- a/rusoto/services/mq/src/generated.rs
+++ b/rusoto/services/mq/src/generated.rs
@@ -1204,20 +1204,16 @@ impl CreateBrokerError {
 }
 impl fmt::Display for CreateBrokerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBrokerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBrokerError::BadRequest(ref cause) => cause,
-            CreateBrokerError::Conflict(ref cause) => cause,
-            CreateBrokerError::Forbidden(ref cause) => cause,
-            CreateBrokerError::InternalServerError(ref cause) => cause,
-            CreateBrokerError::Unauthorized(ref cause) => cause,
+            CreateBrokerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateBrokerError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateBrokerError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateBrokerError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateBrokerError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBrokerError {}
 /// Errors returned by CreateConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateConfigurationError {
@@ -1258,19 +1254,15 @@ impl CreateConfigurationError {
 }
 impl fmt::Display for CreateConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConfigurationError::BadRequest(ref cause) => cause,
-            CreateConfigurationError::Conflict(ref cause) => cause,
-            CreateConfigurationError::Forbidden(ref cause) => cause,
-            CreateConfigurationError::InternalServerError(ref cause) => cause,
+            CreateConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateConfigurationError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConfigurationError {}
 /// Errors returned by CreateTags
 #[derive(Debug, PartialEq)]
 pub enum CreateTagsError {
@@ -1309,19 +1301,15 @@ impl CreateTagsError {
 }
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTagsError::BadRequest(ref cause) => cause,
-            CreateTagsError::Forbidden(ref cause) => cause,
-            CreateTagsError::InternalServerError(ref cause) => cause,
-            CreateTagsError::NotFound(ref cause) => cause,
+            CreateTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTagsError {}
 /// Errors returned by CreateUser
 #[derive(Debug, PartialEq)]
 pub enum CreateUserError {
@@ -1365,20 +1353,16 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::BadRequest(ref cause) => cause,
-            CreateUserError::Conflict(ref cause) => cause,
-            CreateUserError::Forbidden(ref cause) => cause,
-            CreateUserError::InternalServerError(ref cause) => cause,
-            CreateUserError::NotFound(ref cause) => cause,
+            CreateUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateUserError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateUserError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by DeleteBroker
 #[derive(Debug, PartialEq)]
 pub enum DeleteBrokerError {
@@ -1417,19 +1401,15 @@ impl DeleteBrokerError {
 }
 impl fmt::Display for DeleteBrokerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBrokerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBrokerError::BadRequest(ref cause) => cause,
-            DeleteBrokerError::Forbidden(ref cause) => cause,
-            DeleteBrokerError::InternalServerError(ref cause) => cause,
-            DeleteBrokerError::NotFound(ref cause) => cause,
+            DeleteBrokerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteBrokerError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteBrokerError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteBrokerError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBrokerError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -1468,19 +1448,15 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::BadRequest(ref cause) => cause,
-            DeleteTagsError::Forbidden(ref cause) => cause,
-            DeleteTagsError::InternalServerError(ref cause) => cause,
-            DeleteTagsError::NotFound(ref cause) => cause,
+            DeleteTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -1519,19 +1495,15 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::BadRequest(ref cause) => cause,
-            DeleteUserError::Forbidden(ref cause) => cause,
-            DeleteUserError::InternalServerError(ref cause) => cause,
-            DeleteUserError::NotFound(ref cause) => cause,
+            DeleteUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DescribeBroker
 #[derive(Debug, PartialEq)]
 pub enum DescribeBrokerError {
@@ -1570,19 +1542,15 @@ impl DescribeBrokerError {
 }
 impl fmt::Display for DescribeBrokerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBrokerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBrokerError::BadRequest(ref cause) => cause,
-            DescribeBrokerError::Forbidden(ref cause) => cause,
-            DescribeBrokerError::InternalServerError(ref cause) => cause,
-            DescribeBrokerError::NotFound(ref cause) => cause,
+            DescribeBrokerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBrokerError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeBrokerError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeBrokerError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBrokerError {}
 /// Errors returned by DescribeBrokerEngineTypes
 #[derive(Debug, PartialEq)]
 pub enum DescribeBrokerEngineTypesError {
@@ -1620,18 +1588,16 @@ impl DescribeBrokerEngineTypesError {
 }
 impl fmt::Display for DescribeBrokerEngineTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBrokerEngineTypesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBrokerEngineTypesError::BadRequest(ref cause) => cause,
-            DescribeBrokerEngineTypesError::Forbidden(ref cause) => cause,
-            DescribeBrokerEngineTypesError::InternalServerError(ref cause) => cause,
+            DescribeBrokerEngineTypesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBrokerEngineTypesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeBrokerEngineTypesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeBrokerEngineTypesError {}
 /// Errors returned by DescribeBrokerInstanceOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeBrokerInstanceOptionsError {
@@ -1673,18 +1639,16 @@ impl DescribeBrokerInstanceOptionsError {
 }
 impl fmt::Display for DescribeBrokerInstanceOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBrokerInstanceOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBrokerInstanceOptionsError::BadRequest(ref cause) => cause,
-            DescribeBrokerInstanceOptionsError::Forbidden(ref cause) => cause,
-            DescribeBrokerInstanceOptionsError::InternalServerError(ref cause) => cause,
+            DescribeBrokerInstanceOptionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeBrokerInstanceOptionsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeBrokerInstanceOptionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeBrokerInstanceOptionsError {}
 /// Errors returned by DescribeConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationError {
@@ -1725,19 +1689,15 @@ impl DescribeConfigurationError {
 }
 impl fmt::Display for DescribeConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationError::BadRequest(ref cause) => cause,
-            DescribeConfigurationError::Forbidden(ref cause) => cause,
-            DescribeConfigurationError::InternalServerError(ref cause) => cause,
-            DescribeConfigurationError::NotFound(ref cause) => cause,
+            DescribeConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationError {}
 /// Errors returned by DescribeConfigurationRevision
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationRevisionError {
@@ -1786,19 +1746,17 @@ impl DescribeConfigurationRevisionError {
 }
 impl fmt::Display for DescribeConfigurationRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationRevisionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationRevisionError::BadRequest(ref cause) => cause,
-            DescribeConfigurationRevisionError::Forbidden(ref cause) => cause,
-            DescribeConfigurationRevisionError::InternalServerError(ref cause) => cause,
-            DescribeConfigurationRevisionError::NotFound(ref cause) => cause,
+            DescribeConfigurationRevisionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationRevisionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeConfigurationRevisionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeConfigurationRevisionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConfigurationRevisionError {}
 /// Errors returned by DescribeUser
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserError {
@@ -1837,19 +1795,15 @@ impl DescribeUserError {
 }
 impl fmt::Display for DescribeUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserError::BadRequest(ref cause) => cause,
-            DescribeUserError::Forbidden(ref cause) => cause,
-            DescribeUserError::InternalServerError(ref cause) => cause,
-            DescribeUserError::NotFound(ref cause) => cause,
+            DescribeUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserError {}
 /// Errors returned by ListBrokers
 #[derive(Debug, PartialEq)]
 pub enum ListBrokersError {
@@ -1883,18 +1837,14 @@ impl ListBrokersError {
 }
 impl fmt::Display for ListBrokersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBrokersError {
-    fn description(&self) -> &str {
         match *self {
-            ListBrokersError::BadRequest(ref cause) => cause,
-            ListBrokersError::Forbidden(ref cause) => cause,
-            ListBrokersError::InternalServerError(ref cause) => cause,
+            ListBrokersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListBrokersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListBrokersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBrokersError {}
 /// Errors returned by ListConfigurationRevisions
 #[derive(Debug, PartialEq)]
 pub enum ListConfigurationRevisionsError {
@@ -1941,19 +1891,17 @@ impl ListConfigurationRevisionsError {
 }
 impl fmt::Display for ListConfigurationRevisionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConfigurationRevisionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListConfigurationRevisionsError::BadRequest(ref cause) => cause,
-            ListConfigurationRevisionsError::Forbidden(ref cause) => cause,
-            ListConfigurationRevisionsError::InternalServerError(ref cause) => cause,
-            ListConfigurationRevisionsError::NotFound(ref cause) => cause,
+            ListConfigurationRevisionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListConfigurationRevisionsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListConfigurationRevisionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListConfigurationRevisionsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListConfigurationRevisionsError {}
 /// Errors returned by ListConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListConfigurationsError {
@@ -1989,18 +1937,14 @@ impl ListConfigurationsError {
 }
 impl fmt::Display for ListConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListConfigurationsError::BadRequest(ref cause) => cause,
-            ListConfigurationsError::Forbidden(ref cause) => cause,
-            ListConfigurationsError::InternalServerError(ref cause) => cause,
+            ListConfigurationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListConfigurationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListConfigurationsError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -2039,19 +1983,15 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::BadRequest(ref cause) => cause,
-            ListTagsError::Forbidden(ref cause) => cause,
-            ListTagsError::InternalServerError(ref cause) => cause,
-            ListTagsError::NotFound(ref cause) => cause,
+            ListTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by ListUsers
 #[derive(Debug, PartialEq)]
 pub enum ListUsersError {
@@ -2090,19 +2030,15 @@ impl ListUsersError {
 }
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersError::BadRequest(ref cause) => cause,
-            ListUsersError::Forbidden(ref cause) => cause,
-            ListUsersError::InternalServerError(ref cause) => cause,
-            ListUsersError::NotFound(ref cause) => cause,
+            ListUsersError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListUsersError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListUsersError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListUsersError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersError {}
 /// Errors returned by RebootBroker
 #[derive(Debug, PartialEq)]
 pub enum RebootBrokerError {
@@ -2141,19 +2077,15 @@ impl RebootBrokerError {
 }
 impl fmt::Display for RebootBrokerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootBrokerError {
-    fn description(&self) -> &str {
         match *self {
-            RebootBrokerError::BadRequest(ref cause) => cause,
-            RebootBrokerError::Forbidden(ref cause) => cause,
-            RebootBrokerError::InternalServerError(ref cause) => cause,
-            RebootBrokerError::NotFound(ref cause) => cause,
+            RebootBrokerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            RebootBrokerError::Forbidden(ref cause) => write!(f, "{}", cause),
+            RebootBrokerError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RebootBrokerError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootBrokerError {}
 /// Errors returned by UpdateBroker
 #[derive(Debug, PartialEq)]
 pub enum UpdateBrokerError {
@@ -2197,20 +2129,16 @@ impl UpdateBrokerError {
 }
 impl fmt::Display for UpdateBrokerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBrokerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBrokerError::BadRequest(ref cause) => cause,
-            UpdateBrokerError::Conflict(ref cause) => cause,
-            UpdateBrokerError::Forbidden(ref cause) => cause,
-            UpdateBrokerError::InternalServerError(ref cause) => cause,
-            UpdateBrokerError::NotFound(ref cause) => cause,
+            UpdateBrokerError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateBrokerError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateBrokerError {}
 /// Errors returned by UpdateConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateConfigurationError {
@@ -2256,20 +2184,16 @@ impl UpdateConfigurationError {
 }
 impl fmt::Display for UpdateConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConfigurationError::BadRequest(ref cause) => cause,
-            UpdateConfigurationError::Conflict(ref cause) => cause,
-            UpdateConfigurationError::Forbidden(ref cause) => cause,
-            UpdateConfigurationError::InternalServerError(ref cause) => cause,
-            UpdateConfigurationError::NotFound(ref cause) => cause,
+            UpdateConfigurationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateConfigurationError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateConfigurationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateConfigurationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateConfigurationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConfigurationError {}
 /// Errors returned by UpdateUser
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserError {
@@ -2313,20 +2237,16 @@ impl UpdateUserError {
 }
 impl fmt::Display for UpdateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserError::BadRequest(ref cause) => cause,
-            UpdateUserError::Conflict(ref cause) => cause,
-            UpdateUserError::Forbidden(ref cause) => cause,
-            UpdateUserError::InternalServerError(ref cause) => cause,
-            UpdateUserError::NotFound(ref cause) => cause,
+            UpdateUserError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserError {}
 /// Trait representing the capabilities of the AmazonMQ API. AmazonMQ clients implement this trait.
 pub trait MQ {
     /// <p>Creates a broker. Note: This API is asynchronous.</p>

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -1566,17 +1566,13 @@ impl AcceptQualificationRequestError {
 }
 impl fmt::Display for AcceptQualificationRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptQualificationRequestError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptQualificationRequestError::RequestError(ref cause) => cause,
-            AcceptQualificationRequestError::ServiceFault(ref cause) => cause,
+            AcceptQualificationRequestError::RequestError(ref cause) => write!(f, "{}", cause),
+            AcceptQualificationRequestError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptQualificationRequestError {}
 /// Errors returned by ApproveAssignment
 #[derive(Debug, PartialEq)]
 pub enum ApproveAssignmentError {
@@ -1605,17 +1601,13 @@ impl ApproveAssignmentError {
 }
 impl fmt::Display for ApproveAssignmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApproveAssignmentError {
-    fn description(&self) -> &str {
         match *self {
-            ApproveAssignmentError::RequestError(ref cause) => cause,
-            ApproveAssignmentError::ServiceFault(ref cause) => cause,
+            ApproveAssignmentError::RequestError(ref cause) => write!(f, "{}", cause),
+            ApproveAssignmentError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ApproveAssignmentError {}
 /// Errors returned by AssociateQualificationWithWorker
 #[derive(Debug, PartialEq)]
 pub enum AssociateQualificationWithWorkerError {
@@ -1650,17 +1642,17 @@ impl AssociateQualificationWithWorkerError {
 }
 impl fmt::Display for AssociateQualificationWithWorkerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateQualificationWithWorkerError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateQualificationWithWorkerError::RequestError(ref cause) => cause,
-            AssociateQualificationWithWorkerError::ServiceFault(ref cause) => cause,
+            AssociateQualificationWithWorkerError::RequestError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateQualificationWithWorkerError::ServiceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateQualificationWithWorkerError {}
 /// Errors returned by CreateAdditionalAssignmentsForHIT
 #[derive(Debug, PartialEq)]
 pub enum CreateAdditionalAssignmentsForHITError {
@@ -1695,17 +1687,17 @@ impl CreateAdditionalAssignmentsForHITError {
 }
 impl fmt::Display for CreateAdditionalAssignmentsForHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAdditionalAssignmentsForHITError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAdditionalAssignmentsForHITError::RequestError(ref cause) => cause,
-            CreateAdditionalAssignmentsForHITError::ServiceFault(ref cause) => cause,
+            CreateAdditionalAssignmentsForHITError::RequestError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAdditionalAssignmentsForHITError::ServiceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateAdditionalAssignmentsForHITError {}
 /// Errors returned by CreateHIT
 #[derive(Debug, PartialEq)]
 pub enum CreateHITError {
@@ -1734,17 +1726,13 @@ impl CreateHITError {
 }
 impl fmt::Display for CreateHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHITError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHITError::RequestError(ref cause) => cause,
-            CreateHITError::ServiceFault(ref cause) => cause,
+            CreateHITError::RequestError(ref cause) => write!(f, "{}", cause),
+            CreateHITError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHITError {}
 /// Errors returned by CreateHITType
 #[derive(Debug, PartialEq)]
 pub enum CreateHITTypeError {
@@ -1773,17 +1761,13 @@ impl CreateHITTypeError {
 }
 impl fmt::Display for CreateHITTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHITTypeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHITTypeError::RequestError(ref cause) => cause,
-            CreateHITTypeError::ServiceFault(ref cause) => cause,
+            CreateHITTypeError::RequestError(ref cause) => write!(f, "{}", cause),
+            CreateHITTypeError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHITTypeError {}
 /// Errors returned by CreateHITWithHITType
 #[derive(Debug, PartialEq)]
 pub enum CreateHITWithHITTypeError {
@@ -1812,17 +1796,13 @@ impl CreateHITWithHITTypeError {
 }
 impl fmt::Display for CreateHITWithHITTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHITWithHITTypeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHITWithHITTypeError::RequestError(ref cause) => cause,
-            CreateHITWithHITTypeError::ServiceFault(ref cause) => cause,
+            CreateHITWithHITTypeError::RequestError(ref cause) => write!(f, "{}", cause),
+            CreateHITWithHITTypeError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHITWithHITTypeError {}
 /// Errors returned by CreateQualificationType
 #[derive(Debug, PartialEq)]
 pub enum CreateQualificationTypeError {
@@ -1855,17 +1835,13 @@ impl CreateQualificationTypeError {
 }
 impl fmt::Display for CreateQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateQualificationTypeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateQualificationTypeError::RequestError(ref cause) => cause,
-            CreateQualificationTypeError::ServiceFault(ref cause) => cause,
+            CreateQualificationTypeError::RequestError(ref cause) => write!(f, "{}", cause),
+            CreateQualificationTypeError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateQualificationTypeError {}
 /// Errors returned by CreateWorkerBlock
 #[derive(Debug, PartialEq)]
 pub enum CreateWorkerBlockError {
@@ -1894,17 +1870,13 @@ impl CreateWorkerBlockError {
 }
 impl fmt::Display for CreateWorkerBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWorkerBlockError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWorkerBlockError::RequestError(ref cause) => cause,
-            CreateWorkerBlockError::ServiceFault(ref cause) => cause,
+            CreateWorkerBlockError::RequestError(ref cause) => write!(f, "{}", cause),
+            CreateWorkerBlockError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWorkerBlockError {}
 /// Errors returned by DeleteHIT
 #[derive(Debug, PartialEq)]
 pub enum DeleteHITError {
@@ -1933,17 +1905,13 @@ impl DeleteHITError {
 }
 impl fmt::Display for DeleteHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHITError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHITError::RequestError(ref cause) => cause,
-            DeleteHITError::ServiceFault(ref cause) => cause,
+            DeleteHITError::RequestError(ref cause) => write!(f, "{}", cause),
+            DeleteHITError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteHITError {}
 /// Errors returned by DeleteQualificationType
 #[derive(Debug, PartialEq)]
 pub enum DeleteQualificationTypeError {
@@ -1976,17 +1944,13 @@ impl DeleteQualificationTypeError {
 }
 impl fmt::Display for DeleteQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteQualificationTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteQualificationTypeError::RequestError(ref cause) => cause,
-            DeleteQualificationTypeError::ServiceFault(ref cause) => cause,
+            DeleteQualificationTypeError::RequestError(ref cause) => write!(f, "{}", cause),
+            DeleteQualificationTypeError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteQualificationTypeError {}
 /// Errors returned by DeleteWorkerBlock
 #[derive(Debug, PartialEq)]
 pub enum DeleteWorkerBlockError {
@@ -2015,17 +1979,13 @@ impl DeleteWorkerBlockError {
 }
 impl fmt::Display for DeleteWorkerBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWorkerBlockError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWorkerBlockError::RequestError(ref cause) => cause,
-            DeleteWorkerBlockError::ServiceFault(ref cause) => cause,
+            DeleteWorkerBlockError::RequestError(ref cause) => write!(f, "{}", cause),
+            DeleteWorkerBlockError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWorkerBlockError {}
 /// Errors returned by DisassociateQualificationFromWorker
 #[derive(Debug, PartialEq)]
 pub enum DisassociateQualificationFromWorkerError {
@@ -2060,17 +2020,17 @@ impl DisassociateQualificationFromWorkerError {
 }
 impl fmt::Display for DisassociateQualificationFromWorkerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateQualificationFromWorkerError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateQualificationFromWorkerError::RequestError(ref cause) => cause,
-            DisassociateQualificationFromWorkerError::ServiceFault(ref cause) => cause,
+            DisassociateQualificationFromWorkerError::RequestError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateQualificationFromWorkerError::ServiceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateQualificationFromWorkerError {}
 /// Errors returned by GetAccountBalance
 #[derive(Debug, PartialEq)]
 pub enum GetAccountBalanceError {
@@ -2099,17 +2059,13 @@ impl GetAccountBalanceError {
 }
 impl fmt::Display for GetAccountBalanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountBalanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountBalanceError::RequestError(ref cause) => cause,
-            GetAccountBalanceError::ServiceFault(ref cause) => cause,
+            GetAccountBalanceError::RequestError(ref cause) => write!(f, "{}", cause),
+            GetAccountBalanceError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountBalanceError {}
 /// Errors returned by GetAssignment
 #[derive(Debug, PartialEq)]
 pub enum GetAssignmentError {
@@ -2138,17 +2094,13 @@ impl GetAssignmentError {
 }
 impl fmt::Display for GetAssignmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAssignmentError {
-    fn description(&self) -> &str {
         match *self {
-            GetAssignmentError::RequestError(ref cause) => cause,
-            GetAssignmentError::ServiceFault(ref cause) => cause,
+            GetAssignmentError::RequestError(ref cause) => write!(f, "{}", cause),
+            GetAssignmentError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAssignmentError {}
 /// Errors returned by GetFileUploadURL
 #[derive(Debug, PartialEq)]
 pub enum GetFileUploadURLError {
@@ -2177,17 +2129,13 @@ impl GetFileUploadURLError {
 }
 impl fmt::Display for GetFileUploadURLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFileUploadURLError {
-    fn description(&self) -> &str {
         match *self {
-            GetFileUploadURLError::RequestError(ref cause) => cause,
-            GetFileUploadURLError::ServiceFault(ref cause) => cause,
+            GetFileUploadURLError::RequestError(ref cause) => write!(f, "{}", cause),
+            GetFileUploadURLError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFileUploadURLError {}
 /// Errors returned by GetHIT
 #[derive(Debug, PartialEq)]
 pub enum GetHITError {
@@ -2212,17 +2160,13 @@ impl GetHITError {
 }
 impl fmt::Display for GetHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHITError {
-    fn description(&self) -> &str {
         match *self {
-            GetHITError::RequestError(ref cause) => cause,
-            GetHITError::ServiceFault(ref cause) => cause,
+            GetHITError::RequestError(ref cause) => write!(f, "{}", cause),
+            GetHITError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetHITError {}
 /// Errors returned by GetQualificationScore
 #[derive(Debug, PartialEq)]
 pub enum GetQualificationScoreError {
@@ -2251,17 +2195,13 @@ impl GetQualificationScoreError {
 }
 impl fmt::Display for GetQualificationScoreError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQualificationScoreError {
-    fn description(&self) -> &str {
         match *self {
-            GetQualificationScoreError::RequestError(ref cause) => cause,
-            GetQualificationScoreError::ServiceFault(ref cause) => cause,
+            GetQualificationScoreError::RequestError(ref cause) => write!(f, "{}", cause),
+            GetQualificationScoreError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQualificationScoreError {}
 /// Errors returned by GetQualificationType
 #[derive(Debug, PartialEq)]
 pub enum GetQualificationTypeError {
@@ -2290,17 +2230,13 @@ impl GetQualificationTypeError {
 }
 impl fmt::Display for GetQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQualificationTypeError {
-    fn description(&self) -> &str {
         match *self {
-            GetQualificationTypeError::RequestError(ref cause) => cause,
-            GetQualificationTypeError::ServiceFault(ref cause) => cause,
+            GetQualificationTypeError::RequestError(ref cause) => write!(f, "{}", cause),
+            GetQualificationTypeError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQualificationTypeError {}
 /// Errors returned by ListAssignmentsForHIT
 #[derive(Debug, PartialEq)]
 pub enum ListAssignmentsForHITError {
@@ -2329,17 +2265,13 @@ impl ListAssignmentsForHITError {
 }
 impl fmt::Display for ListAssignmentsForHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssignmentsForHITError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssignmentsForHITError::RequestError(ref cause) => cause,
-            ListAssignmentsForHITError::ServiceFault(ref cause) => cause,
+            ListAssignmentsForHITError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListAssignmentsForHITError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAssignmentsForHITError {}
 /// Errors returned by ListBonusPayments
 #[derive(Debug, PartialEq)]
 pub enum ListBonusPaymentsError {
@@ -2368,17 +2300,13 @@ impl ListBonusPaymentsError {
 }
 impl fmt::Display for ListBonusPaymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBonusPaymentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListBonusPaymentsError::RequestError(ref cause) => cause,
-            ListBonusPaymentsError::ServiceFault(ref cause) => cause,
+            ListBonusPaymentsError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListBonusPaymentsError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBonusPaymentsError {}
 /// Errors returned by ListHITs
 #[derive(Debug, PartialEq)]
 pub enum ListHITsError {
@@ -2407,17 +2335,13 @@ impl ListHITsError {
 }
 impl fmt::Display for ListHITsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHITsError {
-    fn description(&self) -> &str {
         match *self {
-            ListHITsError::RequestError(ref cause) => cause,
-            ListHITsError::ServiceFault(ref cause) => cause,
+            ListHITsError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListHITsError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHITsError {}
 /// Errors returned by ListHITsForQualificationType
 #[derive(Debug, PartialEq)]
 pub enum ListHITsForQualificationTypeError {
@@ -2452,17 +2376,13 @@ impl ListHITsForQualificationTypeError {
 }
 impl fmt::Display for ListHITsForQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHITsForQualificationTypeError {
-    fn description(&self) -> &str {
         match *self {
-            ListHITsForQualificationTypeError::RequestError(ref cause) => cause,
-            ListHITsForQualificationTypeError::ServiceFault(ref cause) => cause,
+            ListHITsForQualificationTypeError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListHITsForQualificationTypeError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHITsForQualificationTypeError {}
 /// Errors returned by ListQualificationRequests
 #[derive(Debug, PartialEq)]
 pub enum ListQualificationRequestsError {
@@ -2495,17 +2415,13 @@ impl ListQualificationRequestsError {
 }
 impl fmt::Display for ListQualificationRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQualificationRequestsError {
-    fn description(&self) -> &str {
         match *self {
-            ListQualificationRequestsError::RequestError(ref cause) => cause,
-            ListQualificationRequestsError::ServiceFault(ref cause) => cause,
+            ListQualificationRequestsError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListQualificationRequestsError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListQualificationRequestsError {}
 /// Errors returned by ListQualificationTypes
 #[derive(Debug, PartialEq)]
 pub enum ListQualificationTypesError {
@@ -2534,17 +2450,13 @@ impl ListQualificationTypesError {
 }
 impl fmt::Display for ListQualificationTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQualificationTypesError {
-    fn description(&self) -> &str {
         match *self {
-            ListQualificationTypesError::RequestError(ref cause) => cause,
-            ListQualificationTypesError::ServiceFault(ref cause) => cause,
+            ListQualificationTypesError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListQualificationTypesError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListQualificationTypesError {}
 /// Errors returned by ListReviewPolicyResultsForHIT
 #[derive(Debug, PartialEq)]
 pub enum ListReviewPolicyResultsForHITError {
@@ -2579,17 +2491,13 @@ impl ListReviewPolicyResultsForHITError {
 }
 impl fmt::Display for ListReviewPolicyResultsForHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReviewPolicyResultsForHITError {
-    fn description(&self) -> &str {
         match *self {
-            ListReviewPolicyResultsForHITError::RequestError(ref cause) => cause,
-            ListReviewPolicyResultsForHITError::ServiceFault(ref cause) => cause,
+            ListReviewPolicyResultsForHITError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListReviewPolicyResultsForHITError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListReviewPolicyResultsForHITError {}
 /// Errors returned by ListReviewableHITs
 #[derive(Debug, PartialEq)]
 pub enum ListReviewableHITsError {
@@ -2618,17 +2526,13 @@ impl ListReviewableHITsError {
 }
 impl fmt::Display for ListReviewableHITsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReviewableHITsError {
-    fn description(&self) -> &str {
         match *self {
-            ListReviewableHITsError::RequestError(ref cause) => cause,
-            ListReviewableHITsError::ServiceFault(ref cause) => cause,
+            ListReviewableHITsError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListReviewableHITsError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListReviewableHITsError {}
 /// Errors returned by ListWorkerBlocks
 #[derive(Debug, PartialEq)]
 pub enum ListWorkerBlocksError {
@@ -2657,17 +2561,13 @@ impl ListWorkerBlocksError {
 }
 impl fmt::Display for ListWorkerBlocksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWorkerBlocksError {
-    fn description(&self) -> &str {
         match *self {
-            ListWorkerBlocksError::RequestError(ref cause) => cause,
-            ListWorkerBlocksError::ServiceFault(ref cause) => cause,
+            ListWorkerBlocksError::RequestError(ref cause) => write!(f, "{}", cause),
+            ListWorkerBlocksError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWorkerBlocksError {}
 /// Errors returned by ListWorkersWithQualificationType
 #[derive(Debug, PartialEq)]
 pub enum ListWorkersWithQualificationTypeError {
@@ -2702,17 +2602,17 @@ impl ListWorkersWithQualificationTypeError {
 }
 impl fmt::Display for ListWorkersWithQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWorkersWithQualificationTypeError {
-    fn description(&self) -> &str {
         match *self {
-            ListWorkersWithQualificationTypeError::RequestError(ref cause) => cause,
-            ListWorkersWithQualificationTypeError::ServiceFault(ref cause) => cause,
+            ListWorkersWithQualificationTypeError::RequestError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWorkersWithQualificationTypeError::ServiceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListWorkersWithQualificationTypeError {}
 /// Errors returned by NotifyWorkers
 #[derive(Debug, PartialEq)]
 pub enum NotifyWorkersError {
@@ -2741,17 +2641,13 @@ impl NotifyWorkersError {
 }
 impl fmt::Display for NotifyWorkersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for NotifyWorkersError {
-    fn description(&self) -> &str {
         match *self {
-            NotifyWorkersError::RequestError(ref cause) => cause,
-            NotifyWorkersError::ServiceFault(ref cause) => cause,
+            NotifyWorkersError::RequestError(ref cause) => write!(f, "{}", cause),
+            NotifyWorkersError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for NotifyWorkersError {}
 /// Errors returned by RejectAssignment
 #[derive(Debug, PartialEq)]
 pub enum RejectAssignmentError {
@@ -2780,17 +2676,13 @@ impl RejectAssignmentError {
 }
 impl fmt::Display for RejectAssignmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RejectAssignmentError {
-    fn description(&self) -> &str {
         match *self {
-            RejectAssignmentError::RequestError(ref cause) => cause,
-            RejectAssignmentError::ServiceFault(ref cause) => cause,
+            RejectAssignmentError::RequestError(ref cause) => write!(f, "{}", cause),
+            RejectAssignmentError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RejectAssignmentError {}
 /// Errors returned by RejectQualificationRequest
 #[derive(Debug, PartialEq)]
 pub enum RejectQualificationRequestError {
@@ -2825,17 +2717,13 @@ impl RejectQualificationRequestError {
 }
 impl fmt::Display for RejectQualificationRequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RejectQualificationRequestError {
-    fn description(&self) -> &str {
         match *self {
-            RejectQualificationRequestError::RequestError(ref cause) => cause,
-            RejectQualificationRequestError::ServiceFault(ref cause) => cause,
+            RejectQualificationRequestError::RequestError(ref cause) => write!(f, "{}", cause),
+            RejectQualificationRequestError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RejectQualificationRequestError {}
 /// Errors returned by SendBonus
 #[derive(Debug, PartialEq)]
 pub enum SendBonusError {
@@ -2864,17 +2752,13 @@ impl SendBonusError {
 }
 impl fmt::Display for SendBonusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendBonusError {
-    fn description(&self) -> &str {
         match *self {
-            SendBonusError::RequestError(ref cause) => cause,
-            SendBonusError::ServiceFault(ref cause) => cause,
+            SendBonusError::RequestError(ref cause) => write!(f, "{}", cause),
+            SendBonusError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendBonusError {}
 /// Errors returned by SendTestEventNotification
 #[derive(Debug, PartialEq)]
 pub enum SendTestEventNotificationError {
@@ -2907,17 +2791,13 @@ impl SendTestEventNotificationError {
 }
 impl fmt::Display for SendTestEventNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendTestEventNotificationError {
-    fn description(&self) -> &str {
         match *self {
-            SendTestEventNotificationError::RequestError(ref cause) => cause,
-            SendTestEventNotificationError::ServiceFault(ref cause) => cause,
+            SendTestEventNotificationError::RequestError(ref cause) => write!(f, "{}", cause),
+            SendTestEventNotificationError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendTestEventNotificationError {}
 /// Errors returned by UpdateExpirationForHIT
 #[derive(Debug, PartialEq)]
 pub enum UpdateExpirationForHITError {
@@ -2946,17 +2826,13 @@ impl UpdateExpirationForHITError {
 }
 impl fmt::Display for UpdateExpirationForHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateExpirationForHITError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateExpirationForHITError::RequestError(ref cause) => cause,
-            UpdateExpirationForHITError::ServiceFault(ref cause) => cause,
+            UpdateExpirationForHITError::RequestError(ref cause) => write!(f, "{}", cause),
+            UpdateExpirationForHITError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateExpirationForHITError {}
 /// Errors returned by UpdateHITReviewStatus
 #[derive(Debug, PartialEq)]
 pub enum UpdateHITReviewStatusError {
@@ -2985,17 +2861,13 @@ impl UpdateHITReviewStatusError {
 }
 impl fmt::Display for UpdateHITReviewStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateHITReviewStatusError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateHITReviewStatusError::RequestError(ref cause) => cause,
-            UpdateHITReviewStatusError::ServiceFault(ref cause) => cause,
+            UpdateHITReviewStatusError::RequestError(ref cause) => write!(f, "{}", cause),
+            UpdateHITReviewStatusError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateHITReviewStatusError {}
 /// Errors returned by UpdateHITTypeOfHIT
 #[derive(Debug, PartialEq)]
 pub enum UpdateHITTypeOfHITError {
@@ -3024,17 +2896,13 @@ impl UpdateHITTypeOfHITError {
 }
 impl fmt::Display for UpdateHITTypeOfHITError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateHITTypeOfHITError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateHITTypeOfHITError::RequestError(ref cause) => cause,
-            UpdateHITTypeOfHITError::ServiceFault(ref cause) => cause,
+            UpdateHITTypeOfHITError::RequestError(ref cause) => write!(f, "{}", cause),
+            UpdateHITTypeOfHITError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateHITTypeOfHITError {}
 /// Errors returned by UpdateNotificationSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateNotificationSettingsError {
@@ -3069,17 +2937,13 @@ impl UpdateNotificationSettingsError {
 }
 impl fmt::Display for UpdateNotificationSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNotificationSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNotificationSettingsError::RequestError(ref cause) => cause,
-            UpdateNotificationSettingsError::ServiceFault(ref cause) => cause,
+            UpdateNotificationSettingsError::RequestError(ref cause) => write!(f, "{}", cause),
+            UpdateNotificationSettingsError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNotificationSettingsError {}
 /// Errors returned by UpdateQualificationType
 #[derive(Debug, PartialEq)]
 pub enum UpdateQualificationTypeError {
@@ -3112,17 +2976,13 @@ impl UpdateQualificationTypeError {
 }
 impl fmt::Display for UpdateQualificationTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateQualificationTypeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateQualificationTypeError::RequestError(ref cause) => cause,
-            UpdateQualificationTypeError::ServiceFault(ref cause) => cause,
+            UpdateQualificationTypeError::RequestError(ref cause) => write!(f, "{}", cause),
+            UpdateQualificationTypeError::ServiceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateQualificationTypeError {}
 /// Trait representing the capabilities of the Amazon MTurk API. Amazon MTurk clients implement this trait.
 pub trait MechanicalTurk {
     /// <p> The <code>AcceptQualificationRequest</code> operation approves a Worker's request for a Qualification. </p> <p> Only the owner of the Qualification type can grant a Qualification request for that type. </p> <p> A successful request for the <code>AcceptQualificationRequest</code> operation returns with no errors and an empty body. </p>

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -8185,19 +8185,21 @@ impl AddRoleToDBClusterError {
 }
 impl fmt::Display for AddRoleToDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddRoleToDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            AddRoleToDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            AddRoleToDBClusterError::DBClusterRoleAlreadyExistsFault(ref cause) => cause,
-            AddRoleToDBClusterError::DBClusterRoleQuotaExceededFault(ref cause) => cause,
-            AddRoleToDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            AddRoleToDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddRoleToDBClusterError::DBClusterRoleAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddRoleToDBClusterError::DBClusterRoleQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddRoleToDBClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddRoleToDBClusterError {}
 /// Errors returned by AddSourceIdentifierToSubscription
 #[derive(Debug, PartialEq)]
 pub enum AddSourceIdentifierToSubscriptionError {
@@ -8248,17 +8250,17 @@ impl AddSourceIdentifierToSubscriptionError {
 }
 impl fmt::Display for AddSourceIdentifierToSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddSourceIdentifierToSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            AddSourceIdentifierToSubscriptionError::SourceNotFoundFault(ref cause) => cause,
-            AddSourceIdentifierToSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
+            AddSourceIdentifierToSubscriptionError::SourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddSourceIdentifierToSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddSourceIdentifierToSubscriptionError {}
 /// Errors returned by AddTagsToResource
 #[derive(Debug, PartialEq)]
 pub enum AddTagsToResourceError {
@@ -8310,18 +8312,14 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            AddTagsToResourceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by ApplyPendingMaintenanceAction
 #[derive(Debug, PartialEq)]
 pub enum ApplyPendingMaintenanceActionError {
@@ -8363,16 +8361,14 @@ impl ApplyPendingMaintenanceActionError {
 }
 impl fmt::Display for ApplyPendingMaintenanceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApplyPendingMaintenanceActionError {
-    fn description(&self) -> &str {
         match *self {
-            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => cause,
+            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ApplyPendingMaintenanceActionError {}
 /// Errors returned by CopyDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CopyDBClusterParameterGroupError {
@@ -8432,22 +8428,20 @@ impl CopyDBClusterParameterGroupError {
 }
 impl fmt::Display for CopyDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CopyDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CopyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            CopyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CopyDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CopyDBClusterParameterGroupError {}
 /// Errors returned by CopyDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CopyDBClusterSnapshotError {
@@ -8532,21 +8526,29 @@ impl CopyDBClusterSnapshotError {
 }
 impl fmt::Display for CopyDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CopyDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CopyDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CopyDBClusterSnapshotError {}
 /// Errors returned by CopyDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CopyDBParameterGroupError {
@@ -8604,18 +8606,20 @@ impl CopyDBParameterGroupError {
 }
 impl fmt::Display for CopyDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CopyDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => cause,
-            CopyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            CopyDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => cause,
+            CopyDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CopyDBParameterGroupError {}
 /// Errors returned by CreateDBCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterError {
@@ -8759,30 +8763,34 @@ impl CreateDBClusterError {
 }
 impl fmt::Display for CreateDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBClusterError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterQuotaExceededFault(ref cause) => cause,
-            CreateDBClusterError::DBInstanceNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::InsufficientStorageClusterCapacityFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidSubnet(ref cause) => cause,
-            CreateDBClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateDBClusterError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateDBClusterError::StorageQuotaExceededFault(ref cause) => cause,
+            CreateDBClusterError::DBClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::DBClusterQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InsufficientStorageClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBClusterError {}
 /// Errors returned by CreateDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterParameterGroupError {
@@ -8833,21 +8841,17 @@ impl CreateDBClusterParameterGroupError {
 }
 impl fmt::Display for CreateDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CreateDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CreateDBClusterParameterGroupError {}
 /// Errors returned by CreateDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterSnapshotError {
@@ -8923,20 +8927,26 @@ impl CreateDBClusterSnapshotError {
 }
 impl fmt::Display for CreateDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBClusterSnapshotError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CreateDBClusterSnapshotError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBClusterSnapshotError {}
 /// Errors returned by CreateDBInstance
 #[derive(Debug, PartialEq)]
 pub enum CreateDBInstanceError {
@@ -9109,33 +9119,43 @@ impl CreateDBInstanceError {
 }
 impl fmt::Display for CreateDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBInstanceError::AuthorizationNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            CreateDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DomainNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::InstanceQuotaExceededFault(ref cause) => cause,
-            CreateDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            CreateDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBInstanceError::InvalidSubnet(ref cause) => cause,
-            CreateDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateDBInstanceError::OptionGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => cause,
-            CreateDBInstanceError::StorageQuotaExceededFault(ref cause) => cause,
-            CreateDBInstanceError::StorageTypeNotSupportedFault(ref cause) => cause,
+            CreateDBInstanceError::AuthorizationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DomainNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InstanceQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::OptionGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBInstanceError {}
 /// Errors returned by CreateDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBParameterGroupError {
@@ -9184,17 +9204,17 @@ impl CreateDBParameterGroupError {
 }
 impl fmt::Display for CreateDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => cause,
-            CreateDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => cause,
+            CreateDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBParameterGroupError {}
 /// Errors returned by CreateDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBSubnetGroupError {
@@ -9268,20 +9288,24 @@ impl CreateDBSubnetGroupError {
 }
 impl fmt::Display for CreateDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetGroupQuotaExceededFault(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => cause,
-            CreateDBSubnetGroupError::InvalidSubnet(ref cause) => cause,
+            CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBSubnetGroupError {}
 /// Errors returned by CreateEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateEventSubscriptionError {
@@ -9373,22 +9397,28 @@ impl CreateEventSubscriptionError {
 }
 impl fmt::Display for CreateEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SourceNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionAlreadyExistFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => cause,
+            CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SubscriptionAlreadyExistFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateEventSubscriptionError {}
 /// Errors returned by DeleteDBCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterError {
@@ -9458,20 +9488,20 @@ impl DeleteDBClusterError {
 }
 impl fmt::Display for DeleteDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            DeleteDBClusterError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteDBClusterError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            DeleteDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            DeleteDBClusterError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBClusterError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBClusterError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBClusterError {}
 /// Errors returned by DeleteDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterParameterGroupError {
@@ -9522,19 +9552,17 @@ impl DeleteDBClusterParameterGroupError {
 }
 impl fmt::Display for DeleteDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteDBClusterParameterGroupError {}
 /// Errors returned by DeleteDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterSnapshotError {
@@ -9583,17 +9611,17 @@ impl DeleteDBClusterSnapshotError {
 }
 impl fmt::Display for DeleteDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            DeleteDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
+            DeleteDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBClusterSnapshotError {}
 /// Errors returned by DeleteDBInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBInstanceError {
@@ -9663,20 +9691,18 @@ impl DeleteDBInstanceError {
 }
 impl fmt::Display for DeleteDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            DeleteDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            DeleteDBInstanceError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBInstanceError {}
 /// Errors returned by DeleteDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBParameterGroupError {
@@ -9725,17 +9751,17 @@ impl DeleteDBParameterGroupError {
 }
 impl fmt::Display for DeleteDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            DeleteDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => cause,
+            DeleteDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBParameterGroupError {}
 /// Errors returned by DeleteDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBSubnetGroupError {
@@ -9793,18 +9819,20 @@ impl DeleteDBSubnetGroupError {
 }
 impl fmt::Display for DeleteDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            DeleteDBSubnetGroupError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            DeleteDBSubnetGroupError::InvalidDBSubnetStateFault(ref cause) => cause,
+            DeleteDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBSubnetGroupError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBSubnetGroupError::InvalidDBSubnetStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBSubnetGroupError {}
 /// Errors returned by DeleteEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteEventSubscriptionError {
@@ -9853,17 +9881,17 @@ impl DeleteEventSubscriptionError {
 }
 impl fmt::Display for DeleteEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEventSubscriptionError::InvalidEventSubscriptionStateFault(ref cause) => cause,
-            DeleteEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
+            DeleteEventSubscriptionError::InvalidEventSubscriptionStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteEventSubscriptionError {}
 /// Errors returned by DescribeDBClusterParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterParameterGroupsError {
@@ -9905,18 +9933,14 @@ impl DescribeDBClusterParameterGroupsError {
 }
 impl fmt::Display for DescribeDBClusterParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDBClusterParameterGroupsError::DBParameterGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeDBClusterParameterGroupsError {}
 /// Errors returned by DescribeDBClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterParametersError {
@@ -9958,16 +9982,14 @@ impl DescribeDBClusterParametersError {
 }
 impl fmt::Display for DescribeDBClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterParametersError {}
 /// Errors returned by DescribeDBClusterSnapshotAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterSnapshotAttributesError {
@@ -10007,18 +10029,14 @@ impl DescribeDBClusterSnapshotAttributesError {
 }
 impl fmt::Display for DescribeDBClusterSnapshotAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterSnapshotAttributesError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDBClusterSnapshotAttributesError::DBClusterSnapshotNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeDBClusterSnapshotAttributesError {}
 /// Errors returned by DescribeDBClusterSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterSnapshotsError {
@@ -10060,16 +10078,14 @@ impl DescribeDBClusterSnapshotsError {
 }
 impl fmt::Display for DescribeDBClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterSnapshotsError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
+            DescribeDBClusterSnapshotsError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterSnapshotsError {}
 /// Errors returned by DescribeDBClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClustersError {
@@ -10107,16 +10123,12 @@ impl DescribeDBClustersError {
 }
 impl fmt::Display for DescribeDBClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClustersError::DBClusterNotFoundFault(ref cause) => cause,
+            DescribeDBClustersError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBClustersError {}
 /// Errors returned by DescribeDBEngineVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBEngineVersionsError {}
@@ -10146,14 +10158,10 @@ impl DescribeDBEngineVersionsError {
 }
 impl fmt::Display for DescribeDBEngineVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBEngineVersionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeDBEngineVersionsError {}
 /// Errors returned by DescribeDBInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBInstancesError {
@@ -10191,16 +10199,12 @@ impl DescribeDBInstancesError {
 }
 impl fmt::Display for DescribeDBInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBInstancesError::DBInstanceNotFoundFault(ref cause) => cause,
+            DescribeDBInstancesError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBInstancesError {}
 /// Errors returned by DescribeDBParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBParameterGroupsError {
@@ -10240,16 +10244,14 @@ impl DescribeDBParameterGroupsError {
 }
 impl fmt::Display for DescribeDBParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBParameterGroupsError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeDBParameterGroupsError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBParameterGroupsError {}
 /// Errors returned by DescribeDBParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBParametersError {
@@ -10289,16 +10291,14 @@ impl DescribeDBParametersError {
 }
 impl fmt::Display for DescribeDBParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBParametersError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeDBParametersError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBParametersError {}
 /// Errors returned by DescribeDBSubnetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBSubnetGroupsError {
@@ -10338,16 +10338,14 @@ impl DescribeDBSubnetGroupsError {
 }
 impl fmt::Display for DescribeDBSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBSubnetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBSubnetGroupsError::DBSubnetGroupNotFoundFault(ref cause) => cause,
+            DescribeDBSubnetGroupsError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBSubnetGroupsError {}
 /// Errors returned by DescribeEngineDefaultClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeEngineDefaultClusterParametersError {}
@@ -10379,14 +10377,10 @@ impl DescribeEngineDefaultClusterParametersError {
 }
 impl fmt::Display for DescribeEngineDefaultClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEngineDefaultClusterParametersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEngineDefaultClusterParametersError {}
 /// Errors returned by DescribeEngineDefaultParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeEngineDefaultParametersError {}
@@ -10418,14 +10412,10 @@ impl DescribeEngineDefaultParametersError {
 }
 impl fmt::Display for DescribeEngineDefaultParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEngineDefaultParametersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEngineDefaultParametersError {}
 /// Errors returned by DescribeEventCategories
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventCategoriesError {}
@@ -10455,14 +10445,10 @@ impl DescribeEventCategoriesError {
 }
 impl fmt::Display for DescribeEventCategoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventCategoriesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventCategoriesError {}
 /// Errors returned by DescribeEventSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventSubscriptionsError {
@@ -10504,16 +10490,14 @@ impl DescribeEventSubscriptionsError {
 }
 impl fmt::Display for DescribeEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventSubscriptionsError::SubscriptionNotFoundFault(ref cause) => cause,
+            DescribeEventSubscriptionsError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEventSubscriptionsError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {}
@@ -10543,14 +10527,10 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeOrderableDBInstanceOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrderableDBInstanceOptionsError {}
@@ -10582,14 +10562,10 @@ impl DescribeOrderableDBInstanceOptionsError {
 }
 impl fmt::Display for DescribeOrderableDBInstanceOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrderableDBInstanceOptionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeOrderableDBInstanceOptionsError {}
 /// Errors returned by DescribePendingMaintenanceActions
 #[derive(Debug, PartialEq)]
 pub enum DescribePendingMaintenanceActionsError {
@@ -10631,16 +10607,14 @@ impl DescribePendingMaintenanceActionsError {
 }
 impl fmt::Display for DescribePendingMaintenanceActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePendingMaintenanceActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePendingMaintenanceActionsError {}
 /// Errors returned by DescribeValidDBInstanceModifications
 #[derive(Debug, PartialEq)]
 pub enum DescribeValidDBInstanceModificationsError {
@@ -10691,19 +10665,17 @@ impl DescribeValidDBInstanceModificationsError {
 }
 impl fmt::Display for DescribeValidDBInstanceModificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeValidDBInstanceModificationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeValidDBInstanceModificationsError::DBInstanceNotFoundFault(ref cause) => cause,
+            DescribeValidDBInstanceModificationsError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeValidDBInstanceModificationsError::InvalidDBInstanceStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeValidDBInstanceModificationsError {}
 /// Errors returned by FailoverDBCluster
 #[derive(Debug, PartialEq)]
 pub enum FailoverDBClusterError {
@@ -10759,18 +10731,16 @@ impl FailoverDBClusterError {
 }
 impl fmt::Display for FailoverDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FailoverDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            FailoverDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            FailoverDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            FailoverDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
+            FailoverDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            FailoverDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            FailoverDBClusterError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for FailoverDBClusterError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -10822,18 +10792,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            ListTagsForResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            ListTagsForResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            ListTagsForResourceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ModifyDBCluster
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterError {
@@ -10947,26 +10913,28 @@ impl ModifyDBClusterError {
 }
 impl fmt::Display for ModifyDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBClusterError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            ModifyDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidSubnet(ref cause) => cause,
-            ModifyDBClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyDBClusterError::StorageQuotaExceededFault(ref cause) => cause,
+            ModifyDBClusterError::DBClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBClusterError {}
 /// Errors returned by ModifyDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterParameterGroupError {
@@ -11017,19 +10985,17 @@ impl ModifyDBClusterParameterGroupError {
 }
 impl fmt::Display for ModifyDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ModifyDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ModifyDBClusterParameterGroupError {}
 /// Errors returned by ModifyDBClusterSnapshotAttribute
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterSnapshotAttributeError {
@@ -11087,24 +11053,20 @@ impl ModifyDBClusterSnapshotAttributeError {
 }
 impl fmt::Display for ModifyDBClusterSnapshotAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterSnapshotAttributeError {
-    fn description(&self) -> &str {
         match *self {
             ModifyDBClusterSnapshotAttributeError::DBClusterSnapshotNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             ModifyDBClusterSnapshotAttributeError::InvalidDBClusterSnapshotStateFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ModifyDBClusterSnapshotAttributeError::SharedSnapshotQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ModifyDBClusterSnapshotAttributeError {}
 /// Errors returned by ModifyDBInstance
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBInstanceError {
@@ -11267,31 +11229,43 @@ impl ModifyDBInstanceError {
 }
 impl fmt::Display for ModifyDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBInstanceError::AuthorizationNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::CertificateNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            ModifyDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBUpgradeDependencyFailureFault(ref cause) => cause,
-            ModifyDBInstanceError::DomainNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyDBInstanceError::OptionGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => cause,
-            ModifyDBInstanceError::StorageQuotaExceededFault(ref cause) => cause,
-            ModifyDBInstanceError::StorageTypeNotSupportedFault(ref cause) => cause,
+            ModifyDBInstanceError::AuthorizationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::CertificateNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBUpgradeDependencyFailureFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DomainNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::OptionGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBInstanceError {}
 /// Errors returned by ModifyDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBParameterGroupError {
@@ -11340,17 +11314,17 @@ impl ModifyDBParameterGroupError {
 }
 impl fmt::Display for ModifyDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => cause,
+            ModifyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBParameterGroupError {}
 /// Errors returned by ModifyDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBSubnetGroupError {
@@ -11422,20 +11396,22 @@ impl ModifyDBSubnetGroupError {
 }
 impl fmt::Display for ModifyDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            ModifyDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => cause,
-            ModifyDBSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            ModifyDBSubnetGroupError::SubnetAlreadyInUse(ref cause) => cause,
+            ModifyDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyDBSubnetGroupError::SubnetAlreadyInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBSubnetGroupError {}
 /// Errors returned by ModifyEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum ModifyEventSubscriptionError {
@@ -11520,21 +11496,27 @@ impl ModifyEventSubscriptionError {
 }
 impl fmt::Display for ModifyEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
+            ModifyEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyEventSubscriptionError {}
 /// Errors returned by PromoteReadReplicaDBCluster
 #[derive(Debug, PartialEq)]
 pub enum PromoteReadReplicaDBClusterError {
@@ -11585,17 +11567,17 @@ impl PromoteReadReplicaDBClusterError {
 }
 impl fmt::Display for PromoteReadReplicaDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PromoteReadReplicaDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            PromoteReadReplicaDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            PromoteReadReplicaDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            PromoteReadReplicaDBClusterError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PromoteReadReplicaDBClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PromoteReadReplicaDBClusterError {}
 /// Errors returned by RebootDBInstance
 #[derive(Debug, PartialEq)]
 pub enum RebootDBInstanceError {
@@ -11642,17 +11624,13 @@ impl RebootDBInstanceError {
 }
 impl fmt::Display for RebootDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RebootDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            RebootDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
+            RebootDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RebootDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootDBInstanceError {}
 /// Errors returned by RemoveRoleFromDBCluster
 #[derive(Debug, PartialEq)]
 pub enum RemoveRoleFromDBClusterError {
@@ -11710,18 +11688,20 @@ impl RemoveRoleFromDBClusterError {
 }
 impl fmt::Display for RemoveRoleFromDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveRoleFromDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveRoleFromDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            RemoveRoleFromDBClusterError::DBClusterRoleNotFoundFault(ref cause) => cause,
-            RemoveRoleFromDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            RemoveRoleFromDBClusterError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveRoleFromDBClusterError::DBClusterRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveRoleFromDBClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveRoleFromDBClusterError {}
 /// Errors returned by RemoveSourceIdentifierFromSubscription
 #[derive(Debug, PartialEq)]
 pub enum RemoveSourceIdentifierFromSubscriptionError {
@@ -11772,19 +11752,17 @@ impl RemoveSourceIdentifierFromSubscriptionError {
 }
 impl fmt::Display for RemoveSourceIdentifierFromSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveSourceIdentifierFromSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveSourceIdentifierFromSubscriptionError::SourceNotFoundFault(ref cause) => cause,
+            RemoveSourceIdentifierFromSubscriptionError::SourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RemoveSourceIdentifierFromSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for RemoveSourceIdentifierFromSubscriptionError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -11842,18 +11820,20 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            RemoveTagsFromResourceError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromResourceError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromResourceError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by ResetDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ResetDBClusterParameterGroupError {
@@ -11904,19 +11884,17 @@ impl ResetDBClusterParameterGroupError {
 }
 impl fmt::Display for ResetDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ResetDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ResetDBClusterParameterGroupError {}
 /// Errors returned by ResetDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ResetDBParameterGroupError {
@@ -11965,17 +11943,17 @@ impl ResetDBParameterGroupError {
 }
 impl fmt::Display for ResetDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ResetDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            ResetDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => cause,
+            ResetDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResetDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ResetDBParameterGroupError {}
 /// Errors returned by RestoreDBClusterFromSnapshot
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBClusterFromSnapshotError {
@@ -12148,39 +12126,57 @@ impl RestoreDBClusterFromSnapshotError {
 }
 impl fmt::Display for RestoreDBClusterFromSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBClusterFromSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBClusterFromSnapshotError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBClusterParameterGroupNotFoundFault(ref cause) => {
-                cause
+            RestoreDBClusterFromSnapshotError::DBClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterFromSnapshotError::DBClusterQuotaExceededFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => cause,
+            RestoreDBClusterFromSnapshotError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBClusterFromSnapshotError::InsufficientDBClusterCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RestoreDBClusterFromSnapshotError::InsufficientStorageClusterCapacityFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RestoreDBClusterFromSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterFromSnapshotError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidSubnet(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::OptionGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::StorageQuotaExceededFault(ref cause) => cause,
+            RestoreDBClusterFromSnapshotError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterFromSnapshotError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBClusterFromSnapshotError {}
 /// Errors returned by RestoreDBClusterToPointInTime
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBClusterToPointInTimeError {
@@ -12360,40 +12356,60 @@ impl RestoreDBClusterToPointInTimeError {
 }
 impl fmt::Display for RestoreDBClusterToPointInTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBClusterToPointInTimeError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBClusterToPointInTimeError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterParameterGroupNotFoundFault(ref cause) => {
-                cause
+            RestoreDBClusterToPointInTimeError::DBClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterToPointInTimeError::DBClusterQuotaExceededFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => cause,
+            RestoreDBClusterToPointInTimeError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBClusterToPointInTimeError::InsufficientDBClusterCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RestoreDBClusterToPointInTimeError::InsufficientStorageClusterCapacityFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RestoreDBClusterToPointInTimeError::InvalidDBClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterToPointInTimeError::InvalidDBClusterStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidSubnet(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::OptionGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::StorageQuotaExceededFault(ref cause) => cause,
+            RestoreDBClusterToPointInTimeError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBClusterToPointInTimeError {}
 /// Trait representing the capabilities of the Amazon Neptune API. Amazon Neptune clients implement this trait.
 pub trait Neptune {
     /// <p>Associates an Identity and Access Management (IAM) role from an Neptune DB cluster.</p>

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -3279,16 +3279,12 @@ impl AssignInstanceError {
 }
 impl fmt::Display for AssignInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssignInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            AssignInstanceError::ResourceNotFound(ref cause) => cause,
+            AssignInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssignInstanceError {}
 /// Errors returned by AssignVolume
 #[derive(Debug, PartialEq)]
 pub enum AssignVolumeError {
@@ -3312,16 +3308,12 @@ impl AssignVolumeError {
 }
 impl fmt::Display for AssignVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssignVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            AssignVolumeError::ResourceNotFound(ref cause) => cause,
+            AssignVolumeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssignVolumeError {}
 /// Errors returned by AssociateElasticIp
 #[derive(Debug, PartialEq)]
 pub enum AssociateElasticIpError {
@@ -3345,16 +3337,12 @@ impl AssociateElasticIpError {
 }
 impl fmt::Display for AssociateElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateElasticIpError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateElasticIpError::ResourceNotFound(ref cause) => cause,
+            AssociateElasticIpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateElasticIpError {}
 /// Errors returned by AttachElasticLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum AttachElasticLoadBalancerError {
@@ -3380,16 +3368,12 @@ impl AttachElasticLoadBalancerError {
 }
 impl fmt::Display for AttachElasticLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachElasticLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            AttachElasticLoadBalancerError::ResourceNotFound(ref cause) => cause,
+            AttachElasticLoadBalancerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachElasticLoadBalancerError {}
 /// Errors returned by CloneStack
 #[derive(Debug, PartialEq)]
 pub enum CloneStackError {
@@ -3413,16 +3397,12 @@ impl CloneStackError {
 }
 impl fmt::Display for CloneStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CloneStackError {
-    fn description(&self) -> &str {
         match *self {
-            CloneStackError::ResourceNotFound(ref cause) => cause,
+            CloneStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CloneStackError {}
 /// Errors returned by CreateApp
 #[derive(Debug, PartialEq)]
 pub enum CreateAppError {
@@ -3446,16 +3426,12 @@ impl CreateAppError {
 }
 impl fmt::Display for CreateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAppError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAppError::ResourceNotFound(ref cause) => cause,
+            CreateAppError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAppError {}
 /// Errors returned by CreateDeployment
 #[derive(Debug, PartialEq)]
 pub enum CreateDeploymentError {
@@ -3479,16 +3455,12 @@ impl CreateDeploymentError {
 }
 impl fmt::Display for CreateDeploymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDeploymentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDeploymentError::ResourceNotFound(ref cause) => cause,
+            CreateDeploymentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDeploymentError {}
 /// Errors returned by CreateInstance
 #[derive(Debug, PartialEq)]
 pub enum CreateInstanceError {
@@ -3512,16 +3484,12 @@ impl CreateInstanceError {
 }
 impl fmt::Display for CreateInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInstanceError::ResourceNotFound(ref cause) => cause,
+            CreateInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInstanceError {}
 /// Errors returned by CreateLayer
 #[derive(Debug, PartialEq)]
 pub enum CreateLayerError {
@@ -3545,16 +3513,12 @@ impl CreateLayerError {
 }
 impl fmt::Display for CreateLayerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLayerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLayerError::ResourceNotFound(ref cause) => cause,
+            CreateLayerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLayerError {}
 /// Errors returned by CreateStack
 #[derive(Debug, PartialEq)]
 pub enum CreateStackError {}
@@ -3572,14 +3536,10 @@ impl CreateStackError {
 }
 impl fmt::Display for CreateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStackError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreateStackError {}
 /// Errors returned by CreateUserProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateUserProfileError {}
@@ -3597,14 +3557,10 @@ impl CreateUserProfileError {
 }
 impl fmt::Display for CreateUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserProfileError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreateUserProfileError {}
 /// Errors returned by DeleteApp
 #[derive(Debug, PartialEq)]
 pub enum DeleteAppError {
@@ -3628,16 +3584,12 @@ impl DeleteAppError {
 }
 impl fmt::Display for DeleteAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAppError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAppError::ResourceNotFound(ref cause) => cause,
+            DeleteAppError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAppError {}
 /// Errors returned by DeleteInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteInstanceError {
@@ -3661,16 +3613,12 @@ impl DeleteInstanceError {
 }
 impl fmt::Display for DeleteInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInstanceError::ResourceNotFound(ref cause) => cause,
+            DeleteInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInstanceError {}
 /// Errors returned by DeleteLayer
 #[derive(Debug, PartialEq)]
 pub enum DeleteLayerError {
@@ -3694,16 +3642,12 @@ impl DeleteLayerError {
 }
 impl fmt::Display for DeleteLayerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLayerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLayerError::ResourceNotFound(ref cause) => cause,
+            DeleteLayerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLayerError {}
 /// Errors returned by DeleteStack
 #[derive(Debug, PartialEq)]
 pub enum DeleteStackError {
@@ -3727,16 +3671,12 @@ impl DeleteStackError {
 }
 impl fmt::Display for DeleteStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStackError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStackError::ResourceNotFound(ref cause) => cause,
+            DeleteStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStackError {}
 /// Errors returned by DeleteUserProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserProfileError {
@@ -3760,16 +3700,12 @@ impl DeleteUserProfileError {
 }
 impl fmt::Display for DeleteUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserProfileError::ResourceNotFound(ref cause) => cause,
+            DeleteUserProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserProfileError {}
 /// Errors returned by DeregisterEcsCluster
 #[derive(Debug, PartialEq)]
 pub enum DeregisterEcsClusterError {
@@ -3795,16 +3731,12 @@ impl DeregisterEcsClusterError {
 }
 impl fmt::Display for DeregisterEcsClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterEcsClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterEcsClusterError::ResourceNotFound(ref cause) => cause,
+            DeregisterEcsClusterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterEcsClusterError {}
 /// Errors returned by DeregisterElasticIp
 #[derive(Debug, PartialEq)]
 pub enum DeregisterElasticIpError {
@@ -3830,16 +3762,12 @@ impl DeregisterElasticIpError {
 }
 impl fmt::Display for DeregisterElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterElasticIpError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterElasticIpError::ResourceNotFound(ref cause) => cause,
+            DeregisterElasticIpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterElasticIpError {}
 /// Errors returned by DeregisterInstance
 #[derive(Debug, PartialEq)]
 pub enum DeregisterInstanceError {
@@ -3863,16 +3791,12 @@ impl DeregisterInstanceError {
 }
 impl fmt::Display for DeregisterInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterInstanceError::ResourceNotFound(ref cause) => cause,
+            DeregisterInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterInstanceError {}
 /// Errors returned by DeregisterRdsDbInstance
 #[derive(Debug, PartialEq)]
 pub enum DeregisterRdsDbInstanceError {
@@ -3898,16 +3822,12 @@ impl DeregisterRdsDbInstanceError {
 }
 impl fmt::Display for DeregisterRdsDbInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterRdsDbInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterRdsDbInstanceError::ResourceNotFound(ref cause) => cause,
+            DeregisterRdsDbInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterRdsDbInstanceError {}
 /// Errors returned by DeregisterVolume
 #[derive(Debug, PartialEq)]
 pub enum DeregisterVolumeError {
@@ -3931,16 +3851,12 @@ impl DeregisterVolumeError {
 }
 impl fmt::Display for DeregisterVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterVolumeError::ResourceNotFound(ref cause) => cause,
+            DeregisterVolumeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterVolumeError {}
 /// Errors returned by DescribeAgentVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeAgentVersionsError {
@@ -3966,16 +3882,12 @@ impl DescribeAgentVersionsError {
 }
 impl fmt::Display for DescribeAgentVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAgentVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAgentVersionsError::ResourceNotFound(ref cause) => cause,
+            DescribeAgentVersionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAgentVersionsError {}
 /// Errors returned by DescribeApps
 #[derive(Debug, PartialEq)]
 pub enum DescribeAppsError {
@@ -3999,16 +3911,12 @@ impl DescribeAppsError {
 }
 impl fmt::Display for DescribeAppsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAppsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAppsError::ResourceNotFound(ref cause) => cause,
+            DescribeAppsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAppsError {}
 /// Errors returned by DescribeCommands
 #[derive(Debug, PartialEq)]
 pub enum DescribeCommandsError {
@@ -4032,16 +3940,12 @@ impl DescribeCommandsError {
 }
 impl fmt::Display for DescribeCommandsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCommandsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCommandsError::ResourceNotFound(ref cause) => cause,
+            DescribeCommandsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCommandsError {}
 /// Errors returned by DescribeDeployments
 #[derive(Debug, PartialEq)]
 pub enum DescribeDeploymentsError {
@@ -4067,16 +3971,12 @@ impl DescribeDeploymentsError {
 }
 impl fmt::Display for DescribeDeploymentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDeploymentsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDeploymentsError::ResourceNotFound(ref cause) => cause,
+            DescribeDeploymentsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDeploymentsError {}
 /// Errors returned by DescribeEcsClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeEcsClustersError {
@@ -4102,16 +4002,12 @@ impl DescribeEcsClustersError {
 }
 impl fmt::Display for DescribeEcsClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEcsClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEcsClustersError::ResourceNotFound(ref cause) => cause,
+            DescribeEcsClustersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEcsClustersError {}
 /// Errors returned by DescribeElasticIps
 #[derive(Debug, PartialEq)]
 pub enum DescribeElasticIpsError {
@@ -4135,16 +4031,12 @@ impl DescribeElasticIpsError {
 }
 impl fmt::Display for DescribeElasticIpsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeElasticIpsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeElasticIpsError::ResourceNotFound(ref cause) => cause,
+            DescribeElasticIpsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeElasticIpsError {}
 /// Errors returned by DescribeElasticLoadBalancers
 #[derive(Debug, PartialEq)]
 pub enum DescribeElasticLoadBalancersError {
@@ -4172,16 +4064,14 @@ impl DescribeElasticLoadBalancersError {
 }
 impl fmt::Display for DescribeElasticLoadBalancersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeElasticLoadBalancersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeElasticLoadBalancersError::ResourceNotFound(ref cause) => cause,
+            DescribeElasticLoadBalancersError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeElasticLoadBalancersError {}
 /// Errors returned by DescribeInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstancesError {
@@ -4205,16 +4095,12 @@ impl DescribeInstancesError {
 }
 impl fmt::Display for DescribeInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstancesError::ResourceNotFound(ref cause) => cause,
+            DescribeInstancesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInstancesError {}
 /// Errors returned by DescribeLayers
 #[derive(Debug, PartialEq)]
 pub enum DescribeLayersError {
@@ -4238,16 +4124,12 @@ impl DescribeLayersError {
 }
 impl fmt::Display for DescribeLayersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLayersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLayersError::ResourceNotFound(ref cause) => cause,
+            DescribeLayersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLayersError {}
 /// Errors returned by DescribeLoadBasedAutoScaling
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoadBasedAutoScalingError {
@@ -4275,16 +4157,14 @@ impl DescribeLoadBasedAutoScalingError {
 }
 impl fmt::Display for DescribeLoadBasedAutoScalingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoadBasedAutoScalingError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoadBasedAutoScalingError::ResourceNotFound(ref cause) => cause,
+            DescribeLoadBasedAutoScalingError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeLoadBasedAutoScalingError {}
 /// Errors returned by DescribeMyUserProfile
 #[derive(Debug, PartialEq)]
 pub enum DescribeMyUserProfileError {}
@@ -4302,14 +4182,10 @@ impl DescribeMyUserProfileError {
 }
 impl fmt::Display for DescribeMyUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMyUserProfileError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeMyUserProfileError {}
 /// Errors returned by DescribeOperatingSystems
 #[derive(Debug, PartialEq)]
 pub enum DescribeOperatingSystemsError {}
@@ -4327,14 +4203,10 @@ impl DescribeOperatingSystemsError {
 }
 impl fmt::Display for DescribeOperatingSystemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOperatingSystemsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeOperatingSystemsError {}
 /// Errors returned by DescribePermissions
 #[derive(Debug, PartialEq)]
 pub enum DescribePermissionsError {
@@ -4360,16 +4232,12 @@ impl DescribePermissionsError {
 }
 impl fmt::Display for DescribePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePermissionsError::ResourceNotFound(ref cause) => cause,
+            DescribePermissionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePermissionsError {}
 /// Errors returned by DescribeRaidArrays
 #[derive(Debug, PartialEq)]
 pub enum DescribeRaidArraysError {
@@ -4393,16 +4261,12 @@ impl DescribeRaidArraysError {
 }
 impl fmt::Display for DescribeRaidArraysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRaidArraysError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRaidArraysError::ResourceNotFound(ref cause) => cause,
+            DescribeRaidArraysError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRaidArraysError {}
 /// Errors returned by DescribeRdsDbInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeRdsDbInstancesError {
@@ -4428,16 +4292,12 @@ impl DescribeRdsDbInstancesError {
 }
 impl fmt::Display for DescribeRdsDbInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRdsDbInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRdsDbInstancesError::ResourceNotFound(ref cause) => cause,
+            DescribeRdsDbInstancesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRdsDbInstancesError {}
 /// Errors returned by DescribeServiceErrors
 #[derive(Debug, PartialEq)]
 pub enum DescribeServiceErrorsError {
@@ -4463,16 +4323,12 @@ impl DescribeServiceErrorsError {
 }
 impl fmt::Display for DescribeServiceErrorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServiceErrorsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServiceErrorsError::ResourceNotFound(ref cause) => cause,
+            DescribeServiceErrorsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeServiceErrorsError {}
 /// Errors returned by DescribeStackProvisioningParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackProvisioningParametersError {
@@ -4500,16 +4356,14 @@ impl DescribeStackProvisioningParametersError {
 }
 impl fmt::Display for DescribeStackProvisioningParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackProvisioningParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStackProvisioningParametersError::ResourceNotFound(ref cause) => cause,
+            DescribeStackProvisioningParametersError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeStackProvisioningParametersError {}
 /// Errors returned by DescribeStackSummary
 #[derive(Debug, PartialEq)]
 pub enum DescribeStackSummaryError {
@@ -4535,16 +4389,12 @@ impl DescribeStackSummaryError {
 }
 impl fmt::Display for DescribeStackSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStackSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStackSummaryError::ResourceNotFound(ref cause) => cause,
+            DescribeStackSummaryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStackSummaryError {}
 /// Errors returned by DescribeStacks
 #[derive(Debug, PartialEq)]
 pub enum DescribeStacksError {
@@ -4568,16 +4418,12 @@ impl DescribeStacksError {
 }
 impl fmt::Display for DescribeStacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStacksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStacksError::ResourceNotFound(ref cause) => cause,
+            DescribeStacksError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStacksError {}
 /// Errors returned by DescribeTimeBasedAutoScaling
 #[derive(Debug, PartialEq)]
 pub enum DescribeTimeBasedAutoScalingError {
@@ -4605,16 +4451,14 @@ impl DescribeTimeBasedAutoScalingError {
 }
 impl fmt::Display for DescribeTimeBasedAutoScalingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTimeBasedAutoScalingError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTimeBasedAutoScalingError::ResourceNotFound(ref cause) => cause,
+            DescribeTimeBasedAutoScalingError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTimeBasedAutoScalingError {}
 /// Errors returned by DescribeUserProfiles
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserProfilesError {
@@ -4640,16 +4484,12 @@ impl DescribeUserProfilesError {
 }
 impl fmt::Display for DescribeUserProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserProfilesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserProfilesError::ResourceNotFound(ref cause) => cause,
+            DescribeUserProfilesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserProfilesError {}
 /// Errors returned by DescribeVolumes
 #[derive(Debug, PartialEq)]
 pub enum DescribeVolumesError {
@@ -4673,16 +4513,12 @@ impl DescribeVolumesError {
 }
 impl fmt::Display for DescribeVolumesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVolumesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVolumesError::ResourceNotFound(ref cause) => cause,
+            DescribeVolumesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVolumesError {}
 /// Errors returned by DetachElasticLoadBalancer
 #[derive(Debug, PartialEq)]
 pub enum DetachElasticLoadBalancerError {
@@ -4708,16 +4544,12 @@ impl DetachElasticLoadBalancerError {
 }
 impl fmt::Display for DetachElasticLoadBalancerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachElasticLoadBalancerError {
-    fn description(&self) -> &str {
         match *self {
-            DetachElasticLoadBalancerError::ResourceNotFound(ref cause) => cause,
+            DetachElasticLoadBalancerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachElasticLoadBalancerError {}
 /// Errors returned by DisassociateElasticIp
 #[derive(Debug, PartialEq)]
 pub enum DisassociateElasticIpError {
@@ -4743,16 +4575,12 @@ impl DisassociateElasticIpError {
 }
 impl fmt::Display for DisassociateElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateElasticIpError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateElasticIpError::ResourceNotFound(ref cause) => cause,
+            DisassociateElasticIpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateElasticIpError {}
 /// Errors returned by GetHostnameSuggestion
 #[derive(Debug, PartialEq)]
 pub enum GetHostnameSuggestionError {
@@ -4778,16 +4606,12 @@ impl GetHostnameSuggestionError {
 }
 impl fmt::Display for GetHostnameSuggestionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHostnameSuggestionError {
-    fn description(&self) -> &str {
         match *self {
-            GetHostnameSuggestionError::ResourceNotFound(ref cause) => cause,
+            GetHostnameSuggestionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetHostnameSuggestionError {}
 /// Errors returned by GrantAccess
 #[derive(Debug, PartialEq)]
 pub enum GrantAccessError {
@@ -4811,16 +4635,12 @@ impl GrantAccessError {
 }
 impl fmt::Display for GrantAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GrantAccessError {
-    fn description(&self) -> &str {
         match *self {
-            GrantAccessError::ResourceNotFound(ref cause) => cause,
+            GrantAccessError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GrantAccessError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {
@@ -4844,16 +4664,12 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsError::ResourceNotFound(ref cause) => cause,
+            ListTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by RebootInstance
 #[derive(Debug, PartialEq)]
 pub enum RebootInstanceError {
@@ -4877,16 +4693,12 @@ impl RebootInstanceError {
 }
 impl fmt::Display for RebootInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RebootInstanceError::ResourceNotFound(ref cause) => cause,
+            RebootInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootInstanceError {}
 /// Errors returned by RegisterEcsCluster
 #[derive(Debug, PartialEq)]
 pub enum RegisterEcsClusterError {
@@ -4910,16 +4722,12 @@ impl RegisterEcsClusterError {
 }
 impl fmt::Display for RegisterEcsClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterEcsClusterError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterEcsClusterError::ResourceNotFound(ref cause) => cause,
+            RegisterEcsClusterError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterEcsClusterError {}
 /// Errors returned by RegisterElasticIp
 #[derive(Debug, PartialEq)]
 pub enum RegisterElasticIpError {
@@ -4943,16 +4751,12 @@ impl RegisterElasticIpError {
 }
 impl fmt::Display for RegisterElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterElasticIpError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterElasticIpError::ResourceNotFound(ref cause) => cause,
+            RegisterElasticIpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterElasticIpError {}
 /// Errors returned by RegisterInstance
 #[derive(Debug, PartialEq)]
 pub enum RegisterInstanceError {
@@ -4976,16 +4780,12 @@ impl RegisterInstanceError {
 }
 impl fmt::Display for RegisterInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterInstanceError::ResourceNotFound(ref cause) => cause,
+            RegisterInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterInstanceError {}
 /// Errors returned by RegisterRdsDbInstance
 #[derive(Debug, PartialEq)]
 pub enum RegisterRdsDbInstanceError {
@@ -5011,16 +4811,12 @@ impl RegisterRdsDbInstanceError {
 }
 impl fmt::Display for RegisterRdsDbInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterRdsDbInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterRdsDbInstanceError::ResourceNotFound(ref cause) => cause,
+            RegisterRdsDbInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterRdsDbInstanceError {}
 /// Errors returned by RegisterVolume
 #[derive(Debug, PartialEq)]
 pub enum RegisterVolumeError {
@@ -5044,16 +4840,12 @@ impl RegisterVolumeError {
 }
 impl fmt::Display for RegisterVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterVolumeError::ResourceNotFound(ref cause) => cause,
+            RegisterVolumeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterVolumeError {}
 /// Errors returned by SetLoadBasedAutoScaling
 #[derive(Debug, PartialEq)]
 pub enum SetLoadBasedAutoScalingError {
@@ -5079,16 +4871,12 @@ impl SetLoadBasedAutoScalingError {
 }
 impl fmt::Display for SetLoadBasedAutoScalingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetLoadBasedAutoScalingError {
-    fn description(&self) -> &str {
         match *self {
-            SetLoadBasedAutoScalingError::ResourceNotFound(ref cause) => cause,
+            SetLoadBasedAutoScalingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetLoadBasedAutoScalingError {}
 /// Errors returned by SetPermission
 #[derive(Debug, PartialEq)]
 pub enum SetPermissionError {
@@ -5112,16 +4900,12 @@ impl SetPermissionError {
 }
 impl fmt::Display for SetPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            SetPermissionError::ResourceNotFound(ref cause) => cause,
+            SetPermissionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetPermissionError {}
 /// Errors returned by SetTimeBasedAutoScaling
 #[derive(Debug, PartialEq)]
 pub enum SetTimeBasedAutoScalingError {
@@ -5147,16 +4931,12 @@ impl SetTimeBasedAutoScalingError {
 }
 impl fmt::Display for SetTimeBasedAutoScalingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetTimeBasedAutoScalingError {
-    fn description(&self) -> &str {
         match *self {
-            SetTimeBasedAutoScalingError::ResourceNotFound(ref cause) => cause,
+            SetTimeBasedAutoScalingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetTimeBasedAutoScalingError {}
 /// Errors returned by StartInstance
 #[derive(Debug, PartialEq)]
 pub enum StartInstanceError {
@@ -5180,16 +4960,12 @@ impl StartInstanceError {
 }
 impl fmt::Display for StartInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            StartInstanceError::ResourceNotFound(ref cause) => cause,
+            StartInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartInstanceError {}
 /// Errors returned by StartStack
 #[derive(Debug, PartialEq)]
 pub enum StartStackError {
@@ -5213,16 +4989,12 @@ impl StartStackError {
 }
 impl fmt::Display for StartStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartStackError {
-    fn description(&self) -> &str {
         match *self {
-            StartStackError::ResourceNotFound(ref cause) => cause,
+            StartStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartStackError {}
 /// Errors returned by StopInstance
 #[derive(Debug, PartialEq)]
 pub enum StopInstanceError {
@@ -5246,16 +5018,12 @@ impl StopInstanceError {
 }
 impl fmt::Display for StopInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            StopInstanceError::ResourceNotFound(ref cause) => cause,
+            StopInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopInstanceError {}
 /// Errors returned by StopStack
 #[derive(Debug, PartialEq)]
 pub enum StopStackError {
@@ -5279,16 +5047,12 @@ impl StopStackError {
 }
 impl fmt::Display for StopStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopStackError {
-    fn description(&self) -> &str {
         match *self {
-            StopStackError::ResourceNotFound(ref cause) => cause,
+            StopStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopStackError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5312,16 +5076,12 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UnassignInstance
 #[derive(Debug, PartialEq)]
 pub enum UnassignInstanceError {
@@ -5345,16 +5105,12 @@ impl UnassignInstanceError {
 }
 impl fmt::Display for UnassignInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnassignInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            UnassignInstanceError::ResourceNotFound(ref cause) => cause,
+            UnassignInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnassignInstanceError {}
 /// Errors returned by UnassignVolume
 #[derive(Debug, PartialEq)]
 pub enum UnassignVolumeError {
@@ -5378,16 +5134,12 @@ impl UnassignVolumeError {
 }
 impl fmt::Display for UnassignVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnassignVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            UnassignVolumeError::ResourceNotFound(ref cause) => cause,
+            UnassignVolumeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnassignVolumeError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -5411,16 +5163,12 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateApp
 #[derive(Debug, PartialEq)]
 pub enum UpdateAppError {
@@ -5444,16 +5192,12 @@ impl UpdateAppError {
 }
 impl fmt::Display for UpdateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAppError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAppError::ResourceNotFound(ref cause) => cause,
+            UpdateAppError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAppError {}
 /// Errors returned by UpdateElasticIp
 #[derive(Debug, PartialEq)]
 pub enum UpdateElasticIpError {
@@ -5477,16 +5221,12 @@ impl UpdateElasticIpError {
 }
 impl fmt::Display for UpdateElasticIpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateElasticIpError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateElasticIpError::ResourceNotFound(ref cause) => cause,
+            UpdateElasticIpError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateElasticIpError {}
 /// Errors returned by UpdateInstance
 #[derive(Debug, PartialEq)]
 pub enum UpdateInstanceError {
@@ -5510,16 +5250,12 @@ impl UpdateInstanceError {
 }
 impl fmt::Display for UpdateInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateInstanceError::ResourceNotFound(ref cause) => cause,
+            UpdateInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateInstanceError {}
 /// Errors returned by UpdateLayer
 #[derive(Debug, PartialEq)]
 pub enum UpdateLayerError {
@@ -5543,16 +5279,12 @@ impl UpdateLayerError {
 }
 impl fmt::Display for UpdateLayerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLayerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLayerError::ResourceNotFound(ref cause) => cause,
+            UpdateLayerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLayerError {}
 /// Errors returned by UpdateMyUserProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateMyUserProfileError {}
@@ -5570,14 +5302,10 @@ impl UpdateMyUserProfileError {
 }
 impl fmt::Display for UpdateMyUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMyUserProfileError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UpdateMyUserProfileError {}
 /// Errors returned by UpdateRdsDbInstance
 #[derive(Debug, PartialEq)]
 pub enum UpdateRdsDbInstanceError {
@@ -5603,16 +5331,12 @@ impl UpdateRdsDbInstanceError {
 }
 impl fmt::Display for UpdateRdsDbInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRdsDbInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRdsDbInstanceError::ResourceNotFound(ref cause) => cause,
+            UpdateRdsDbInstanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRdsDbInstanceError {}
 /// Errors returned by UpdateStack
 #[derive(Debug, PartialEq)]
 pub enum UpdateStackError {
@@ -5636,16 +5360,12 @@ impl UpdateStackError {
 }
 impl fmt::Display for UpdateStackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStackError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStackError::ResourceNotFound(ref cause) => cause,
+            UpdateStackError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStackError {}
 /// Errors returned by UpdateUserProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserProfileError {
@@ -5669,16 +5389,12 @@ impl UpdateUserProfileError {
 }
 impl fmt::Display for UpdateUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserProfileError::ResourceNotFound(ref cause) => cause,
+            UpdateUserProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserProfileError {}
 /// Errors returned by UpdateVolume
 #[derive(Debug, PartialEq)]
 pub enum UpdateVolumeError {
@@ -5702,16 +5418,12 @@ impl UpdateVolumeError {
 }
 impl fmt::Display for UpdateVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVolumeError::ResourceNotFound(ref cause) => cause,
+            UpdateVolumeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVolumeError {}
 /// Trait representing the capabilities of the AWS OpsWorks API. AWS OpsWorks clients implement this trait.
 pub trait OpsWorks {
     /// <p>Assign a registered instance to a layer.</p> <ul> <li> <p>You can assign registered on-premises instances to any layer type.</p> </li> <li> <p>You can assign registered Amazon EC2 instances only to custom layers.</p> </li> <li> <p>You cannot use this action with instances that were created with AWS OpsWorks Stacks.</p> </li> </ul> <p> <b>Required Permissions</b>: To use this action, an AWS Identity and Access Management (IAM) user must have a Manage permissions level for the stack or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="https://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -723,17 +723,13 @@ impl AssociateNodeError {
 }
 impl fmt::Display for AssociateNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateNodeError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateNodeError::InvalidState(ref cause) => cause,
-            AssociateNodeError::ResourceNotFound(ref cause) => cause,
+            AssociateNodeError::InvalidState(ref cause) => write!(f, "{}", cause),
+            AssociateNodeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateNodeError {}
 /// Errors returned by CreateBackup
 #[derive(Debug, PartialEq)]
 pub enum CreateBackupError {
@@ -767,18 +763,14 @@ impl CreateBackupError {
 }
 impl fmt::Display for CreateBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBackupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBackupError::InvalidState(ref cause) => cause,
-            CreateBackupError::LimitExceeded(ref cause) => cause,
-            CreateBackupError::ResourceNotFound(ref cause) => cause,
+            CreateBackupError::InvalidState(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateBackupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBackupError {}
 /// Errors returned by CreateServer
 #[derive(Debug, PartialEq)]
 pub enum CreateServerError {
@@ -812,18 +804,14 @@ impl CreateServerError {
 }
 impl fmt::Display for CreateServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateServerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateServerError::LimitExceeded(ref cause) => cause,
-            CreateServerError::ResourceAlreadyExists(ref cause) => cause,
-            CreateServerError::ResourceNotFound(ref cause) => cause,
+            CreateServerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateServerError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateServerError {}
 /// Errors returned by DeleteBackup
 #[derive(Debug, PartialEq)]
 pub enum DeleteBackupError {
@@ -852,17 +840,13 @@ impl DeleteBackupError {
 }
 impl fmt::Display for DeleteBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBackupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBackupError::InvalidState(ref cause) => cause,
-            DeleteBackupError::ResourceNotFound(ref cause) => cause,
+            DeleteBackupError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DeleteBackupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteBackupError {}
 /// Errors returned by DeleteServer
 #[derive(Debug, PartialEq)]
 pub enum DeleteServerError {
@@ -891,17 +875,13 @@ impl DeleteServerError {
 }
 impl fmt::Display for DeleteServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServerError::InvalidState(ref cause) => cause,
-            DeleteServerError::ResourceNotFound(ref cause) => cause,
+            DeleteServerError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DeleteServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServerError {}
 /// Errors returned by DescribeAccountAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountAttributesError {}
@@ -919,14 +899,10 @@ impl DescribeAccountAttributesError {
 }
 impl fmt::Display for DescribeAccountAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAccountAttributesError {}
 /// Errors returned by DescribeBackups
 #[derive(Debug, PartialEq)]
 pub enum DescribeBackupsError {
@@ -955,17 +931,13 @@ impl DescribeBackupsError {
 }
 impl fmt::Display for DescribeBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBackupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBackupsError::InvalidNextToken(ref cause) => cause,
-            DescribeBackupsError::ResourceNotFound(ref cause) => cause,
+            DescribeBackupsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeBackupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeBackupsError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {
@@ -994,17 +966,13 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventsError::InvalidNextToken(ref cause) => cause,
-            DescribeEventsError::ResourceNotFound(ref cause) => cause,
+            DescribeEventsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeEventsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeNodeAssociationStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeNodeAssociationStatusError {
@@ -1032,16 +1000,14 @@ impl DescribeNodeAssociationStatusError {
 }
 impl fmt::Display for DescribeNodeAssociationStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNodeAssociationStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeNodeAssociationStatusError::ResourceNotFound(ref cause) => cause,
+            DescribeNodeAssociationStatusError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeNodeAssociationStatusError {}
 /// Errors returned by DescribeServers
 #[derive(Debug, PartialEq)]
 pub enum DescribeServersError {
@@ -1070,17 +1036,13 @@ impl DescribeServersError {
 }
 impl fmt::Display for DescribeServersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServersError::InvalidNextToken(ref cause) => cause,
-            DescribeServersError::ResourceNotFound(ref cause) => cause,
+            DescribeServersError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeServersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeServersError {}
 /// Errors returned by DisassociateNode
 #[derive(Debug, PartialEq)]
 pub enum DisassociateNodeError {
@@ -1109,17 +1071,13 @@ impl DisassociateNodeError {
 }
 impl fmt::Display for DisassociateNodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateNodeError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateNodeError::InvalidState(ref cause) => cause,
-            DisassociateNodeError::ResourceNotFound(ref cause) => cause,
+            DisassociateNodeError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DisassociateNodeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateNodeError {}
 /// Errors returned by ExportServerEngineAttribute
 #[derive(Debug, PartialEq)]
 pub enum ExportServerEngineAttributeError {
@@ -1154,17 +1112,13 @@ impl ExportServerEngineAttributeError {
 }
 impl fmt::Display for ExportServerEngineAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExportServerEngineAttributeError {
-    fn description(&self) -> &str {
         match *self {
-            ExportServerEngineAttributeError::InvalidState(ref cause) => cause,
-            ExportServerEngineAttributeError::ResourceNotFound(ref cause) => cause,
+            ExportServerEngineAttributeError::InvalidState(ref cause) => write!(f, "{}", cause),
+            ExportServerEngineAttributeError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExportServerEngineAttributeError {}
 /// Errors returned by RestoreServer
 #[derive(Debug, PartialEq)]
 pub enum RestoreServerError {
@@ -1193,17 +1147,13 @@ impl RestoreServerError {
 }
 impl fmt::Display for RestoreServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreServerError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreServerError::InvalidState(ref cause) => cause,
-            RestoreServerError::ResourceNotFound(ref cause) => cause,
+            RestoreServerError::InvalidState(ref cause) => write!(f, "{}", cause),
+            RestoreServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreServerError {}
 /// Errors returned by StartMaintenance
 #[derive(Debug, PartialEq)]
 pub enum StartMaintenanceError {
@@ -1232,17 +1182,13 @@ impl StartMaintenanceError {
 }
 impl fmt::Display for StartMaintenanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMaintenanceError {
-    fn description(&self) -> &str {
         match *self {
-            StartMaintenanceError::InvalidState(ref cause) => cause,
-            StartMaintenanceError::ResourceNotFound(ref cause) => cause,
+            StartMaintenanceError::InvalidState(ref cause) => write!(f, "{}", cause),
+            StartMaintenanceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMaintenanceError {}
 /// Errors returned by UpdateServer
 #[derive(Debug, PartialEq)]
 pub enum UpdateServerError {
@@ -1271,17 +1217,13 @@ impl UpdateServerError {
 }
 impl fmt::Display for UpdateServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServerError::InvalidState(ref cause) => cause,
-            UpdateServerError::ResourceNotFound(ref cause) => cause,
+            UpdateServerError::InvalidState(ref cause) => write!(f, "{}", cause),
+            UpdateServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServerError {}
 /// Errors returned by UpdateServerEngineAttributes
 #[derive(Debug, PartialEq)]
 pub enum UpdateServerEngineAttributesError {
@@ -1316,17 +1258,15 @@ impl UpdateServerEngineAttributesError {
 }
 impl fmt::Display for UpdateServerEngineAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServerEngineAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServerEngineAttributesError::InvalidState(ref cause) => cause,
-            UpdateServerEngineAttributesError::ResourceNotFound(ref cause) => cause,
+            UpdateServerEngineAttributesError::InvalidState(ref cause) => write!(f, "{}", cause),
+            UpdateServerEngineAttributesError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateServerEngineAttributesError {}
 /// Trait representing the capabilities of the OpsWorksCM API. OpsWorksCM clients implement this trait.
 pub trait OpsWorksCM {
     /// <p> Associates a new node with the server. For more information about how to disassociate a node, see <a>DisassociateNode</a>.</p> <p> On a Chef server: This command is an alternative to <code>knife bootstrap</code>.</p> <p> Example (Chef): <code>aws opsworks-cm associate-node --server-name <i>MyServer</i> --node-name <i>MyManagedNode</i> --engine-attributes "Name=<i>CHEF_ORGANIZATION</i>,Value=default" "Name=<i>CHEF_NODE_PUBLIC_KEY</i>,Value=<i>public-key-pem</i>"</code> </p> <p> On a Puppet server, this command is an alternative to the <code>puppet cert sign</code> command that signs a Puppet node CSR. </p> <p> Example (Chef): <code>aws opsworks-cm associate-node --server-name <i>MyServer</i> --node-name <i>MyManagedNode</i> --engine-attributes "Name=<i>PUPPET_NODE_CSR</i>,Value=<i>csr-pem</i>"</code> </p> <p> A node can can only be associated with servers that are in a <code>HEALTHY</code> state. Otherwise, an <code>InvalidStateException</code> is thrown. A <code>ResourceNotFoundException</code> is thrown when the server does not exist. A <code>ValidationException</code> is raised when parameters of the request are not valid. The AssociateNode API call can be integrated into Auto Scaling configurations, AWS Cloudformation templates, or the user data of a server's instance. </p>

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -1354,26 +1354,22 @@ impl AcceptHandshakeError {
 }
 impl fmt::Display for AcceptHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptHandshakeError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptHandshakeError::AWSOrganizationsNotInUse(ref cause) => cause,
-            AcceptHandshakeError::AccessDenied(ref cause) => cause,
-            AcceptHandshakeError::AccessDeniedForDependency(ref cause) => cause,
-            AcceptHandshakeError::ConcurrentModification(ref cause) => cause,
-            AcceptHandshakeError::HandshakeAlreadyInState(ref cause) => cause,
-            AcceptHandshakeError::HandshakeConstraintViolation(ref cause) => cause,
-            AcceptHandshakeError::HandshakeNotFound(ref cause) => cause,
-            AcceptHandshakeError::InvalidHandshakeTransition(ref cause) => cause,
-            AcceptHandshakeError::InvalidInput(ref cause) => cause,
-            AcceptHandshakeError::Service(ref cause) => cause,
-            AcceptHandshakeError::TooManyRequests(ref cause) => cause,
+            AcceptHandshakeError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::AccessDeniedForDependency(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::HandshakeAlreadyInState(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::HandshakeConstraintViolation(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::HandshakeNotFound(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::InvalidHandshakeTransition(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::Service(ref cause) => write!(f, "{}", cause),
+            AcceptHandshakeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptHandshakeError {}
 /// Errors returned by AttachPolicy
 #[derive(Debug, PartialEq)]
 pub enum AttachPolicyError {
@@ -1463,28 +1459,24 @@ impl AttachPolicyError {
 }
 impl fmt::Display for AttachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            AttachPolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            AttachPolicyError::AccessDenied(ref cause) => cause,
-            AttachPolicyError::ConcurrentModification(ref cause) => cause,
-            AttachPolicyError::ConstraintViolation(ref cause) => cause,
-            AttachPolicyError::DuplicatePolicyAttachment(ref cause) => cause,
-            AttachPolicyError::InvalidInput(ref cause) => cause,
-            AttachPolicyError::PolicyChangesInProgress(ref cause) => cause,
-            AttachPolicyError::PolicyNotFound(ref cause) => cause,
-            AttachPolicyError::PolicyTypeNotEnabled(ref cause) => cause,
-            AttachPolicyError::Service(ref cause) => cause,
-            AttachPolicyError::TargetNotFound(ref cause) => cause,
-            AttachPolicyError::TooManyRequests(ref cause) => cause,
-            AttachPolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            AttachPolicyError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::DuplicatePolicyAttachment(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::PolicyChangesInProgress(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::PolicyTypeNotEnabled(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::Service(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::TargetNotFound(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AttachPolicyError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachPolicyError {}
 /// Errors returned by CancelHandshake
 #[derive(Debug, PartialEq)]
 pub enum CancelHandshakeError {
@@ -1549,23 +1541,19 @@ impl CancelHandshakeError {
 }
 impl fmt::Display for CancelHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelHandshakeError {
-    fn description(&self) -> &str {
         match *self {
-            CancelHandshakeError::AccessDenied(ref cause) => cause,
-            CancelHandshakeError::ConcurrentModification(ref cause) => cause,
-            CancelHandshakeError::HandshakeAlreadyInState(ref cause) => cause,
-            CancelHandshakeError::HandshakeNotFound(ref cause) => cause,
-            CancelHandshakeError::InvalidHandshakeTransition(ref cause) => cause,
-            CancelHandshakeError::InvalidInput(ref cause) => cause,
-            CancelHandshakeError::Service(ref cause) => cause,
-            CancelHandshakeError::TooManyRequests(ref cause) => cause,
+            CancelHandshakeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CancelHandshakeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CancelHandshakeError::HandshakeAlreadyInState(ref cause) => write!(f, "{}", cause),
+            CancelHandshakeError::HandshakeNotFound(ref cause) => write!(f, "{}", cause),
+            CancelHandshakeError::InvalidHandshakeTransition(ref cause) => write!(f, "{}", cause),
+            CancelHandshakeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CancelHandshakeError::Service(ref cause) => write!(f, "{}", cause),
+            CancelHandshakeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelHandshakeError {}
 /// Errors returned by CreateAccount
 #[derive(Debug, PartialEq)]
 pub enum CreateAccountError {
@@ -1637,24 +1625,20 @@ impl CreateAccountError {
 }
 impl fmt::Display for CreateAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAccountError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAccountError::AWSOrganizationsNotInUse(ref cause) => cause,
-            CreateAccountError::AccessDenied(ref cause) => cause,
-            CreateAccountError::ConcurrentModification(ref cause) => cause,
-            CreateAccountError::ConstraintViolation(ref cause) => cause,
-            CreateAccountError::FinalizingOrganization(ref cause) => cause,
-            CreateAccountError::InvalidInput(ref cause) => cause,
-            CreateAccountError::Service(ref cause) => cause,
-            CreateAccountError::TooManyRequests(ref cause) => cause,
-            CreateAccountError::UnsupportedAPIEndpoint(ref cause) => cause,
+            CreateAccountError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::FinalizingOrganization(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::Service(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateAccountError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAccountError {}
 /// Errors returned by CreateGovCloudAccount
 #[derive(Debug, PartialEq)]
 pub enum CreateGovCloudAccountError {
@@ -1730,24 +1714,22 @@ impl CreateGovCloudAccountError {
 }
 impl fmt::Display for CreateGovCloudAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGovCloudAccountError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGovCloudAccountError::AWSOrganizationsNotInUse(ref cause) => cause,
-            CreateGovCloudAccountError::AccessDenied(ref cause) => cause,
-            CreateGovCloudAccountError::ConcurrentModification(ref cause) => cause,
-            CreateGovCloudAccountError::ConstraintViolation(ref cause) => cause,
-            CreateGovCloudAccountError::FinalizingOrganization(ref cause) => cause,
-            CreateGovCloudAccountError::InvalidInput(ref cause) => cause,
-            CreateGovCloudAccountError::Service(ref cause) => cause,
-            CreateGovCloudAccountError::TooManyRequests(ref cause) => cause,
-            CreateGovCloudAccountError::UnsupportedAPIEndpoint(ref cause) => cause,
+            CreateGovCloudAccountError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateGovCloudAccountError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateGovCloudAccountError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateGovCloudAccountError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            CreateGovCloudAccountError::FinalizingOrganization(ref cause) => write!(f, "{}", cause),
+            CreateGovCloudAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateGovCloudAccountError::Service(ref cause) => write!(f, "{}", cause),
+            CreateGovCloudAccountError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateGovCloudAccountError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGovCloudAccountError {}
 /// Errors returned by CreateOrganization
 #[derive(Debug, PartialEq)]
 pub enum CreateOrganizationError {
@@ -1814,23 +1796,19 @@ impl CreateOrganizationError {
 }
 impl fmt::Display for CreateOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOrganizationError::AccessDenied(ref cause) => cause,
-            CreateOrganizationError::AccessDeniedForDependency(ref cause) => cause,
-            CreateOrganizationError::AlreadyInOrganization(ref cause) => cause,
-            CreateOrganizationError::ConcurrentModification(ref cause) => cause,
-            CreateOrganizationError::ConstraintViolation(ref cause) => cause,
-            CreateOrganizationError::InvalidInput(ref cause) => cause,
-            CreateOrganizationError::Service(ref cause) => cause,
-            CreateOrganizationError::TooManyRequests(ref cause) => cause,
+            CreateOrganizationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationError::AccessDeniedForDependency(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationError::AlreadyInOrganization(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateOrganizationError {}
 /// Errors returned by CreateOrganizationalUnit
 #[derive(Debug, PartialEq)]
 pub enum CreateOrganizationalUnitError {
@@ -1910,24 +1888,26 @@ impl CreateOrganizationalUnitError {
 }
 impl fmt::Display for CreateOrganizationalUnitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOrganizationalUnitError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => cause,
-            CreateOrganizationalUnitError::AccessDenied(ref cause) => cause,
-            CreateOrganizationalUnitError::ConcurrentModification(ref cause) => cause,
-            CreateOrganizationalUnitError::ConstraintViolation(ref cause) => cause,
-            CreateOrganizationalUnitError::DuplicateOrganizationalUnit(ref cause) => cause,
-            CreateOrganizationalUnitError::InvalidInput(ref cause) => cause,
-            CreateOrganizationalUnitError::ParentNotFound(ref cause) => cause,
-            CreateOrganizationalUnitError::Service(ref cause) => cause,
-            CreateOrganizationalUnitError::TooManyRequests(ref cause) => cause,
+            CreateOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateOrganizationalUnitError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationalUnitError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateOrganizationalUnitError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationalUnitError::DuplicateOrganizationalUnit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateOrganizationalUnitError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationalUnitError::ParentNotFound(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationalUnitError::Service(ref cause) => write!(f, "{}", cause),
+            CreateOrganizationalUnitError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateOrganizationalUnitError {}
 /// Errors returned by CreatePolicy
 #[derive(Debug, PartialEq)]
 pub enum CreatePolicyError {
@@ -2007,26 +1987,24 @@ impl CreatePolicyError {
 }
 impl fmt::Display for CreatePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            CreatePolicyError::AccessDenied(ref cause) => cause,
-            CreatePolicyError::ConcurrentModification(ref cause) => cause,
-            CreatePolicyError::ConstraintViolation(ref cause) => cause,
-            CreatePolicyError::DuplicatePolicy(ref cause) => cause,
-            CreatePolicyError::InvalidInput(ref cause) => cause,
-            CreatePolicyError::MalformedPolicyDocument(ref cause) => cause,
-            CreatePolicyError::PolicyTypeNotAvailableForOrganization(ref cause) => cause,
-            CreatePolicyError::Service(ref cause) => cause,
-            CreatePolicyError::TooManyRequests(ref cause) => cause,
-            CreatePolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            CreatePolicyError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::DuplicatePolicy(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::PolicyTypeNotAvailableForOrganization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePolicyError::Service(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreatePolicyError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePolicyError {}
 /// Errors returned by DeclineHandshake
 #[derive(Debug, PartialEq)]
 pub enum DeclineHandshakeError {
@@ -2091,23 +2069,19 @@ impl DeclineHandshakeError {
 }
 impl fmt::Display for DeclineHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeclineHandshakeError {
-    fn description(&self) -> &str {
         match *self {
-            DeclineHandshakeError::AccessDenied(ref cause) => cause,
-            DeclineHandshakeError::ConcurrentModification(ref cause) => cause,
-            DeclineHandshakeError::HandshakeAlreadyInState(ref cause) => cause,
-            DeclineHandshakeError::HandshakeNotFound(ref cause) => cause,
-            DeclineHandshakeError::InvalidHandshakeTransition(ref cause) => cause,
-            DeclineHandshakeError::InvalidInput(ref cause) => cause,
-            DeclineHandshakeError::Service(ref cause) => cause,
-            DeclineHandshakeError::TooManyRequests(ref cause) => cause,
+            DeclineHandshakeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeclineHandshakeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeclineHandshakeError::HandshakeAlreadyInState(ref cause) => write!(f, "{}", cause),
+            DeclineHandshakeError::HandshakeNotFound(ref cause) => write!(f, "{}", cause),
+            DeclineHandshakeError::InvalidHandshakeTransition(ref cause) => write!(f, "{}", cause),
+            DeclineHandshakeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeclineHandshakeError::Service(ref cause) => write!(f, "{}", cause),
+            DeclineHandshakeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeclineHandshakeError {}
 /// Errors returned by DeleteOrganization
 #[derive(Debug, PartialEq)]
 pub enum DeleteOrganizationError {
@@ -2167,22 +2141,18 @@ impl DeleteOrganizationError {
 }
 impl fmt::Display for DeleteOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteOrganizationError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DeleteOrganizationError::AccessDenied(ref cause) => cause,
-            DeleteOrganizationError::ConcurrentModification(ref cause) => cause,
-            DeleteOrganizationError::InvalidInput(ref cause) => cause,
-            DeleteOrganizationError::OrganizationNotEmpty(ref cause) => cause,
-            DeleteOrganizationError::Service(ref cause) => cause,
-            DeleteOrganizationError::TooManyRequests(ref cause) => cause,
+            DeleteOrganizationError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationError::OrganizationNotEmpty(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteOrganizationError {}
 /// Errors returned by DeleteOrganizationalUnit
 #[derive(Debug, PartialEq)]
 pub enum DeleteOrganizationalUnitError {
@@ -2255,23 +2225,27 @@ impl DeleteOrganizationalUnitError {
 }
 impl fmt::Display for DeleteOrganizationalUnitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOrganizationalUnitError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DeleteOrganizationalUnitError::AccessDenied(ref cause) => cause,
-            DeleteOrganizationalUnitError::ConcurrentModification(ref cause) => cause,
-            DeleteOrganizationalUnitError::InvalidInput(ref cause) => cause,
-            DeleteOrganizationalUnitError::OrganizationalUnitNotEmpty(ref cause) => cause,
-            DeleteOrganizationalUnitError::OrganizationalUnitNotFound(ref cause) => cause,
-            DeleteOrganizationalUnitError::Service(ref cause) => cause,
-            DeleteOrganizationalUnitError::TooManyRequests(ref cause) => cause,
+            DeleteOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOrganizationalUnitError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationalUnitError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOrganizationalUnitError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationalUnitError::OrganizationalUnitNotEmpty(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOrganizationalUnitError::OrganizationalUnitNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOrganizationalUnitError::Service(ref cause) => write!(f, "{}", cause),
+            DeleteOrganizationalUnitError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteOrganizationalUnitError {}
 /// Errors returned by DeletePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeletePolicyError {
@@ -2337,24 +2311,20 @@ impl DeletePolicyError {
 }
 impl fmt::Display for DeletePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DeletePolicyError::AccessDenied(ref cause) => cause,
-            DeletePolicyError::ConcurrentModification(ref cause) => cause,
-            DeletePolicyError::InvalidInput(ref cause) => cause,
-            DeletePolicyError::PolicyInUse(ref cause) => cause,
-            DeletePolicyError::PolicyNotFound(ref cause) => cause,
-            DeletePolicyError::Service(ref cause) => cause,
-            DeletePolicyError::TooManyRequests(ref cause) => cause,
-            DeletePolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            DeletePolicyError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::PolicyInUse(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::Service(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeletePolicyError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePolicyError {}
 /// Errors returned by DescribeAccount
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountError {
@@ -2405,21 +2375,17 @@ impl DescribeAccountError {
 }
 impl fmt::Display for DescribeAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAccountError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DescribeAccountError::AccessDenied(ref cause) => cause,
-            DescribeAccountError::AccountNotFound(ref cause) => cause,
-            DescribeAccountError::InvalidInput(ref cause) => cause,
-            DescribeAccountError::Service(ref cause) => cause,
-            DescribeAccountError::TooManyRequests(ref cause) => cause,
+            DescribeAccountError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            DescribeAccountError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeAccountError::AccountNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeAccountError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeAccountError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAccountError {}
 /// Errors returned by DescribeCreateAccountStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeCreateAccountStatusError {
@@ -2487,22 +2453,24 @@ impl DescribeCreateAccountStatusError {
 }
 impl fmt::Display for DescribeCreateAccountStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCreateAccountStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCreateAccountStatusError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DescribeCreateAccountStatusError::AccessDenied(ref cause) => cause,
-            DescribeCreateAccountStatusError::CreateAccountStatusNotFound(ref cause) => cause,
-            DescribeCreateAccountStatusError::InvalidInput(ref cause) => cause,
-            DescribeCreateAccountStatusError::Service(ref cause) => cause,
-            DescribeCreateAccountStatusError::TooManyRequests(ref cause) => cause,
-            DescribeCreateAccountStatusError::UnsupportedAPIEndpoint(ref cause) => cause,
+            DescribeCreateAccountStatusError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCreateAccountStatusError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeCreateAccountStatusError::CreateAccountStatusNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCreateAccountStatusError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeCreateAccountStatusError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeCreateAccountStatusError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeCreateAccountStatusError::UnsupportedAPIEndpoint(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCreateAccountStatusError {}
 /// Errors returned by DescribeEffectivePolicy
 #[derive(Debug, PartialEq)]
 pub enum DescribeEffectivePolicyError {
@@ -2582,24 +2550,26 @@ impl DescribeEffectivePolicyError {
 }
 impl fmt::Display for DescribeEffectivePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEffectivePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEffectivePolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DescribeEffectivePolicyError::AccessDenied(ref cause) => cause,
-            DescribeEffectivePolicyError::ConstraintViolation(ref cause) => cause,
-            DescribeEffectivePolicyError::EffectivePolicyNotFound(ref cause) => cause,
-            DescribeEffectivePolicyError::InvalidInput(ref cause) => cause,
-            DescribeEffectivePolicyError::Service(ref cause) => cause,
-            DescribeEffectivePolicyError::TargetNotFound(ref cause) => cause,
-            DescribeEffectivePolicyError::TooManyRequests(ref cause) => cause,
-            DescribeEffectivePolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            DescribeEffectivePolicyError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEffectivePolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeEffectivePolicyError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            DescribeEffectivePolicyError::EffectivePolicyNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEffectivePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeEffectivePolicyError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeEffectivePolicyError::TargetNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeEffectivePolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeEffectivePolicyError::UnsupportedAPIEndpoint(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEffectivePolicyError {}
 /// Errors returned by DescribeHandshake
 #[derive(Debug, PartialEq)]
 pub enum DescribeHandshakeError {
@@ -2650,21 +2620,17 @@ impl DescribeHandshakeError {
 }
 impl fmt::Display for DescribeHandshakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHandshakeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHandshakeError::AccessDenied(ref cause) => cause,
-            DescribeHandshakeError::ConcurrentModification(ref cause) => cause,
-            DescribeHandshakeError::HandshakeNotFound(ref cause) => cause,
-            DescribeHandshakeError::InvalidInput(ref cause) => cause,
-            DescribeHandshakeError::Service(ref cause) => cause,
-            DescribeHandshakeError::TooManyRequests(ref cause) => cause,
+            DescribeHandshakeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeHandshakeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DescribeHandshakeError::HandshakeNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeHandshakeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeHandshakeError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeHandshakeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeHandshakeError {}
 /// Errors returned by DescribeOrganization
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrganizationError {
@@ -2714,20 +2680,18 @@ impl DescribeOrganizationError {
 }
 impl fmt::Display for DescribeOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOrganizationError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DescribeOrganizationError::AccessDenied(ref cause) => cause,
-            DescribeOrganizationError::ConcurrentModification(ref cause) => cause,
-            DescribeOrganizationError::Service(ref cause) => cause,
-            DescribeOrganizationError::TooManyRequests(ref cause) => cause,
+            DescribeOrganizationError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeOrganizationError {}
 /// Errors returned by DescribeOrganizationalUnit
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrganizationalUnitError {
@@ -2788,21 +2752,21 @@ impl DescribeOrganizationalUnitError {
 }
 impl fmt::Display for DescribeOrganizationalUnitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrganizationalUnitError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DescribeOrganizationalUnitError::AccessDenied(ref cause) => cause,
-            DescribeOrganizationalUnitError::InvalidInput(ref cause) => cause,
-            DescribeOrganizationalUnitError::OrganizationalUnitNotFound(ref cause) => cause,
-            DescribeOrganizationalUnitError::Service(ref cause) => cause,
-            DescribeOrganizationalUnitError::TooManyRequests(ref cause) => cause,
+            DescribeOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationalUnitError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationalUnitError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationalUnitError::OrganizationalUnitNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeOrganizationalUnitError::Service(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationalUnitError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeOrganizationalUnitError {}
 /// Errors returned by DescribePolicy
 #[derive(Debug, PartialEq)]
 pub enum DescribePolicyError {
@@ -2860,22 +2824,18 @@ impl DescribePolicyError {
 }
 impl fmt::Display for DescribePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DescribePolicyError::AccessDenied(ref cause) => cause,
-            DescribePolicyError::InvalidInput(ref cause) => cause,
-            DescribePolicyError::PolicyNotFound(ref cause) => cause,
-            DescribePolicyError::Service(ref cause) => cause,
-            DescribePolicyError::TooManyRequests(ref cause) => cause,
-            DescribePolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            DescribePolicyError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            DescribePolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribePolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
+            DescribePolicyError::Service(ref cause) => write!(f, "{}", cause),
+            DescribePolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribePolicyError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePolicyError {}
 /// Errors returned by DetachPolicy
 #[derive(Debug, PartialEq)]
 pub enum DetachPolicyError {
@@ -2958,27 +2918,23 @@ impl DetachPolicyError {
 }
 impl fmt::Display for DetachPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DetachPolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DetachPolicyError::AccessDenied(ref cause) => cause,
-            DetachPolicyError::ConcurrentModification(ref cause) => cause,
-            DetachPolicyError::ConstraintViolation(ref cause) => cause,
-            DetachPolicyError::InvalidInput(ref cause) => cause,
-            DetachPolicyError::PolicyChangesInProgress(ref cause) => cause,
-            DetachPolicyError::PolicyNotAttached(ref cause) => cause,
-            DetachPolicyError::PolicyNotFound(ref cause) => cause,
-            DetachPolicyError::Service(ref cause) => cause,
-            DetachPolicyError::TargetNotFound(ref cause) => cause,
-            DetachPolicyError::TooManyRequests(ref cause) => cause,
-            DetachPolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            DetachPolicyError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::PolicyChangesInProgress(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::PolicyNotAttached(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::Service(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::TargetNotFound(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DetachPolicyError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachPolicyError {}
 /// Errors returned by DisableAWSServiceAccess
 #[derive(Debug, PartialEq)]
 pub enum DisableAWSServiceAccessError {
@@ -3044,22 +3000,22 @@ impl DisableAWSServiceAccessError {
 }
 impl fmt::Display for DisableAWSServiceAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableAWSServiceAccessError {
-    fn description(&self) -> &str {
         match *self {
-            DisableAWSServiceAccessError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DisableAWSServiceAccessError::AccessDenied(ref cause) => cause,
-            DisableAWSServiceAccessError::ConcurrentModification(ref cause) => cause,
-            DisableAWSServiceAccessError::ConstraintViolation(ref cause) => cause,
-            DisableAWSServiceAccessError::InvalidInput(ref cause) => cause,
-            DisableAWSServiceAccessError::Service(ref cause) => cause,
-            DisableAWSServiceAccessError::TooManyRequests(ref cause) => cause,
+            DisableAWSServiceAccessError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisableAWSServiceAccessError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisableAWSServiceAccessError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisableAWSServiceAccessError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            DisableAWSServiceAccessError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisableAWSServiceAccessError::Service(ref cause) => write!(f, "{}", cause),
+            DisableAWSServiceAccessError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableAWSServiceAccessError {}
 /// Errors returned by DisablePolicyType
 #[derive(Debug, PartialEq)]
 pub enum DisablePolicyTypeError {
@@ -3145,26 +3101,22 @@ impl DisablePolicyTypeError {
 }
 impl fmt::Display for DisablePolicyTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisablePolicyTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DisablePolicyTypeError::AWSOrganizationsNotInUse(ref cause) => cause,
-            DisablePolicyTypeError::AccessDenied(ref cause) => cause,
-            DisablePolicyTypeError::ConcurrentModification(ref cause) => cause,
-            DisablePolicyTypeError::ConstraintViolation(ref cause) => cause,
-            DisablePolicyTypeError::InvalidInput(ref cause) => cause,
-            DisablePolicyTypeError::PolicyChangesInProgress(ref cause) => cause,
-            DisablePolicyTypeError::PolicyTypeNotEnabled(ref cause) => cause,
-            DisablePolicyTypeError::RootNotFound(ref cause) => cause,
-            DisablePolicyTypeError::Service(ref cause) => cause,
-            DisablePolicyTypeError::TooManyRequests(ref cause) => cause,
-            DisablePolicyTypeError::UnsupportedAPIEndpoint(ref cause) => cause,
+            DisablePolicyTypeError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::PolicyChangesInProgress(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::PolicyTypeNotEnabled(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::RootNotFound(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::Service(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DisablePolicyTypeError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisablePolicyTypeError {}
 /// Errors returned by EnableAWSServiceAccess
 #[derive(Debug, PartialEq)]
 pub enum EnableAWSServiceAccessError {
@@ -3226,22 +3178,22 @@ impl EnableAWSServiceAccessError {
 }
 impl fmt::Display for EnableAWSServiceAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableAWSServiceAccessError {
-    fn description(&self) -> &str {
         match *self {
-            EnableAWSServiceAccessError::AWSOrganizationsNotInUse(ref cause) => cause,
-            EnableAWSServiceAccessError::AccessDenied(ref cause) => cause,
-            EnableAWSServiceAccessError::ConcurrentModification(ref cause) => cause,
-            EnableAWSServiceAccessError::ConstraintViolation(ref cause) => cause,
-            EnableAWSServiceAccessError::InvalidInput(ref cause) => cause,
-            EnableAWSServiceAccessError::Service(ref cause) => cause,
-            EnableAWSServiceAccessError::TooManyRequests(ref cause) => cause,
+            EnableAWSServiceAccessError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableAWSServiceAccessError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            EnableAWSServiceAccessError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableAWSServiceAccessError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            EnableAWSServiceAccessError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            EnableAWSServiceAccessError::Service(ref cause) => write!(f, "{}", cause),
+            EnableAWSServiceAccessError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableAWSServiceAccessError {}
 /// Errors returned by EnableAllFeatures
 #[derive(Debug, PartialEq)]
 pub enum EnableAllFeaturesError {
@@ -3301,22 +3253,20 @@ impl EnableAllFeaturesError {
 }
 impl fmt::Display for EnableAllFeaturesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableAllFeaturesError {
-    fn description(&self) -> &str {
         match *self {
-            EnableAllFeaturesError::AWSOrganizationsNotInUse(ref cause) => cause,
-            EnableAllFeaturesError::AccessDenied(ref cause) => cause,
-            EnableAllFeaturesError::ConcurrentModification(ref cause) => cause,
-            EnableAllFeaturesError::HandshakeConstraintViolation(ref cause) => cause,
-            EnableAllFeaturesError::InvalidInput(ref cause) => cause,
-            EnableAllFeaturesError::Service(ref cause) => cause,
-            EnableAllFeaturesError::TooManyRequests(ref cause) => cause,
+            EnableAllFeaturesError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            EnableAllFeaturesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            EnableAllFeaturesError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            EnableAllFeaturesError::HandshakeConstraintViolation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableAllFeaturesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            EnableAllFeaturesError::Service(ref cause) => write!(f, "{}", cause),
+            EnableAllFeaturesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableAllFeaturesError {}
 /// Errors returned by EnablePolicyType
 #[derive(Debug, PartialEq)]
 pub enum EnablePolicyTypeError {
@@ -3409,27 +3359,25 @@ impl EnablePolicyTypeError {
 }
 impl fmt::Display for EnablePolicyTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnablePolicyTypeError {
-    fn description(&self) -> &str {
         match *self {
-            EnablePolicyTypeError::AWSOrganizationsNotInUse(ref cause) => cause,
-            EnablePolicyTypeError::AccessDenied(ref cause) => cause,
-            EnablePolicyTypeError::ConcurrentModification(ref cause) => cause,
-            EnablePolicyTypeError::ConstraintViolation(ref cause) => cause,
-            EnablePolicyTypeError::InvalidInput(ref cause) => cause,
-            EnablePolicyTypeError::PolicyChangesInProgress(ref cause) => cause,
-            EnablePolicyTypeError::PolicyTypeAlreadyEnabled(ref cause) => cause,
-            EnablePolicyTypeError::PolicyTypeNotAvailableForOrganization(ref cause) => cause,
-            EnablePolicyTypeError::RootNotFound(ref cause) => cause,
-            EnablePolicyTypeError::Service(ref cause) => cause,
-            EnablePolicyTypeError::TooManyRequests(ref cause) => cause,
-            EnablePolicyTypeError::UnsupportedAPIEndpoint(ref cause) => cause,
+            EnablePolicyTypeError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::PolicyChangesInProgress(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::PolicyTypeAlreadyEnabled(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::PolicyTypeNotAvailableForOrganization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnablePolicyTypeError::RootNotFound(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::Service(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            EnablePolicyTypeError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnablePolicyTypeError {}
 /// Errors returned by InviteAccountToOrganization
 #[derive(Debug, PartialEq)]
 pub enum InviteAccountToOrganizationError {
@@ -3518,25 +3466,33 @@ impl InviteAccountToOrganizationError {
 }
 impl fmt::Display for InviteAccountToOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InviteAccountToOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            InviteAccountToOrganizationError::AWSOrganizationsNotInUse(ref cause) => cause,
-            InviteAccountToOrganizationError::AccessDenied(ref cause) => cause,
-            InviteAccountToOrganizationError::AccountOwnerNotVerified(ref cause) => cause,
-            InviteAccountToOrganizationError::ConcurrentModification(ref cause) => cause,
-            InviteAccountToOrganizationError::DuplicateHandshake(ref cause) => cause,
-            InviteAccountToOrganizationError::FinalizingOrganization(ref cause) => cause,
-            InviteAccountToOrganizationError::HandshakeConstraintViolation(ref cause) => cause,
-            InviteAccountToOrganizationError::InvalidInput(ref cause) => cause,
-            InviteAccountToOrganizationError::Service(ref cause) => cause,
-            InviteAccountToOrganizationError::TooManyRequests(ref cause) => cause,
+            InviteAccountToOrganizationError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InviteAccountToOrganizationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            InviteAccountToOrganizationError::AccountOwnerNotVerified(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InviteAccountToOrganizationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InviteAccountToOrganizationError::DuplicateHandshake(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InviteAccountToOrganizationError::FinalizingOrganization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InviteAccountToOrganizationError::HandshakeConstraintViolation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InviteAccountToOrganizationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            InviteAccountToOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            InviteAccountToOrganizationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InviteAccountToOrganizationError {}
 /// Errors returned by LeaveOrganization
 #[derive(Debug, PartialEq)]
 pub enum LeaveOrganizationError {
@@ -3608,24 +3564,22 @@ impl LeaveOrganizationError {
 }
 impl fmt::Display for LeaveOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for LeaveOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            LeaveOrganizationError::AWSOrganizationsNotInUse(ref cause) => cause,
-            LeaveOrganizationError::AccessDenied(ref cause) => cause,
-            LeaveOrganizationError::AccountNotFound(ref cause) => cause,
-            LeaveOrganizationError::ConcurrentModification(ref cause) => cause,
-            LeaveOrganizationError::ConstraintViolation(ref cause) => cause,
-            LeaveOrganizationError::InvalidInput(ref cause) => cause,
-            LeaveOrganizationError::MasterCannotLeaveOrganization(ref cause) => cause,
-            LeaveOrganizationError::Service(ref cause) => cause,
-            LeaveOrganizationError::TooManyRequests(ref cause) => cause,
+            LeaveOrganizationError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            LeaveOrganizationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            LeaveOrganizationError::AccountNotFound(ref cause) => write!(f, "{}", cause),
+            LeaveOrganizationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            LeaveOrganizationError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            LeaveOrganizationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            LeaveOrganizationError::MasterCannotLeaveOrganization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            LeaveOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            LeaveOrganizationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for LeaveOrganizationError {}
 /// Errors returned by ListAWSServiceAccessForOrganization
 #[derive(Debug, PartialEq)]
 pub enum ListAWSServiceAccessForOrganizationError {
@@ -3688,21 +3642,27 @@ impl ListAWSServiceAccessForOrganizationError {
 }
 impl fmt::Display for ListAWSServiceAccessForOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAWSServiceAccessForOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            ListAWSServiceAccessForOrganizationError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListAWSServiceAccessForOrganizationError::AccessDenied(ref cause) => cause,
-            ListAWSServiceAccessForOrganizationError::ConstraintViolation(ref cause) => cause,
-            ListAWSServiceAccessForOrganizationError::InvalidInput(ref cause) => cause,
-            ListAWSServiceAccessForOrganizationError::Service(ref cause) => cause,
-            ListAWSServiceAccessForOrganizationError::TooManyRequests(ref cause) => cause,
+            ListAWSServiceAccessForOrganizationError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAWSServiceAccessForOrganizationError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAWSServiceAccessForOrganizationError::ConstraintViolation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAWSServiceAccessForOrganizationError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAWSServiceAccessForOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            ListAWSServiceAccessForOrganizationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListAWSServiceAccessForOrganizationError {}
 /// Errors returned by ListAccounts
 #[derive(Debug, PartialEq)]
 pub enum ListAccountsError {
@@ -3748,20 +3708,16 @@ impl ListAccountsError {
 }
 impl fmt::Display for ListAccountsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAccountsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAccountsError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListAccountsError::AccessDenied(ref cause) => cause,
-            ListAccountsError::InvalidInput(ref cause) => cause,
-            ListAccountsError::Service(ref cause) => cause,
-            ListAccountsError::TooManyRequests(ref cause) => cause,
+            ListAccountsError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::Service(ref cause) => write!(f, "{}", cause),
+            ListAccountsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAccountsError {}
 /// Errors returned by ListAccountsForParent
 #[derive(Debug, PartialEq)]
 pub enum ListAccountsForParentError {
@@ -3816,21 +3772,19 @@ impl ListAccountsForParentError {
 }
 impl fmt::Display for ListAccountsForParentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAccountsForParentError {
-    fn description(&self) -> &str {
         match *self {
-            ListAccountsForParentError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListAccountsForParentError::AccessDenied(ref cause) => cause,
-            ListAccountsForParentError::InvalidInput(ref cause) => cause,
-            ListAccountsForParentError::ParentNotFound(ref cause) => cause,
-            ListAccountsForParentError::Service(ref cause) => cause,
-            ListAccountsForParentError::TooManyRequests(ref cause) => cause,
+            ListAccountsForParentError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAccountsForParentError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListAccountsForParentError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListAccountsForParentError::ParentNotFound(ref cause) => write!(f, "{}", cause),
+            ListAccountsForParentError::Service(ref cause) => write!(f, "{}", cause),
+            ListAccountsForParentError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAccountsForParentError {}
 /// Errors returned by ListChildren
 #[derive(Debug, PartialEq)]
 pub enum ListChildrenError {
@@ -3881,21 +3835,17 @@ impl ListChildrenError {
 }
 impl fmt::Display for ListChildrenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListChildrenError {
-    fn description(&self) -> &str {
         match *self {
-            ListChildrenError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListChildrenError::AccessDenied(ref cause) => cause,
-            ListChildrenError::InvalidInput(ref cause) => cause,
-            ListChildrenError::ParentNotFound(ref cause) => cause,
-            ListChildrenError::Service(ref cause) => cause,
-            ListChildrenError::TooManyRequests(ref cause) => cause,
+            ListChildrenError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            ListChildrenError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListChildrenError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListChildrenError::ParentNotFound(ref cause) => write!(f, "{}", cause),
+            ListChildrenError::Service(ref cause) => write!(f, "{}", cause),
+            ListChildrenError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListChildrenError {}
 /// Errors returned by ListCreateAccountStatus
 #[derive(Debug, PartialEq)]
 pub enum ListCreateAccountStatusError {
@@ -3954,21 +3904,21 @@ impl ListCreateAccountStatusError {
 }
 impl fmt::Display for ListCreateAccountStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCreateAccountStatusError {
-    fn description(&self) -> &str {
         match *self {
-            ListCreateAccountStatusError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListCreateAccountStatusError::AccessDenied(ref cause) => cause,
-            ListCreateAccountStatusError::InvalidInput(ref cause) => cause,
-            ListCreateAccountStatusError::Service(ref cause) => cause,
-            ListCreateAccountStatusError::TooManyRequests(ref cause) => cause,
-            ListCreateAccountStatusError::UnsupportedAPIEndpoint(ref cause) => cause,
+            ListCreateAccountStatusError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListCreateAccountStatusError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListCreateAccountStatusError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListCreateAccountStatusError::Service(ref cause) => write!(f, "{}", cause),
+            ListCreateAccountStatusError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListCreateAccountStatusError::UnsupportedAPIEndpoint(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListCreateAccountStatusError {}
 /// Errors returned by ListHandshakesForAccount
 #[derive(Debug, PartialEq)]
 pub enum ListHandshakesForAccountError {
@@ -4020,20 +3970,18 @@ impl ListHandshakesForAccountError {
 }
 impl fmt::Display for ListHandshakesForAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHandshakesForAccountError {
-    fn description(&self) -> &str {
         match *self {
-            ListHandshakesForAccountError::AccessDenied(ref cause) => cause,
-            ListHandshakesForAccountError::ConcurrentModification(ref cause) => cause,
-            ListHandshakesForAccountError::InvalidInput(ref cause) => cause,
-            ListHandshakesForAccountError::Service(ref cause) => cause,
-            ListHandshakesForAccountError::TooManyRequests(ref cause) => cause,
+            ListHandshakesForAccountError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListHandshakesForAccountError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListHandshakesForAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListHandshakesForAccountError::Service(ref cause) => write!(f, "{}", cause),
+            ListHandshakesForAccountError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHandshakesForAccountError {}
 /// Errors returned by ListHandshakesForOrganization
 #[derive(Debug, PartialEq)]
 pub enum ListHandshakesForOrganizationError {
@@ -4096,21 +4044,23 @@ impl ListHandshakesForOrganizationError {
 }
 impl fmt::Display for ListHandshakesForOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHandshakesForOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            ListHandshakesForOrganizationError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListHandshakesForOrganizationError::AccessDenied(ref cause) => cause,
-            ListHandshakesForOrganizationError::ConcurrentModification(ref cause) => cause,
-            ListHandshakesForOrganizationError::InvalidInput(ref cause) => cause,
-            ListHandshakesForOrganizationError::Service(ref cause) => cause,
-            ListHandshakesForOrganizationError::TooManyRequests(ref cause) => cause,
+            ListHandshakesForOrganizationError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListHandshakesForOrganizationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListHandshakesForOrganizationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListHandshakesForOrganizationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListHandshakesForOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            ListHandshakesForOrganizationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListHandshakesForOrganizationError {}
 /// Errors returned by ListOrganizationalUnitsForParent
 #[derive(Debug, PartialEq)]
 pub enum ListOrganizationalUnitsForParentError {
@@ -4173,21 +4123,27 @@ impl ListOrganizationalUnitsForParentError {
 }
 impl fmt::Display for ListOrganizationalUnitsForParentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOrganizationalUnitsForParentError {
-    fn description(&self) -> &str {
         match *self {
-            ListOrganizationalUnitsForParentError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListOrganizationalUnitsForParentError::AccessDenied(ref cause) => cause,
-            ListOrganizationalUnitsForParentError::InvalidInput(ref cause) => cause,
-            ListOrganizationalUnitsForParentError::ParentNotFound(ref cause) => cause,
-            ListOrganizationalUnitsForParentError::Service(ref cause) => cause,
-            ListOrganizationalUnitsForParentError::TooManyRequests(ref cause) => cause,
+            ListOrganizationalUnitsForParentError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOrganizationalUnitsForParentError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOrganizationalUnitsForParentError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOrganizationalUnitsForParentError::ParentNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOrganizationalUnitsForParentError::Service(ref cause) => write!(f, "{}", cause),
+            ListOrganizationalUnitsForParentError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListOrganizationalUnitsForParentError {}
 /// Errors returned by ListParents
 #[derive(Debug, PartialEq)]
 pub enum ListParentsError {
@@ -4238,21 +4194,17 @@ impl ListParentsError {
 }
 impl fmt::Display for ListParentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListParentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListParentsError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListParentsError::AccessDenied(ref cause) => cause,
-            ListParentsError::ChildNotFound(ref cause) => cause,
-            ListParentsError::InvalidInput(ref cause) => cause,
-            ListParentsError::Service(ref cause) => cause,
-            ListParentsError::TooManyRequests(ref cause) => cause,
+            ListParentsError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            ListParentsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListParentsError::ChildNotFound(ref cause) => write!(f, "{}", cause),
+            ListParentsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListParentsError::Service(ref cause) => write!(f, "{}", cause),
+            ListParentsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListParentsError {}
 /// Errors returned by ListPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListPoliciesError {
@@ -4303,21 +4255,17 @@ impl ListPoliciesError {
 }
 impl fmt::Display for ListPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPoliciesError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListPoliciesError::AccessDenied(ref cause) => cause,
-            ListPoliciesError::InvalidInput(ref cause) => cause,
-            ListPoliciesError::Service(ref cause) => cause,
-            ListPoliciesError::TooManyRequests(ref cause) => cause,
-            ListPoliciesError::UnsupportedAPIEndpoint(ref cause) => cause,
+            ListPoliciesError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::Service(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListPoliciesError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPoliciesError {}
 /// Errors returned by ListPoliciesForTarget
 #[derive(Debug, PartialEq)]
 pub enum ListPoliciesForTargetError {
@@ -4379,22 +4327,20 @@ impl ListPoliciesForTargetError {
 }
 impl fmt::Display for ListPoliciesForTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPoliciesForTargetError {
-    fn description(&self) -> &str {
         match *self {
-            ListPoliciesForTargetError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListPoliciesForTargetError::AccessDenied(ref cause) => cause,
-            ListPoliciesForTargetError::InvalidInput(ref cause) => cause,
-            ListPoliciesForTargetError::Service(ref cause) => cause,
-            ListPoliciesForTargetError::TargetNotFound(ref cause) => cause,
-            ListPoliciesForTargetError::TooManyRequests(ref cause) => cause,
-            ListPoliciesForTargetError::UnsupportedAPIEndpoint(ref cause) => cause,
+            ListPoliciesForTargetError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListPoliciesForTargetError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListPoliciesForTargetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListPoliciesForTargetError::Service(ref cause) => write!(f, "{}", cause),
+            ListPoliciesForTargetError::TargetNotFound(ref cause) => write!(f, "{}", cause),
+            ListPoliciesForTargetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListPoliciesForTargetError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPoliciesForTargetError {}
 /// Errors returned by ListRoots
 #[derive(Debug, PartialEq)]
 pub enum ListRootsError {
@@ -4438,20 +4384,16 @@ impl ListRootsError {
 }
 impl fmt::Display for ListRootsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRootsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRootsError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListRootsError::AccessDenied(ref cause) => cause,
-            ListRootsError::InvalidInput(ref cause) => cause,
-            ListRootsError::Service(ref cause) => cause,
-            ListRootsError::TooManyRequests(ref cause) => cause,
+            ListRootsError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            ListRootsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListRootsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListRootsError::Service(ref cause) => write!(f, "{}", cause),
+            ListRootsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRootsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -4502,21 +4444,17 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListTagsForResourceError::AccessDenied(ref cause) => cause,
-            ListTagsForResourceError::InvalidInput(ref cause) => cause,
-            ListTagsForResourceError::Service(ref cause) => cause,
-            ListTagsForResourceError::TargetNotFound(ref cause) => cause,
-            ListTagsForResourceError::TooManyRequests(ref cause) => cause,
+            ListTagsForResourceError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Service(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TargetNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTargetsForPolicy
 #[derive(Debug, PartialEq)]
 pub enum ListTargetsForPolicyError {
@@ -4576,22 +4514,20 @@ impl ListTargetsForPolicyError {
 }
 impl fmt::Display for ListTargetsForPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTargetsForPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            ListTargetsForPolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            ListTargetsForPolicyError::AccessDenied(ref cause) => cause,
-            ListTargetsForPolicyError::InvalidInput(ref cause) => cause,
-            ListTargetsForPolicyError::PolicyNotFound(ref cause) => cause,
-            ListTargetsForPolicyError::Service(ref cause) => cause,
-            ListTargetsForPolicyError::TooManyRequests(ref cause) => cause,
-            ListTargetsForPolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            ListTargetsForPolicyError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTargetsForPolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::Service(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListTargetsForPolicyError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTargetsForPolicyError {}
 /// Errors returned by MoveAccount
 #[derive(Debug, PartialEq)]
 pub enum MoveAccountError {
@@ -4664,25 +4600,21 @@ impl MoveAccountError {
 }
 impl fmt::Display for MoveAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for MoveAccountError {
-    fn description(&self) -> &str {
         match *self {
-            MoveAccountError::AWSOrganizationsNotInUse(ref cause) => cause,
-            MoveAccountError::AccessDenied(ref cause) => cause,
-            MoveAccountError::AccountNotFound(ref cause) => cause,
-            MoveAccountError::ConcurrentModification(ref cause) => cause,
-            MoveAccountError::DestinationParentNotFound(ref cause) => cause,
-            MoveAccountError::DuplicateAccount(ref cause) => cause,
-            MoveAccountError::InvalidInput(ref cause) => cause,
-            MoveAccountError::Service(ref cause) => cause,
-            MoveAccountError::SourceParentNotFound(ref cause) => cause,
-            MoveAccountError::TooManyRequests(ref cause) => cause,
+            MoveAccountError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::AccountNotFound(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::DestinationParentNotFound(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::DuplicateAccount(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::Service(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::SourceParentNotFound(ref cause) => write!(f, "{}", cause),
+            MoveAccountError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for MoveAccountError {}
 /// Errors returned by RemoveAccountFromOrganization
 #[derive(Debug, PartialEq)]
 pub enum RemoveAccountFromOrganizationError {
@@ -4766,24 +4698,32 @@ impl RemoveAccountFromOrganizationError {
 }
 impl fmt::Display for RemoveAccountFromOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveAccountFromOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveAccountFromOrganizationError::AWSOrganizationsNotInUse(ref cause) => cause,
-            RemoveAccountFromOrganizationError::AccessDenied(ref cause) => cause,
-            RemoveAccountFromOrganizationError::AccountNotFound(ref cause) => cause,
-            RemoveAccountFromOrganizationError::ConcurrentModification(ref cause) => cause,
-            RemoveAccountFromOrganizationError::ConstraintViolation(ref cause) => cause,
-            RemoveAccountFromOrganizationError::InvalidInput(ref cause) => cause,
-            RemoveAccountFromOrganizationError::MasterCannotLeaveOrganization(ref cause) => cause,
-            RemoveAccountFromOrganizationError::Service(ref cause) => cause,
-            RemoveAccountFromOrganizationError::TooManyRequests(ref cause) => cause,
+            RemoveAccountFromOrganizationError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAccountFromOrganizationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RemoveAccountFromOrganizationError::AccountNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAccountFromOrganizationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAccountFromOrganizationError::ConstraintViolation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAccountFromOrganizationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RemoveAccountFromOrganizationError::MasterCannotLeaveOrganization(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAccountFromOrganizationError::Service(ref cause) => write!(f, "{}", cause),
+            RemoveAccountFromOrganizationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveAccountFromOrganizationError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -4844,23 +4784,19 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AWSOrganizationsNotInUse(ref cause) => cause,
-            TagResourceError::AccessDenied(ref cause) => cause,
-            TagResourceError::ConcurrentModification(ref cause) => cause,
-            TagResourceError::ConstraintViolation(ref cause) => cause,
-            TagResourceError::InvalidInput(ref cause) => cause,
-            TagResourceError::Service(ref cause) => cause,
-            TagResourceError::TargetNotFound(ref cause) => cause,
-            TagResourceError::TooManyRequests(ref cause) => cause,
+            TagResourceError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            TagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TagResourceError::Service(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TargetNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -4923,23 +4859,19 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AWSOrganizationsNotInUse(ref cause) => cause,
-            UntagResourceError::AccessDenied(ref cause) => cause,
-            UntagResourceError::ConcurrentModification(ref cause) => cause,
-            UntagResourceError::ConstraintViolation(ref cause) => cause,
-            UntagResourceError::InvalidInput(ref cause) => cause,
-            UntagResourceError::Service(ref cause) => cause,
-            UntagResourceError::TargetNotFound(ref cause) => cause,
-            UntagResourceError::TooManyRequests(ref cause) => cause,
+            UntagResourceError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::Service(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TargetNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateOrganizationalUnit
 #[derive(Debug, PartialEq)]
 pub enum UpdateOrganizationalUnitError {
@@ -5012,23 +4944,27 @@ impl UpdateOrganizationalUnitError {
 }
 impl fmt::Display for UpdateOrganizationalUnitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateOrganizationalUnitError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => cause,
-            UpdateOrganizationalUnitError::AccessDenied(ref cause) => cause,
-            UpdateOrganizationalUnitError::ConcurrentModification(ref cause) => cause,
-            UpdateOrganizationalUnitError::DuplicateOrganizationalUnit(ref cause) => cause,
-            UpdateOrganizationalUnitError::InvalidInput(ref cause) => cause,
-            UpdateOrganizationalUnitError::OrganizationalUnitNotFound(ref cause) => cause,
-            UpdateOrganizationalUnitError::Service(ref cause) => cause,
-            UpdateOrganizationalUnitError::TooManyRequests(ref cause) => cause,
+            UpdateOrganizationalUnitError::AWSOrganizationsNotInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateOrganizationalUnitError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateOrganizationalUnitError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateOrganizationalUnitError::DuplicateOrganizationalUnit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateOrganizationalUnitError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateOrganizationalUnitError::OrganizationalUnitNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateOrganizationalUnitError::Service(ref cause) => write!(f, "{}", cause),
+            UpdateOrganizationalUnitError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateOrganizationalUnitError {}
 /// Errors returned by UpdatePolicy
 #[derive(Debug, PartialEq)]
 pub enum UpdatePolicyError {
@@ -5113,27 +5049,23 @@ impl UpdatePolicyError {
 }
 impl fmt::Display for UpdatePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePolicyError::AWSOrganizationsNotInUse(ref cause) => cause,
-            UpdatePolicyError::AccessDenied(ref cause) => cause,
-            UpdatePolicyError::ConcurrentModification(ref cause) => cause,
-            UpdatePolicyError::ConstraintViolation(ref cause) => cause,
-            UpdatePolicyError::DuplicatePolicy(ref cause) => cause,
-            UpdatePolicyError::InvalidInput(ref cause) => cause,
-            UpdatePolicyError::MalformedPolicyDocument(ref cause) => cause,
-            UpdatePolicyError::PolicyChangesInProgress(ref cause) => cause,
-            UpdatePolicyError::PolicyNotFound(ref cause) => cause,
-            UpdatePolicyError::Service(ref cause) => cause,
-            UpdatePolicyError::TooManyRequests(ref cause) => cause,
-            UpdatePolicyError::UnsupportedAPIEndpoint(ref cause) => cause,
+            UpdatePolicyError::AWSOrganizationsNotInUse(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::DuplicatePolicy(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::PolicyChangesInProgress(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::PolicyNotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::Service(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdatePolicyError::UnsupportedAPIEndpoint(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePolicyError {}
 /// Trait representing the capabilities of the Organizations API. Organizations clients implement this trait.
 pub trait Organizations {
     /// <p>Sends a response to the originator of a handshake agreeing to the action proposed by the handshake request. </p> <p>This operation can be called only by the following principals when they also have the relevant IAM permissions:</p> <ul> <li> <p> <b>Invitation to join</b> or <b>Approve all features request</b> handshakes: only a principal from the member account. </p> <p>The user who calls the API for an invitation to join must have the <code>organizations:AcceptHandshake</code> permission. If you enabled all features in the organization, the user must also have the <code>iam:CreateServiceLinkedRole</code> permission so that AWS Organizations can create the required service-linked role named <code>AWSServiceRoleForOrganizations</code>. For more information, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_integration_services.html#orgs_integration_service-linked-roles">AWS Organizations and Service-Linked Roles</a> in the <i>AWS Organizations User Guide</i>.</p> </li> <li> <p> <b>Enable all features final confirmation</b> handshake: only a principal from the master account.</p> <p>For more information about invitations, see <a href="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_invites.html">Inviting an AWS Account to Join Your Organization</a> in the <i>AWS Organizations User Guide.</i> For more information about requests to enable all features in the organization, see <a href="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_org_support-all-features.html">Enabling All Features in Your Organization</a> in the <i>AWS Organizations User Guide.</i> </p> </li> </ul> <p>After you accept a handshake, it continues to appear in the results of relevant APIs for only 30 days. After that, it's deleted.</p>

--- a/rusoto/services/pi/src/generated.rs
+++ b/rusoto/services/pi/src/generated.rs
@@ -281,18 +281,14 @@ impl DescribeDimensionKeysError {
 }
 impl fmt::Display for DescribeDimensionKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDimensionKeysError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDimensionKeysError::InternalServiceError(ref cause) => cause,
-            DescribeDimensionKeysError::InvalidArgument(ref cause) => cause,
-            DescribeDimensionKeysError::NotAuthorized(ref cause) => cause,
+            DescribeDimensionKeysError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DescribeDimensionKeysError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeDimensionKeysError::NotAuthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDimensionKeysError {}
 /// Errors returned by GetResourceMetrics
 #[derive(Debug, PartialEq)]
 pub enum GetResourceMetricsError {
@@ -328,18 +324,14 @@ impl GetResourceMetricsError {
 }
 impl fmt::Display for GetResourceMetricsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceMetricsError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceMetricsError::InternalServiceError(ref cause) => cause,
-            GetResourceMetricsError::InvalidArgument(ref cause) => cause,
-            GetResourceMetricsError::NotAuthorized(ref cause) => cause,
+            GetResourceMetricsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            GetResourceMetricsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetResourceMetricsError::NotAuthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourceMetricsError {}
 /// Trait representing the capabilities of the AWS PI API. AWS PI clients implement this trait.
 pub trait PerformanceInsights {
     /// <p>For a specific time period, retrieve the top <code>N</code> dimension keys for a metric.</p>

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -458,17 +458,13 @@ impl DeleteLexiconError {
 }
 impl fmt::Display for DeleteLexiconError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLexiconError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLexiconError::LexiconNotFound(ref cause) => cause,
-            DeleteLexiconError::ServiceFailure(ref cause) => cause,
+            DeleteLexiconError::LexiconNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLexiconError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLexiconError {}
 /// Errors returned by DescribeVoices
 #[derive(Debug, PartialEq)]
 pub enum DescribeVoicesError {
@@ -497,17 +493,13 @@ impl DescribeVoicesError {
 }
 impl fmt::Display for DescribeVoicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVoicesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVoicesError::InvalidNextToken(ref cause) => cause,
-            DescribeVoicesError::ServiceFailure(ref cause) => cause,
+            DescribeVoicesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeVoicesError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVoicesError {}
 /// Errors returned by GetLexicon
 #[derive(Debug, PartialEq)]
 pub enum GetLexiconError {
@@ -536,17 +528,13 @@ impl GetLexiconError {
 }
 impl fmt::Display for GetLexiconError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLexiconError {
-    fn description(&self) -> &str {
         match *self {
-            GetLexiconError::LexiconNotFound(ref cause) => cause,
-            GetLexiconError::ServiceFailure(ref cause) => cause,
+            GetLexiconError::LexiconNotFound(ref cause) => write!(f, "{}", cause),
+            GetLexiconError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLexiconError {}
 /// Errors returned by GetSpeechSynthesisTask
 #[derive(Debug, PartialEq)]
 pub enum GetSpeechSynthesisTaskError {
@@ -586,18 +574,14 @@ impl GetSpeechSynthesisTaskError {
 }
 impl fmt::Display for GetSpeechSynthesisTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSpeechSynthesisTaskError {
-    fn description(&self) -> &str {
         match *self {
-            GetSpeechSynthesisTaskError::InvalidTaskId(ref cause) => cause,
-            GetSpeechSynthesisTaskError::ServiceFailure(ref cause) => cause,
-            GetSpeechSynthesisTaskError::SynthesisTaskNotFound(ref cause) => cause,
+            GetSpeechSynthesisTaskError::InvalidTaskId(ref cause) => write!(f, "{}", cause),
+            GetSpeechSynthesisTaskError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            GetSpeechSynthesisTaskError::SynthesisTaskNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSpeechSynthesisTaskError {}
 /// Errors returned by ListLexicons
 #[derive(Debug, PartialEq)]
 pub enum ListLexiconsError {
@@ -626,17 +610,13 @@ impl ListLexiconsError {
 }
 impl fmt::Display for ListLexiconsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLexiconsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLexiconsError::InvalidNextToken(ref cause) => cause,
-            ListLexiconsError::ServiceFailure(ref cause) => cause,
+            ListLexiconsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListLexiconsError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLexiconsError {}
 /// Errors returned by ListSpeechSynthesisTasks
 #[derive(Debug, PartialEq)]
 pub enum ListSpeechSynthesisTasksError {
@@ -669,17 +649,13 @@ impl ListSpeechSynthesisTasksError {
 }
 impl fmt::Display for ListSpeechSynthesisTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSpeechSynthesisTasksError {
-    fn description(&self) -> &str {
         match *self {
-            ListSpeechSynthesisTasksError::InvalidNextToken(ref cause) => cause,
-            ListSpeechSynthesisTasksError::ServiceFailure(ref cause) => cause,
+            ListSpeechSynthesisTasksError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListSpeechSynthesisTasksError::ServiceFailure(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSpeechSynthesisTasksError {}
 /// Errors returned by PutLexicon
 #[derive(Debug, PartialEq)]
 pub enum PutLexiconError {
@@ -735,22 +711,18 @@ impl PutLexiconError {
 }
 impl fmt::Display for PutLexiconError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLexiconError {
-    fn description(&self) -> &str {
         match *self {
-            PutLexiconError::InvalidLexicon(ref cause) => cause,
-            PutLexiconError::LexiconSizeExceeded(ref cause) => cause,
-            PutLexiconError::MaxLexemeLengthExceeded(ref cause) => cause,
-            PutLexiconError::MaxLexiconsNumberExceeded(ref cause) => cause,
-            PutLexiconError::ServiceFailure(ref cause) => cause,
-            PutLexiconError::UnsupportedPlsAlphabet(ref cause) => cause,
-            PutLexiconError::UnsupportedPlsLanguage(ref cause) => cause,
+            PutLexiconError::InvalidLexicon(ref cause) => write!(f, "{}", cause),
+            PutLexiconError::LexiconSizeExceeded(ref cause) => write!(f, "{}", cause),
+            PutLexiconError::MaxLexemeLengthExceeded(ref cause) => write!(f, "{}", cause),
+            PutLexiconError::MaxLexiconsNumberExceeded(ref cause) => write!(f, "{}", cause),
+            PutLexiconError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            PutLexiconError::UnsupportedPlsAlphabet(ref cause) => write!(f, "{}", cause),
+            PutLexiconError::UnsupportedPlsLanguage(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLexiconError {}
 /// Errors returned by StartSpeechSynthesisTask
 #[derive(Debug, PartialEq)]
 pub enum StartSpeechSynthesisTaskError {
@@ -853,27 +825,29 @@ impl StartSpeechSynthesisTaskError {
 }
 impl fmt::Display for StartSpeechSynthesisTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartSpeechSynthesisTaskError {
-    fn description(&self) -> &str {
         match *self {
-            StartSpeechSynthesisTaskError::EngineNotSupported(ref cause) => cause,
-            StartSpeechSynthesisTaskError::InvalidS3Bucket(ref cause) => cause,
-            StartSpeechSynthesisTaskError::InvalidS3Key(ref cause) => cause,
-            StartSpeechSynthesisTaskError::InvalidSampleRate(ref cause) => cause,
-            StartSpeechSynthesisTaskError::InvalidSnsTopicArn(ref cause) => cause,
-            StartSpeechSynthesisTaskError::InvalidSsml(ref cause) => cause,
-            StartSpeechSynthesisTaskError::LanguageNotSupported(ref cause) => cause,
-            StartSpeechSynthesisTaskError::LexiconNotFound(ref cause) => cause,
-            StartSpeechSynthesisTaskError::MarksNotSupportedForFormat(ref cause) => cause,
-            StartSpeechSynthesisTaskError::ServiceFailure(ref cause) => cause,
-            StartSpeechSynthesisTaskError::SsmlMarksNotSupportedForTextType(ref cause) => cause,
-            StartSpeechSynthesisTaskError::TextLengthExceeded(ref cause) => cause,
+            StartSpeechSynthesisTaskError::EngineNotSupported(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::InvalidS3Bucket(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::InvalidS3Key(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::InvalidSampleRate(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::InvalidSnsTopicArn(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::InvalidSsml(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::LanguageNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartSpeechSynthesisTaskError::LexiconNotFound(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::MarksNotSupportedForFormat(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartSpeechSynthesisTaskError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            StartSpeechSynthesisTaskError::SsmlMarksNotSupportedForTextType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartSpeechSynthesisTaskError::TextLengthExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartSpeechSynthesisTaskError {}
 /// Errors returned by SynthesizeSpeech
 #[derive(Debug, PartialEq)]
 pub enum SynthesizeSpeechError {
@@ -943,24 +917,22 @@ impl SynthesizeSpeechError {
 }
 impl fmt::Display for SynthesizeSpeechError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SynthesizeSpeechError {
-    fn description(&self) -> &str {
         match *self {
-            SynthesizeSpeechError::EngineNotSupported(ref cause) => cause,
-            SynthesizeSpeechError::InvalidSampleRate(ref cause) => cause,
-            SynthesizeSpeechError::InvalidSsml(ref cause) => cause,
-            SynthesizeSpeechError::LanguageNotSupported(ref cause) => cause,
-            SynthesizeSpeechError::LexiconNotFound(ref cause) => cause,
-            SynthesizeSpeechError::MarksNotSupportedForFormat(ref cause) => cause,
-            SynthesizeSpeechError::ServiceFailure(ref cause) => cause,
-            SynthesizeSpeechError::SsmlMarksNotSupportedForTextType(ref cause) => cause,
-            SynthesizeSpeechError::TextLengthExceeded(ref cause) => cause,
+            SynthesizeSpeechError::EngineNotSupported(ref cause) => write!(f, "{}", cause),
+            SynthesizeSpeechError::InvalidSampleRate(ref cause) => write!(f, "{}", cause),
+            SynthesizeSpeechError::InvalidSsml(ref cause) => write!(f, "{}", cause),
+            SynthesizeSpeechError::LanguageNotSupported(ref cause) => write!(f, "{}", cause),
+            SynthesizeSpeechError::LexiconNotFound(ref cause) => write!(f, "{}", cause),
+            SynthesizeSpeechError::MarksNotSupportedForFormat(ref cause) => write!(f, "{}", cause),
+            SynthesizeSpeechError::ServiceFailure(ref cause) => write!(f, "{}", cause),
+            SynthesizeSpeechError::SsmlMarksNotSupportedForTextType(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SynthesizeSpeechError::TextLengthExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SynthesizeSpeechError {}
 /// Trait representing the capabilities of the Amazon Polly API. Amazon Polly clients implement this trait.
 pub trait Polly {
     /// <p>Deletes the specified pronunciation lexicon stored in an AWS Region. A lexicon which has been deleted is not available for speech synthesis, nor is it possible to retrieve it using either the <code>GetLexicon</code> or <code>ListLexicon</code> APIs.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html">Managing Lexicons</a>.</p>

--- a/rusoto/services/pricing/src/generated.rs
+++ b/rusoto/services/pricing/src/generated.rs
@@ -213,20 +213,16 @@ impl DescribeServicesError {
 }
 impl fmt::Display for DescribeServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServicesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServicesError::ExpiredNextToken(ref cause) => cause,
-            DescribeServicesError::InternalError(ref cause) => cause,
-            DescribeServicesError::InvalidNextToken(ref cause) => cause,
-            DescribeServicesError::InvalidParameter(ref cause) => cause,
-            DescribeServicesError::NotFound(ref cause) => cause,
+            DescribeServicesError::ExpiredNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeServicesError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeServicesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeServicesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeServicesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeServicesError {}
 /// Errors returned by GetAttributeValues
 #[derive(Debug, PartialEq)]
 pub enum GetAttributeValuesError {
@@ -270,20 +266,16 @@ impl GetAttributeValuesError {
 }
 impl fmt::Display for GetAttributeValuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAttributeValuesError {
-    fn description(&self) -> &str {
         match *self {
-            GetAttributeValuesError::ExpiredNextToken(ref cause) => cause,
-            GetAttributeValuesError::InternalError(ref cause) => cause,
-            GetAttributeValuesError::InvalidNextToken(ref cause) => cause,
-            GetAttributeValuesError::InvalidParameter(ref cause) => cause,
-            GetAttributeValuesError::NotFound(ref cause) => cause,
+            GetAttributeValuesError::ExpiredNextToken(ref cause) => write!(f, "{}", cause),
+            GetAttributeValuesError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetAttributeValuesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetAttributeValuesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetAttributeValuesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAttributeValuesError {}
 /// Errors returned by GetProducts
 #[derive(Debug, PartialEq)]
 pub enum GetProductsError {
@@ -327,20 +319,16 @@ impl GetProductsError {
 }
 impl fmt::Display for GetProductsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetProductsError {
-    fn description(&self) -> &str {
         match *self {
-            GetProductsError::ExpiredNextToken(ref cause) => cause,
-            GetProductsError::InternalError(ref cause) => cause,
-            GetProductsError::InvalidNextToken(ref cause) => cause,
-            GetProductsError::InvalidParameter(ref cause) => cause,
-            GetProductsError::NotFound(ref cause) => cause,
+            GetProductsError::ExpiredNextToken(ref cause) => write!(f, "{}", cause),
+            GetProductsError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetProductsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetProductsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetProductsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetProductsError {}
 /// Trait representing the capabilities of the AWS Pricing API. AWS Pricing clients implement this trait.
 pub trait Pricing {
     /// <p>Returns the metadata for one service or a list of the metadata for all services. Use this without a service code to get the service codes for all services. Use it with a service code, such as <code>AmazonEC2</code>, to get information specific to that service, such as the attribute names available for that service. For example, some of the attribute names available for EC2 are <code>volumeType</code>, <code>maxIopsVolume</code>, <code>operation</code>, <code>locationType</code>, and <code>instanceCapacity10xlarge</code>.</p>

--- a/rusoto/services/qldb-session/src/generated.rs
+++ b/rusoto/services/qldb-session/src/generated.rs
@@ -298,20 +298,16 @@ impl SendCommandError {
 }
 impl fmt::Display for SendCommandError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendCommandError {
-    fn description(&self) -> &str {
         match *self {
-            SendCommandError::BadRequest(ref cause) => cause,
-            SendCommandError::InvalidSession(ref cause) => cause,
-            SendCommandError::LimitExceeded(ref cause) => cause,
-            SendCommandError::OccConflict(ref cause) => cause,
-            SendCommandError::RateExceeded(ref cause) => cause,
+            SendCommandError::BadRequest(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidSession(ref cause) => write!(f, "{}", cause),
+            SendCommandError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            SendCommandError::OccConflict(ref cause) => write!(f, "{}", cause),
+            SendCommandError::RateExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendCommandError {}
 /// Trait representing the capabilities of the QLDB Session API. QLDB Session clients implement this trait.
 pub trait QldbSession {
     /// <p>Sends a command to an Amazon QLDB ledger.</p>

--- a/rusoto/services/qldb/src/generated.rs
+++ b/rusoto/services/qldb/src/generated.rs
@@ -507,19 +507,15 @@ impl CreateLedgerError {
 }
 impl fmt::Display for CreateLedgerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLedgerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLedgerError::InvalidParameter(ref cause) => cause,
-            CreateLedgerError::LimitExceeded(ref cause) => cause,
-            CreateLedgerError::ResourceAlreadyExists(ref cause) => cause,
-            CreateLedgerError::ResourceInUse(ref cause) => cause,
+            CreateLedgerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateLedgerError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateLedgerError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateLedgerError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLedgerError {}
 /// Errors returned by DeleteLedger
 #[derive(Debug, PartialEq)]
 pub enum DeleteLedgerError {
@@ -560,19 +556,15 @@ impl DeleteLedgerError {
 }
 impl fmt::Display for DeleteLedgerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLedgerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLedgerError::InvalidParameter(ref cause) => cause,
-            DeleteLedgerError::ResourceInUse(ref cause) => cause,
-            DeleteLedgerError::ResourceNotFound(ref cause) => cause,
-            DeleteLedgerError::ResourcePreconditionNotMet(ref cause) => cause,
+            DeleteLedgerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteLedgerError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteLedgerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteLedgerError::ResourcePreconditionNotMet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLedgerError {}
 /// Errors returned by DescribeJournalS3Export
 #[derive(Debug, PartialEq)]
 pub enum DescribeJournalS3ExportError {
@@ -598,16 +590,12 @@ impl DescribeJournalS3ExportError {
 }
 impl fmt::Display for DescribeJournalS3ExportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJournalS3ExportError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJournalS3ExportError::ResourceNotFound(ref cause) => cause,
+            DescribeJournalS3ExportError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJournalS3ExportError {}
 /// Errors returned by DescribeLedger
 #[derive(Debug, PartialEq)]
 pub enum DescribeLedgerError {
@@ -636,17 +624,13 @@ impl DescribeLedgerError {
 }
 impl fmt::Display for DescribeLedgerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLedgerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLedgerError::InvalidParameter(ref cause) => cause,
-            DescribeLedgerError::ResourceNotFound(ref cause) => cause,
+            DescribeLedgerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeLedgerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLedgerError {}
 /// Errors returned by ExportJournalToS3
 #[derive(Debug, PartialEq)]
 pub enum ExportJournalToS3Error {
@@ -677,17 +661,13 @@ impl ExportJournalToS3Error {
 }
 impl fmt::Display for ExportJournalToS3Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExportJournalToS3Error {
-    fn description(&self) -> &str {
         match *self {
-            ExportJournalToS3Error::ResourceNotFound(ref cause) => cause,
-            ExportJournalToS3Error::ResourcePreconditionNotMet(ref cause) => cause,
+            ExportJournalToS3Error::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ExportJournalToS3Error::ResourcePreconditionNotMet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExportJournalToS3Error {}
 /// Errors returned by GetBlock
 #[derive(Debug, PartialEq)]
 pub enum GetBlockError {
@@ -721,18 +701,14 @@ impl GetBlockError {
 }
 impl fmt::Display for GetBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBlockError {
-    fn description(&self) -> &str {
         match *self {
-            GetBlockError::InvalidParameter(ref cause) => cause,
-            GetBlockError::ResourceNotFound(ref cause) => cause,
-            GetBlockError::ResourcePreconditionNotMet(ref cause) => cause,
+            GetBlockError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetBlockError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetBlockError::ResourcePreconditionNotMet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetBlockError {}
 /// Errors returned by GetDigest
 #[derive(Debug, PartialEq)]
 pub enum GetDigestError {
@@ -768,18 +744,14 @@ impl GetDigestError {
 }
 impl fmt::Display for GetDigestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDigestError {
-    fn description(&self) -> &str {
         match *self {
-            GetDigestError::InvalidParameter(ref cause) => cause,
-            GetDigestError::ResourceNotFound(ref cause) => cause,
-            GetDigestError::ResourcePreconditionNotMet(ref cause) => cause,
+            GetDigestError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetDigestError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetDigestError::ResourcePreconditionNotMet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDigestError {}
 /// Errors returned by GetRevision
 #[derive(Debug, PartialEq)]
 pub enum GetRevisionError {
@@ -815,18 +787,14 @@ impl GetRevisionError {
 }
 impl fmt::Display for GetRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRevisionError {
-    fn description(&self) -> &str {
         match *self {
-            GetRevisionError::InvalidParameter(ref cause) => cause,
-            GetRevisionError::ResourceNotFound(ref cause) => cause,
-            GetRevisionError::ResourcePreconditionNotMet(ref cause) => cause,
+            GetRevisionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetRevisionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetRevisionError::ResourcePreconditionNotMet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRevisionError {}
 /// Errors returned by ListJournalS3Exports
 #[derive(Debug, PartialEq)]
 pub enum ListJournalS3ExportsError {}
@@ -844,14 +812,10 @@ impl ListJournalS3ExportsError {
 }
 impl fmt::Display for ListJournalS3ExportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJournalS3ExportsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListJournalS3ExportsError {}
 /// Errors returned by ListJournalS3ExportsForLedger
 #[derive(Debug, PartialEq)]
 pub enum ListJournalS3ExportsForLedgerError {}
@@ -871,14 +835,10 @@ impl ListJournalS3ExportsForLedgerError {
 }
 impl fmt::Display for ListJournalS3ExportsForLedgerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJournalS3ExportsForLedgerError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListJournalS3ExportsForLedgerError {}
 /// Errors returned by ListLedgers
 #[derive(Debug, PartialEq)]
 pub enum ListLedgersError {}
@@ -896,14 +856,10 @@ impl ListLedgersError {
 }
 impl fmt::Display for ListLedgersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLedgersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListLedgersError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -936,17 +892,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -975,17 +927,13 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1014,17 +962,13 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateLedger
 #[derive(Debug, PartialEq)]
 pub enum UpdateLedgerError {
@@ -1053,17 +997,13 @@ impl UpdateLedgerError {
 }
 impl fmt::Display for UpdateLedgerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateLedgerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateLedgerError::InvalidParameter(ref cause) => cause,
-            UpdateLedgerError::ResourceNotFound(ref cause) => cause,
+            UpdateLedgerError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateLedgerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateLedgerError {}
 /// Trait representing the capabilities of the QLDB API. QLDB clients implement this trait.
 pub trait Qldb {
     /// <p>Creates a new ledger in your AWS account.</p>

--- a/rusoto/services/ram/src/generated.rs
+++ b/rusoto/services/ram/src/generated.rs
@@ -1080,31 +1080,37 @@ impl AcceptResourceShareInvitationError {
 }
 impl fmt::Display for AcceptResourceShareInvitationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptResourceShareInvitationError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptResourceShareInvitationError::IdempotentParameterMismatch(ref cause) => cause,
-            AcceptResourceShareInvitationError::InvalidClientToken(ref cause) => cause,
-            AcceptResourceShareInvitationError::MalformedArn(ref cause) => cause,
-            AcceptResourceShareInvitationError::OperationNotPermitted(ref cause) => cause,
+            AcceptResourceShareInvitationError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptResourceShareInvitationError::InvalidClientToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptResourceShareInvitationError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            AcceptResourceShareInvitationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
             AcceptResourceShareInvitationError::ResourceShareInvitationAlreadyAccepted(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             AcceptResourceShareInvitationError::ResourceShareInvitationAlreadyRejected(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             AcceptResourceShareInvitationError::ResourceShareInvitationArnNotFound(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            AcceptResourceShareInvitationError::ResourceShareInvitationExpired(ref cause) => cause,
-            AcceptResourceShareInvitationError::ServerInternal(ref cause) => cause,
-            AcceptResourceShareInvitationError::ServiceUnavailable(ref cause) => cause,
+            AcceptResourceShareInvitationError::ResourceShareInvitationExpired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptResourceShareInvitationError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            AcceptResourceShareInvitationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AcceptResourceShareInvitationError {}
 /// Errors returned by AssociateResourceShare
 #[derive(Debug, PartialEq)]
 pub enum AssociateResourceShareError {
@@ -1191,25 +1197,27 @@ impl AssociateResourceShareError {
 }
 impl fmt::Display for AssociateResourceShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateResourceShareError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateResourceShareError::IdempotentParameterMismatch(ref cause) => cause,
-            AssociateResourceShareError::InvalidClientToken(ref cause) => cause,
-            AssociateResourceShareError::InvalidParameter(ref cause) => cause,
-            AssociateResourceShareError::InvalidStateTransition(ref cause) => cause,
-            AssociateResourceShareError::MalformedArn(ref cause) => cause,
-            AssociateResourceShareError::OperationNotPermitted(ref cause) => cause,
-            AssociateResourceShareError::ResourceShareLimitExceeded(ref cause) => cause,
-            AssociateResourceShareError::ServerInternal(ref cause) => cause,
-            AssociateResourceShareError::ServiceUnavailable(ref cause) => cause,
-            AssociateResourceShareError::UnknownResource(ref cause) => cause,
+            AssociateResourceShareError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceShareError::InvalidClientToken(ref cause) => write!(f, "{}", cause),
+            AssociateResourceShareError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateResourceShareError::InvalidStateTransition(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceShareError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            AssociateResourceShareError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            AssociateResourceShareError::ResourceShareLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceShareError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            AssociateResourceShareError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AssociateResourceShareError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateResourceShareError {}
 /// Errors returned by AssociateResourceSharePermission
 #[derive(Debug, PartialEq)]
 pub enum AssociateResourceSharePermissionError {
@@ -1279,22 +1287,32 @@ impl AssociateResourceSharePermissionError {
 }
 impl fmt::Display for AssociateResourceSharePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateResourceSharePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateResourceSharePermissionError::InvalidClientToken(ref cause) => cause,
-            AssociateResourceSharePermissionError::InvalidParameter(ref cause) => cause,
-            AssociateResourceSharePermissionError::MalformedArn(ref cause) => cause,
-            AssociateResourceSharePermissionError::OperationNotPermitted(ref cause) => cause,
-            AssociateResourceSharePermissionError::ServerInternal(ref cause) => cause,
-            AssociateResourceSharePermissionError::ServiceUnavailable(ref cause) => cause,
-            AssociateResourceSharePermissionError::UnknownResource(ref cause) => cause,
+            AssociateResourceSharePermissionError::InvalidClientToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceSharePermissionError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceSharePermissionError::MalformedArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceSharePermissionError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceSharePermissionError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceSharePermissionError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateResourceSharePermissionError::UnknownResource(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateResourceSharePermissionError {}
 /// Errors returned by CreateResourceShare
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceShareError {
@@ -1384,26 +1402,26 @@ impl CreateResourceShareError {
 }
 impl fmt::Display for CreateResourceShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceShareError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceShareError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateResourceShareError::InvalidClientToken(ref cause) => cause,
-            CreateResourceShareError::InvalidParameter(ref cause) => cause,
-            CreateResourceShareError::InvalidStateTransition(ref cause) => cause,
-            CreateResourceShareError::MalformedArn(ref cause) => cause,
-            CreateResourceShareError::OperationNotPermitted(ref cause) => cause,
-            CreateResourceShareError::ResourceShareLimitExceeded(ref cause) => cause,
-            CreateResourceShareError::ServerInternal(ref cause) => cause,
-            CreateResourceShareError::ServiceUnavailable(ref cause) => cause,
-            CreateResourceShareError::TagPolicyViolation(ref cause) => cause,
-            CreateResourceShareError::UnknownResource(ref cause) => cause,
+            CreateResourceShareError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateResourceShareError::InvalidClientToken(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::InvalidStateTransition(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::ResourceShareLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateResourceShareError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::TagPolicyViolation(ref cause) => write!(f, "{}", cause),
+            CreateResourceShareError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateResourceShareError {}
 /// Errors returned by DeleteResourceShare
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourceShareError {
@@ -1479,24 +1497,22 @@ impl DeleteResourceShareError {
 }
 impl fmt::Display for DeleteResourceShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourceShareError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourceShareError::IdempotentParameterMismatch(ref cause) => cause,
-            DeleteResourceShareError::InvalidClientToken(ref cause) => cause,
-            DeleteResourceShareError::InvalidParameter(ref cause) => cause,
-            DeleteResourceShareError::InvalidStateTransition(ref cause) => cause,
-            DeleteResourceShareError::MalformedArn(ref cause) => cause,
-            DeleteResourceShareError::OperationNotPermitted(ref cause) => cause,
-            DeleteResourceShareError::ServerInternal(ref cause) => cause,
-            DeleteResourceShareError::ServiceUnavailable(ref cause) => cause,
-            DeleteResourceShareError::UnknownResource(ref cause) => cause,
+            DeleteResourceShareError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteResourceShareError::InvalidClientToken(ref cause) => write!(f, "{}", cause),
+            DeleteResourceShareError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteResourceShareError::InvalidStateTransition(ref cause) => write!(f, "{}", cause),
+            DeleteResourceShareError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            DeleteResourceShareError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteResourceShareError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            DeleteResourceShareError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteResourceShareError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourceShareError {}
 /// Errors returned by DisassociateResourceShare
 #[derive(Debug, PartialEq)]
 pub enum DisassociateResourceShareError {
@@ -1585,25 +1601,29 @@ impl DisassociateResourceShareError {
 }
 impl fmt::Display for DisassociateResourceShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateResourceShareError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateResourceShareError::IdempotentParameterMismatch(ref cause) => cause,
-            DisassociateResourceShareError::InvalidClientToken(ref cause) => cause,
-            DisassociateResourceShareError::InvalidParameter(ref cause) => cause,
-            DisassociateResourceShareError::InvalidStateTransition(ref cause) => cause,
-            DisassociateResourceShareError::MalformedArn(ref cause) => cause,
-            DisassociateResourceShareError::OperationNotPermitted(ref cause) => cause,
-            DisassociateResourceShareError::ResourceShareLimitExceeded(ref cause) => cause,
-            DisassociateResourceShareError::ServerInternal(ref cause) => cause,
-            DisassociateResourceShareError::ServiceUnavailable(ref cause) => cause,
-            DisassociateResourceShareError::UnknownResource(ref cause) => cause,
+            DisassociateResourceShareError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceShareError::InvalidClientToken(ref cause) => write!(f, "{}", cause),
+            DisassociateResourceShareError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DisassociateResourceShareError::InvalidStateTransition(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceShareError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            DisassociateResourceShareError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceShareError::ResourceShareLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceShareError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            DisassociateResourceShareError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DisassociateResourceShareError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateResourceShareError {}
 /// Errors returned by DisassociateResourceSharePermission
 #[derive(Debug, PartialEq)]
 pub enum DisassociateResourceSharePermissionError {
@@ -1673,22 +1693,32 @@ impl DisassociateResourceSharePermissionError {
 }
 impl fmt::Display for DisassociateResourceSharePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateResourceSharePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateResourceSharePermissionError::InvalidClientToken(ref cause) => cause,
-            DisassociateResourceSharePermissionError::InvalidParameter(ref cause) => cause,
-            DisassociateResourceSharePermissionError::MalformedArn(ref cause) => cause,
-            DisassociateResourceSharePermissionError::OperationNotPermitted(ref cause) => cause,
-            DisassociateResourceSharePermissionError::ServerInternal(ref cause) => cause,
-            DisassociateResourceSharePermissionError::ServiceUnavailable(ref cause) => cause,
-            DisassociateResourceSharePermissionError::UnknownResource(ref cause) => cause,
+            DisassociateResourceSharePermissionError::InvalidClientToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceSharePermissionError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceSharePermissionError::MalformedArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceSharePermissionError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceSharePermissionError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceSharePermissionError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateResourceSharePermissionError::UnknownResource(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateResourceSharePermissionError {}
 /// Errors returned by EnableSharingWithAwsOrganization
 #[derive(Debug, PartialEq)]
 pub enum EnableSharingWithAwsOrganizationError {
@@ -1730,18 +1760,20 @@ impl EnableSharingWithAwsOrganizationError {
 }
 impl fmt::Display for EnableSharingWithAwsOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableSharingWithAwsOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            EnableSharingWithAwsOrganizationError::OperationNotPermitted(ref cause) => cause,
-            EnableSharingWithAwsOrganizationError::ServerInternal(ref cause) => cause,
-            EnableSharingWithAwsOrganizationError::ServiceUnavailable(ref cause) => cause,
+            EnableSharingWithAwsOrganizationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableSharingWithAwsOrganizationError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableSharingWithAwsOrganizationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for EnableSharingWithAwsOrganizationError {}
 /// Errors returned by GetPermission
 #[derive(Debug, PartialEq)]
 pub enum GetPermissionError {
@@ -1790,21 +1822,17 @@ impl GetPermissionError {
 }
 impl fmt::Display for GetPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            GetPermissionError::InvalidParameter(ref cause) => cause,
-            GetPermissionError::MalformedArn(ref cause) => cause,
-            GetPermissionError::OperationNotPermitted(ref cause) => cause,
-            GetPermissionError::ServerInternal(ref cause) => cause,
-            GetPermissionError::ServiceUnavailable(ref cause) => cause,
-            GetPermissionError::UnknownResource(ref cause) => cause,
+            GetPermissionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetPermissionError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            GetPermissionError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GetPermissionError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            GetPermissionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetPermissionError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPermissionError {}
 /// Errors returned by GetResourcePolicies
 #[derive(Debug, PartialEq)]
 pub enum GetResourcePoliciesError {
@@ -1854,20 +1882,16 @@ impl GetResourcePoliciesError {
 }
 impl fmt::Display for GetResourcePoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourcePoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourcePoliciesError::InvalidNextToken(ref cause) => cause,
-            GetResourcePoliciesError::InvalidParameter(ref cause) => cause,
-            GetResourcePoliciesError::MalformedArn(ref cause) => cause,
-            GetResourcePoliciesError::ServerInternal(ref cause) => cause,
-            GetResourcePoliciesError::ServiceUnavailable(ref cause) => cause,
+            GetResourcePoliciesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetResourcePoliciesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetResourcePoliciesError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            GetResourcePoliciesError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            GetResourcePoliciesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourcePoliciesError {}
 /// Errors returned by GetResourceShareAssociations
 #[derive(Debug, PartialEq)]
 pub enum GetResourceShareAssociationsError {
@@ -1937,22 +1961,26 @@ impl GetResourceShareAssociationsError {
 }
 impl fmt::Display for GetResourceShareAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceShareAssociationsError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceShareAssociationsError::InvalidNextToken(ref cause) => cause,
-            GetResourceShareAssociationsError::InvalidParameter(ref cause) => cause,
-            GetResourceShareAssociationsError::MalformedArn(ref cause) => cause,
-            GetResourceShareAssociationsError::OperationNotPermitted(ref cause) => cause,
-            GetResourceShareAssociationsError::ServerInternal(ref cause) => cause,
-            GetResourceShareAssociationsError::ServiceUnavailable(ref cause) => cause,
-            GetResourceShareAssociationsError::UnknownResource(ref cause) => cause,
+            GetResourceShareAssociationsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetResourceShareAssociationsError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetResourceShareAssociationsError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            GetResourceShareAssociationsError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetResourceShareAssociationsError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            GetResourceShareAssociationsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetResourceShareAssociationsError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourceShareAssociationsError {}
 /// Errors returned by GetResourceShareInvitations
 #[derive(Debug, PartialEq)]
 pub enum GetResourceShareInvitationsError {
@@ -2024,24 +2052,24 @@ impl GetResourceShareInvitationsError {
 }
 impl fmt::Display for GetResourceShareInvitationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceShareInvitationsError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceShareInvitationsError::InvalidMaxResults(ref cause) => cause,
-            GetResourceShareInvitationsError::InvalidNextToken(ref cause) => cause,
-            GetResourceShareInvitationsError::InvalidParameter(ref cause) => cause,
-            GetResourceShareInvitationsError::MalformedArn(ref cause) => cause,
-            GetResourceShareInvitationsError::ResourceShareInvitationArnNotFound(ref cause) => {
-                cause
+            GetResourceShareInvitationsError::InvalidMaxResults(ref cause) => {
+                write!(f, "{}", cause)
             }
-            GetResourceShareInvitationsError::ServerInternal(ref cause) => cause,
-            GetResourceShareInvitationsError::ServiceUnavailable(ref cause) => cause,
+            GetResourceShareInvitationsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetResourceShareInvitationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetResourceShareInvitationsError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            GetResourceShareInvitationsError::ResourceShareInvitationArnNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetResourceShareInvitationsError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            GetResourceShareInvitationsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetResourceShareInvitationsError {}
 /// Errors returned by GetResourceShares
 #[derive(Debug, PartialEq)]
 pub enum GetResourceSharesError {
@@ -2092,21 +2120,17 @@ impl GetResourceSharesError {
 }
 impl fmt::Display for GetResourceSharesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourceSharesError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourceSharesError::InvalidNextToken(ref cause) => cause,
-            GetResourceSharesError::InvalidParameter(ref cause) => cause,
-            GetResourceSharesError::MalformedArn(ref cause) => cause,
-            GetResourceSharesError::ServerInternal(ref cause) => cause,
-            GetResourceSharesError::ServiceUnavailable(ref cause) => cause,
-            GetResourceSharesError::UnknownResource(ref cause) => cause,
+            GetResourceSharesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetResourceSharesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetResourceSharesError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            GetResourceSharesError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            GetResourceSharesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetResourceSharesError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourceSharesError {}
 /// Errors returned by ListPendingInvitationResources
 #[derive(Debug, PartialEq)]
 pub enum ListPendingInvitationResourcesError {
@@ -2196,28 +2220,36 @@ impl ListPendingInvitationResourcesError {
 }
 impl fmt::Display for ListPendingInvitationResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPendingInvitationResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListPendingInvitationResourcesError::InvalidNextToken(ref cause) => cause,
-            ListPendingInvitationResourcesError::InvalidParameter(ref cause) => cause,
-            ListPendingInvitationResourcesError::MalformedArn(ref cause) => cause,
-            ListPendingInvitationResourcesError::MissingRequiredParameter(ref cause) => cause,
+            ListPendingInvitationResourcesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListPendingInvitationResourcesError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListPendingInvitationResourcesError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            ListPendingInvitationResourcesError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ListPendingInvitationResourcesError::ResourceShareInvitationAlreadyRejected(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ListPendingInvitationResourcesError::ResourceShareInvitationArnNotFound(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            ListPendingInvitationResourcesError::ResourceShareInvitationExpired(ref cause) => cause,
-            ListPendingInvitationResourcesError::ServerInternal(ref cause) => cause,
-            ListPendingInvitationResourcesError::ServiceUnavailable(ref cause) => cause,
+            ListPendingInvitationResourcesError::ResourceShareInvitationExpired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListPendingInvitationResourcesError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListPendingInvitationResourcesError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListPendingInvitationResourcesError {}
 /// Errors returned by ListPermissions
 #[derive(Debug, PartialEq)]
 pub enum ListPermissionsError {
@@ -2263,20 +2295,16 @@ impl ListPermissionsError {
 }
 impl fmt::Display for ListPermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPermissionsError::InvalidNextToken(ref cause) => cause,
-            ListPermissionsError::InvalidParameter(ref cause) => cause,
-            ListPermissionsError::OperationNotPermitted(ref cause) => cause,
-            ListPermissionsError::ServerInternal(ref cause) => cause,
-            ListPermissionsError::ServiceUnavailable(ref cause) => cause,
+            ListPermissionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            ListPermissionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPermissionsError {}
 /// Errors returned by ListPrincipals
 #[derive(Debug, PartialEq)]
 pub enum ListPrincipalsError {
@@ -2325,21 +2353,17 @@ impl ListPrincipalsError {
 }
 impl fmt::Display for ListPrincipalsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPrincipalsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPrincipalsError::InvalidNextToken(ref cause) => cause,
-            ListPrincipalsError::InvalidParameter(ref cause) => cause,
-            ListPrincipalsError::MalformedArn(ref cause) => cause,
-            ListPrincipalsError::ServerInternal(ref cause) => cause,
-            ListPrincipalsError::ServiceUnavailable(ref cause) => cause,
-            ListPrincipalsError::UnknownResource(ref cause) => cause,
+            ListPrincipalsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListPrincipalsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListPrincipalsError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            ListPrincipalsError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            ListPrincipalsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListPrincipalsError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPrincipalsError {}
 /// Errors returned by ListResourceSharePermissions
 #[derive(Debug, PartialEq)]
 pub enum ListResourceSharePermissionsError {
@@ -2409,22 +2433,26 @@ impl ListResourceSharePermissionsError {
 }
 impl fmt::Display for ListResourceSharePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceSharePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceSharePermissionsError::InvalidNextToken(ref cause) => cause,
-            ListResourceSharePermissionsError::InvalidParameter(ref cause) => cause,
-            ListResourceSharePermissionsError::MalformedArn(ref cause) => cause,
-            ListResourceSharePermissionsError::OperationNotPermitted(ref cause) => cause,
-            ListResourceSharePermissionsError::ServerInternal(ref cause) => cause,
-            ListResourceSharePermissionsError::ServiceUnavailable(ref cause) => cause,
-            ListResourceSharePermissionsError::UnknownResource(ref cause) => cause,
+            ListResourceSharePermissionsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListResourceSharePermissionsError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListResourceSharePermissionsError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            ListResourceSharePermissionsError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListResourceSharePermissionsError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            ListResourceSharePermissionsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListResourceSharePermissionsError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourceSharePermissionsError {}
 /// Errors returned by ListResources
 #[derive(Debug, PartialEq)]
 pub enum ListResourcesError {
@@ -2478,22 +2506,18 @@ impl ListResourcesError {
 }
 impl fmt::Display for ListResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourcesError::InvalidNextToken(ref cause) => cause,
-            ListResourcesError::InvalidParameter(ref cause) => cause,
-            ListResourcesError::InvalidResourceType(ref cause) => cause,
-            ListResourcesError::MalformedArn(ref cause) => cause,
-            ListResourcesError::ServerInternal(ref cause) => cause,
-            ListResourcesError::ServiceUnavailable(ref cause) => cause,
-            ListResourcesError::UnknownResource(ref cause) => cause,
+            ListResourcesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::InvalidResourceType(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourcesError {}
 /// Errors returned by PromoteResourceShareCreatedFromPolicy
 #[derive(Debug, PartialEq)]
 pub enum PromoteResourceShareCreatedFromPolicyError {
@@ -2558,23 +2582,29 @@ impl PromoteResourceShareCreatedFromPolicyError {
 }
 impl fmt::Display for PromoteResourceShareCreatedFromPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PromoteResourceShareCreatedFromPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PromoteResourceShareCreatedFromPolicyError::InvalidParameter(ref cause) => cause,
-            PromoteResourceShareCreatedFromPolicyError::MalformedArn(ref cause) => cause,
-            PromoteResourceShareCreatedFromPolicyError::MissingRequiredParameter(ref cause) => {
-                cause
+            PromoteResourceShareCreatedFromPolicyError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
             }
-            PromoteResourceShareCreatedFromPolicyError::OperationNotPermitted(ref cause) => cause,
-            PromoteResourceShareCreatedFromPolicyError::ServerInternal(ref cause) => cause,
-            PromoteResourceShareCreatedFromPolicyError::ServiceUnavailable(ref cause) => cause,
+            PromoteResourceShareCreatedFromPolicyError::MalformedArn(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PromoteResourceShareCreatedFromPolicyError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PromoteResourceShareCreatedFromPolicyError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PromoteResourceShareCreatedFromPolicyError::ServerInternal(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PromoteResourceShareCreatedFromPolicyError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PromoteResourceShareCreatedFromPolicyError {}
 /// Errors returned by RejectResourceShareInvitation
 #[derive(Debug, PartialEq)]
 pub enum RejectResourceShareInvitationError {
@@ -2671,31 +2701,37 @@ impl RejectResourceShareInvitationError {
 }
 impl fmt::Display for RejectResourceShareInvitationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RejectResourceShareInvitationError {
-    fn description(&self) -> &str {
         match *self {
-            RejectResourceShareInvitationError::IdempotentParameterMismatch(ref cause) => cause,
-            RejectResourceShareInvitationError::InvalidClientToken(ref cause) => cause,
-            RejectResourceShareInvitationError::MalformedArn(ref cause) => cause,
-            RejectResourceShareInvitationError::OperationNotPermitted(ref cause) => cause,
+            RejectResourceShareInvitationError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RejectResourceShareInvitationError::InvalidClientToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RejectResourceShareInvitationError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            RejectResourceShareInvitationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RejectResourceShareInvitationError::ResourceShareInvitationAlreadyAccepted(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RejectResourceShareInvitationError::ResourceShareInvitationAlreadyRejected(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RejectResourceShareInvitationError::ResourceShareInvitationArnNotFound(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RejectResourceShareInvitationError::ResourceShareInvitationExpired(ref cause) => cause,
-            RejectResourceShareInvitationError::ServerInternal(ref cause) => cause,
-            RejectResourceShareInvitationError::ServiceUnavailable(ref cause) => cause,
+            RejectResourceShareInvitationError::ResourceShareInvitationExpired(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RejectResourceShareInvitationError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            RejectResourceShareInvitationError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RejectResourceShareInvitationError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2749,22 +2785,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::MalformedArn(ref cause) => cause,
-            TagResourceError::ResourceArnNotFound(ref cause) => cause,
-            TagResourceError::ServerInternal(ref cause) => cause,
-            TagResourceError::ServiceUnavailable(ref cause) => cause,
-            TagResourceError::TagLimitExceeded(ref cause) => cause,
-            TagResourceError::TagPolicyViolation(ref cause) => cause,
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceArnNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagPolicyViolation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2798,18 +2830,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::ServerInternal(ref cause) => cause,
-            UntagResourceError::ServiceUnavailable(ref cause) => cause,
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateResourceShare
 #[derive(Debug, PartialEq)]
 pub enum UpdateResourceShareError {
@@ -2885,24 +2913,22 @@ impl UpdateResourceShareError {
 }
 impl fmt::Display for UpdateResourceShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateResourceShareError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateResourceShareError::IdempotentParameterMismatch(ref cause) => cause,
-            UpdateResourceShareError::InvalidClientToken(ref cause) => cause,
-            UpdateResourceShareError::InvalidParameter(ref cause) => cause,
-            UpdateResourceShareError::MalformedArn(ref cause) => cause,
-            UpdateResourceShareError::MissingRequiredParameter(ref cause) => cause,
-            UpdateResourceShareError::OperationNotPermitted(ref cause) => cause,
-            UpdateResourceShareError::ServerInternal(ref cause) => cause,
-            UpdateResourceShareError::ServiceUnavailable(ref cause) => cause,
-            UpdateResourceShareError::UnknownResource(ref cause) => cause,
+            UpdateResourceShareError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateResourceShareError::InvalidClientToken(ref cause) => write!(f, "{}", cause),
+            UpdateResourceShareError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateResourceShareError::MalformedArn(ref cause) => write!(f, "{}", cause),
+            UpdateResourceShareError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            UpdateResourceShareError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            UpdateResourceShareError::ServerInternal(ref cause) => write!(f, "{}", cause),
+            UpdateResourceShareError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateResourceShareError::UnknownResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateResourceShareError {}
 /// Trait representing the capabilities of the RAM API. RAM clients implement this trait.
 pub trait Ram {
     /// <p>Accepts an invitation to a resource share from another AWS account.</p>

--- a/rusoto/services/rds-data/src/generated.rs
+++ b/rusoto/services/rds-data/src/generated.rs
@@ -559,20 +559,18 @@ impl BatchExecuteStatementError {
 }
 impl fmt::Display for BatchExecuteStatementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchExecuteStatementError {
-    fn description(&self) -> &str {
         match *self {
-            BatchExecuteStatementError::BadRequest(ref cause) => cause,
-            BatchExecuteStatementError::Forbidden(ref cause) => cause,
-            BatchExecuteStatementError::InternalServerError(ref cause) => cause,
-            BatchExecuteStatementError::ServiceUnavailableError(ref cause) => cause,
-            BatchExecuteStatementError::StatementTimeout(ref cause) => cause,
+            BatchExecuteStatementError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BatchExecuteStatementError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BatchExecuteStatementError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            BatchExecuteStatementError::ServiceUnavailableError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchExecuteStatementError::StatementTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchExecuteStatementError {}
 /// Errors returned by BeginTransaction
 #[derive(Debug, PartialEq)]
 pub enum BeginTransactionError {
@@ -620,20 +618,16 @@ impl BeginTransactionError {
 }
 impl fmt::Display for BeginTransactionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BeginTransactionError {
-    fn description(&self) -> &str {
         match *self {
-            BeginTransactionError::BadRequest(ref cause) => cause,
-            BeginTransactionError::Forbidden(ref cause) => cause,
-            BeginTransactionError::InternalServerError(ref cause) => cause,
-            BeginTransactionError::ServiceUnavailableError(ref cause) => cause,
-            BeginTransactionError::StatementTimeout(ref cause) => cause,
+            BeginTransactionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            BeginTransactionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            BeginTransactionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            BeginTransactionError::ServiceUnavailableError(ref cause) => write!(f, "{}", cause),
+            BeginTransactionError::StatementTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BeginTransactionError {}
 /// Errors returned by CommitTransaction
 #[derive(Debug, PartialEq)]
 pub enum CommitTransactionError {
@@ -686,21 +680,17 @@ impl CommitTransactionError {
 }
 impl fmt::Display for CommitTransactionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CommitTransactionError {
-    fn description(&self) -> &str {
         match *self {
-            CommitTransactionError::BadRequest(ref cause) => cause,
-            CommitTransactionError::Forbidden(ref cause) => cause,
-            CommitTransactionError::InternalServerError(ref cause) => cause,
-            CommitTransactionError::NotFound(ref cause) => cause,
-            CommitTransactionError::ServiceUnavailableError(ref cause) => cause,
-            CommitTransactionError::StatementTimeout(ref cause) => cause,
+            CommitTransactionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CommitTransactionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CommitTransactionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CommitTransactionError::NotFound(ref cause) => write!(f, "{}", cause),
+            CommitTransactionError::ServiceUnavailableError(ref cause) => write!(f, "{}", cause),
+            CommitTransactionError::StatementTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CommitTransactionError {}
 /// Errors returned by ExecuteSql
 #[derive(Debug, PartialEq)]
 pub enum ExecuteSqlError {
@@ -739,19 +729,15 @@ impl ExecuteSqlError {
 }
 impl fmt::Display for ExecuteSqlError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExecuteSqlError {
-    fn description(&self) -> &str {
         match *self {
-            ExecuteSqlError::BadRequest(ref cause) => cause,
-            ExecuteSqlError::Forbidden(ref cause) => cause,
-            ExecuteSqlError::InternalServerError(ref cause) => cause,
-            ExecuteSqlError::ServiceUnavailableError(ref cause) => cause,
+            ExecuteSqlError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ExecuteSqlError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ExecuteSqlError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ExecuteSqlError::ServiceUnavailableError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExecuteSqlError {}
 /// Errors returned by ExecuteStatement
 #[derive(Debug, PartialEq)]
 pub enum ExecuteStatementError {
@@ -799,20 +785,16 @@ impl ExecuteStatementError {
 }
 impl fmt::Display for ExecuteStatementError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExecuteStatementError {
-    fn description(&self) -> &str {
         match *self {
-            ExecuteStatementError::BadRequest(ref cause) => cause,
-            ExecuteStatementError::Forbidden(ref cause) => cause,
-            ExecuteStatementError::InternalServerError(ref cause) => cause,
-            ExecuteStatementError::ServiceUnavailableError(ref cause) => cause,
-            ExecuteStatementError::StatementTimeout(ref cause) => cause,
+            ExecuteStatementError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ExecuteStatementError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ExecuteStatementError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ExecuteStatementError::ServiceUnavailableError(ref cause) => write!(f, "{}", cause),
+            ExecuteStatementError::StatementTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ExecuteStatementError {}
 /// Errors returned by RollbackTransaction
 #[derive(Debug, PartialEq)]
 pub enum RollbackTransactionError {
@@ -867,21 +849,17 @@ impl RollbackTransactionError {
 }
 impl fmt::Display for RollbackTransactionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RollbackTransactionError {
-    fn description(&self) -> &str {
         match *self {
-            RollbackTransactionError::BadRequest(ref cause) => cause,
-            RollbackTransactionError::Forbidden(ref cause) => cause,
-            RollbackTransactionError::InternalServerError(ref cause) => cause,
-            RollbackTransactionError::NotFound(ref cause) => cause,
-            RollbackTransactionError::ServiceUnavailableError(ref cause) => cause,
-            RollbackTransactionError::StatementTimeout(ref cause) => cause,
+            RollbackTransactionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            RollbackTransactionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            RollbackTransactionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RollbackTransactionError::NotFound(ref cause) => write!(f, "{}", cause),
+            RollbackTransactionError::ServiceUnavailableError(ref cause) => write!(f, "{}", cause),
+            RollbackTransactionError::StatementTimeout(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RollbackTransactionError {}
 /// Trait representing the capabilities of the AWS RDS DataService API. AWS RDS DataService clients implement this trait.
 pub trait RdsData {
     /// <p><p>Runs a batch SQL statement over an array of data.</p> <p>You can run bulk update and insert operations for multiple records using a DML statement with different parameter sets. Bulk operations can provide a significant performance improvement over individual insert and update operations.</p> <important> <p>If a call isn&#39;t part of a transaction because it doesn&#39;t include the <code>transactionID</code> parameter, changes that result from the call are committed automatically.</p> </important></p>

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -17902,19 +17902,21 @@ impl AddRoleToDBClusterError {
 }
 impl fmt::Display for AddRoleToDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddRoleToDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            AddRoleToDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            AddRoleToDBClusterError::DBClusterRoleAlreadyExistsFault(ref cause) => cause,
-            AddRoleToDBClusterError::DBClusterRoleQuotaExceededFault(ref cause) => cause,
-            AddRoleToDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            AddRoleToDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddRoleToDBClusterError::DBClusterRoleAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddRoleToDBClusterError::DBClusterRoleQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddRoleToDBClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddRoleToDBClusterError {}
 /// Errors returned by AddRoleToDBInstance
 #[derive(Debug, PartialEq)]
 pub enum AddRoleToDBInstanceError {
@@ -17979,19 +17981,21 @@ impl AddRoleToDBInstanceError {
 }
 impl fmt::Display for AddRoleToDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddRoleToDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            AddRoleToDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            AddRoleToDBInstanceError::DBInstanceRoleAlreadyExistsFault(ref cause) => cause,
-            AddRoleToDBInstanceError::DBInstanceRoleQuotaExceededFault(ref cause) => cause,
-            AddRoleToDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
+            AddRoleToDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddRoleToDBInstanceError::DBInstanceRoleAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddRoleToDBInstanceError::DBInstanceRoleQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddRoleToDBInstanceError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddRoleToDBInstanceError {}
 /// Errors returned by AddSourceIdentifierToSubscription
 #[derive(Debug, PartialEq)]
 pub enum AddSourceIdentifierToSubscriptionError {
@@ -18042,17 +18046,17 @@ impl AddSourceIdentifierToSubscriptionError {
 }
 impl fmt::Display for AddSourceIdentifierToSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddSourceIdentifierToSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            AddSourceIdentifierToSubscriptionError::SourceNotFoundFault(ref cause) => cause,
-            AddSourceIdentifierToSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
+            AddSourceIdentifierToSubscriptionError::SourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddSourceIdentifierToSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddSourceIdentifierToSubscriptionError {}
 /// Errors returned by AddTagsToResource
 #[derive(Debug, PartialEq)]
 pub enum AddTagsToResourceError {
@@ -18104,18 +18108,14 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            AddTagsToResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            AddTagsToResourceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by ApplyPendingMaintenanceAction
 #[derive(Debug, PartialEq)]
 pub enum ApplyPendingMaintenanceActionError {
@@ -18175,18 +18175,20 @@ impl ApplyPendingMaintenanceActionError {
 }
 impl fmt::Display for ApplyPendingMaintenanceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ApplyPendingMaintenanceActionError {
-    fn description(&self) -> &str {
         match *self {
-            ApplyPendingMaintenanceActionError::InvalidDBClusterStateFault(ref cause) => cause,
-            ApplyPendingMaintenanceActionError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => cause,
+            ApplyPendingMaintenanceActionError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ApplyPendingMaintenanceActionError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ApplyPendingMaintenanceActionError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ApplyPendingMaintenanceActionError {}
 /// Errors returned by AuthorizeDBSecurityGroupIngress
 #[derive(Debug, PartialEq)]
 pub enum AuthorizeDBSecurityGroupIngressError {
@@ -18255,25 +18257,23 @@ impl AuthorizeDBSecurityGroupIngressError {
 }
 impl fmt::Display for AuthorizeDBSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AuthorizeDBSecurityGroupIngressError {
-    fn description(&self) -> &str {
         match *self {
             AuthorizeDBSecurityGroupIngressError::AuthorizationAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             AuthorizeDBSecurityGroupIngressError::AuthorizationQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            AuthorizeDBSecurityGroupIngressError::DBSecurityGroupNotFoundFault(ref cause) => cause,
+            AuthorizeDBSecurityGroupIngressError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             AuthorizeDBSecurityGroupIngressError::InvalidDBSecurityGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for AuthorizeDBSecurityGroupIngressError {}
 /// Errors returned by BacktrackDBCluster
 #[derive(Debug, PartialEq)]
 pub enum BacktrackDBClusterError {
@@ -18320,17 +18320,15 @@ impl BacktrackDBClusterError {
 }
 impl fmt::Display for BacktrackDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BacktrackDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            BacktrackDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            BacktrackDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            BacktrackDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            BacktrackDBClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BacktrackDBClusterError {}
 /// Errors returned by CopyDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CopyDBClusterParameterGroupError {
@@ -18390,22 +18388,20 @@ impl CopyDBClusterParameterGroupError {
 }
 impl fmt::Display for CopyDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CopyDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CopyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            CopyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CopyDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CopyDBClusterParameterGroupError {}
 /// Errors returned by CopyDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CopyDBClusterSnapshotError {
@@ -18490,21 +18486,29 @@ impl CopyDBClusterSnapshotError {
 }
 impl fmt::Display for CopyDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CopyDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CopyDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CopyDBClusterSnapshotError {}
 /// Errors returned by CopyDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CopyDBParameterGroupError {
@@ -18562,18 +18566,20 @@ impl CopyDBParameterGroupError {
 }
 impl fmt::Display for CopyDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CopyDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => cause,
-            CopyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            CopyDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => cause,
+            CopyDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CopyDBParameterGroupError {}
 /// Errors returned by CopyDBSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CopyDBSnapshotError {
@@ -18639,20 +18645,16 @@ impl CopyDBSnapshotError {
 }
 impl fmt::Display for CopyDBSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyDBSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CopyDBSnapshotError::DBSnapshotAlreadyExistsFault(ref cause) => cause,
-            CopyDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => cause,
-            CopyDBSnapshotError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            CopyDBSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CopyDBSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CopyDBSnapshotError::DBSnapshotAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CopyDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CopyDBSnapshotError::InvalidDBSnapshotStateFault(ref cause) => write!(f, "{}", cause),
+            CopyDBSnapshotError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CopyDBSnapshotError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopyDBSnapshotError {}
 /// Errors returned by CopyOptionGroup
 #[derive(Debug, PartialEq)]
 pub enum CopyOptionGroupError {
@@ -18708,18 +18710,18 @@ impl CopyOptionGroupError {
 }
 impl fmt::Display for CopyOptionGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyOptionGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CopyOptionGroupError::OptionGroupAlreadyExistsFault(ref cause) => cause,
-            CopyOptionGroupError::OptionGroupNotFoundFault(ref cause) => cause,
-            CopyOptionGroupError::OptionGroupQuotaExceededFault(ref cause) => cause,
+            CopyOptionGroupError::OptionGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyOptionGroupError::OptionGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CopyOptionGroupError::OptionGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CopyOptionGroupError {}
 /// Errors returned by CreateCustomAvailabilityZone
 #[derive(Debug, PartialEq)]
 pub enum CreateCustomAvailabilityZoneError {
@@ -18775,22 +18777,20 @@ impl CreateCustomAvailabilityZoneError {
 }
 impl fmt::Display for CreateCustomAvailabilityZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCustomAvailabilityZoneError {
-    fn description(&self) -> &str {
         match *self {
             CreateCustomAvailabilityZoneError::CustomAvailabilityZoneAlreadyExistsFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateCustomAvailabilityZoneError::CustomAvailabilityZoneQuotaExceededFault(
                 ref cause,
-            ) => cause,
-            CreateCustomAvailabilityZoneError::KMSKeyNotAccessibleFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            CreateCustomAvailabilityZoneError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCustomAvailabilityZoneError {}
 /// Errors returned by CreateDBCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterError {
@@ -18957,33 +18957,39 @@ impl CreateDBClusterError {
 }
 impl fmt::Display for CreateDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBClusterError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBClusterQuotaExceededFault(ref cause) => cause,
-            CreateDBClusterError::DBInstanceNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::DomainNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::GlobalClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterError::InsufficientStorageClusterCapacityFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidGlobalClusterStateFault(ref cause) => cause,
-            CreateDBClusterError::InvalidSubnet(ref cause) => cause,
-            CreateDBClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateDBClusterError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateDBClusterError::StorageQuotaExceededFault(ref cause) => cause,
+            CreateDBClusterError::DBClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::DBClusterQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::DomainNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::GlobalClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InsufficientStorageClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::InvalidGlobalClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CreateDBClusterError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBClusterError {}
 /// Errors returned by CreateDBClusterEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterEndpointError {
@@ -19068,21 +19074,29 @@ impl CreateDBClusterEndpointError {
 }
 impl fmt::Display for CreateDBClusterEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBClusterEndpointError::DBClusterEndpointAlreadyExistsFault(ref cause) => cause,
-            CreateDBClusterEndpointError::DBClusterEndpointQuotaExceededFault(ref cause) => cause,
-            CreateDBClusterEndpointError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterEndpointError::DBInstanceNotFoundFault(ref cause) => cause,
-            CreateDBClusterEndpointError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBClusterEndpointError::InvalidDBInstanceStateFault(ref cause) => cause,
+            CreateDBClusterEndpointError::DBClusterEndpointAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterEndpointError::DBClusterEndpointQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterEndpointError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterEndpointError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterEndpointError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterEndpointError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBClusterEndpointError {}
 /// Errors returned by CreateDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterParameterGroupError {
@@ -19133,21 +19147,17 @@ impl CreateDBClusterParameterGroupError {
 }
 impl fmt::Display for CreateDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CreateDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CreateDBClusterParameterGroupError {}
 /// Errors returned by CreateDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateDBClusterSnapshotError {
@@ -19223,20 +19233,26 @@ impl CreateDBClusterSnapshotError {
 }
 impl fmt::Display for CreateDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBClusterSnapshotError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CreateDBClusterSnapshotError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBClusterSnapshotError::SnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBClusterSnapshotError {}
 /// Errors returned by CreateDBInstance
 #[derive(Debug, PartialEq)]
 pub enum CreateDBInstanceError {
@@ -19416,34 +19432,44 @@ impl CreateDBInstanceError {
 }
 impl fmt::Display for CreateDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBInstanceError::AuthorizationNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::BackupPolicyNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            CreateDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::DomainNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::InstanceQuotaExceededFault(ref cause) => cause,
-            CreateDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            CreateDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            CreateDBInstanceError::InvalidSubnet(ref cause) => cause,
-            CreateDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateDBInstanceError::OptionGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => cause,
-            CreateDBInstanceError::StorageQuotaExceededFault(ref cause) => cause,
-            CreateDBInstanceError::StorageTypeNotSupportedFault(ref cause) => cause,
+            CreateDBInstanceError::AuthorizationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::BackupPolicyNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::DomainNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InstanceQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::OptionGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBInstanceError {}
 /// Errors returned by CreateDBInstanceReadReplica
 #[derive(Debug, PartialEq)]
 pub enum CreateDBInstanceReadReplicaError {
@@ -19645,40 +19671,66 @@ impl CreateDBInstanceReadReplicaError {
 }
 impl fmt::Display for CreateDBInstanceReadReplicaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBInstanceReadReplicaError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBInstanceReadReplicaError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::DBInstanceNotFoundFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::DBSecurityGroupNotFoundFault(ref cause) => cause,
+            CreateDBInstanceReadReplicaError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateDBInstanceReadReplicaError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateDBInstanceReadReplicaError::DBSubnetGroupNotAllowedFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::DomainNotFoundFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::InstanceQuotaExceededFault(ref cause) => cause,
+            CreateDBInstanceReadReplicaError::DBSubnetGroupNotAllowedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::DomainNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::InstanceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateDBInstanceReadReplicaError::InsufficientDBInstanceCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateDBInstanceReadReplicaError::InvalidDBInstanceStateFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::InvalidDBSubnetGroupFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::InvalidSubnet(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::OptionGroupNotFoundFault(ref cause) => cause,
+            CreateDBInstanceReadReplicaError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::InvalidDBSubnetGroupFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateDBInstanceReadReplicaError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateDBInstanceReadReplicaError::ProvisionedIopsNotAvailableInAZFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateDBInstanceReadReplicaError::StorageQuotaExceededFault(ref cause) => cause,
-            CreateDBInstanceReadReplicaError::StorageTypeNotSupportedFault(ref cause) => cause,
+            CreateDBInstanceReadReplicaError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBInstanceReadReplicaError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBInstanceReadReplicaError {}
 /// Errors returned by CreateDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBParameterGroupError {
@@ -19727,17 +19779,17 @@ impl CreateDBParameterGroupError {
 }
 impl fmt::Display for CreateDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => cause,
-            CreateDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => cause,
+            CreateDBParameterGroupError::DBParameterGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBParameterGroupError::DBParameterGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBParameterGroupError {}
 /// Errors returned by CreateDBProxy
 #[derive(Debug, PartialEq)]
 pub enum CreateDBProxyError {
@@ -19789,18 +19841,14 @@ impl CreateDBProxyError {
 }
 impl fmt::Display for CreateDBProxyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBProxyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBProxyError::DBProxyAlreadyExistsFault(ref cause) => cause,
-            CreateDBProxyError::DBProxyQuotaExceededFault(ref cause) => cause,
-            CreateDBProxyError::InvalidSubnet(ref cause) => cause,
+            CreateDBProxyError::DBProxyAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateDBProxyError::DBProxyQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateDBProxyError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBProxyError {}
 /// Errors returned by CreateDBSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBSecurityGroupError {
@@ -19858,18 +19906,20 @@ impl CreateDBSecurityGroupError {
 }
 impl fmt::Display for CreateDBSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBSecurityGroupError::DBSecurityGroupAlreadyExistsFault(ref cause) => cause,
-            CreateDBSecurityGroupError::DBSecurityGroupNotSupportedFault(ref cause) => cause,
-            CreateDBSecurityGroupError::DBSecurityGroupQuotaExceededFault(ref cause) => cause,
+            CreateDBSecurityGroupError::DBSecurityGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSecurityGroupError::DBSecurityGroupNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSecurityGroupError::DBSecurityGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateDBSecurityGroupError {}
 /// Errors returned by CreateDBSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateDBSnapshotError {
@@ -19932,19 +19982,17 @@ impl CreateDBSnapshotError {
 }
 impl fmt::Display for CreateDBSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBSnapshotError::DBInstanceNotFoundFault(ref cause) => cause,
-            CreateDBSnapshotError::DBSnapshotAlreadyExistsFault(ref cause) => cause,
-            CreateDBSnapshotError::InvalidDBInstanceStateFault(ref cause) => cause,
-            CreateDBSnapshotError::SnapshotQuotaExceededFault(ref cause) => cause,
+            CreateDBSnapshotError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateDBSnapshotError::DBSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSnapshotError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            CreateDBSnapshotError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBSnapshotError {}
 /// Errors returned by CreateDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateDBSubnetGroupError {
@@ -20018,20 +20066,24 @@ impl CreateDBSubnetGroupError {
 }
 impl fmt::Display for CreateDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetGroupQuotaExceededFault(ref cause) => cause,
-            CreateDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => cause,
-            CreateDBSubnetGroupError::InvalidSubnet(ref cause) => cause,
+            CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateDBSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDBSubnetGroupError {}
 /// Errors returned by CreateEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateEventSubscriptionError {
@@ -20123,22 +20175,28 @@ impl CreateEventSubscriptionError {
 }
 impl fmt::Display for CreateEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SourceNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionAlreadyExistFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => cause,
+            CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SubscriptionAlreadyExistFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateEventSubscriptionError {}
 /// Errors returned by CreateGlobalCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateGlobalClusterError {
@@ -20203,19 +20261,21 @@ impl CreateGlobalClusterError {
 }
 impl fmt::Display for CreateGlobalClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGlobalClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGlobalClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            CreateGlobalClusterError::GlobalClusterAlreadyExistsFault(ref cause) => cause,
-            CreateGlobalClusterError::GlobalClusterQuotaExceededFault(ref cause) => cause,
-            CreateGlobalClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            CreateGlobalClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateGlobalClusterError::GlobalClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateGlobalClusterError::GlobalClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateGlobalClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateGlobalClusterError {}
 /// Errors returned by CreateOptionGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateOptionGroupError {
@@ -20264,17 +20324,17 @@ impl CreateOptionGroupError {
 }
 impl fmt::Display for CreateOptionGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOptionGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOptionGroupError::OptionGroupAlreadyExistsFault(ref cause) => cause,
-            CreateOptionGroupError::OptionGroupQuotaExceededFault(ref cause) => cause,
+            CreateOptionGroupError::OptionGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateOptionGroupError::OptionGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateOptionGroupError {}
 /// Errors returned by DeleteCustomAvailabilityZone
 #[derive(Debug, PartialEq)]
 pub enum DeleteCustomAvailabilityZoneError {
@@ -20325,19 +20385,17 @@ impl DeleteCustomAvailabilityZoneError {
 }
 impl fmt::Display for DeleteCustomAvailabilityZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCustomAvailabilityZoneError {
-    fn description(&self) -> &str {
         match *self {
             DeleteCustomAvailabilityZoneError::CustomAvailabilityZoneNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DeleteCustomAvailabilityZoneError::KMSKeyNotAccessibleFault(ref cause) => cause,
+            DeleteCustomAvailabilityZoneError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCustomAvailabilityZoneError {}
 /// Errors returned by DeleteDBCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterError {
@@ -20407,20 +20465,20 @@ impl DeleteDBClusterError {
 }
 impl fmt::Display for DeleteDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            DeleteDBClusterError::DBClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteDBClusterError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
-            DeleteDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            DeleteDBClusterError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBClusterError::DBClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBClusterError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBClusterError {}
 /// Errors returned by DeleteDBClusterEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterEndpointError {
@@ -20478,18 +20536,20 @@ impl DeleteDBClusterEndpointError {
 }
 impl fmt::Display for DeleteDBClusterEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterEndpointError::DBClusterEndpointNotFoundFault(ref cause) => cause,
-            DeleteDBClusterEndpointError::InvalidDBClusterEndpointStateFault(ref cause) => cause,
-            DeleteDBClusterEndpointError::InvalidDBClusterStateFault(ref cause) => cause,
+            DeleteDBClusterEndpointError::DBClusterEndpointNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterEndpointError::InvalidDBClusterEndpointStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterEndpointError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBClusterEndpointError {}
 /// Errors returned by DeleteDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterParameterGroupError {
@@ -20540,19 +20600,17 @@ impl DeleteDBClusterParameterGroupError {
 }
 impl fmt::Display for DeleteDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteDBClusterParameterGroupError {}
 /// Errors returned by DeleteDBClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBClusterSnapshotError {
@@ -20601,17 +20659,17 @@ impl DeleteDBClusterSnapshotError {
 }
 impl fmt::Display for DeleteDBClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            DeleteDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => cause,
+            DeleteDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBClusterSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBClusterSnapshotError {}
 /// Errors returned by DeleteDBInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBInstanceError {
@@ -20690,21 +20748,21 @@ impl DeleteDBInstanceError {
 }
 impl fmt::Display for DeleteDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBInstanceError::DBInstanceAutomatedBackupQuotaExceededFault(ref cause) => cause,
-            DeleteDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            DeleteDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            DeleteDBInstanceError::SnapshotQuotaExceededFault(ref cause) => cause,
+            DeleteDBInstanceError::DBInstanceAutomatedBackupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBInstanceError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBInstanceError {}
 /// Errors returned by DeleteDBInstanceAutomatedBackup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBInstanceAutomatedBackupError {
@@ -20741,21 +20799,17 @@ impl DeleteDBInstanceAutomatedBackupError {
 }
 impl fmt::Display for DeleteDBInstanceAutomatedBackupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBInstanceAutomatedBackupError {
-    fn description(&self) -> &str {
         match *self {
             DeleteDBInstanceAutomatedBackupError::DBInstanceAutomatedBackupNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             DeleteDBInstanceAutomatedBackupError::InvalidDBInstanceAutomatedBackupStateFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBInstanceAutomatedBackupError {}
 /// Errors returned by DeleteDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBParameterGroupError {
@@ -20804,17 +20858,17 @@ impl DeleteDBParameterGroupError {
 }
 impl fmt::Display for DeleteDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            DeleteDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => cause,
+            DeleteDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBParameterGroupError {}
 /// Errors returned by DeleteDBProxy
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBProxyError {
@@ -20859,17 +20913,13 @@ impl DeleteDBProxyError {
 }
 impl fmt::Display for DeleteDBProxyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBProxyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBProxyError::DBProxyNotFoundFault(ref cause) => cause,
-            DeleteDBProxyError::InvalidDBProxyStateFault(ref cause) => cause,
+            DeleteDBProxyError::DBProxyNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBProxyError::InvalidDBProxyStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBProxyError {}
 /// Errors returned by DeleteDBSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBSecurityGroupError {
@@ -20918,17 +20968,17 @@ impl DeleteDBSecurityGroupError {
 }
 impl fmt::Display for DeleteDBSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBSecurityGroupError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            DeleteDBSecurityGroupError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
+            DeleteDBSecurityGroupError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBSecurityGroupError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBSecurityGroupError {}
 /// Errors returned by DeleteDBSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBSnapshotError {
@@ -20975,17 +21025,13 @@ impl DeleteDBSnapshotError {
 }
 impl fmt::Display for DeleteDBSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => cause,
-            DeleteDBSnapshotError::InvalidDBSnapshotStateFault(ref cause) => cause,
+            DeleteDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteDBSnapshotError::InvalidDBSnapshotStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDBSnapshotError {}
 /// Errors returned by DeleteDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteDBSubnetGroupError {
@@ -21043,18 +21089,20 @@ impl DeleteDBSubnetGroupError {
 }
 impl fmt::Display for DeleteDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            DeleteDBSubnetGroupError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            DeleteDBSubnetGroupError::InvalidDBSubnetStateFault(ref cause) => cause,
+            DeleteDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBSubnetGroupError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteDBSubnetGroupError::InvalidDBSubnetStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteDBSubnetGroupError {}
 /// Errors returned by DeleteEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteEventSubscriptionError {
@@ -21103,17 +21151,17 @@ impl DeleteEventSubscriptionError {
 }
 impl fmt::Display for DeleteEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEventSubscriptionError::InvalidEventSubscriptionStateFault(ref cause) => cause,
-            DeleteEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
+            DeleteEventSubscriptionError::InvalidEventSubscriptionStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteEventSubscriptionError {}
 /// Errors returned by DeleteGlobalCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteGlobalClusterError {
@@ -21162,17 +21210,17 @@ impl DeleteGlobalClusterError {
 }
 impl fmt::Display for DeleteGlobalClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGlobalClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGlobalClusterError::GlobalClusterNotFoundFault(ref cause) => cause,
-            DeleteGlobalClusterError::InvalidGlobalClusterStateFault(ref cause) => cause,
+            DeleteGlobalClusterError::GlobalClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteGlobalClusterError::InvalidGlobalClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteGlobalClusterError {}
 /// Errors returned by DeleteInstallationMedia
 #[derive(Debug, PartialEq)]
 pub enum DeleteInstallationMediaError {
@@ -21212,16 +21260,14 @@ impl DeleteInstallationMediaError {
 }
 impl fmt::Display for DeleteInstallationMediaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInstallationMediaError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInstallationMediaError::InstallationMediaNotFoundFault(ref cause) => cause,
+            DeleteInstallationMediaError::InstallationMediaNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteInstallationMediaError {}
 /// Errors returned by DeleteOptionGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteOptionGroupError {
@@ -21268,17 +21314,15 @@ impl DeleteOptionGroupError {
 }
 impl fmt::Display for DeleteOptionGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteOptionGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteOptionGroupError::InvalidOptionGroupStateFault(ref cause) => cause,
-            DeleteOptionGroupError::OptionGroupNotFoundFault(ref cause) => cause,
+            DeleteOptionGroupError::InvalidOptionGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteOptionGroupError::OptionGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteOptionGroupError {}
 /// Errors returned by DeregisterDBProxyTargets
 #[derive(Debug, PartialEq)]
 pub enum DeregisterDBProxyTargetsError {
@@ -21336,18 +21380,20 @@ impl DeregisterDBProxyTargetsError {
 }
 impl fmt::Display for DeregisterDBProxyTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterDBProxyTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterDBProxyTargetsError::DBProxyNotFoundFault(ref cause) => cause,
-            DeregisterDBProxyTargetsError::DBProxyTargetGroupNotFoundFault(ref cause) => cause,
-            DeregisterDBProxyTargetsError::DBProxyTargetNotFoundFault(ref cause) => cause,
+            DeregisterDBProxyTargetsError::DBProxyNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterDBProxyTargetsError::DBProxyTargetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterDBProxyTargetsError::DBProxyTargetNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterDBProxyTargetsError {}
 /// Errors returned by DescribeAccountAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountAttributesError {}
@@ -21377,14 +21423,10 @@ impl DescribeAccountAttributesError {
 }
 impl fmt::Display for DescribeAccountAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAccountAttributesError {}
 /// Errors returned by DescribeCertificates
 #[derive(Debug, PartialEq)]
 pub enum DescribeCertificatesError {
@@ -21424,16 +21466,14 @@ impl DescribeCertificatesError {
 }
 impl fmt::Display for DescribeCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCertificatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCertificatesError::CertificateNotFoundFault(ref cause) => cause,
+            DescribeCertificatesError::CertificateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCertificatesError {}
 /// Errors returned by DescribeCustomAvailabilityZones
 #[derive(Debug, PartialEq)]
 pub enum DescribeCustomAvailabilityZonesError {
@@ -21473,18 +21513,14 @@ impl DescribeCustomAvailabilityZonesError {
 }
 impl fmt::Display for DescribeCustomAvailabilityZonesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCustomAvailabilityZonesError {
-    fn description(&self) -> &str {
         match *self {
             DescribeCustomAvailabilityZonesError::CustomAvailabilityZoneNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCustomAvailabilityZonesError {}
 /// Errors returned by DescribeDBClusterBacktracks
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterBacktracksError {
@@ -21535,17 +21571,17 @@ impl DescribeDBClusterBacktracksError {
 }
 impl fmt::Display for DescribeDBClusterBacktracksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterBacktracksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterBacktracksError::DBClusterBacktrackNotFoundFault(ref cause) => cause,
-            DescribeDBClusterBacktracksError::DBClusterNotFoundFault(ref cause) => cause,
+            DescribeDBClusterBacktracksError::DBClusterBacktrackNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDBClusterBacktracksError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterBacktracksError {}
 /// Errors returned by DescribeDBClusterEndpoints
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterEndpointsError {
@@ -21587,16 +21623,14 @@ impl DescribeDBClusterEndpointsError {
 }
 impl fmt::Display for DescribeDBClusterEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterEndpointsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterEndpointsError::DBClusterNotFoundFault(ref cause) => cause,
+            DescribeDBClusterEndpointsError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterEndpointsError {}
 /// Errors returned by DescribeDBClusterParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterParameterGroupsError {
@@ -21638,18 +21672,14 @@ impl DescribeDBClusterParameterGroupsError {
 }
 impl fmt::Display for DescribeDBClusterParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDBClusterParameterGroupsError::DBParameterGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeDBClusterParameterGroupsError {}
 /// Errors returned by DescribeDBClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterParametersError {
@@ -21691,16 +21721,14 @@ impl DescribeDBClusterParametersError {
 }
 impl fmt::Display for DescribeDBClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterParametersError {}
 /// Errors returned by DescribeDBClusterSnapshotAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterSnapshotAttributesError {
@@ -21740,18 +21768,14 @@ impl DescribeDBClusterSnapshotAttributesError {
 }
 impl fmt::Display for DescribeDBClusterSnapshotAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterSnapshotAttributesError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDBClusterSnapshotAttributesError::DBClusterSnapshotNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeDBClusterSnapshotAttributesError {}
 /// Errors returned by DescribeDBClusterSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClusterSnapshotsError {
@@ -21793,16 +21817,14 @@ impl DescribeDBClusterSnapshotsError {
 }
 impl fmt::Display for DescribeDBClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClusterSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClusterSnapshotsError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
+            DescribeDBClusterSnapshotsError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBClusterSnapshotsError {}
 /// Errors returned by DescribeDBClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBClustersError {
@@ -21840,16 +21862,12 @@ impl DescribeDBClustersError {
 }
 impl fmt::Display for DescribeDBClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBClustersError::DBClusterNotFoundFault(ref cause) => cause,
+            DescribeDBClustersError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBClustersError {}
 /// Errors returned by DescribeDBEngineVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBEngineVersionsError {}
@@ -21879,14 +21897,10 @@ impl DescribeDBEngineVersionsError {
 }
 impl fmt::Display for DescribeDBEngineVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBEngineVersionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeDBEngineVersionsError {}
 /// Errors returned by DescribeDBInstanceAutomatedBackups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBInstanceAutomatedBackupsError {
@@ -21921,18 +21935,14 @@ impl DescribeDBInstanceAutomatedBackupsError {
 }
 impl fmt::Display for DescribeDBInstanceAutomatedBackupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBInstanceAutomatedBackupsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeDBInstanceAutomatedBackupsError::DBInstanceAutomatedBackupNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBInstanceAutomatedBackupsError {}
 /// Errors returned by DescribeDBInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBInstancesError {
@@ -21970,16 +21980,12 @@ impl DescribeDBInstancesError {
 }
 impl fmt::Display for DescribeDBInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBInstancesError::DBInstanceNotFoundFault(ref cause) => cause,
+            DescribeDBInstancesError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBInstancesError {}
 /// Errors returned by DescribeDBLogFiles
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBLogFilesError {
@@ -22017,16 +22023,12 @@ impl DescribeDBLogFilesError {
 }
 impl fmt::Display for DescribeDBLogFilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBLogFilesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBLogFilesError::DBInstanceNotFoundFault(ref cause) => cause,
+            DescribeDBLogFilesError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBLogFilesError {}
 /// Errors returned by DescribeDBParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBParameterGroupsError {
@@ -22066,16 +22068,14 @@ impl DescribeDBParameterGroupsError {
 }
 impl fmt::Display for DescribeDBParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBParameterGroupsError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeDBParameterGroupsError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBParameterGroupsError {}
 /// Errors returned by DescribeDBParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBParametersError {
@@ -22115,16 +22115,14 @@ impl DescribeDBParametersError {
 }
 impl fmt::Display for DescribeDBParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBParametersError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeDBParametersError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBParametersError {}
 /// Errors returned by DescribeDBProxies
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBProxiesError {
@@ -22162,16 +22160,12 @@ impl DescribeDBProxiesError {
 }
 impl fmt::Display for DescribeDBProxiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBProxiesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBProxiesError::DBProxyNotFoundFault(ref cause) => cause,
+            DescribeDBProxiesError::DBProxyNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBProxiesError {}
 /// Errors returned by DescribeDBProxyTargetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBProxyTargetGroupsError {
@@ -22213,16 +22207,14 @@ impl DescribeDBProxyTargetGroupsError {
 }
 impl fmt::Display for DescribeDBProxyTargetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBProxyTargetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBProxyTargetGroupsError::DBProxyTargetGroupNotFoundFault(ref cause) => cause,
+            DescribeDBProxyTargetGroupsError::DBProxyTargetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBProxyTargetGroupsError {}
 /// Errors returned by DescribeDBProxyTargets
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBProxyTargetsError {
@@ -22278,18 +22270,18 @@ impl DescribeDBProxyTargetsError {
 }
 impl fmt::Display for DescribeDBProxyTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBProxyTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBProxyTargetsError::DBProxyNotFoundFault(ref cause) => cause,
-            DescribeDBProxyTargetsError::DBProxyTargetGroupNotFoundFault(ref cause) => cause,
-            DescribeDBProxyTargetsError::DBProxyTargetNotFoundFault(ref cause) => cause,
+            DescribeDBProxyTargetsError::DBProxyNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DescribeDBProxyTargetsError::DBProxyTargetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDBProxyTargetsError::DBProxyTargetNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBProxyTargetsError {}
 /// Errors returned by DescribeDBSecurityGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBSecurityGroupsError {
@@ -22329,16 +22321,14 @@ impl DescribeDBSecurityGroupsError {
 }
 impl fmt::Display for DescribeDBSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBSecurityGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBSecurityGroupsError::DBSecurityGroupNotFoundFault(ref cause) => cause,
+            DescribeDBSecurityGroupsError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBSecurityGroupsError {}
 /// Errors returned by DescribeDBSnapshotAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBSnapshotAttributesError {
@@ -22380,16 +22370,14 @@ impl DescribeDBSnapshotAttributesError {
 }
 impl fmt::Display for DescribeDBSnapshotAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBSnapshotAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBSnapshotAttributesError::DBSnapshotNotFoundFault(ref cause) => cause,
+            DescribeDBSnapshotAttributesError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBSnapshotAttributesError {}
 /// Errors returned by DescribeDBSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBSnapshotsError {
@@ -22427,16 +22415,12 @@ impl DescribeDBSnapshotsError {
 }
 impl fmt::Display for DescribeDBSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBSnapshotsError::DBSnapshotNotFoundFault(ref cause) => cause,
+            DescribeDBSnapshotsError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDBSnapshotsError {}
 /// Errors returned by DescribeDBSubnetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeDBSubnetGroupsError {
@@ -22476,16 +22460,14 @@ impl DescribeDBSubnetGroupsError {
 }
 impl fmt::Display for DescribeDBSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDBSubnetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDBSubnetGroupsError::DBSubnetGroupNotFoundFault(ref cause) => cause,
+            DescribeDBSubnetGroupsError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDBSubnetGroupsError {}
 /// Errors returned by DescribeEngineDefaultClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeEngineDefaultClusterParametersError {}
@@ -22517,14 +22499,10 @@ impl DescribeEngineDefaultClusterParametersError {
 }
 impl fmt::Display for DescribeEngineDefaultClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEngineDefaultClusterParametersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEngineDefaultClusterParametersError {}
 /// Errors returned by DescribeEngineDefaultParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeEngineDefaultParametersError {}
@@ -22556,14 +22534,10 @@ impl DescribeEngineDefaultParametersError {
 }
 impl fmt::Display for DescribeEngineDefaultParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEngineDefaultParametersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEngineDefaultParametersError {}
 /// Errors returned by DescribeEventCategories
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventCategoriesError {}
@@ -22593,14 +22567,10 @@ impl DescribeEventCategoriesError {
 }
 impl fmt::Display for DescribeEventCategoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventCategoriesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventCategoriesError {}
 /// Errors returned by DescribeEventSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventSubscriptionsError {
@@ -22642,16 +22612,14 @@ impl DescribeEventSubscriptionsError {
 }
 impl fmt::Display for DescribeEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventSubscriptionsError::SubscriptionNotFoundFault(ref cause) => cause,
+            DescribeEventSubscriptionsError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEventSubscriptionsError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {}
@@ -22681,14 +22649,10 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeGlobalClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeGlobalClustersError {
@@ -22728,16 +22692,14 @@ impl DescribeGlobalClustersError {
 }
 impl fmt::Display for DescribeGlobalClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGlobalClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGlobalClustersError::GlobalClusterNotFoundFault(ref cause) => cause,
+            DescribeGlobalClustersError::GlobalClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeGlobalClustersError {}
 /// Errors returned by DescribeInstallationMedia
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstallationMediaError {
@@ -22777,16 +22739,14 @@ impl DescribeInstallationMediaError {
 }
 impl fmt::Display for DescribeInstallationMediaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstallationMediaError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstallationMediaError::InstallationMediaNotFoundFault(ref cause) => cause,
+            DescribeInstallationMediaError::InstallationMediaNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeInstallationMediaError {}
 /// Errors returned by DescribeOptionGroupOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeOptionGroupOptionsError {}
@@ -22818,14 +22778,10 @@ impl DescribeOptionGroupOptionsError {
 }
 impl fmt::Display for DescribeOptionGroupOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOptionGroupOptionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeOptionGroupOptionsError {}
 /// Errors returned by DescribeOptionGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeOptionGroupsError {
@@ -22865,16 +22821,14 @@ impl DescribeOptionGroupsError {
 }
 impl fmt::Display for DescribeOptionGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOptionGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOptionGroupsError::OptionGroupNotFoundFault(ref cause) => cause,
+            DescribeOptionGroupsError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeOptionGroupsError {}
 /// Errors returned by DescribeOrderableDBInstanceOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrderableDBInstanceOptionsError {}
@@ -22906,14 +22860,10 @@ impl DescribeOrderableDBInstanceOptionsError {
 }
 impl fmt::Display for DescribeOrderableDBInstanceOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrderableDBInstanceOptionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeOrderableDBInstanceOptionsError {}
 /// Errors returned by DescribePendingMaintenanceActions
 #[derive(Debug, PartialEq)]
 pub enum DescribePendingMaintenanceActionsError {
@@ -22955,16 +22905,14 @@ impl DescribePendingMaintenanceActionsError {
 }
 impl fmt::Display for DescribePendingMaintenanceActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePendingMaintenanceActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribePendingMaintenanceActionsError::ResourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePendingMaintenanceActionsError {}
 /// Errors returned by DescribeReservedDBInstances
 #[derive(Debug, PartialEq)]
 pub enum DescribeReservedDBInstancesError {
@@ -23006,16 +22954,14 @@ impl DescribeReservedDBInstancesError {
 }
 impl fmt::Display for DescribeReservedDBInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReservedDBInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReservedDBInstancesError::ReservedDBInstanceNotFoundFault(ref cause) => cause,
+            DescribeReservedDBInstancesError::ReservedDBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReservedDBInstancesError {}
 /// Errors returned by DescribeReservedDBInstancesOfferings
 #[derive(Debug, PartialEq)]
 pub enum DescribeReservedDBInstancesOfferingsError {
@@ -23050,18 +22996,14 @@ impl DescribeReservedDBInstancesOfferingsError {
 }
 impl fmt::Display for DescribeReservedDBInstancesOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReservedDBInstancesOfferingsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeReservedDBInstancesOfferingsError::ReservedDBInstancesOfferingNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeReservedDBInstancesOfferingsError {}
 /// Errors returned by DescribeSourceRegions
 #[derive(Debug, PartialEq)]
 pub enum DescribeSourceRegionsError {}
@@ -23091,14 +23033,10 @@ impl DescribeSourceRegionsError {
 }
 impl fmt::Display for DescribeSourceRegionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSourceRegionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeSourceRegionsError {}
 /// Errors returned by DescribeValidDBInstanceModifications
 #[derive(Debug, PartialEq)]
 pub enum DescribeValidDBInstanceModificationsError {
@@ -23149,19 +23087,17 @@ impl DescribeValidDBInstanceModificationsError {
 }
 impl fmt::Display for DescribeValidDBInstanceModificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeValidDBInstanceModificationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeValidDBInstanceModificationsError::DBInstanceNotFoundFault(ref cause) => cause,
+            DescribeValidDBInstanceModificationsError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeValidDBInstanceModificationsError::InvalidDBInstanceStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeValidDBInstanceModificationsError {}
 /// Errors returned by DownloadDBLogFilePortion
 #[derive(Debug, PartialEq)]
 pub enum DownloadDBLogFilePortionError {
@@ -23210,17 +23146,17 @@ impl DownloadDBLogFilePortionError {
 }
 impl fmt::Display for DownloadDBLogFilePortionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DownloadDBLogFilePortionError {
-    fn description(&self) -> &str {
         match *self {
-            DownloadDBLogFilePortionError::DBInstanceNotFoundFault(ref cause) => cause,
-            DownloadDBLogFilePortionError::DBLogFileNotFoundFault(ref cause) => cause,
+            DownloadDBLogFilePortionError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DownloadDBLogFilePortionError::DBLogFileNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DownloadDBLogFilePortionError {}
 /// Errors returned by FailoverDBCluster
 #[derive(Debug, PartialEq)]
 pub enum FailoverDBClusterError {
@@ -23276,18 +23212,16 @@ impl FailoverDBClusterError {
 }
 impl fmt::Display for FailoverDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for FailoverDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            FailoverDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            FailoverDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            FailoverDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
+            FailoverDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            FailoverDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            FailoverDBClusterError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for FailoverDBClusterError {}
 /// Errors returned by ImportInstallationMedia
 #[derive(Debug, PartialEq)]
 pub enum ImportInstallationMediaError {
@@ -23336,17 +23270,17 @@ impl ImportInstallationMediaError {
 }
 impl fmt::Display for ImportInstallationMediaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportInstallationMediaError {
-    fn description(&self) -> &str {
         match *self {
-            ImportInstallationMediaError::CustomAvailabilityZoneNotFoundFault(ref cause) => cause,
-            ImportInstallationMediaError::InstallationMediaAlreadyExistsFault(ref cause) => cause,
+            ImportInstallationMediaError::CustomAvailabilityZoneNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ImportInstallationMediaError::InstallationMediaAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ImportInstallationMediaError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -23398,18 +23332,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            ListTagsForResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            ListTagsForResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            ListTagsForResourceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ModifyCurrentDBClusterCapacity
 #[derive(Debug, PartialEq)]
 pub enum ModifyCurrentDBClusterCapacityError {
@@ -23469,18 +23399,20 @@ impl ModifyCurrentDBClusterCapacityError {
 }
 impl fmt::Display for ModifyCurrentDBClusterCapacityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyCurrentDBClusterCapacityError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyCurrentDBClusterCapacityError::DBClusterNotFoundFault(ref cause) => cause,
-            ModifyCurrentDBClusterCapacityError::InvalidDBClusterCapacityFault(ref cause) => cause,
-            ModifyCurrentDBClusterCapacityError::InvalidDBClusterStateFault(ref cause) => cause,
+            ModifyCurrentDBClusterCapacityError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCurrentDBClusterCapacityError::InvalidDBClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyCurrentDBClusterCapacityError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyCurrentDBClusterCapacityError {}
 /// Errors returned by ModifyDBCluster
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterError {
@@ -23601,27 +23533,29 @@ impl ModifyDBClusterError {
 }
 impl fmt::Display for ModifyDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBClusterError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            ModifyDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::DomainNotFoundFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            ModifyDBClusterError::InvalidSubnet(ref cause) => cause,
-            ModifyDBClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyDBClusterError::StorageQuotaExceededFault(ref cause) => cause,
+            ModifyDBClusterError::DBClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::DomainNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBClusterError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBClusterError {}
 /// Errors returned by ModifyDBClusterEndpoint
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterEndpointError {
@@ -23697,20 +23631,26 @@ impl ModifyDBClusterEndpointError {
 }
 impl fmt::Display for ModifyDBClusterEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBClusterEndpointError::DBClusterEndpointNotFoundFault(ref cause) => cause,
-            ModifyDBClusterEndpointError::DBInstanceNotFoundFault(ref cause) => cause,
-            ModifyDBClusterEndpointError::InvalidDBClusterEndpointStateFault(ref cause) => cause,
-            ModifyDBClusterEndpointError::InvalidDBClusterStateFault(ref cause) => cause,
-            ModifyDBClusterEndpointError::InvalidDBInstanceStateFault(ref cause) => cause,
+            ModifyDBClusterEndpointError::DBClusterEndpointNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterEndpointError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterEndpointError::InvalidDBClusterEndpointStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterEndpointError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBClusterEndpointError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBClusterEndpointError {}
 /// Errors returned by ModifyDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterParameterGroupError {
@@ -23761,19 +23701,17 @@ impl ModifyDBClusterParameterGroupError {
 }
 impl fmt::Display for ModifyDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ModifyDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ModifyDBClusterParameterGroupError {}
 /// Errors returned by ModifyDBClusterSnapshotAttribute
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBClusterSnapshotAttributeError {
@@ -23831,24 +23769,20 @@ impl ModifyDBClusterSnapshotAttributeError {
 }
 impl fmt::Display for ModifyDBClusterSnapshotAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBClusterSnapshotAttributeError {
-    fn description(&self) -> &str {
         match *self {
             ModifyDBClusterSnapshotAttributeError::DBClusterSnapshotNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             ModifyDBClusterSnapshotAttributeError::InvalidDBClusterSnapshotStateFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             ModifyDBClusterSnapshotAttributeError::SharedSnapshotQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ModifyDBClusterSnapshotAttributeError {}
 /// Errors returned by ModifyDBInstance
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBInstanceError {
@@ -24018,32 +23952,44 @@ impl ModifyDBInstanceError {
 }
 impl fmt::Display for ModifyDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBInstanceError::AuthorizationNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::BackupPolicyNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::CertificateNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            ModifyDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::DBUpgradeDependencyFailureFault(ref cause) => cause,
-            ModifyDBInstanceError::DomainNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
-            ModifyDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            ModifyDBInstanceError::OptionGroupNotFoundFault(ref cause) => cause,
-            ModifyDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => cause,
-            ModifyDBInstanceError::StorageQuotaExceededFault(ref cause) => cause,
-            ModifyDBInstanceError::StorageTypeNotSupportedFault(ref cause) => cause,
+            ModifyDBInstanceError::AuthorizationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::BackupPolicyNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::CertificateNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DBUpgradeDependencyFailureFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::DomainNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::OptionGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::ProvisionedIopsNotAvailableInAZFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBInstanceError::StorageQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBInstanceError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBInstanceError {}
 /// Errors returned by ModifyDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBParameterGroupError {
@@ -24092,17 +24038,17 @@ impl ModifyDBParameterGroupError {
 }
 impl fmt::Display for ModifyDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => cause,
+            ModifyDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBParameterGroupError {}
 /// Errors returned by ModifyDBProxy
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBProxyError {
@@ -24154,18 +24100,14 @@ impl ModifyDBProxyError {
 }
 impl fmt::Display for ModifyDBProxyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBProxyError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBProxyError::DBProxyAlreadyExistsFault(ref cause) => cause,
-            ModifyDBProxyError::DBProxyNotFoundFault(ref cause) => cause,
-            ModifyDBProxyError::InvalidDBProxyStateFault(ref cause) => cause,
+            ModifyDBProxyError::DBProxyAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBProxyError::DBProxyNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyDBProxyError::InvalidDBProxyStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBProxyError {}
 /// Errors returned by ModifyDBProxyTargetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBProxyTargetGroupError {
@@ -24214,17 +24156,17 @@ impl ModifyDBProxyTargetGroupError {
 }
 impl fmt::Display for ModifyDBProxyTargetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBProxyTargetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBProxyTargetGroupError::DBProxyNotFoundFault(ref cause) => cause,
-            ModifyDBProxyTargetGroupError::DBProxyTargetGroupNotFoundFault(ref cause) => cause,
+            ModifyDBProxyTargetGroupError::DBProxyNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBProxyTargetGroupError::DBProxyTargetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBProxyTargetGroupError {}
 /// Errors returned by ModifyDBSnapshot
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBSnapshotError {
@@ -24262,16 +24204,12 @@ impl ModifyDBSnapshotError {
 }
 impl fmt::Display for ModifyDBSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => cause,
+            ModifyDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBSnapshotError {}
 /// Errors returned by ModifyDBSnapshotAttribute
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBSnapshotAttributeError {
@@ -24329,18 +24267,20 @@ impl ModifyDBSnapshotAttributeError {
 }
 impl fmt::Display for ModifyDBSnapshotAttributeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBSnapshotAttributeError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBSnapshotAttributeError::DBSnapshotNotFoundFault(ref cause) => cause,
-            ModifyDBSnapshotAttributeError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            ModifyDBSnapshotAttributeError::SharedSnapshotQuotaExceededFault(ref cause) => cause,
+            ModifyDBSnapshotAttributeError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSnapshotAttributeError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSnapshotAttributeError::SharedSnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDBSnapshotAttributeError {}
 /// Errors returned by ModifyDBSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyDBSubnetGroupError {
@@ -24412,20 +24352,22 @@ impl ModifyDBSubnetGroupError {
 }
 impl fmt::Display for ModifyDBSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDBSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            ModifyDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => cause,
-            ModifyDBSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            ModifyDBSubnetGroupError::SubnetAlreadyInUse(ref cause) => cause,
+            ModifyDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::DBSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDBSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyDBSubnetGroupError::SubnetAlreadyInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyDBSubnetGroupError {}
 /// Errors returned by ModifyEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum ModifyEventSubscriptionError {
@@ -24510,21 +24452,27 @@ impl ModifyEventSubscriptionError {
 }
 impl fmt::Display for ModifyEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
+            ModifyEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyEventSubscriptionError {}
 /// Errors returned by ModifyGlobalCluster
 #[derive(Debug, PartialEq)]
 pub enum ModifyGlobalClusterError {
@@ -24573,17 +24521,17 @@ impl ModifyGlobalClusterError {
 }
 impl fmt::Display for ModifyGlobalClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyGlobalClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyGlobalClusterError::GlobalClusterNotFoundFault(ref cause) => cause,
-            ModifyGlobalClusterError::InvalidGlobalClusterStateFault(ref cause) => cause,
+            ModifyGlobalClusterError::GlobalClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyGlobalClusterError::InvalidGlobalClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyGlobalClusterError {}
 /// Errors returned by ModifyOptionGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyOptionGroupError {
@@ -24630,17 +24578,15 @@ impl ModifyOptionGroupError {
 }
 impl fmt::Display for ModifyOptionGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyOptionGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyOptionGroupError::InvalidOptionGroupStateFault(ref cause) => cause,
-            ModifyOptionGroupError::OptionGroupNotFoundFault(ref cause) => cause,
+            ModifyOptionGroupError::InvalidOptionGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyOptionGroupError::OptionGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyOptionGroupError {}
 /// Errors returned by PromoteReadReplica
 #[derive(Debug, PartialEq)]
 pub enum PromoteReadReplicaError {
@@ -24687,17 +24633,15 @@ impl PromoteReadReplicaError {
 }
 impl fmt::Display for PromoteReadReplicaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PromoteReadReplicaError {
-    fn description(&self) -> &str {
         match *self {
-            PromoteReadReplicaError::DBInstanceNotFoundFault(ref cause) => cause,
-            PromoteReadReplicaError::InvalidDBInstanceStateFault(ref cause) => cause,
+            PromoteReadReplicaError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            PromoteReadReplicaError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PromoteReadReplicaError {}
 /// Errors returned by PromoteReadReplicaDBCluster
 #[derive(Debug, PartialEq)]
 pub enum PromoteReadReplicaDBClusterError {
@@ -24748,17 +24692,17 @@ impl PromoteReadReplicaDBClusterError {
 }
 impl fmt::Display for PromoteReadReplicaDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PromoteReadReplicaDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            PromoteReadReplicaDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            PromoteReadReplicaDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            PromoteReadReplicaDBClusterError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PromoteReadReplicaDBClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PromoteReadReplicaDBClusterError {}
 /// Errors returned by PurchaseReservedDBInstancesOffering
 #[derive(Debug, PartialEq)]
 pub enum PurchaseReservedDBInstancesOfferingError {
@@ -24797,24 +24741,20 @@ impl PurchaseReservedDBInstancesOfferingError {
 }
 impl fmt::Display for PurchaseReservedDBInstancesOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PurchaseReservedDBInstancesOfferingError {
-    fn description(&self) -> &str {
         match *self {
             PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceAlreadyExistsFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceQuotaExceededFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             PurchaseReservedDBInstancesOfferingError::ReservedDBInstancesOfferingNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PurchaseReservedDBInstancesOfferingError {}
 /// Errors returned by RebootDBInstance
 #[derive(Debug, PartialEq)]
 pub enum RebootDBInstanceError {
@@ -24861,17 +24801,13 @@ impl RebootDBInstanceError {
 }
 impl fmt::Display for RebootDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RebootDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            RebootDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
+            RebootDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RebootDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootDBInstanceError {}
 /// Errors returned by RegisterDBProxyTargets
 #[derive(Debug, PartialEq)]
 pub enum RegisterDBProxyTargetsError {
@@ -24963,22 +24899,30 @@ impl RegisterDBProxyTargetsError {
 }
 impl fmt::Display for RegisterDBProxyTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterDBProxyTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterDBProxyTargetsError::DBClusterNotFoundFault(ref cause) => cause,
-            RegisterDBProxyTargetsError::DBInstanceNotFoundFault(ref cause) => cause,
-            RegisterDBProxyTargetsError::DBProxyNotFoundFault(ref cause) => cause,
-            RegisterDBProxyTargetsError::DBProxyTargetAlreadyRegisteredFault(ref cause) => cause,
-            RegisterDBProxyTargetsError::DBProxyTargetGroupNotFoundFault(ref cause) => cause,
-            RegisterDBProxyTargetsError::InvalidDBClusterStateFault(ref cause) => cause,
-            RegisterDBProxyTargetsError::InvalidDBInstanceStateFault(ref cause) => cause,
+            RegisterDBProxyTargetsError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterDBProxyTargetsError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterDBProxyTargetsError::DBProxyNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RegisterDBProxyTargetsError::DBProxyTargetAlreadyRegisteredFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterDBProxyTargetsError::DBProxyTargetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterDBProxyTargetsError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterDBProxyTargetsError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterDBProxyTargetsError {}
 /// Errors returned by RemoveFromGlobalCluster
 #[derive(Debug, PartialEq)]
 pub enum RemoveFromGlobalClusterError {
@@ -25036,18 +24980,20 @@ impl RemoveFromGlobalClusterError {
 }
 impl fmt::Display for RemoveFromGlobalClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveFromGlobalClusterError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveFromGlobalClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            RemoveFromGlobalClusterError::GlobalClusterNotFoundFault(ref cause) => cause,
-            RemoveFromGlobalClusterError::InvalidGlobalClusterStateFault(ref cause) => cause,
+            RemoveFromGlobalClusterError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveFromGlobalClusterError::GlobalClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveFromGlobalClusterError::InvalidGlobalClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveFromGlobalClusterError {}
 /// Errors returned by RemoveRoleFromDBCluster
 #[derive(Debug, PartialEq)]
 pub enum RemoveRoleFromDBClusterError {
@@ -25105,18 +25051,20 @@ impl RemoveRoleFromDBClusterError {
 }
 impl fmt::Display for RemoveRoleFromDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveRoleFromDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveRoleFromDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            RemoveRoleFromDBClusterError::DBClusterRoleNotFoundFault(ref cause) => cause,
-            RemoveRoleFromDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
+            RemoveRoleFromDBClusterError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveRoleFromDBClusterError::DBClusterRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveRoleFromDBClusterError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveRoleFromDBClusterError {}
 /// Errors returned by RemoveRoleFromDBInstance
 #[derive(Debug, PartialEq)]
 pub enum RemoveRoleFromDBInstanceError {
@@ -25174,18 +25122,20 @@ impl RemoveRoleFromDBInstanceError {
 }
 impl fmt::Display for RemoveRoleFromDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveRoleFromDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveRoleFromDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            RemoveRoleFromDBInstanceError::DBInstanceRoleNotFoundFault(ref cause) => cause,
-            RemoveRoleFromDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
+            RemoveRoleFromDBInstanceError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveRoleFromDBInstanceError::DBInstanceRoleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveRoleFromDBInstanceError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveRoleFromDBInstanceError {}
 /// Errors returned by RemoveSourceIdentifierFromSubscription
 #[derive(Debug, PartialEq)]
 pub enum RemoveSourceIdentifierFromSubscriptionError {
@@ -25236,19 +25186,17 @@ impl RemoveSourceIdentifierFromSubscriptionError {
 }
 impl fmt::Display for RemoveSourceIdentifierFromSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveSourceIdentifierFromSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveSourceIdentifierFromSubscriptionError::SourceNotFoundFault(ref cause) => cause,
+            RemoveSourceIdentifierFromSubscriptionError::SourceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RemoveSourceIdentifierFromSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for RemoveSourceIdentifierFromSubscriptionError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -25306,18 +25254,20 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::DBClusterNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::DBInstanceNotFoundFault(ref cause) => cause,
-            RemoveTagsFromResourceError::DBSnapshotNotFoundFault(ref cause) => cause,
+            RemoveTagsFromResourceError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromResourceError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveTagsFromResourceError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by ResetDBClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ResetDBClusterParameterGroupError {
@@ -25368,19 +25318,17 @@ impl ResetDBClusterParameterGroupError {
 }
 impl fmt::Display for ResetDBClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetDBClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
+            ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ResetDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ResetDBClusterParameterGroupError {}
 /// Errors returned by ResetDBParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ResetDBParameterGroupError {
@@ -25429,17 +25377,17 @@ impl ResetDBParameterGroupError {
 }
 impl fmt::Display for ResetDBParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetDBParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ResetDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            ResetDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => cause,
+            ResetDBParameterGroupError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResetDBParameterGroupError::InvalidDBParameterGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ResetDBParameterGroupError {}
 /// Errors returned by RestoreDBClusterFromS3
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBClusterFromS3Error {
@@ -25590,31 +25538,47 @@ impl RestoreDBClusterFromS3Error {
 }
 impl fmt::Display for RestoreDBClusterFromS3Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBClusterFromS3Error {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBClusterFromS3Error::DBClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::DBClusterNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::DBClusterParameterGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::DBClusterQuotaExceededFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::DomainNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::InsufficientStorageClusterCapacityFault(ref cause) => {
-                cause
+            RestoreDBClusterFromS3Error::DBClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterFromS3Error::InvalidDBClusterStateFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::InvalidDBSubnetGroupStateFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::InvalidS3BucketFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::InvalidSubnet(ref cause) => cause,
-            RestoreDBClusterFromS3Error::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBClusterFromS3Error::StorageQuotaExceededFault(ref cause) => cause,
+            RestoreDBClusterFromS3Error::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::DBClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::DomainNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterFromS3Error::InsufficientStorageClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::InvalidDBSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::InvalidS3BucketFault(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterFromS3Error::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterFromS3Error::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromS3Error::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBClusterFromS3Error {}
 /// Errors returned by RestoreDBClusterFromSnapshot
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBClusterFromSnapshotError {
@@ -25796,40 +25760,60 @@ impl RestoreDBClusterFromSnapshotError {
 }
 impl fmt::Display for RestoreDBClusterFromSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBClusterFromSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBClusterFromSnapshotError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBClusterParameterGroupNotFoundFault(ref cause) => {
-                cause
+            RestoreDBClusterFromSnapshotError::DBClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterFromSnapshotError::DBClusterQuotaExceededFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::DomainNotFoundFault(ref cause) => cause,
+            RestoreDBClusterFromSnapshotError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::DomainNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBClusterFromSnapshotError::InsufficientDBClusterCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RestoreDBClusterFromSnapshotError::InsufficientStorageClusterCapacityFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RestoreDBClusterFromSnapshotError::InvalidDBClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterFromSnapshotError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidSubnet(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::OptionGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterFromSnapshotError::StorageQuotaExceededFault(ref cause) => cause,
+            RestoreDBClusterFromSnapshotError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterFromSnapshotError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterFromSnapshotError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBClusterFromSnapshotError {}
 /// Errors returned by RestoreDBClusterToPointInTime
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBClusterToPointInTimeError {
@@ -26018,41 +26002,63 @@ impl RestoreDBClusterToPointInTimeError {
 }
 impl fmt::Display for RestoreDBClusterToPointInTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBClusterToPointInTimeError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBClusterToPointInTimeError::DBClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterParameterGroupNotFoundFault(ref cause) => {
-                cause
+            RestoreDBClusterToPointInTimeError::DBClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterToPointInTimeError::DBClusterQuotaExceededFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBClusterSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::DomainNotFoundFault(ref cause) => cause,
+            RestoreDBClusterToPointInTimeError::DBClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::DomainNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBClusterToPointInTimeError::InsufficientDBClusterCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RestoreDBClusterToPointInTimeError::InsufficientStorageClusterCapacityFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RestoreDBClusterToPointInTimeError::InvalidDBClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBClusterToPointInTimeError::InvalidDBClusterStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidSubnet(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::OptionGroupNotFoundFault(ref cause) => cause,
-            RestoreDBClusterToPointInTimeError::StorageQuotaExceededFault(ref cause) => cause,
+            RestoreDBClusterToPointInTimeError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBClusterToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBClusterToPointInTimeError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBClusterToPointInTimeError {}
 /// Errors returned by RestoreDBInstanceFromDBSnapshot
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBInstanceFromDBSnapshotError {
@@ -26259,41 +26265,71 @@ impl RestoreDBInstanceFromDBSnapshotError {
 }
 impl fmt::Display for RestoreDBInstanceFromDBSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBInstanceFromDBSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBInstanceFromDBSnapshotError::AuthorizationNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::BackupPolicyNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
-                cause
+            RestoreDBInstanceFromDBSnapshotError::AuthorizationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            RestoreDBInstanceFromDBSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::DomainNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::InstanceQuotaExceededFault(ref cause) => cause,
+            RestoreDBInstanceFromDBSnapshotError::BackupPolicyNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::DBSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::DomainNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::InstanceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBInstanceFromDBSnapshotError::InsufficientDBInstanceCapacityFault(
                 ref cause,
-            ) => cause,
-            RestoreDBInstanceFromDBSnapshotError::InvalidDBSnapshotStateFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::InvalidSubnet(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::OptionGroupNotFoundFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            RestoreDBInstanceFromDBSnapshotError::InvalidDBSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::InvalidSubnet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBInstanceFromDBSnapshotError::ProvisionedIopsNotAvailableInAZFault(
                 ref cause,
-            ) => cause,
-            RestoreDBInstanceFromDBSnapshotError::StorageQuotaExceededFault(ref cause) => cause,
-            RestoreDBInstanceFromDBSnapshotError::StorageTypeNotSupportedFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            RestoreDBInstanceFromDBSnapshotError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromDBSnapshotError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBInstanceFromDBSnapshotError {}
 /// Errors returned by RestoreDBInstanceFromS3
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBInstanceFromS3Error {
@@ -26475,32 +26511,58 @@ impl RestoreDBInstanceFromS3Error {
 }
 impl fmt::Display for RestoreDBInstanceFromS3Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBInstanceFromS3Error {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBInstanceFromS3Error::AuthorizationNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::BackupPolicyNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::DBInstanceAlreadyExistsFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::DBParameterGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::InstanceQuotaExceededFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::InvalidS3BucketFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::InvalidSubnet(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::OptionGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::ProvisionedIopsNotAvailableInAZFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::StorageQuotaExceededFault(ref cause) => cause,
-            RestoreDBInstanceFromS3Error::StorageTypeNotSupportedFault(ref cause) => cause,
+            RestoreDBInstanceFromS3Error::AuthorizationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::BackupPolicyNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::InstanceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::InvalidS3BucketFault(ref cause) => write!(f, "{}", cause),
+            RestoreDBInstanceFromS3Error::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBInstanceFromS3Error::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::ProvisionedIopsNotAvailableInAZFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceFromS3Error::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBInstanceFromS3Error {}
 /// Errors returned by RestoreDBInstanceToPointInTime
 #[derive(Debug, PartialEq)]
 pub enum RestoreDBInstanceToPointInTimeError {
@@ -26725,47 +26787,75 @@ impl RestoreDBInstanceToPointInTimeError {
 }
 impl fmt::Display for RestoreDBInstanceToPointInTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDBInstanceToPointInTimeError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDBInstanceToPointInTimeError::AuthorizationNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::BackupPolicyNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::DBInstanceAlreadyExistsFault(ref cause) => cause,
+            RestoreDBInstanceToPointInTimeError::AuthorizationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::BackupPolicyNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::DBInstanceAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBInstanceToPointInTimeError::DBInstanceAutomatedBackupNotFoundFault(
                 ref cause,
-            ) => cause,
-            RestoreDBInstanceToPointInTimeError::DBInstanceNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::DBParameterGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::DBSecurityGroupNotFoundFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            RestoreDBInstanceToPointInTimeError::DBInstanceNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::DBParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBInstanceToPointInTimeError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBInstanceToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::DomainNotFoundFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::InstanceQuotaExceededFault(ref cause) => cause,
+            RestoreDBInstanceToPointInTimeError::DBSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::DomainNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::InstanceQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBInstanceToPointInTimeError::InsufficientDBInstanceCapacityFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreDBInstanceToPointInTimeError::InvalidDBInstanceStateFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::InvalidRestoreFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::InvalidSubnet(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::OptionGroupNotFoundFault(ref cause) => cause,
+            RestoreDBInstanceToPointInTimeError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreDBInstanceToPointInTimeError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::KMSKeyNotAccessibleFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::OptionGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreDBInstanceToPointInTimeError::PointInTimeRestoreNotEnabledFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             RestoreDBInstanceToPointInTimeError::ProvisionedIopsNotAvailableInAZFault(
                 ref cause,
-            ) => cause,
-            RestoreDBInstanceToPointInTimeError::StorageQuotaExceededFault(ref cause) => cause,
-            RestoreDBInstanceToPointInTimeError::StorageTypeNotSupportedFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            RestoreDBInstanceToPointInTimeError::StorageQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreDBInstanceToPointInTimeError::StorageTypeNotSupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreDBInstanceToPointInTimeError {}
 /// Errors returned by RevokeDBSecurityGroupIngress
 #[derive(Debug, PartialEq)]
 pub enum RevokeDBSecurityGroupIngressError {
@@ -26825,18 +26915,20 @@ impl RevokeDBSecurityGroupIngressError {
 }
 impl fmt::Display for RevokeDBSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeDBSecurityGroupIngressError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeDBSecurityGroupIngressError::AuthorizationNotFoundFault(ref cause) => cause,
-            RevokeDBSecurityGroupIngressError::DBSecurityGroupNotFoundFault(ref cause) => cause,
-            RevokeDBSecurityGroupIngressError::InvalidDBSecurityGroupStateFault(ref cause) => cause,
+            RevokeDBSecurityGroupIngressError::AuthorizationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RevokeDBSecurityGroupIngressError::DBSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RevokeDBSecurityGroupIngressError::InvalidDBSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RevokeDBSecurityGroupIngressError {}
 /// Errors returned by StartActivityStream
 #[derive(Debug, PartialEq)]
 pub enum StartActivityStreamError {
@@ -26915,21 +27007,21 @@ impl StartActivityStreamError {
 }
 impl fmt::Display for StartActivityStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartActivityStreamError {
-    fn description(&self) -> &str {
         match *self {
-            StartActivityStreamError::DBClusterNotFoundFault(ref cause) => cause,
-            StartActivityStreamError::DBInstanceNotFoundFault(ref cause) => cause,
-            StartActivityStreamError::InvalidDBClusterStateFault(ref cause) => cause,
-            StartActivityStreamError::InvalidDBInstanceStateFault(ref cause) => cause,
-            StartActivityStreamError::KMSKeyNotAccessibleFault(ref cause) => cause,
-            StartActivityStreamError::ResourceNotFoundFault(ref cause) => cause,
+            StartActivityStreamError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartActivityStreamError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartActivityStreamError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartActivityStreamError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartActivityStreamError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
+            StartActivityStreamError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartActivityStreamError {}
 /// Errors returned by StartDBCluster
 #[derive(Debug, PartialEq)]
 pub enum StartDBClusterError {
@@ -26981,18 +27073,14 @@ impl StartDBClusterError {
 }
 impl fmt::Display for StartDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            StartDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            StartDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            StartDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
+            StartDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            StartDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartDBClusterError {}
 /// Errors returned by StartDBInstance
 #[derive(Debug, PartialEq)]
 pub enum StartDBInstanceError {
@@ -27104,26 +27192,26 @@ impl StartDBInstanceError {
 }
 impl fmt::Display for StartDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            StartDBInstanceError::AuthorizationNotFoundFault(ref cause) => cause,
-            StartDBInstanceError::DBClusterNotFoundFault(ref cause) => cause,
-            StartDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            StartDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => cause,
-            StartDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => cause,
-            StartDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => cause,
-            StartDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            StartDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            StartDBInstanceError::InvalidSubnet(ref cause) => cause,
-            StartDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            StartDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => cause,
+            StartDBInstanceError::AuthorizationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDBInstanceError::DBSubnetGroupNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::InsufficientDBInstanceCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            StartDBInstanceError::KMSKeyNotAccessibleFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartDBInstanceError {}
 /// Errors returned by StopActivityStream
 #[derive(Debug, PartialEq)]
 pub enum StopActivityStreamError {
@@ -27193,20 +27281,20 @@ impl StopActivityStreamError {
 }
 impl fmt::Display for StopActivityStreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopActivityStreamError {
-    fn description(&self) -> &str {
         match *self {
-            StopActivityStreamError::DBClusterNotFoundFault(ref cause) => cause,
-            StopActivityStreamError::DBInstanceNotFoundFault(ref cause) => cause,
-            StopActivityStreamError::InvalidDBClusterStateFault(ref cause) => cause,
-            StopActivityStreamError::InvalidDBInstanceStateFault(ref cause) => cause,
-            StopActivityStreamError::ResourceNotFoundFault(ref cause) => cause,
+            StopActivityStreamError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StopActivityStreamError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StopActivityStreamError::InvalidDBClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopActivityStreamError::InvalidDBInstanceStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopActivityStreamError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopActivityStreamError {}
 /// Errors returned by StopDBCluster
 #[derive(Debug, PartialEq)]
 pub enum StopDBClusterError {
@@ -27258,18 +27346,14 @@ impl StopDBClusterError {
 }
 impl fmt::Display for StopDBClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopDBClusterError {
-    fn description(&self) -> &str {
         match *self {
-            StopDBClusterError::DBClusterNotFoundFault(ref cause) => cause,
-            StopDBClusterError::InvalidDBClusterStateFault(ref cause) => cause,
-            StopDBClusterError::InvalidDBInstanceStateFault(ref cause) => cause,
+            StopDBClusterError::DBClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StopDBClusterError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            StopDBClusterError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopDBClusterError {}
 /// Errors returned by StopDBInstance
 #[derive(Debug, PartialEq)]
 pub enum StopDBInstanceError {
@@ -27335,20 +27419,16 @@ impl StopDBInstanceError {
 }
 impl fmt::Display for StopDBInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopDBInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            StopDBInstanceError::DBInstanceNotFoundFault(ref cause) => cause,
-            StopDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => cause,
-            StopDBInstanceError::InvalidDBClusterStateFault(ref cause) => cause,
-            StopDBInstanceError::InvalidDBInstanceStateFault(ref cause) => cause,
-            StopDBInstanceError::SnapshotQuotaExceededFault(ref cause) => cause,
+            StopDBInstanceError::DBInstanceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            StopDBInstanceError::DBSnapshotAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            StopDBInstanceError::InvalidDBClusterStateFault(ref cause) => write!(f, "{}", cause),
+            StopDBInstanceError::InvalidDBInstanceStateFault(ref cause) => write!(f, "{}", cause),
+            StopDBInstanceError::SnapshotQuotaExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopDBInstanceError {}
 /// Trait representing the capabilities of the Amazon RDS API. Amazon RDS clients implement this trait.
 pub trait Rds {
     /// <p><p>Associates an Identity and Access Management (IAM) role from an Amazon Aurora DB cluster. For more information, see <a href="https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.Authorizing.html">Authorizing Amazon Aurora MySQL to Access Other AWS Services on Your Behalf</a> in the <i>Amazon Aurora User Guide</i>.</p> <note> <p>This action only applies to Aurora DB clusters.</p> </note></p>

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -11027,22 +11027,32 @@ impl AcceptReservedNodeExchangeError {
 }
 impl fmt::Display for AcceptReservedNodeExchangeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptReservedNodeExchangeError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptReservedNodeExchangeError::DependentServiceUnavailableFault(ref cause) => cause,
-            AcceptReservedNodeExchangeError::InvalidReservedNodeStateFault(ref cause) => cause,
-            AcceptReservedNodeExchangeError::ReservedNodeAlreadyExistsFault(ref cause) => cause,
-            AcceptReservedNodeExchangeError::ReservedNodeAlreadyMigratedFault(ref cause) => cause,
-            AcceptReservedNodeExchangeError::ReservedNodeNotFoundFault(ref cause) => cause,
-            AcceptReservedNodeExchangeError::ReservedNodeOfferingNotFoundFault(ref cause) => cause,
-            AcceptReservedNodeExchangeError::UnsupportedOperationFault(ref cause) => cause,
+            AcceptReservedNodeExchangeError::DependentServiceUnavailableFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptReservedNodeExchangeError::InvalidReservedNodeStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptReservedNodeExchangeError::ReservedNodeAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptReservedNodeExchangeError::ReservedNodeAlreadyMigratedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptReservedNodeExchangeError::ReservedNodeNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptReservedNodeExchangeError::ReservedNodeOfferingNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AcceptReservedNodeExchangeError::UnsupportedOperationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AcceptReservedNodeExchangeError {}
 /// Errors returned by AuthorizeClusterSecurityGroupIngress
 #[derive(Debug, PartialEq)]
 pub enum AuthorizeClusterSecurityGroupIngressError {
@@ -11083,27 +11093,23 @@ impl AuthorizeClusterSecurityGroupIngressError {
 }
 impl fmt::Display for AuthorizeClusterSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AuthorizeClusterSecurityGroupIngressError {
-    fn description(&self) -> &str {
         match *self {
             AuthorizeClusterSecurityGroupIngressError::AuthorizationAlreadyExistsFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             AuthorizeClusterSecurityGroupIngressError::AuthorizationQuotaExceededFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             AuthorizeClusterSecurityGroupIngressError::ClusterSecurityGroupNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             AuthorizeClusterSecurityGroupIngressError::InvalidClusterSecurityGroupStateFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AuthorizeClusterSecurityGroupIngressError {}
 /// Errors returned by AuthorizeSnapshotAccess
 #[derive(Debug, PartialEq)]
 pub enum AuthorizeSnapshotAccessError {
@@ -11186,23 +11192,27 @@ impl AuthorizeSnapshotAccessError {
 }
 impl fmt::Display for AuthorizeSnapshotAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AuthorizeSnapshotAccessError {
-    fn description(&self) -> &str {
         match *self {
-            AuthorizeSnapshotAccessError::AuthorizationAlreadyExistsFault(ref cause) => cause,
-            AuthorizeSnapshotAccessError::AuthorizationQuotaExceededFault(ref cause) => cause,
-            AuthorizeSnapshotAccessError::ClusterSnapshotNotFoundFault(ref cause) => cause,
-            AuthorizeSnapshotAccessError::DependentServiceRequestThrottlingFault(ref cause) => {
-                cause
+            AuthorizeSnapshotAccessError::AuthorizationAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            AuthorizeSnapshotAccessError::InvalidClusterSnapshotStateFault(ref cause) => cause,
-            AuthorizeSnapshotAccessError::LimitExceededFault(ref cause) => cause,
+            AuthorizeSnapshotAccessError::AuthorizationQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AuthorizeSnapshotAccessError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AuthorizeSnapshotAccessError::DependentServiceRequestThrottlingFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AuthorizeSnapshotAccessError::InvalidClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AuthorizeSnapshotAccessError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AuthorizeSnapshotAccessError {}
 /// Errors returned by BatchDeleteClusterSnapshots
 #[derive(Debug, PartialEq)]
 pub enum BatchDeleteClusterSnapshotsError {
@@ -11244,18 +11254,14 @@ impl BatchDeleteClusterSnapshotsError {
 }
 impl fmt::Display for BatchDeleteClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteClusterSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
             BatchDeleteClusterSnapshotsError::BatchDeleteRequestSizeExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for BatchDeleteClusterSnapshotsError {}
 /// Errors returned by BatchModifyClusterSnapshots
 #[derive(Debug, PartialEq)]
 pub enum BatchModifyClusterSnapshotsError {
@@ -11292,19 +11298,17 @@ impl BatchModifyClusterSnapshotsError {
 }
 impl fmt::Display for BatchModifyClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchModifyClusterSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
             BatchModifyClusterSnapshotsError::BatchModifyClusterSnapshotsLimitExceededFault(
                 ref cause,
-            ) => cause,
-            BatchModifyClusterSnapshotsError::InvalidRetentionPeriodFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            BatchModifyClusterSnapshotsError::InvalidRetentionPeriodFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchModifyClusterSnapshotsError {}
 /// Errors returned by CancelResize
 #[derive(Debug, PartialEq)]
 pub enum CancelResizeError {
@@ -11363,19 +11367,15 @@ impl CancelResizeError {
 }
 impl fmt::Display for CancelResizeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelResizeError {
-    fn description(&self) -> &str {
         match *self {
-            CancelResizeError::ClusterNotFoundFault(ref cause) => cause,
-            CancelResizeError::InvalidClusterStateFault(ref cause) => cause,
-            CancelResizeError::ResizeNotFoundFault(ref cause) => cause,
-            CancelResizeError::UnsupportedOperationFault(ref cause) => cause,
+            CancelResizeError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CancelResizeError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            CancelResizeError::ResizeNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CancelResizeError::UnsupportedOperationFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelResizeError {}
 /// Errors returned by CopyClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CopyClusterSnapshotError {
@@ -11451,20 +11451,26 @@ impl CopyClusterSnapshotError {
 }
 impl fmt::Display for CopyClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CopyClusterSnapshotError::ClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CopyClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => cause,
-            CopyClusterSnapshotError::ClusterSnapshotQuotaExceededFault(ref cause) => cause,
-            CopyClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => cause,
-            CopyClusterSnapshotError::InvalidRetentionPeriodFault(ref cause) => cause,
+            CopyClusterSnapshotError::ClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyClusterSnapshotError::ClusterSnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CopyClusterSnapshotError::InvalidRetentionPeriodFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CopyClusterSnapshotError {}
 /// Errors returned by CreateCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterError {
@@ -11667,37 +11673,51 @@ impl CreateClusterError {
 }
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterError::ClusterAlreadyExistsFault(ref cause) => cause,
-            CreateClusterError::ClusterParameterGroupNotFoundFault(ref cause) => cause,
-            CreateClusterError::ClusterQuotaExceededFault(ref cause) => cause,
-            CreateClusterError::ClusterSecurityGroupNotFoundFault(ref cause) => cause,
-            CreateClusterError::ClusterSubnetGroupNotFoundFault(ref cause) => cause,
-            CreateClusterError::DependentServiceRequestThrottlingFault(ref cause) => cause,
-            CreateClusterError::HsmClientCertificateNotFoundFault(ref cause) => cause,
-            CreateClusterError::HsmConfigurationNotFoundFault(ref cause) => cause,
-            CreateClusterError::InsufficientClusterCapacityFault(ref cause) => cause,
-            CreateClusterError::InvalidClusterSubnetGroupStateFault(ref cause) => cause,
-            CreateClusterError::InvalidClusterTrackFault(ref cause) => cause,
-            CreateClusterError::InvalidElasticIpFault(ref cause) => cause,
-            CreateClusterError::InvalidRetentionPeriodFault(ref cause) => cause,
-            CreateClusterError::InvalidSubnet(ref cause) => cause,
-            CreateClusterError::InvalidTagFault(ref cause) => cause,
-            CreateClusterError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            CreateClusterError::LimitExceededFault(ref cause) => cause,
-            CreateClusterError::NumberOfNodesPerClusterLimitExceededFault(ref cause) => cause,
-            CreateClusterError::NumberOfNodesQuotaExceededFault(ref cause) => cause,
-            CreateClusterError::SnapshotScheduleNotFoundFault(ref cause) => cause,
-            CreateClusterError::TagLimitExceededFault(ref cause) => cause,
-            CreateClusterError::UnauthorizedOperation(ref cause) => cause,
+            CreateClusterError::ClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::ClusterQuotaExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::ClusterSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::ClusterSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::DependentServiceRequestThrottlingFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::HsmClientCertificateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::HsmConfigurationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InsufficientClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::InvalidClusterSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::InvalidClusterTrackFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidElasticIpFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidRetentionPeriodFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidVPCNetworkStateFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::NumberOfNodesPerClusterLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::NumberOfNodesQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterError::SnapshotScheduleNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::TagLimitExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterError {}
 /// Errors returned by CreateClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterParameterGroupError {
@@ -11760,23 +11780,21 @@ impl CreateClusterParameterGroupError {
 }
 impl fmt::Display for CreateClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             CreateClusterParameterGroupError::ClusterParameterGroupAlreadyExistsFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateClusterParameterGroupError::ClusterParameterGroupQuotaExceededFault(
                 ref cause,
-            ) => cause,
-            CreateClusterParameterGroupError::InvalidTagFault(ref cause) => cause,
-            CreateClusterParameterGroupError::TagLimitExceededFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            CreateClusterParameterGroupError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterParameterGroupError::TagLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateClusterParameterGroupError {}
 /// Errors returned by CreateClusterSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterSecurityGroupError {
@@ -11843,23 +11861,21 @@ impl CreateClusterSecurityGroupError {
 }
 impl fmt::Display for CreateClusterSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
             CreateClusterSecurityGroupError::ClusterSecurityGroupAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateClusterSecurityGroupError::ClusterSecurityGroupQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateClusterSecurityGroupError::InvalidTagFault(ref cause) => cause,
-            CreateClusterSecurityGroupError::TagLimitExceededFault(ref cause) => cause,
+            CreateClusterSecurityGroupError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterSecurityGroupError::TagLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateClusterSecurityGroupError {}
 /// Errors returned by CreateClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterSnapshotError {
@@ -11947,22 +11963,26 @@ impl CreateClusterSnapshotError {
 }
 impl fmt::Display for CreateClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterSnapshotError::ClusterNotFoundFault(ref cause) => cause,
-            CreateClusterSnapshotError::ClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            CreateClusterSnapshotError::ClusterSnapshotQuotaExceededFault(ref cause) => cause,
-            CreateClusterSnapshotError::InvalidClusterStateFault(ref cause) => cause,
-            CreateClusterSnapshotError::InvalidRetentionPeriodFault(ref cause) => cause,
-            CreateClusterSnapshotError::InvalidTagFault(ref cause) => cause,
-            CreateClusterSnapshotError::TagLimitExceededFault(ref cause) => cause,
+            CreateClusterSnapshotError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterSnapshotError::ClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSnapshotError::ClusterSnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSnapshotError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSnapshotError::InvalidRetentionPeriodFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSnapshotError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterSnapshotError::TagLimitExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterSnapshotError {}
 /// Errors returned by CreateClusterSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterSubnetGroupError {
@@ -12061,25 +12081,31 @@ impl CreateClusterSubnetGroupError {
 }
 impl fmt::Display for CreateClusterSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterSubnetGroupError::ClusterSubnetGroupAlreadyExistsFault(ref cause) => cause,
-            CreateClusterSubnetGroupError::ClusterSubnetGroupQuotaExceededFault(ref cause) => cause,
-            CreateClusterSubnetGroupError::ClusterSubnetQuotaExceededFault(ref cause) => cause,
-            CreateClusterSubnetGroupError::DependentServiceRequestThrottlingFault(ref cause) => {
-                cause
+            CreateClusterSubnetGroupError::ClusterSubnetGroupAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            CreateClusterSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            CreateClusterSubnetGroupError::InvalidTagFault(ref cause) => cause,
-            CreateClusterSubnetGroupError::TagLimitExceededFault(ref cause) => cause,
-            CreateClusterSubnetGroupError::UnauthorizedOperation(ref cause) => cause,
+            CreateClusterSubnetGroupError::ClusterSubnetGroupQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSubnetGroupError::ClusterSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSubnetGroupError::DependentServiceRequestThrottlingFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            CreateClusterSubnetGroupError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateClusterSubnetGroupError::TagLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateClusterSubnetGroupError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateClusterSubnetGroupError {}
 /// Errors returned by CreateEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateEventSubscriptionError {
@@ -12205,26 +12231,38 @@ impl CreateEventSubscriptionError {
 }
 impl fmt::Display for CreateEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => cause,
-            CreateEventSubscriptionError::InvalidTagFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
-            CreateEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SourceNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionAlreadyExistFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionEventIdNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::SubscriptionSeverityNotFoundFault(ref cause) => cause,
-            CreateEventSubscriptionError::TagLimitExceededFault(ref cause) => cause,
+            CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateEventSubscriptionError::SubscriptionAlreadyExistFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SubscriptionEventIdNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::SubscriptionSeverityNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateEventSubscriptionError::TagLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateEventSubscriptionError {}
 /// Errors returned by CreateHsmClientCertificate
 #[derive(Debug, PartialEq)]
 pub enum CreateHsmClientCertificateError {
@@ -12291,23 +12329,21 @@ impl CreateHsmClientCertificateError {
 }
 impl fmt::Display for CreateHsmClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHsmClientCertificateError {
-    fn description(&self) -> &str {
         match *self {
             CreateHsmClientCertificateError::HsmClientCertificateAlreadyExistsFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             CreateHsmClientCertificateError::HsmClientCertificateQuotaExceededFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateHsmClientCertificateError::InvalidTagFault(ref cause) => cause,
-            CreateHsmClientCertificateError::TagLimitExceededFault(ref cause) => cause,
+            CreateHsmClientCertificateError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateHsmClientCertificateError::TagLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateHsmClientCertificateError {}
 /// Errors returned by CreateHsmConfiguration
 #[derive(Debug, PartialEq)]
 pub enum CreateHsmConfigurationError {
@@ -12372,19 +12408,19 @@ impl CreateHsmConfigurationError {
 }
 impl fmt::Display for CreateHsmConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHsmConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHsmConfigurationError::HsmConfigurationAlreadyExistsFault(ref cause) => cause,
-            CreateHsmConfigurationError::HsmConfigurationQuotaExceededFault(ref cause) => cause,
-            CreateHsmConfigurationError::InvalidTagFault(ref cause) => cause,
-            CreateHsmConfigurationError::TagLimitExceededFault(ref cause) => cause,
+            CreateHsmConfigurationError::HsmConfigurationAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateHsmConfigurationError::HsmConfigurationQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateHsmConfigurationError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateHsmConfigurationError::TagLimitExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHsmConfigurationError {}
 /// Errors returned by CreateScheduledAction
 #[derive(Debug, PartialEq)]
 pub enum CreateScheduledActionError {
@@ -12465,21 +12501,25 @@ impl CreateScheduledActionError {
 }
 impl fmt::Display for CreateScheduledActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateScheduledActionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateScheduledActionError::InvalidScheduleFault(ref cause) => cause,
-            CreateScheduledActionError::InvalidScheduledActionFault(ref cause) => cause,
-            CreateScheduledActionError::ScheduledActionAlreadyExistsFault(ref cause) => cause,
-            CreateScheduledActionError::ScheduledActionQuotaExceededFault(ref cause) => cause,
-            CreateScheduledActionError::ScheduledActionTypeUnsupportedFault(ref cause) => cause,
-            CreateScheduledActionError::UnauthorizedOperation(ref cause) => cause,
+            CreateScheduledActionError::InvalidScheduleFault(ref cause) => write!(f, "{}", cause),
+            CreateScheduledActionError::InvalidScheduledActionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateScheduledActionError::ScheduledActionAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateScheduledActionError::ScheduledActionQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateScheduledActionError::ScheduledActionTypeUnsupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateScheduledActionError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateScheduledActionError {}
 /// Errors returned by CreateSnapshotCopyGrant
 #[derive(Debug, PartialEq)]
 pub enum CreateSnapshotCopyGrantError {
@@ -12560,23 +12600,25 @@ impl CreateSnapshotCopyGrantError {
 }
 impl fmt::Display for CreateSnapshotCopyGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSnapshotCopyGrantError {
-    fn description(&self) -> &str {
         match *self {
             CreateSnapshotCopyGrantError::DependentServiceRequestThrottlingFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateSnapshotCopyGrantError::InvalidTagFault(ref cause) => cause,
-            CreateSnapshotCopyGrantError::LimitExceededFault(ref cause) => cause,
-            CreateSnapshotCopyGrantError::SnapshotCopyGrantAlreadyExistsFault(ref cause) => cause,
-            CreateSnapshotCopyGrantError::SnapshotCopyGrantQuotaExceededFault(ref cause) => cause,
-            CreateSnapshotCopyGrantError::TagLimitExceededFault(ref cause) => cause,
+            CreateSnapshotCopyGrantError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotCopyGrantError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotCopyGrantError::SnapshotCopyGrantAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotCopyGrantError::SnapshotCopyGrantQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotCopyGrantError::TagLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateSnapshotCopyGrantError {}
 /// Errors returned by CreateSnapshotSchedule
 #[derive(Debug, PartialEq)]
 pub enum CreateSnapshotScheduleError {
@@ -12650,20 +12692,22 @@ impl CreateSnapshotScheduleError {
 }
 impl fmt::Display for CreateSnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSnapshotScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSnapshotScheduleError::InvalidScheduleFault(ref cause) => cause,
-            CreateSnapshotScheduleError::ScheduleDefinitionTypeUnsupportedFault(ref cause) => cause,
-            CreateSnapshotScheduleError::SnapshotScheduleAlreadyExistsFault(ref cause) => cause,
-            CreateSnapshotScheduleError::SnapshotScheduleQuotaExceededFault(ref cause) => cause,
-            CreateSnapshotScheduleError::TagLimitExceededFault(ref cause) => cause,
+            CreateSnapshotScheduleError::InvalidScheduleFault(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotScheduleError::ScheduleDefinitionTypeUnsupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotScheduleError::SnapshotScheduleAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotScheduleError::SnapshotScheduleQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotScheduleError::TagLimitExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSnapshotScheduleError {}
 /// Errors returned by CreateTags
 #[derive(Debug, PartialEq)]
 pub enum CreateTagsError {
@@ -12715,18 +12759,14 @@ impl CreateTagsError {
 }
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTagsError::InvalidTagFault(ref cause) => cause,
-            CreateTagsError::ResourceNotFoundFault(ref cause) => cause,
-            CreateTagsError::TagLimitExceededFault(ref cause) => cause,
+            CreateTagsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::TagLimitExceededFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTagsError {}
 /// Errors returned by DeleteCluster
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterError {
@@ -12796,20 +12836,20 @@ impl DeleteClusterError {
 }
 impl fmt::Display for DeleteClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterError::ClusterNotFoundFault(ref cause) => cause,
-            DeleteClusterError::ClusterSnapshotAlreadyExistsFault(ref cause) => cause,
-            DeleteClusterError::ClusterSnapshotQuotaExceededFault(ref cause) => cause,
-            DeleteClusterError::InvalidClusterStateFault(ref cause) => cause,
-            DeleteClusterError::InvalidRetentionPeriodFault(ref cause) => cause,
+            DeleteClusterError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::ClusterSnapshotAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteClusterError::ClusterSnapshotQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteClusterError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DeleteClusterError::InvalidRetentionPeriodFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteClusterError {}
 /// Errors returned by DeleteClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterParameterGroupError {
@@ -12858,21 +12898,17 @@ impl DeleteClusterParameterGroupError {
 }
 impl fmt::Display for DeleteClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             DeleteClusterParameterGroupError::ClusterParameterGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DeleteClusterParameterGroupError::InvalidClusterParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteClusterParameterGroupError {}
 /// Errors returned by DeleteClusterSecurityGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterSecurityGroupError {
@@ -12923,19 +12959,17 @@ impl DeleteClusterSecurityGroupError {
 }
 impl fmt::Display for DeleteClusterSecurityGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterSecurityGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterSecurityGroupError::ClusterSecurityGroupNotFoundFault(ref cause) => cause,
+            DeleteClusterSecurityGroupError::ClusterSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteClusterSecurityGroupError::InvalidClusterSecurityGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteClusterSecurityGroupError {}
 /// Errors returned by DeleteClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterSnapshotError {
@@ -12984,17 +13018,17 @@ impl DeleteClusterSnapshotError {
 }
 impl fmt::Display for DeleteClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => cause,
-            DeleteClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => cause,
+            DeleteClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteClusterSnapshotError {}
 /// Errors returned by DeleteClusterSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteClusterSubnetGroupError {
@@ -13052,18 +13086,20 @@ impl DeleteClusterSubnetGroupError {
 }
 impl fmt::Display for DeleteClusterSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteClusterSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteClusterSubnetGroupError::ClusterSubnetGroupNotFoundFault(ref cause) => cause,
-            DeleteClusterSubnetGroupError::InvalidClusterSubnetGroupStateFault(ref cause) => cause,
-            DeleteClusterSubnetGroupError::InvalidClusterSubnetStateFault(ref cause) => cause,
+            DeleteClusterSubnetGroupError::ClusterSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteClusterSubnetGroupError::InvalidClusterSubnetGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteClusterSubnetGroupError::InvalidClusterSubnetStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteClusterSubnetGroupError {}
 /// Errors returned by DeleteEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteEventSubscriptionError {
@@ -13112,17 +13148,17 @@ impl DeleteEventSubscriptionError {
 }
 impl fmt::Display for DeleteEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEventSubscriptionError::InvalidSubscriptionStateFault(ref cause) => cause,
-            DeleteEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
+            DeleteEventSubscriptionError::InvalidSubscriptionStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteEventSubscriptionError {}
 /// Errors returned by DeleteHsmClientCertificate
 #[derive(Debug, PartialEq)]
 pub enum DeleteHsmClientCertificateError {
@@ -13173,19 +13209,17 @@ impl DeleteHsmClientCertificateError {
 }
 impl fmt::Display for DeleteHsmClientCertificateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHsmClientCertificateError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHsmClientCertificateError::HsmClientCertificateNotFoundFault(ref cause) => cause,
+            DeleteHsmClientCertificateError::HsmClientCertificateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteHsmClientCertificateError::InvalidHsmClientCertificateStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteHsmClientCertificateError {}
 /// Errors returned by DeleteHsmConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteHsmConfigurationError {
@@ -13234,17 +13268,17 @@ impl DeleteHsmConfigurationError {
 }
 impl fmt::Display for DeleteHsmConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHsmConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHsmConfigurationError::HsmConfigurationNotFoundFault(ref cause) => cause,
-            DeleteHsmConfigurationError::InvalidHsmConfigurationStateFault(ref cause) => cause,
+            DeleteHsmConfigurationError::HsmConfigurationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteHsmConfigurationError::InvalidHsmConfigurationStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteHsmConfigurationError {}
 /// Errors returned by DeleteScheduledAction
 #[derive(Debug, PartialEq)]
 pub enum DeleteScheduledActionError {
@@ -13291,17 +13325,15 @@ impl DeleteScheduledActionError {
 }
 impl fmt::Display for DeleteScheduledActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteScheduledActionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteScheduledActionError::ScheduledActionNotFoundFault(ref cause) => cause,
-            DeleteScheduledActionError::UnauthorizedOperation(ref cause) => cause,
+            DeleteScheduledActionError::ScheduledActionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteScheduledActionError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteScheduledActionError {}
 /// Errors returned by DeleteSnapshotCopyGrant
 #[derive(Debug, PartialEq)]
 pub enum DeleteSnapshotCopyGrantError {
@@ -13350,17 +13382,17 @@ impl DeleteSnapshotCopyGrantError {
 }
 impl fmt::Display for DeleteSnapshotCopyGrantError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSnapshotCopyGrantError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSnapshotCopyGrantError::InvalidSnapshotCopyGrantStateFault(ref cause) => cause,
-            DeleteSnapshotCopyGrantError::SnapshotCopyGrantNotFoundFault(ref cause) => cause,
+            DeleteSnapshotCopyGrantError::InvalidSnapshotCopyGrantStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteSnapshotCopyGrantError::SnapshotCopyGrantNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteSnapshotCopyGrantError {}
 /// Errors returned by DeleteSnapshotSchedule
 #[derive(Debug, PartialEq)]
 pub enum DeleteSnapshotScheduleError {
@@ -13409,19 +13441,17 @@ impl DeleteSnapshotScheduleError {
 }
 impl fmt::Display for DeleteSnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSnapshotScheduleError {
-    fn description(&self) -> &str {
         match *self {
             DeleteSnapshotScheduleError::InvalidClusterSnapshotScheduleStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DeleteSnapshotScheduleError::SnapshotScheduleNotFoundFault(ref cause) => cause,
+            DeleteSnapshotScheduleError::SnapshotScheduleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteSnapshotScheduleError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -13466,17 +13496,13 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::InvalidTagFault(ref cause) => cause,
-            DeleteTagsError::ResourceNotFoundFault(ref cause) => cause,
+            DeleteTagsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DescribeAccountAttributes
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountAttributesError {}
@@ -13506,14 +13532,10 @@ impl DescribeAccountAttributesError {
 }
 impl fmt::Display for DescribeAccountAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAccountAttributesError {}
 /// Errors returned by DescribeClusterDbRevisions
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterDbRevisionsError {
@@ -13564,17 +13586,17 @@ impl DescribeClusterDbRevisionsError {
 }
 impl fmt::Display for DescribeClusterDbRevisionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterDbRevisionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterDbRevisionsError::ClusterNotFoundFault(ref cause) => cause,
-            DescribeClusterDbRevisionsError::InvalidClusterStateFault(ref cause) => cause,
+            DescribeClusterDbRevisionsError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeClusterDbRevisionsError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeClusterDbRevisionsError {}
 /// Errors returned by DescribeClusterParameterGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterParameterGroupsError {
@@ -13625,19 +13647,17 @@ impl DescribeClusterParameterGroupsError {
 }
 impl fmt::Display for DescribeClusterParameterGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterParameterGroupsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeClusterParameterGroupsError::ClusterParameterGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DescribeClusterParameterGroupsError::InvalidTagFault(ref cause) => cause,
+            DescribeClusterParameterGroupsError::InvalidTagFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeClusterParameterGroupsError {}
 /// Errors returned by DescribeClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterParametersError {
@@ -13677,16 +13697,14 @@ impl DescribeClusterParametersError {
 }
 impl fmt::Display for DescribeClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterParametersError::ClusterParameterGroupNotFoundFault(ref cause) => cause,
+            DescribeClusterParametersError::ClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeClusterParametersError {}
 /// Errors returned by DescribeClusterSecurityGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterSecurityGroupsError {
@@ -13737,19 +13755,17 @@ impl DescribeClusterSecurityGroupsError {
 }
 impl fmt::Display for DescribeClusterSecurityGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterSecurityGroupsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeClusterSecurityGroupsError::ClusterSecurityGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DescribeClusterSecurityGroupsError::InvalidTagFault(ref cause) => cause,
+            DescribeClusterSecurityGroupsError::InvalidTagFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeClusterSecurityGroupsError {}
 /// Errors returned by DescribeClusterSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterSnapshotsError {
@@ -13805,18 +13821,18 @@ impl DescribeClusterSnapshotsError {
 }
 impl fmt::Display for DescribeClusterSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterSnapshotsError::ClusterNotFoundFault(ref cause) => cause,
-            DescribeClusterSnapshotsError::ClusterSnapshotNotFoundFault(ref cause) => cause,
-            DescribeClusterSnapshotsError::InvalidTagFault(ref cause) => cause,
+            DescribeClusterSnapshotsError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeClusterSnapshotsError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeClusterSnapshotsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterSnapshotsError {}
 /// Errors returned by DescribeClusterSubnetGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterSubnetGroupsError {
@@ -13865,17 +13881,15 @@ impl DescribeClusterSubnetGroupsError {
 }
 impl fmt::Display for DescribeClusterSubnetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterSubnetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterSubnetGroupsError::ClusterSubnetGroupNotFoundFault(ref cause) => cause,
-            DescribeClusterSubnetGroupsError::InvalidTagFault(ref cause) => cause,
+            DescribeClusterSubnetGroupsError::ClusterSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeClusterSubnetGroupsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterSubnetGroupsError {}
 /// Errors returned by DescribeClusterTracks
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterTracksError {
@@ -13922,17 +13936,15 @@ impl DescribeClusterTracksError {
 }
 impl fmt::Display for DescribeClusterTracksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterTracksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterTracksError::InvalidClusterTrackFault(ref cause) => cause,
-            DescribeClusterTracksError::UnauthorizedOperation(ref cause) => cause,
+            DescribeClusterTracksError::InvalidClusterTrackFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeClusterTracksError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterTracksError {}
 /// Errors returned by DescribeClusterVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterVersionsError {}
@@ -13962,14 +13974,10 @@ impl DescribeClusterVersionsError {
 }
 impl fmt::Display for DescribeClusterVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterVersionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeClusterVersionsError {}
 /// Errors returned by DescribeClusters
 #[derive(Debug, PartialEq)]
 pub enum DescribeClustersError {
@@ -14014,17 +14022,13 @@ impl DescribeClustersError {
 }
 impl fmt::Display for DescribeClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClustersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClustersError::ClusterNotFoundFault(ref cause) => cause,
-            DescribeClustersError::InvalidTagFault(ref cause) => cause,
+            DescribeClustersError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DescribeClustersError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClustersError {}
 /// Errors returned by DescribeDefaultClusterParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeDefaultClusterParametersError {}
@@ -14056,14 +14060,10 @@ impl DescribeDefaultClusterParametersError {
 }
 impl fmt::Display for DescribeDefaultClusterParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDefaultClusterParametersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeDefaultClusterParametersError {}
 /// Errors returned by DescribeEventCategories
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventCategoriesError {}
@@ -14093,14 +14093,10 @@ impl DescribeEventCategoriesError {
 }
 impl fmt::Display for DescribeEventCategoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventCategoriesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventCategoriesError {}
 /// Errors returned by DescribeEventSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventSubscriptionsError {
@@ -14149,17 +14145,15 @@ impl DescribeEventSubscriptionsError {
 }
 impl fmt::Display for DescribeEventSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEventSubscriptionsError::InvalidTagFault(ref cause) => cause,
-            DescribeEventSubscriptionsError::SubscriptionNotFoundFault(ref cause) => cause,
+            DescribeEventSubscriptionsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            DescribeEventSubscriptionsError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEventSubscriptionsError {}
 /// Errors returned by DescribeEvents
 #[derive(Debug, PartialEq)]
 pub enum DescribeEventsError {}
@@ -14189,14 +14183,10 @@ impl DescribeEventsError {
 }
 impl fmt::Display for DescribeEventsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEventsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEventsError {}
 /// Errors returned by DescribeHsmClientCertificates
 #[derive(Debug, PartialEq)]
 pub enum DescribeHsmClientCertificatesError {
@@ -14247,19 +14237,17 @@ impl DescribeHsmClientCertificatesError {
 }
 impl fmt::Display for DescribeHsmClientCertificatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHsmClientCertificatesError {
-    fn description(&self) -> &str {
         match *self {
             DescribeHsmClientCertificatesError::HsmClientCertificateNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DescribeHsmClientCertificatesError::InvalidTagFault(ref cause) => cause,
+            DescribeHsmClientCertificatesError::InvalidTagFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeHsmClientCertificatesError {}
 /// Errors returned by DescribeHsmConfigurations
 #[derive(Debug, PartialEq)]
 pub enum DescribeHsmConfigurationsError {
@@ -14306,17 +14294,15 @@ impl DescribeHsmConfigurationsError {
 }
 impl fmt::Display for DescribeHsmConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHsmConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHsmConfigurationsError::HsmConfigurationNotFoundFault(ref cause) => cause,
-            DescribeHsmConfigurationsError::InvalidTagFault(ref cause) => cause,
+            DescribeHsmConfigurationsError::HsmConfigurationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeHsmConfigurationsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeHsmConfigurationsError {}
 /// Errors returned by DescribeLoggingStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeLoggingStatusError {
@@ -14354,16 +14340,12 @@ impl DescribeLoggingStatusError {
 }
 impl fmt::Display for DescribeLoggingStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLoggingStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLoggingStatusError::ClusterNotFoundFault(ref cause) => cause,
+            DescribeLoggingStatusError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLoggingStatusError {}
 /// Errors returned by DescribeNodeConfigurationOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeNodeConfigurationOptionsError {
@@ -14432,21 +14414,23 @@ impl DescribeNodeConfigurationOptionsError {
 }
 impl fmt::Display for DescribeNodeConfigurationOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNodeConfigurationOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeNodeConfigurationOptionsError::AccessToSnapshotDeniedFault(ref cause) => cause,
-            DescribeNodeConfigurationOptionsError::ClusterNotFoundFault(ref cause) => cause,
-            DescribeNodeConfigurationOptionsError::ClusterSnapshotNotFoundFault(ref cause) => cause,
+            DescribeNodeConfigurationOptionsError::AccessToSnapshotDeniedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNodeConfigurationOptionsError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNodeConfigurationOptionsError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeNodeConfigurationOptionsError::InvalidClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeNodeConfigurationOptionsError {}
 /// Errors returned by DescribeOrderableClusterOptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrderableClusterOptionsError {}
@@ -14478,14 +14462,10 @@ impl DescribeOrderableClusterOptionsError {
 }
 impl fmt::Display for DescribeOrderableClusterOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrderableClusterOptionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeOrderableClusterOptionsError {}
 /// Errors returned by DescribeReservedNodeOfferings
 #[derive(Debug, PartialEq)]
 pub enum DescribeReservedNodeOfferingsError {
@@ -14545,22 +14525,20 @@ impl DescribeReservedNodeOfferingsError {
 }
 impl fmt::Display for DescribeReservedNodeOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReservedNodeOfferingsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeReservedNodeOfferingsError::DependentServiceUnavailableFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DescribeReservedNodeOfferingsError::ReservedNodeOfferingNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DescribeReservedNodeOfferingsError::UnsupportedOperationFault(ref cause) => cause,
+            DescribeReservedNodeOfferingsError::UnsupportedOperationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReservedNodeOfferingsError {}
 /// Errors returned by DescribeReservedNodes
 #[derive(Debug, PartialEq)]
 pub enum DescribeReservedNodesError {
@@ -14609,17 +14587,17 @@ impl DescribeReservedNodesError {
 }
 impl fmt::Display for DescribeReservedNodesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReservedNodesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReservedNodesError::DependentServiceUnavailableFault(ref cause) => cause,
-            DescribeReservedNodesError::ReservedNodeNotFoundFault(ref cause) => cause,
+            DescribeReservedNodesError::DependentServiceUnavailableFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeReservedNodesError::ReservedNodeNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeReservedNodesError {}
 /// Errors returned by DescribeResize
 #[derive(Debug, PartialEq)]
 pub enum DescribeResizeError {
@@ -14664,17 +14642,13 @@ impl DescribeResizeError {
 }
 impl fmt::Display for DescribeResizeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeResizeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeResizeError::ClusterNotFoundFault(ref cause) => cause,
-            DescribeResizeError::ResizeNotFoundFault(ref cause) => cause,
+            DescribeResizeError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DescribeResizeError::ResizeNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeResizeError {}
 /// Errors returned by DescribeScheduledActions
 #[derive(Debug, PartialEq)]
 pub enum DescribeScheduledActionsError {
@@ -14723,17 +14697,17 @@ impl DescribeScheduledActionsError {
 }
 impl fmt::Display for DescribeScheduledActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeScheduledActionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeScheduledActionsError::ScheduledActionNotFoundFault(ref cause) => cause,
-            DescribeScheduledActionsError::UnauthorizedOperation(ref cause) => cause,
+            DescribeScheduledActionsError::ScheduledActionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeScheduledActionsError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeScheduledActionsError {}
 /// Errors returned by DescribeSnapshotCopyGrants
 #[derive(Debug, PartialEq)]
 pub enum DescribeSnapshotCopyGrantsError {
@@ -14782,17 +14756,15 @@ impl DescribeSnapshotCopyGrantsError {
 }
 impl fmt::Display for DescribeSnapshotCopyGrantsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSnapshotCopyGrantsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSnapshotCopyGrantsError::InvalidTagFault(ref cause) => cause,
-            DescribeSnapshotCopyGrantsError::SnapshotCopyGrantNotFoundFault(ref cause) => cause,
+            DescribeSnapshotCopyGrantsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotCopyGrantsError::SnapshotCopyGrantNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeSnapshotCopyGrantsError {}
 /// Errors returned by DescribeSnapshotSchedules
 #[derive(Debug, PartialEq)]
 pub enum DescribeSnapshotSchedulesError {}
@@ -14822,14 +14794,10 @@ impl DescribeSnapshotSchedulesError {
 }
 impl fmt::Display for DescribeSnapshotSchedulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSnapshotSchedulesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeSnapshotSchedulesError {}
 /// Errors returned by DescribeStorage
 #[derive(Debug, PartialEq)]
 pub enum DescribeStorageError {}
@@ -14859,14 +14827,10 @@ impl DescribeStorageError {
 }
 impl fmt::Display for DescribeStorageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStorageError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeStorageError {}
 /// Errors returned by DescribeTableRestoreStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeTableRestoreStatusError {
@@ -14917,17 +14881,17 @@ impl DescribeTableRestoreStatusError {
 }
 impl fmt::Display for DescribeTableRestoreStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTableRestoreStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTableRestoreStatusError::ClusterNotFoundFault(ref cause) => cause,
-            DescribeTableRestoreStatusError::TableRestoreNotFoundFault(ref cause) => cause,
+            DescribeTableRestoreStatusError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeTableRestoreStatusError::TableRestoreNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTableRestoreStatusError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -14972,17 +14936,13 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::InvalidTagFault(ref cause) => cause,
-            DescribeTagsError::ResourceNotFoundFault(ref cause) => cause,
+            DescribeTagsError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            DescribeTagsError::ResourceNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by DisableLogging
 #[derive(Debug, PartialEq)]
 pub enum DisableLoggingError {
@@ -15020,16 +14980,12 @@ impl DisableLoggingError {
 }
 impl fmt::Display for DisableLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableLoggingError {
-    fn description(&self) -> &str {
         match *self {
-            DisableLoggingError::ClusterNotFoundFault(ref cause) => cause,
+            DisableLoggingError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableLoggingError {}
 /// Errors returned by DisableSnapshotCopy
 #[derive(Debug, PartialEq)]
 pub enum DisableSnapshotCopyError {
@@ -15092,19 +15048,17 @@ impl DisableSnapshotCopyError {
 }
 impl fmt::Display for DisableSnapshotCopyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableSnapshotCopyError {
-    fn description(&self) -> &str {
         match *self {
-            DisableSnapshotCopyError::ClusterNotFoundFault(ref cause) => cause,
-            DisableSnapshotCopyError::InvalidClusterStateFault(ref cause) => cause,
-            DisableSnapshotCopyError::SnapshotCopyAlreadyDisabledFault(ref cause) => cause,
-            DisableSnapshotCopyError::UnauthorizedOperation(ref cause) => cause,
+            DisableSnapshotCopyError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            DisableSnapshotCopyError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            DisableSnapshotCopyError::SnapshotCopyAlreadyDisabledFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisableSnapshotCopyError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableSnapshotCopyError {}
 /// Errors returned by EnableLogging
 #[derive(Debug, PartialEq)]
 pub enum EnableLoggingError {
@@ -15172,20 +15126,18 @@ impl EnableLoggingError {
 }
 impl fmt::Display for EnableLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableLoggingError {
-    fn description(&self) -> &str {
         match *self {
-            EnableLoggingError::BucketNotFoundFault(ref cause) => cause,
-            EnableLoggingError::ClusterNotFoundFault(ref cause) => cause,
-            EnableLoggingError::InsufficientS3BucketPolicyFault(ref cause) => cause,
-            EnableLoggingError::InvalidS3BucketNameFault(ref cause) => cause,
-            EnableLoggingError::InvalidS3KeyPrefixFault(ref cause) => cause,
+            EnableLoggingError::BucketNotFoundFault(ref cause) => write!(f, "{}", cause),
+            EnableLoggingError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            EnableLoggingError::InsufficientS3BucketPolicyFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableLoggingError::InvalidS3BucketNameFault(ref cause) => write!(f, "{}", cause),
+            EnableLoggingError::InvalidS3KeyPrefixFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableLoggingError {}
 /// Errors returned by EnableSnapshotCopy
 #[derive(Debug, PartialEq)]
 pub enum EnableSnapshotCopyError {
@@ -15307,26 +15259,34 @@ impl EnableSnapshotCopyError {
 }
 impl fmt::Display for EnableSnapshotCopyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableSnapshotCopyError {
-    fn description(&self) -> &str {
         match *self {
-            EnableSnapshotCopyError::ClusterNotFoundFault(ref cause) => cause,
-            EnableSnapshotCopyError::CopyToRegionDisabledFault(ref cause) => cause,
-            EnableSnapshotCopyError::DependentServiceRequestThrottlingFault(ref cause) => cause,
-            EnableSnapshotCopyError::IncompatibleOrderableOptions(ref cause) => cause,
-            EnableSnapshotCopyError::InvalidClusterStateFault(ref cause) => cause,
-            EnableSnapshotCopyError::InvalidRetentionPeriodFault(ref cause) => cause,
-            EnableSnapshotCopyError::LimitExceededFault(ref cause) => cause,
-            EnableSnapshotCopyError::SnapshotCopyAlreadyEnabledFault(ref cause) => cause,
-            EnableSnapshotCopyError::SnapshotCopyGrantNotFoundFault(ref cause) => cause,
-            EnableSnapshotCopyError::UnauthorizedOperation(ref cause) => cause,
-            EnableSnapshotCopyError::UnknownSnapshotCopyRegionFault(ref cause) => cause,
+            EnableSnapshotCopyError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            EnableSnapshotCopyError::CopyToRegionDisabledFault(ref cause) => write!(f, "{}", cause),
+            EnableSnapshotCopyError::DependentServiceRequestThrottlingFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableSnapshotCopyError::IncompatibleOrderableOptions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableSnapshotCopyError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            EnableSnapshotCopyError::InvalidRetentionPeriodFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableSnapshotCopyError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            EnableSnapshotCopyError::SnapshotCopyAlreadyEnabledFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableSnapshotCopyError::SnapshotCopyGrantNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableSnapshotCopyError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            EnableSnapshotCopyError::UnknownSnapshotCopyRegionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for EnableSnapshotCopyError {}
 /// Errors returned by GetClusterCredentials
 #[derive(Debug, PartialEq)]
 pub enum GetClusterCredentialsError {
@@ -15373,17 +15333,15 @@ impl GetClusterCredentialsError {
 }
 impl fmt::Display for GetClusterCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetClusterCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            GetClusterCredentialsError::ClusterNotFoundFault(ref cause) => cause,
-            GetClusterCredentialsError::UnsupportedOperationFault(ref cause) => cause,
+            GetClusterCredentialsError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            GetClusterCredentialsError::UnsupportedOperationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetClusterCredentialsError {}
 /// Errors returned by GetReservedNodeExchangeOfferings
 #[derive(Debug, PartialEq)]
 pub enum GetReservedNodeExchangeOfferingsError {
@@ -15468,29 +15426,29 @@ impl GetReservedNodeExchangeOfferingsError {
 }
 impl fmt::Display for GetReservedNodeExchangeOfferingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReservedNodeExchangeOfferingsError {
-    fn description(&self) -> &str {
         match *self {
             GetReservedNodeExchangeOfferingsError::DependentServiceUnavailableFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             GetReservedNodeExchangeOfferingsError::InvalidReservedNodeStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             GetReservedNodeExchangeOfferingsError::ReservedNodeAlreadyMigratedFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            GetReservedNodeExchangeOfferingsError::ReservedNodeNotFoundFault(ref cause) => cause,
+            GetReservedNodeExchangeOfferingsError::ReservedNodeNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetReservedNodeExchangeOfferingsError::ReservedNodeOfferingNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            GetReservedNodeExchangeOfferingsError::UnsupportedOperationFault(ref cause) => cause,
+            GetReservedNodeExchangeOfferingsError::UnsupportedOperationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetReservedNodeExchangeOfferingsError {}
 /// Errors returned by ModifyCluster
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterError {
@@ -15670,34 +15628,46 @@ impl ModifyClusterError {
 }
 impl fmt::Display for ModifyClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterError::ClusterAlreadyExistsFault(ref cause) => cause,
-            ModifyClusterError::ClusterNotFoundFault(ref cause) => cause,
-            ModifyClusterError::ClusterParameterGroupNotFoundFault(ref cause) => cause,
-            ModifyClusterError::ClusterSecurityGroupNotFoundFault(ref cause) => cause,
-            ModifyClusterError::DependentServiceRequestThrottlingFault(ref cause) => cause,
-            ModifyClusterError::HsmClientCertificateNotFoundFault(ref cause) => cause,
-            ModifyClusterError::HsmConfigurationNotFoundFault(ref cause) => cause,
-            ModifyClusterError::InsufficientClusterCapacityFault(ref cause) => cause,
-            ModifyClusterError::InvalidClusterSecurityGroupStateFault(ref cause) => cause,
-            ModifyClusterError::InvalidClusterStateFault(ref cause) => cause,
-            ModifyClusterError::InvalidClusterTrackFault(ref cause) => cause,
-            ModifyClusterError::InvalidElasticIpFault(ref cause) => cause,
-            ModifyClusterError::InvalidRetentionPeriodFault(ref cause) => cause,
-            ModifyClusterError::LimitExceededFault(ref cause) => cause,
-            ModifyClusterError::NumberOfNodesPerClusterLimitExceededFault(ref cause) => cause,
-            ModifyClusterError::NumberOfNodesQuotaExceededFault(ref cause) => cause,
-            ModifyClusterError::TableLimitExceededFault(ref cause) => cause,
-            ModifyClusterError::UnauthorizedOperation(ref cause) => cause,
-            ModifyClusterError::UnsupportedOptionFault(ref cause) => cause,
+            ModifyClusterError::ClusterAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::ClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::ClusterSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::DependentServiceRequestThrottlingFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::HsmClientCertificateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::HsmConfigurationNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::InsufficientClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::InvalidClusterSecurityGroupStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::InvalidClusterTrackFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::InvalidElasticIpFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::InvalidRetentionPeriodFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::NumberOfNodesPerClusterLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::NumberOfNodesQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterError::TableLimitExceededFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            ModifyClusterError::UnsupportedOptionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyClusterError {}
 /// Errors returned by ModifyClusterDbRevision
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterDbRevisionError {
@@ -15755,18 +15725,18 @@ impl ModifyClusterDbRevisionError {
 }
 impl fmt::Display for ModifyClusterDbRevisionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterDbRevisionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterDbRevisionError::ClusterNotFoundFault(ref cause) => cause,
-            ModifyClusterDbRevisionError::ClusterOnLatestRevisionFault(ref cause) => cause,
-            ModifyClusterDbRevisionError::InvalidClusterStateFault(ref cause) => cause,
+            ModifyClusterDbRevisionError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterDbRevisionError::ClusterOnLatestRevisionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterDbRevisionError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyClusterDbRevisionError {}
 /// Errors returned by ModifyClusterIamRoles
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterIamRolesError {
@@ -15813,17 +15783,15 @@ impl ModifyClusterIamRolesError {
 }
 impl fmt::Display for ModifyClusterIamRolesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterIamRolesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterIamRolesError::ClusterNotFoundFault(ref cause) => cause,
-            ModifyClusterIamRolesError::InvalidClusterStateFault(ref cause) => cause,
+            ModifyClusterIamRolesError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyClusterIamRolesError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyClusterIamRolesError {}
 /// Errors returned by ModifyClusterMaintenance
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterMaintenanceError {
@@ -15863,16 +15831,14 @@ impl ModifyClusterMaintenanceError {
 }
 impl fmt::Display for ModifyClusterMaintenanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterMaintenanceError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterMaintenanceError::ClusterNotFoundFault(ref cause) => cause,
+            ModifyClusterMaintenanceError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyClusterMaintenanceError {}
 /// Errors returned by ModifyClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterParameterGroupError {
@@ -15921,21 +15887,17 @@ impl ModifyClusterParameterGroupError {
 }
 impl fmt::Display for ModifyClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
             ModifyClusterParameterGroupError::ClusterParameterGroupNotFoundFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             ModifyClusterParameterGroupError::InvalidClusterParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ModifyClusterParameterGroupError {}
 /// Errors returned by ModifyClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterSnapshotError {
@@ -15993,18 +15955,20 @@ impl ModifyClusterSnapshotError {
 }
 impl fmt::Display for ModifyClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => cause,
-            ModifyClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => cause,
-            ModifyClusterSnapshotError::InvalidRetentionPeriodFault(ref cause) => cause,
+            ModifyClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterSnapshotError::InvalidRetentionPeriodFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyClusterSnapshotError {}
 /// Errors returned by ModifyClusterSnapshotSchedule
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterSnapshotScheduleError {
@@ -16043,20 +16007,20 @@ impl ModifyClusterSnapshotScheduleError {
 }
 impl fmt::Display for ModifyClusterSnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterSnapshotScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterSnapshotScheduleError::ClusterNotFoundFault(ref cause) => cause,
+            ModifyClusterSnapshotScheduleError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ModifyClusterSnapshotScheduleError::InvalidClusterSnapshotScheduleStateFault(
                 ref cause,
-            ) => cause,
-            ModifyClusterSnapshotScheduleError::SnapshotScheduleNotFoundFault(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            ModifyClusterSnapshotScheduleError::SnapshotScheduleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyClusterSnapshotScheduleError {}
 /// Errors returned by ModifyClusterSubnetGroup
 #[derive(Debug, PartialEq)]
 pub enum ModifyClusterSubnetGroupError {
@@ -16137,23 +16101,25 @@ impl ModifyClusterSubnetGroupError {
 }
 impl fmt::Display for ModifyClusterSubnetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClusterSubnetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClusterSubnetGroupError::ClusterSubnetGroupNotFoundFault(ref cause) => cause,
-            ModifyClusterSubnetGroupError::ClusterSubnetQuotaExceededFault(ref cause) => cause,
-            ModifyClusterSubnetGroupError::DependentServiceRequestThrottlingFault(ref cause) => {
-                cause
+            ModifyClusterSubnetGroupError::ClusterSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            ModifyClusterSubnetGroupError::InvalidSubnet(ref cause) => cause,
-            ModifyClusterSubnetGroupError::SubnetAlreadyInUse(ref cause) => cause,
-            ModifyClusterSubnetGroupError::UnauthorizedOperation(ref cause) => cause,
+            ModifyClusterSubnetGroupError::ClusterSubnetQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterSubnetGroupError::DependentServiceRequestThrottlingFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClusterSubnetGroupError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            ModifyClusterSubnetGroupError::SubnetAlreadyInUse(ref cause) => write!(f, "{}", cause),
+            ModifyClusterSubnetGroupError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyClusterSubnetGroupError {}
 /// Errors returned by ModifyEventSubscription
 #[derive(Debug, PartialEq)]
 pub enum ModifyEventSubscriptionError {
@@ -16263,24 +16229,34 @@ impl ModifyEventSubscriptionError {
 }
 impl fmt::Display for ModifyEventSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyEventSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyEventSubscriptionError::InvalidSubscriptionStateFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SourceNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionEventIdNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => cause,
-            ModifyEventSubscriptionError::SubscriptionSeverityNotFoundFault(ref cause) => cause,
+            ModifyEventSubscriptionError::InvalidSubscriptionStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SNSInvalidTopicFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::SNSNoAuthorizationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SourceNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SubscriptionEventIdNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SubscriptionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyEventSubscriptionError::SubscriptionSeverityNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyEventSubscriptionError {}
 /// Errors returned by ModifyScheduledAction
 #[derive(Debug, PartialEq)]
 pub enum ModifyScheduledActionError {
@@ -16352,20 +16328,22 @@ impl ModifyScheduledActionError {
 }
 impl fmt::Display for ModifyScheduledActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyScheduledActionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyScheduledActionError::InvalidScheduleFault(ref cause) => cause,
-            ModifyScheduledActionError::InvalidScheduledActionFault(ref cause) => cause,
-            ModifyScheduledActionError::ScheduledActionNotFoundFault(ref cause) => cause,
-            ModifyScheduledActionError::ScheduledActionTypeUnsupportedFault(ref cause) => cause,
-            ModifyScheduledActionError::UnauthorizedOperation(ref cause) => cause,
+            ModifyScheduledActionError::InvalidScheduleFault(ref cause) => write!(f, "{}", cause),
+            ModifyScheduledActionError::InvalidScheduledActionFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyScheduledActionError::ScheduledActionNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyScheduledActionError::ScheduledActionTypeUnsupportedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyScheduledActionError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyScheduledActionError {}
 /// Errors returned by ModifySnapshotCopyRetentionPeriod
 #[derive(Debug, PartialEq)]
 pub enum ModifySnapshotCopyRetentionPeriodError {
@@ -16443,20 +16421,26 @@ impl ModifySnapshotCopyRetentionPeriodError {
 }
 impl fmt::Display for ModifySnapshotCopyRetentionPeriodError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifySnapshotCopyRetentionPeriodError {
-    fn description(&self) -> &str {
         match *self {
-            ModifySnapshotCopyRetentionPeriodError::ClusterNotFoundFault(ref cause) => cause,
-            ModifySnapshotCopyRetentionPeriodError::InvalidClusterStateFault(ref cause) => cause,
-            ModifySnapshotCopyRetentionPeriodError::InvalidRetentionPeriodFault(ref cause) => cause,
-            ModifySnapshotCopyRetentionPeriodError::SnapshotCopyDisabledFault(ref cause) => cause,
-            ModifySnapshotCopyRetentionPeriodError::UnauthorizedOperation(ref cause) => cause,
+            ModifySnapshotCopyRetentionPeriodError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifySnapshotCopyRetentionPeriodError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifySnapshotCopyRetentionPeriodError::InvalidRetentionPeriodFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifySnapshotCopyRetentionPeriodError::SnapshotCopyDisabledFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifySnapshotCopyRetentionPeriodError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifySnapshotCopyRetentionPeriodError {}
 /// Errors returned by ModifySnapshotSchedule
 #[derive(Debug, PartialEq)]
 pub enum ModifySnapshotScheduleError {
@@ -16512,18 +16496,18 @@ impl ModifySnapshotScheduleError {
 }
 impl fmt::Display for ModifySnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifySnapshotScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            ModifySnapshotScheduleError::InvalidScheduleFault(ref cause) => cause,
-            ModifySnapshotScheduleError::SnapshotScheduleNotFoundFault(ref cause) => cause,
-            ModifySnapshotScheduleError::SnapshotScheduleUpdateInProgressFault(ref cause) => cause,
+            ModifySnapshotScheduleError::InvalidScheduleFault(ref cause) => write!(f, "{}", cause),
+            ModifySnapshotScheduleError::SnapshotScheduleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifySnapshotScheduleError::SnapshotScheduleUpdateInProgressFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifySnapshotScheduleError {}
 /// Errors returned by PurchaseReservedNodeOffering
 #[derive(Debug, PartialEq)]
 pub enum PurchaseReservedNodeOfferingError {
@@ -16592,21 +16576,23 @@ impl PurchaseReservedNodeOfferingError {
 }
 impl fmt::Display for PurchaseReservedNodeOfferingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PurchaseReservedNodeOfferingError {
-    fn description(&self) -> &str {
         match *self {
-            PurchaseReservedNodeOfferingError::ReservedNodeAlreadyExistsFault(ref cause) => cause,
-            PurchaseReservedNodeOfferingError::ReservedNodeOfferingNotFoundFault(ref cause) => {
-                cause
+            PurchaseReservedNodeOfferingError::ReservedNodeAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
             }
-            PurchaseReservedNodeOfferingError::ReservedNodeQuotaExceededFault(ref cause) => cause,
-            PurchaseReservedNodeOfferingError::UnsupportedOperationFault(ref cause) => cause,
+            PurchaseReservedNodeOfferingError::ReservedNodeOfferingNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PurchaseReservedNodeOfferingError::ReservedNodeQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PurchaseReservedNodeOfferingError::UnsupportedOperationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PurchaseReservedNodeOfferingError {}
 /// Errors returned by RebootCluster
 #[derive(Debug, PartialEq)]
 pub enum RebootClusterError {
@@ -16651,17 +16637,13 @@ impl RebootClusterError {
 }
 impl fmt::Display for RebootClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootClusterError {
-    fn description(&self) -> &str {
         match *self {
-            RebootClusterError::ClusterNotFoundFault(ref cause) => cause,
-            RebootClusterError::InvalidClusterStateFault(ref cause) => cause,
+            RebootClusterError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RebootClusterError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RebootClusterError {}
 /// Errors returned by ResetClusterParameterGroup
 #[derive(Debug, PartialEq)]
 pub enum ResetClusterParameterGroupError {
@@ -16712,19 +16694,17 @@ impl ResetClusterParameterGroupError {
 }
 impl fmt::Display for ResetClusterParameterGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetClusterParameterGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ResetClusterParameterGroupError::ClusterParameterGroupNotFoundFault(ref cause) => cause,
+            ResetClusterParameterGroupError::ClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ResetClusterParameterGroupError::InvalidClusterParameterGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ResetClusterParameterGroupError {}
 /// Errors returned by ResizeCluster
 #[derive(Debug, PartialEq)]
 pub enum ResizeClusterError {
@@ -16824,24 +16804,26 @@ impl ResizeClusterError {
 }
 impl fmt::Display for ResizeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResizeClusterError {
-    fn description(&self) -> &str {
         match *self {
-            ResizeClusterError::ClusterNotFoundFault(ref cause) => cause,
-            ResizeClusterError::InsufficientClusterCapacityFault(ref cause) => cause,
-            ResizeClusterError::InvalidClusterStateFault(ref cause) => cause,
-            ResizeClusterError::LimitExceededFault(ref cause) => cause,
-            ResizeClusterError::NumberOfNodesPerClusterLimitExceededFault(ref cause) => cause,
-            ResizeClusterError::NumberOfNodesQuotaExceededFault(ref cause) => cause,
-            ResizeClusterError::UnauthorizedOperation(ref cause) => cause,
-            ResizeClusterError::UnsupportedOperationFault(ref cause) => cause,
-            ResizeClusterError::UnsupportedOptionFault(ref cause) => cause,
+            ResizeClusterError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            ResizeClusterError::InsufficientClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResizeClusterError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
+            ResizeClusterError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            ResizeClusterError::NumberOfNodesPerClusterLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResizeClusterError::NumberOfNodesQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResizeClusterError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            ResizeClusterError::UnsupportedOperationFault(ref cause) => write!(f, "{}", cause),
+            ResizeClusterError::UnsupportedOptionFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResizeClusterError {}
 /// Errors returned by RestoreFromClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum RestoreFromClusterSnapshotError {
@@ -17093,46 +17075,82 @@ impl RestoreFromClusterSnapshotError {
 }
 impl fmt::Display for RestoreFromClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreFromClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreFromClusterSnapshotError::AccessToSnapshotDeniedFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::ClusterAlreadyExistsFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::ClusterParameterGroupNotFoundFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::ClusterQuotaExceededFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::ClusterSecurityGroupNotFoundFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::ClusterSubnetGroupNotFoundFault(ref cause) => cause,
+            RestoreFromClusterSnapshotError::AccessToSnapshotDeniedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::ClusterAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::ClusterParameterGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::ClusterQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::ClusterSecurityGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::ClusterSubnetGroupNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreFromClusterSnapshotError::DependentServiceRequestThrottlingFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreFromClusterSnapshotError::HsmClientCertificateNotFoundFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::HsmConfigurationNotFoundFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::InsufficientClusterCapacityFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => cause,
+            RestoreFromClusterSnapshotError::HsmClientCertificateNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::HsmConfigurationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::InsufficientClusterCapacityFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreFromClusterSnapshotError::InvalidClusterSubnetGroupStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreFromClusterSnapshotError::InvalidClusterTrackFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::InvalidElasticIpFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::InvalidRestoreFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::InvalidSubnet(ref cause) => cause,
-            RestoreFromClusterSnapshotError::InvalidTagFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::InvalidVPCNetworkStateFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::LimitExceededFault(ref cause) => cause,
+            RestoreFromClusterSnapshotError::InvalidClusterTrackFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::InvalidElasticIpFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::InvalidRestoreFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::InvalidSubnet(ref cause) => write!(f, "{}", cause),
+            RestoreFromClusterSnapshotError::InvalidTagFault(ref cause) => write!(f, "{}", cause),
+            RestoreFromClusterSnapshotError::InvalidVPCNetworkStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::LimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreFromClusterSnapshotError::NumberOfNodesPerClusterLimitExceededFault(
                 ref cause,
-            ) => cause,
-            RestoreFromClusterSnapshotError::NumberOfNodesQuotaExceededFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::SnapshotScheduleNotFoundFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::TagLimitExceededFault(ref cause) => cause,
-            RestoreFromClusterSnapshotError::UnauthorizedOperation(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            RestoreFromClusterSnapshotError::NumberOfNodesQuotaExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::SnapshotScheduleNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::TagLimitExceededFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreFromClusterSnapshotError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreFromClusterSnapshotError {}
 /// Errors returned by RestoreTableFromClusterSnapshot
 #[derive(Debug, PartialEq)]
 pub enum RestoreTableFromClusterSnapshotError {
@@ -17179,28 +17197,32 @@ impl RestoreTableFromClusterSnapshotError {
 }
 impl fmt::Display for RestoreTableFromClusterSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreTableFromClusterSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreTableFromClusterSnapshotError::ClusterNotFoundFault(ref cause) => cause,
-            RestoreTableFromClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => cause,
+            RestoreTableFromClusterSnapshotError::ClusterNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RestoreTableFromClusterSnapshotError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreTableFromClusterSnapshotError::InProgressTableRestoreQuotaExceededFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RestoreTableFromClusterSnapshotError::InvalidClusterSnapshotStateFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreTableFromClusterSnapshotError::InvalidClusterStateFault(ref cause) => cause,
+            RestoreTableFromClusterSnapshotError::InvalidClusterStateFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RestoreTableFromClusterSnapshotError::InvalidTableRestoreArgumentFault(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            RestoreTableFromClusterSnapshotError::UnsupportedOperationFault(ref cause) => cause,
+            RestoreTableFromClusterSnapshotError::UnsupportedOperationFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RestoreTableFromClusterSnapshotError {}
 /// Errors returned by RevokeClusterSecurityGroupIngress
 #[derive(Debug, PartialEq)]
 pub enum RevokeClusterSecurityGroupIngressError {
@@ -17239,22 +17261,20 @@ impl RevokeClusterSecurityGroupIngressError {
 }
 impl fmt::Display for RevokeClusterSecurityGroupIngressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeClusterSecurityGroupIngressError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeClusterSecurityGroupIngressError::AuthorizationNotFoundFault(ref cause) => cause,
+            RevokeClusterSecurityGroupIngressError::AuthorizationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
             RevokeClusterSecurityGroupIngressError::ClusterSecurityGroupNotFoundFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             RevokeClusterSecurityGroupIngressError::InvalidClusterSecurityGroupStateFault(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RevokeClusterSecurityGroupIngressError {}
 /// Errors returned by RevokeSnapshotAccess
 #[derive(Debug, PartialEq)]
 pub enum RevokeSnapshotAccessError {
@@ -17312,18 +17332,20 @@ impl RevokeSnapshotAccessError {
 }
 impl fmt::Display for RevokeSnapshotAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeSnapshotAccessError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeSnapshotAccessError::AccessToSnapshotDeniedFault(ref cause) => cause,
-            RevokeSnapshotAccessError::AuthorizationNotFoundFault(ref cause) => cause,
-            RevokeSnapshotAccessError::ClusterSnapshotNotFoundFault(ref cause) => cause,
+            RevokeSnapshotAccessError::AccessToSnapshotDeniedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RevokeSnapshotAccessError::AuthorizationNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RevokeSnapshotAccessError::ClusterSnapshotNotFoundFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RevokeSnapshotAccessError {}
 /// Errors returned by RotateEncryptionKey
 #[derive(Debug, PartialEq)]
 pub enum RotateEncryptionKeyError {
@@ -17379,18 +17401,16 @@ impl RotateEncryptionKeyError {
 }
 impl fmt::Display for RotateEncryptionKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RotateEncryptionKeyError {
-    fn description(&self) -> &str {
         match *self {
-            RotateEncryptionKeyError::ClusterNotFoundFault(ref cause) => cause,
-            RotateEncryptionKeyError::DependentServiceRequestThrottlingFault(ref cause) => cause,
-            RotateEncryptionKeyError::InvalidClusterStateFault(ref cause) => cause,
+            RotateEncryptionKeyError::ClusterNotFoundFault(ref cause) => write!(f, "{}", cause),
+            RotateEncryptionKeyError::DependentServiceRequestThrottlingFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RotateEncryptionKeyError::InvalidClusterStateFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RotateEncryptionKeyError {}
 /// Trait representing the capabilities of the Amazon Redshift API. Amazon Redshift clients implement this trait.
 pub trait Redshift {
     /// <p>Exchanges a DC1 Reserved Node for a DC2 Reserved Node with no changes to the configuration (term, payment type, or number of nodes) and no additional costs. </p>

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -2373,23 +2373,19 @@ impl CompareFacesError {
 }
 impl fmt::Display for CompareFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CompareFacesError {
-    fn description(&self) -> &str {
         match *self {
-            CompareFacesError::AccessDenied(ref cause) => cause,
-            CompareFacesError::ImageTooLarge(ref cause) => cause,
-            CompareFacesError::InternalServerError(ref cause) => cause,
-            CompareFacesError::InvalidImageFormat(ref cause) => cause,
-            CompareFacesError::InvalidParameter(ref cause) => cause,
-            CompareFacesError::InvalidS3Object(ref cause) => cause,
-            CompareFacesError::ProvisionedThroughputExceeded(ref cause) => cause,
-            CompareFacesError::Throttling(ref cause) => cause,
+            CompareFacesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CompareFacesError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            CompareFacesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CompareFacesError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            CompareFacesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CompareFacesError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            CompareFacesError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            CompareFacesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CompareFacesError {}
 /// Errors returned by CreateCollection
 #[derive(Debug, PartialEq)]
 pub enum CreateCollectionError {
@@ -2444,21 +2440,19 @@ impl CreateCollectionError {
 }
 impl fmt::Display for CreateCollectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCollectionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCollectionError::AccessDenied(ref cause) => cause,
-            CreateCollectionError::InternalServerError(ref cause) => cause,
-            CreateCollectionError::InvalidParameter(ref cause) => cause,
-            CreateCollectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            CreateCollectionError::ResourceAlreadyExists(ref cause) => cause,
-            CreateCollectionError::Throttling(ref cause) => cause,
+            CreateCollectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateCollectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateCollectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateCollectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCollectionError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateCollectionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCollectionError {}
 /// Errors returned by CreateProject
 #[derive(Debug, PartialEq)]
 pub enum CreateProjectError {
@@ -2514,22 +2508,18 @@ impl CreateProjectError {
 }
 impl fmt::Display for CreateProjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProjectError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProjectError::AccessDenied(ref cause) => cause,
-            CreateProjectError::InternalServerError(ref cause) => cause,
-            CreateProjectError::InvalidParameter(ref cause) => cause,
-            CreateProjectError::LimitExceeded(ref cause) => cause,
-            CreateProjectError::ProvisionedThroughputExceeded(ref cause) => cause,
-            CreateProjectError::ResourceInUse(ref cause) => cause,
-            CreateProjectError::Throttling(ref cause) => cause,
+            CreateProjectError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateProjectError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProjectError {}
 /// Errors returned by CreateProjectVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateProjectVersionError {
@@ -2596,23 +2586,21 @@ impl CreateProjectVersionError {
 }
 impl fmt::Display for CreateProjectVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProjectVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProjectVersionError::AccessDenied(ref cause) => cause,
-            CreateProjectVersionError::InternalServerError(ref cause) => cause,
-            CreateProjectVersionError::InvalidParameter(ref cause) => cause,
-            CreateProjectVersionError::LimitExceeded(ref cause) => cause,
-            CreateProjectVersionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            CreateProjectVersionError::ResourceInUse(ref cause) => cause,
-            CreateProjectVersionError::ResourceNotFound(ref cause) => cause,
-            CreateProjectVersionError::Throttling(ref cause) => cause,
+            CreateProjectVersionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateProjectVersionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateProjectVersionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateProjectVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProjectVersionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProjectVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateProjectVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateProjectVersionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProjectVersionError {}
 /// Errors returned by CreateStreamProcessor
 #[derive(Debug, PartialEq)]
 pub enum CreateStreamProcessorError {
@@ -2672,22 +2660,20 @@ impl CreateStreamProcessorError {
 }
 impl fmt::Display for CreateStreamProcessorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStreamProcessorError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStreamProcessorError::AccessDenied(ref cause) => cause,
-            CreateStreamProcessorError::InternalServerError(ref cause) => cause,
-            CreateStreamProcessorError::InvalidParameter(ref cause) => cause,
-            CreateStreamProcessorError::LimitExceeded(ref cause) => cause,
-            CreateStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => cause,
-            CreateStreamProcessorError::ResourceInUse(ref cause) => cause,
-            CreateStreamProcessorError::Throttling(ref cause) => cause,
+            CreateStreamProcessorError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateStreamProcessorError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateStreamProcessorError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateStreamProcessorError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStreamProcessorError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateStreamProcessorError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStreamProcessorError {}
 /// Errors returned by DeleteCollection
 #[derive(Debug, PartialEq)]
 pub enum DeleteCollectionError {
@@ -2740,21 +2726,19 @@ impl DeleteCollectionError {
 }
 impl fmt::Display for DeleteCollectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCollectionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCollectionError::AccessDenied(ref cause) => cause,
-            DeleteCollectionError::InternalServerError(ref cause) => cause,
-            DeleteCollectionError::InvalidParameter(ref cause) => cause,
-            DeleteCollectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DeleteCollectionError::ResourceNotFound(ref cause) => cause,
-            DeleteCollectionError::Throttling(ref cause) => cause,
+            DeleteCollectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteCollectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteCollectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteCollectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteCollectionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteCollectionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCollectionError {}
 /// Errors returned by DeleteFaces
 #[derive(Debug, PartialEq)]
 pub enum DeleteFacesError {
@@ -2805,21 +2789,17 @@ impl DeleteFacesError {
 }
 impl fmt::Display for DeleteFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFacesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFacesError::AccessDenied(ref cause) => cause,
-            DeleteFacesError::InternalServerError(ref cause) => cause,
-            DeleteFacesError::InvalidParameter(ref cause) => cause,
-            DeleteFacesError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DeleteFacesError::ResourceNotFound(ref cause) => cause,
-            DeleteFacesError::Throttling(ref cause) => cause,
+            DeleteFacesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteFacesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteFacesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteFacesError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteFacesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFacesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFacesError {}
 /// Errors returned by DeleteStreamProcessor
 #[derive(Debug, PartialEq)]
 pub enum DeleteStreamProcessorError {
@@ -2881,22 +2861,20 @@ impl DeleteStreamProcessorError {
 }
 impl fmt::Display for DeleteStreamProcessorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStreamProcessorError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStreamProcessorError::AccessDenied(ref cause) => cause,
-            DeleteStreamProcessorError::InternalServerError(ref cause) => cause,
-            DeleteStreamProcessorError::InvalidParameter(ref cause) => cause,
-            DeleteStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DeleteStreamProcessorError::ResourceInUse(ref cause) => cause,
-            DeleteStreamProcessorError::ResourceNotFound(ref cause) => cause,
-            DeleteStreamProcessorError::Throttling(ref cause) => cause,
+            DeleteStreamProcessorError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteStreamProcessorError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteStreamProcessorError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteStreamProcessorError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteStreamProcessorError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteStreamProcessorError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStreamProcessorError {}
 /// Errors returned by DescribeCollection
 #[derive(Debug, PartialEq)]
 pub enum DescribeCollectionError {
@@ -2949,21 +2927,19 @@ impl DescribeCollectionError {
 }
 impl fmt::Display for DescribeCollectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCollectionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCollectionError::AccessDenied(ref cause) => cause,
-            DescribeCollectionError::InternalServerError(ref cause) => cause,
-            DescribeCollectionError::InvalidParameter(ref cause) => cause,
-            DescribeCollectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DescribeCollectionError::ResourceNotFound(ref cause) => cause,
-            DescribeCollectionError::Throttling(ref cause) => cause,
+            DescribeCollectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeCollectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeCollectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeCollectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCollectionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeCollectionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCollectionError {}
 /// Errors returned by DescribeProjectVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeProjectVersionsError {
@@ -3029,22 +3005,22 @@ impl DescribeProjectVersionsError {
 }
 impl fmt::Display for DescribeProjectVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProjectVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProjectVersionsError::AccessDenied(ref cause) => cause,
-            DescribeProjectVersionsError::InternalServerError(ref cause) => cause,
-            DescribeProjectVersionsError::InvalidPaginationToken(ref cause) => cause,
-            DescribeProjectVersionsError::InvalidParameter(ref cause) => cause,
-            DescribeProjectVersionsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DescribeProjectVersionsError::ResourceNotFound(ref cause) => cause,
-            DescribeProjectVersionsError::Throttling(ref cause) => cause,
+            DescribeProjectVersionsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeProjectVersionsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeProjectVersionsError::InvalidPaginationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProjectVersionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeProjectVersionsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProjectVersionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeProjectVersionsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProjectVersionsError {}
 /// Errors returned by DescribeProjects
 #[derive(Debug, PartialEq)]
 pub enum DescribeProjectsError {
@@ -3099,21 +3075,19 @@ impl DescribeProjectsError {
 }
 impl fmt::Display for DescribeProjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProjectsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProjectsError::AccessDenied(ref cause) => cause,
-            DescribeProjectsError::InternalServerError(ref cause) => cause,
-            DescribeProjectsError::InvalidPaginationToken(ref cause) => cause,
-            DescribeProjectsError::InvalidParameter(ref cause) => cause,
-            DescribeProjectsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DescribeProjectsError::Throttling(ref cause) => cause,
+            DescribeProjectsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeProjectsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeProjectsError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            DescribeProjectsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeProjectsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProjectsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProjectsError {}
 /// Errors returned by DescribeStreamProcessor
 #[derive(Debug, PartialEq)]
 pub enum DescribeStreamProcessorError {
@@ -3172,21 +3146,19 @@ impl DescribeStreamProcessorError {
 }
 impl fmt::Display for DescribeStreamProcessorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStreamProcessorError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStreamProcessorError::AccessDenied(ref cause) => cause,
-            DescribeStreamProcessorError::InternalServerError(ref cause) => cause,
-            DescribeStreamProcessorError::InvalidParameter(ref cause) => cause,
-            DescribeStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DescribeStreamProcessorError::ResourceNotFound(ref cause) => cause,
-            DescribeStreamProcessorError::Throttling(ref cause) => cause,
+            DescribeStreamProcessorError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeStreamProcessorError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeStreamProcessorError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeStreamProcessorError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeStreamProcessorError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStreamProcessorError {}
 /// Errors returned by DetectCustomLabels
 #[derive(Debug, PartialEq)]
 pub enum DetectCustomLabelsError {
@@ -3266,26 +3238,24 @@ impl DetectCustomLabelsError {
 }
 impl fmt::Display for DetectCustomLabelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectCustomLabelsError {
-    fn description(&self) -> &str {
         match *self {
-            DetectCustomLabelsError::AccessDenied(ref cause) => cause,
-            DetectCustomLabelsError::ImageTooLarge(ref cause) => cause,
-            DetectCustomLabelsError::InternalServerError(ref cause) => cause,
-            DetectCustomLabelsError::InvalidImageFormat(ref cause) => cause,
-            DetectCustomLabelsError::InvalidParameter(ref cause) => cause,
-            DetectCustomLabelsError::InvalidS3Object(ref cause) => cause,
-            DetectCustomLabelsError::LimitExceeded(ref cause) => cause,
-            DetectCustomLabelsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DetectCustomLabelsError::ResourceNotFound(ref cause) => cause,
-            DetectCustomLabelsError::ResourceNotReady(ref cause) => cause,
-            DetectCustomLabelsError::Throttling(ref cause) => cause,
+            DetectCustomLabelsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DetectCustomLabelsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::ResourceNotReady(ref cause) => write!(f, "{}", cause),
+            DetectCustomLabelsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectCustomLabelsError {}
 /// Errors returned by DetectFaces
 #[derive(Debug, PartialEq)]
 pub enum DetectFacesError {
@@ -3346,23 +3316,19 @@ impl DetectFacesError {
 }
 impl fmt::Display for DetectFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectFacesError {
-    fn description(&self) -> &str {
         match *self {
-            DetectFacesError::AccessDenied(ref cause) => cause,
-            DetectFacesError::ImageTooLarge(ref cause) => cause,
-            DetectFacesError::InternalServerError(ref cause) => cause,
-            DetectFacesError::InvalidImageFormat(ref cause) => cause,
-            DetectFacesError::InvalidParameter(ref cause) => cause,
-            DetectFacesError::InvalidS3Object(ref cause) => cause,
-            DetectFacesError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DetectFacesError::Throttling(ref cause) => cause,
+            DetectFacesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetectFacesError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            DetectFacesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DetectFacesError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            DetectFacesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DetectFacesError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            DetectFacesError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            DetectFacesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectFacesError {}
 /// Errors returned by DetectLabels
 #[derive(Debug, PartialEq)]
 pub enum DetectLabelsError {
@@ -3423,23 +3389,19 @@ impl DetectLabelsError {
 }
 impl fmt::Display for DetectLabelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectLabelsError {
-    fn description(&self) -> &str {
         match *self {
-            DetectLabelsError::AccessDenied(ref cause) => cause,
-            DetectLabelsError::ImageTooLarge(ref cause) => cause,
-            DetectLabelsError::InternalServerError(ref cause) => cause,
-            DetectLabelsError::InvalidImageFormat(ref cause) => cause,
-            DetectLabelsError::InvalidParameter(ref cause) => cause,
-            DetectLabelsError::InvalidS3Object(ref cause) => cause,
-            DetectLabelsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DetectLabelsError::Throttling(ref cause) => cause,
+            DetectLabelsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetectLabelsError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            DetectLabelsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DetectLabelsError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            DetectLabelsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DetectLabelsError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            DetectLabelsError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            DetectLabelsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectLabelsError {}
 /// Errors returned by DetectModerationLabels
 #[derive(Debug, PartialEq)]
 pub enum DetectModerationLabelsError {
@@ -3517,24 +3479,24 @@ impl DetectModerationLabelsError {
 }
 impl fmt::Display for DetectModerationLabelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectModerationLabelsError {
-    fn description(&self) -> &str {
         match *self {
-            DetectModerationLabelsError::AccessDenied(ref cause) => cause,
-            DetectModerationLabelsError::HumanLoopQuotaExceeded(ref cause) => cause,
-            DetectModerationLabelsError::ImageTooLarge(ref cause) => cause,
-            DetectModerationLabelsError::InternalServerError(ref cause) => cause,
-            DetectModerationLabelsError::InvalidImageFormat(ref cause) => cause,
-            DetectModerationLabelsError::InvalidParameter(ref cause) => cause,
-            DetectModerationLabelsError::InvalidS3Object(ref cause) => cause,
-            DetectModerationLabelsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DetectModerationLabelsError::Throttling(ref cause) => cause,
+            DetectModerationLabelsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetectModerationLabelsError::HumanLoopQuotaExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DetectModerationLabelsError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            DetectModerationLabelsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DetectModerationLabelsError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            DetectModerationLabelsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DetectModerationLabelsError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            DetectModerationLabelsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DetectModerationLabelsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectModerationLabelsError {}
 /// Errors returned by DetectText
 #[derive(Debug, PartialEq)]
 pub enum DetectTextError {
@@ -3595,23 +3557,19 @@ impl DetectTextError {
 }
 impl fmt::Display for DetectTextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectTextError {
-    fn description(&self) -> &str {
         match *self {
-            DetectTextError::AccessDenied(ref cause) => cause,
-            DetectTextError::ImageTooLarge(ref cause) => cause,
-            DetectTextError::InternalServerError(ref cause) => cause,
-            DetectTextError::InvalidImageFormat(ref cause) => cause,
-            DetectTextError::InvalidParameter(ref cause) => cause,
-            DetectTextError::InvalidS3Object(ref cause) => cause,
-            DetectTextError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DetectTextError::Throttling(ref cause) => cause,
+            DetectTextError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetectTextError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            DetectTextError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DetectTextError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            DetectTextError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DetectTextError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            DetectTextError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            DetectTextError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectTextError {}
 /// Errors returned by GetCelebrityInfo
 #[derive(Debug, PartialEq)]
 pub enum GetCelebrityInfoError {
@@ -3664,21 +3622,19 @@ impl GetCelebrityInfoError {
 }
 impl fmt::Display for GetCelebrityInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCelebrityInfoError {
-    fn description(&self) -> &str {
         match *self {
-            GetCelebrityInfoError::AccessDenied(ref cause) => cause,
-            GetCelebrityInfoError::InternalServerError(ref cause) => cause,
-            GetCelebrityInfoError::InvalidParameter(ref cause) => cause,
-            GetCelebrityInfoError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetCelebrityInfoError::ResourceNotFound(ref cause) => cause,
-            GetCelebrityInfoError::Throttling(ref cause) => cause,
+            GetCelebrityInfoError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetCelebrityInfoError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetCelebrityInfoError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetCelebrityInfoError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCelebrityInfoError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetCelebrityInfoError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCelebrityInfoError {}
 /// Errors returned by GetCelebrityRecognition
 #[derive(Debug, PartialEq)]
 pub enum GetCelebrityRecognitionError {
@@ -3744,22 +3700,22 @@ impl GetCelebrityRecognitionError {
 }
 impl fmt::Display for GetCelebrityRecognitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCelebrityRecognitionError {
-    fn description(&self) -> &str {
         match *self {
-            GetCelebrityRecognitionError::AccessDenied(ref cause) => cause,
-            GetCelebrityRecognitionError::InternalServerError(ref cause) => cause,
-            GetCelebrityRecognitionError::InvalidPaginationToken(ref cause) => cause,
-            GetCelebrityRecognitionError::InvalidParameter(ref cause) => cause,
-            GetCelebrityRecognitionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetCelebrityRecognitionError::ResourceNotFound(ref cause) => cause,
-            GetCelebrityRecognitionError::Throttling(ref cause) => cause,
+            GetCelebrityRecognitionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetCelebrityRecognitionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetCelebrityRecognitionError::InvalidPaginationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCelebrityRecognitionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetCelebrityRecognitionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCelebrityRecognitionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetCelebrityRecognitionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCelebrityRecognitionError {}
 /// Errors returned by GetContentModeration
 #[derive(Debug, PartialEq)]
 pub enum GetContentModerationError {
@@ -3823,22 +3779,20 @@ impl GetContentModerationError {
 }
 impl fmt::Display for GetContentModerationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetContentModerationError {
-    fn description(&self) -> &str {
         match *self {
-            GetContentModerationError::AccessDenied(ref cause) => cause,
-            GetContentModerationError::InternalServerError(ref cause) => cause,
-            GetContentModerationError::InvalidPaginationToken(ref cause) => cause,
-            GetContentModerationError::InvalidParameter(ref cause) => cause,
-            GetContentModerationError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetContentModerationError::ResourceNotFound(ref cause) => cause,
-            GetContentModerationError::Throttling(ref cause) => cause,
+            GetContentModerationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetContentModerationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetContentModerationError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            GetContentModerationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetContentModerationError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetContentModerationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetContentModerationError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetContentModerationError {}
 /// Errors returned by GetFaceDetection
 #[derive(Debug, PartialEq)]
 pub enum GetFaceDetectionError {
@@ -3898,22 +3852,20 @@ impl GetFaceDetectionError {
 }
 impl fmt::Display for GetFaceDetectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFaceDetectionError {
-    fn description(&self) -> &str {
         match *self {
-            GetFaceDetectionError::AccessDenied(ref cause) => cause,
-            GetFaceDetectionError::InternalServerError(ref cause) => cause,
-            GetFaceDetectionError::InvalidPaginationToken(ref cause) => cause,
-            GetFaceDetectionError::InvalidParameter(ref cause) => cause,
-            GetFaceDetectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetFaceDetectionError::ResourceNotFound(ref cause) => cause,
-            GetFaceDetectionError::Throttling(ref cause) => cause,
+            GetFaceDetectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetFaceDetectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetFaceDetectionError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            GetFaceDetectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetFaceDetectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetFaceDetectionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetFaceDetectionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFaceDetectionError {}
 /// Errors returned by GetFaceSearch
 #[derive(Debug, PartialEq)]
 pub enum GetFaceSearchError {
@@ -3971,22 +3923,18 @@ impl GetFaceSearchError {
 }
 impl fmt::Display for GetFaceSearchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFaceSearchError {
-    fn description(&self) -> &str {
         match *self {
-            GetFaceSearchError::AccessDenied(ref cause) => cause,
-            GetFaceSearchError::InternalServerError(ref cause) => cause,
-            GetFaceSearchError::InvalidPaginationToken(ref cause) => cause,
-            GetFaceSearchError::InvalidParameter(ref cause) => cause,
-            GetFaceSearchError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetFaceSearchError::ResourceNotFound(ref cause) => cause,
-            GetFaceSearchError::Throttling(ref cause) => cause,
+            GetFaceSearchError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetFaceSearchError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetFaceSearchError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            GetFaceSearchError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetFaceSearchError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            GetFaceSearchError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetFaceSearchError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFaceSearchError {}
 /// Errors returned by GetLabelDetection
 #[derive(Debug, PartialEq)]
 pub enum GetLabelDetectionError {
@@ -4046,22 +3994,20 @@ impl GetLabelDetectionError {
 }
 impl fmt::Display for GetLabelDetectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLabelDetectionError {
-    fn description(&self) -> &str {
         match *self {
-            GetLabelDetectionError::AccessDenied(ref cause) => cause,
-            GetLabelDetectionError::InternalServerError(ref cause) => cause,
-            GetLabelDetectionError::InvalidPaginationToken(ref cause) => cause,
-            GetLabelDetectionError::InvalidParameter(ref cause) => cause,
-            GetLabelDetectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetLabelDetectionError::ResourceNotFound(ref cause) => cause,
-            GetLabelDetectionError::Throttling(ref cause) => cause,
+            GetLabelDetectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetLabelDetectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetLabelDetectionError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            GetLabelDetectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetLabelDetectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetLabelDetectionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetLabelDetectionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLabelDetectionError {}
 /// Errors returned by GetPersonTracking
 #[derive(Debug, PartialEq)]
 pub enum GetPersonTrackingError {
@@ -4121,22 +4067,20 @@ impl GetPersonTrackingError {
 }
 impl fmt::Display for GetPersonTrackingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPersonTrackingError {
-    fn description(&self) -> &str {
         match *self {
-            GetPersonTrackingError::AccessDenied(ref cause) => cause,
-            GetPersonTrackingError::InternalServerError(ref cause) => cause,
-            GetPersonTrackingError::InvalidPaginationToken(ref cause) => cause,
-            GetPersonTrackingError::InvalidParameter(ref cause) => cause,
-            GetPersonTrackingError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetPersonTrackingError::ResourceNotFound(ref cause) => cause,
-            GetPersonTrackingError::Throttling(ref cause) => cause,
+            GetPersonTrackingError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetPersonTrackingError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetPersonTrackingError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            GetPersonTrackingError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetPersonTrackingError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPersonTrackingError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetPersonTrackingError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPersonTrackingError {}
 /// Errors returned by IndexFaces
 #[derive(Debug, PartialEq)]
 pub enum IndexFacesError {
@@ -4202,24 +4146,20 @@ impl IndexFacesError {
 }
 impl fmt::Display for IndexFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for IndexFacesError {
-    fn description(&self) -> &str {
         match *self {
-            IndexFacesError::AccessDenied(ref cause) => cause,
-            IndexFacesError::ImageTooLarge(ref cause) => cause,
-            IndexFacesError::InternalServerError(ref cause) => cause,
-            IndexFacesError::InvalidImageFormat(ref cause) => cause,
-            IndexFacesError::InvalidParameter(ref cause) => cause,
-            IndexFacesError::InvalidS3Object(ref cause) => cause,
-            IndexFacesError::ProvisionedThroughputExceeded(ref cause) => cause,
-            IndexFacesError::ResourceNotFound(ref cause) => cause,
-            IndexFacesError::Throttling(ref cause) => cause,
+            IndexFacesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            IndexFacesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for IndexFacesError {}
 /// Errors returned by ListCollections
 #[derive(Debug, PartialEq)]
 pub enum ListCollectionsError {
@@ -4277,22 +4217,20 @@ impl ListCollectionsError {
 }
 impl fmt::Display for ListCollectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCollectionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListCollectionsError::AccessDenied(ref cause) => cause,
-            ListCollectionsError::InternalServerError(ref cause) => cause,
-            ListCollectionsError::InvalidPaginationToken(ref cause) => cause,
-            ListCollectionsError::InvalidParameter(ref cause) => cause,
-            ListCollectionsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            ListCollectionsError::ResourceNotFound(ref cause) => cause,
-            ListCollectionsError::Throttling(ref cause) => cause,
+            ListCollectionsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListCollectionsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListCollectionsError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            ListCollectionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListCollectionsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListCollectionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListCollectionsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCollectionsError {}
 /// Errors returned by ListFaces
 #[derive(Debug, PartialEq)]
 pub enum ListFacesError {
@@ -4348,22 +4286,18 @@ impl ListFacesError {
 }
 impl fmt::Display for ListFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFacesError {
-    fn description(&self) -> &str {
         match *self {
-            ListFacesError::AccessDenied(ref cause) => cause,
-            ListFacesError::InternalServerError(ref cause) => cause,
-            ListFacesError::InvalidPaginationToken(ref cause) => cause,
-            ListFacesError::InvalidParameter(ref cause) => cause,
-            ListFacesError::ProvisionedThroughputExceeded(ref cause) => cause,
-            ListFacesError::ResourceNotFound(ref cause) => cause,
-            ListFacesError::Throttling(ref cause) => cause,
+            ListFacesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListFacesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListFacesError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            ListFacesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListFacesError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            ListFacesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListFacesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFacesError {}
 /// Errors returned by ListStreamProcessors
 #[derive(Debug, PartialEq)]
 pub enum ListStreamProcessorsError {
@@ -4420,21 +4354,19 @@ impl ListStreamProcessorsError {
 }
 impl fmt::Display for ListStreamProcessorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStreamProcessorsError {
-    fn description(&self) -> &str {
         match *self {
-            ListStreamProcessorsError::AccessDenied(ref cause) => cause,
-            ListStreamProcessorsError::InternalServerError(ref cause) => cause,
-            ListStreamProcessorsError::InvalidPaginationToken(ref cause) => cause,
-            ListStreamProcessorsError::InvalidParameter(ref cause) => cause,
-            ListStreamProcessorsError::ProvisionedThroughputExceeded(ref cause) => cause,
-            ListStreamProcessorsError::Throttling(ref cause) => cause,
+            ListStreamProcessorsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ListStreamProcessorsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListStreamProcessorsError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            ListStreamProcessorsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListStreamProcessorsError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListStreamProcessorsError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStreamProcessorsError {}
 /// Errors returned by RecognizeCelebrities
 #[derive(Debug, PartialEq)]
 pub enum RecognizeCelebritiesError {
@@ -4503,23 +4435,21 @@ impl RecognizeCelebritiesError {
 }
 impl fmt::Display for RecognizeCelebritiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RecognizeCelebritiesError {
-    fn description(&self) -> &str {
         match *self {
-            RecognizeCelebritiesError::AccessDenied(ref cause) => cause,
-            RecognizeCelebritiesError::ImageTooLarge(ref cause) => cause,
-            RecognizeCelebritiesError::InternalServerError(ref cause) => cause,
-            RecognizeCelebritiesError::InvalidImageFormat(ref cause) => cause,
-            RecognizeCelebritiesError::InvalidParameter(ref cause) => cause,
-            RecognizeCelebritiesError::InvalidS3Object(ref cause) => cause,
-            RecognizeCelebritiesError::ProvisionedThroughputExceeded(ref cause) => cause,
-            RecognizeCelebritiesError::Throttling(ref cause) => cause,
+            RecognizeCelebritiesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RecognizeCelebritiesError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            RecognizeCelebritiesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RecognizeCelebritiesError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            RecognizeCelebritiesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RecognizeCelebritiesError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            RecognizeCelebritiesError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RecognizeCelebritiesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RecognizeCelebritiesError {}
 /// Errors returned by SearchFaces
 #[derive(Debug, PartialEq)]
 pub enum SearchFacesError {
@@ -4570,21 +4500,17 @@ impl SearchFacesError {
 }
 impl fmt::Display for SearchFacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchFacesError {
-    fn description(&self) -> &str {
         match *self {
-            SearchFacesError::AccessDenied(ref cause) => cause,
-            SearchFacesError::InternalServerError(ref cause) => cause,
-            SearchFacesError::InvalidParameter(ref cause) => cause,
-            SearchFacesError::ProvisionedThroughputExceeded(ref cause) => cause,
-            SearchFacesError::ResourceNotFound(ref cause) => cause,
-            SearchFacesError::Throttling(ref cause) => cause,
+            SearchFacesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SearchFacesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SearchFacesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SearchFacesError::ProvisionedThroughputExceeded(ref cause) => write!(f, "{}", cause),
+            SearchFacesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SearchFacesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchFacesError {}
 /// Errors returned by SearchFacesByImage
 #[derive(Debug, PartialEq)]
 pub enum SearchFacesByImageError {
@@ -4654,24 +4580,22 @@ impl SearchFacesByImageError {
 }
 impl fmt::Display for SearchFacesByImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchFacesByImageError {
-    fn description(&self) -> &str {
         match *self {
-            SearchFacesByImageError::AccessDenied(ref cause) => cause,
-            SearchFacesByImageError::ImageTooLarge(ref cause) => cause,
-            SearchFacesByImageError::InternalServerError(ref cause) => cause,
-            SearchFacesByImageError::InvalidImageFormat(ref cause) => cause,
-            SearchFacesByImageError::InvalidParameter(ref cause) => cause,
-            SearchFacesByImageError::InvalidS3Object(ref cause) => cause,
-            SearchFacesByImageError::ProvisionedThroughputExceeded(ref cause) => cause,
-            SearchFacesByImageError::ResourceNotFound(ref cause) => cause,
-            SearchFacesByImageError::Throttling(ref cause) => cause,
+            SearchFacesByImageError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            SearchFacesByImageError::ImageTooLarge(ref cause) => write!(f, "{}", cause),
+            SearchFacesByImageError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SearchFacesByImageError::InvalidImageFormat(ref cause) => write!(f, "{}", cause),
+            SearchFacesByImageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SearchFacesByImageError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            SearchFacesByImageError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SearchFacesByImageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SearchFacesByImageError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchFacesByImageError {}
 /// Errors returned by StartCelebrityRecognition
 #[derive(Debug, PartialEq)]
 pub enum StartCelebrityRecognitionError {
@@ -4753,24 +4677,26 @@ impl StartCelebrityRecognitionError {
 }
 impl fmt::Display for StartCelebrityRecognitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartCelebrityRecognitionError {
-    fn description(&self) -> &str {
         match *self {
-            StartCelebrityRecognitionError::AccessDenied(ref cause) => cause,
-            StartCelebrityRecognitionError::IdempotentParameterMismatch(ref cause) => cause,
-            StartCelebrityRecognitionError::InternalServerError(ref cause) => cause,
-            StartCelebrityRecognitionError::InvalidParameter(ref cause) => cause,
-            StartCelebrityRecognitionError::InvalidS3Object(ref cause) => cause,
-            StartCelebrityRecognitionError::LimitExceeded(ref cause) => cause,
-            StartCelebrityRecognitionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartCelebrityRecognitionError::Throttling(ref cause) => cause,
-            StartCelebrityRecognitionError::VideoTooLarge(ref cause) => cause,
+            StartCelebrityRecognitionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartCelebrityRecognitionError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartCelebrityRecognitionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartCelebrityRecognitionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartCelebrityRecognitionError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartCelebrityRecognitionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartCelebrityRecognitionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartCelebrityRecognitionError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartCelebrityRecognitionError::VideoTooLarge(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartCelebrityRecognitionError {}
 /// Errors returned by StartContentModeration
 #[derive(Debug, PartialEq)]
 pub enum StartContentModerationError {
@@ -4848,24 +4774,24 @@ impl StartContentModerationError {
 }
 impl fmt::Display for StartContentModerationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartContentModerationError {
-    fn description(&self) -> &str {
         match *self {
-            StartContentModerationError::AccessDenied(ref cause) => cause,
-            StartContentModerationError::IdempotentParameterMismatch(ref cause) => cause,
-            StartContentModerationError::InternalServerError(ref cause) => cause,
-            StartContentModerationError::InvalidParameter(ref cause) => cause,
-            StartContentModerationError::InvalidS3Object(ref cause) => cause,
-            StartContentModerationError::LimitExceeded(ref cause) => cause,
-            StartContentModerationError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartContentModerationError::Throttling(ref cause) => cause,
-            StartContentModerationError::VideoTooLarge(ref cause) => cause,
+            StartContentModerationError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartContentModerationError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartContentModerationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartContentModerationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartContentModerationError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartContentModerationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartContentModerationError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartContentModerationError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartContentModerationError::VideoTooLarge(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartContentModerationError {}
 /// Errors returned by StartFaceDetection
 #[derive(Debug, PartialEq)]
 pub enum StartFaceDetectionError {
@@ -4935,24 +4861,24 @@ impl StartFaceDetectionError {
 }
 impl fmt::Display for StartFaceDetectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartFaceDetectionError {
-    fn description(&self) -> &str {
         match *self {
-            StartFaceDetectionError::AccessDenied(ref cause) => cause,
-            StartFaceDetectionError::IdempotentParameterMismatch(ref cause) => cause,
-            StartFaceDetectionError::InternalServerError(ref cause) => cause,
-            StartFaceDetectionError::InvalidParameter(ref cause) => cause,
-            StartFaceDetectionError::InvalidS3Object(ref cause) => cause,
-            StartFaceDetectionError::LimitExceeded(ref cause) => cause,
-            StartFaceDetectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartFaceDetectionError::Throttling(ref cause) => cause,
-            StartFaceDetectionError::VideoTooLarge(ref cause) => cause,
+            StartFaceDetectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartFaceDetectionError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartFaceDetectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartFaceDetectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartFaceDetectionError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartFaceDetectionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartFaceDetectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartFaceDetectionError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartFaceDetectionError::VideoTooLarge(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartFaceDetectionError {}
 /// Errors returned by StartFaceSearch
 #[derive(Debug, PartialEq)]
 pub enum StartFaceSearchError {
@@ -5025,25 +4951,23 @@ impl StartFaceSearchError {
 }
 impl fmt::Display for StartFaceSearchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartFaceSearchError {
-    fn description(&self) -> &str {
         match *self {
-            StartFaceSearchError::AccessDenied(ref cause) => cause,
-            StartFaceSearchError::IdempotentParameterMismatch(ref cause) => cause,
-            StartFaceSearchError::InternalServerError(ref cause) => cause,
-            StartFaceSearchError::InvalidParameter(ref cause) => cause,
-            StartFaceSearchError::InvalidS3Object(ref cause) => cause,
-            StartFaceSearchError::LimitExceeded(ref cause) => cause,
-            StartFaceSearchError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartFaceSearchError::ResourceNotFound(ref cause) => cause,
-            StartFaceSearchError::Throttling(ref cause) => cause,
-            StartFaceSearchError::VideoTooLarge(ref cause) => cause,
+            StartFaceSearchError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::IdempotentParameterMismatch(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartFaceSearchError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartFaceSearchError::VideoTooLarge(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartFaceSearchError {}
 /// Errors returned by StartLabelDetection
 #[derive(Debug, PartialEq)]
 pub enum StartLabelDetectionError {
@@ -5115,24 +5039,24 @@ impl StartLabelDetectionError {
 }
 impl fmt::Display for StartLabelDetectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartLabelDetectionError {
-    fn description(&self) -> &str {
         match *self {
-            StartLabelDetectionError::AccessDenied(ref cause) => cause,
-            StartLabelDetectionError::IdempotentParameterMismatch(ref cause) => cause,
-            StartLabelDetectionError::InternalServerError(ref cause) => cause,
-            StartLabelDetectionError::InvalidParameter(ref cause) => cause,
-            StartLabelDetectionError::InvalidS3Object(ref cause) => cause,
-            StartLabelDetectionError::LimitExceeded(ref cause) => cause,
-            StartLabelDetectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartLabelDetectionError::Throttling(ref cause) => cause,
-            StartLabelDetectionError::VideoTooLarge(ref cause) => cause,
+            StartLabelDetectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartLabelDetectionError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartLabelDetectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartLabelDetectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartLabelDetectionError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartLabelDetectionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartLabelDetectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartLabelDetectionError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartLabelDetectionError::VideoTooLarge(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartLabelDetectionError {}
 /// Errors returned by StartPersonTracking
 #[derive(Debug, PartialEq)]
 pub enum StartPersonTrackingError {
@@ -5204,24 +5128,24 @@ impl StartPersonTrackingError {
 }
 impl fmt::Display for StartPersonTrackingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartPersonTrackingError {
-    fn description(&self) -> &str {
         match *self {
-            StartPersonTrackingError::AccessDenied(ref cause) => cause,
-            StartPersonTrackingError::IdempotentParameterMismatch(ref cause) => cause,
-            StartPersonTrackingError::InternalServerError(ref cause) => cause,
-            StartPersonTrackingError::InvalidParameter(ref cause) => cause,
-            StartPersonTrackingError::InvalidS3Object(ref cause) => cause,
-            StartPersonTrackingError::LimitExceeded(ref cause) => cause,
-            StartPersonTrackingError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartPersonTrackingError::Throttling(ref cause) => cause,
-            StartPersonTrackingError::VideoTooLarge(ref cause) => cause,
+            StartPersonTrackingError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartPersonTrackingError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartPersonTrackingError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartPersonTrackingError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartPersonTrackingError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartPersonTrackingError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartPersonTrackingError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartPersonTrackingError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartPersonTrackingError::VideoTooLarge(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartPersonTrackingError {}
 /// Errors returned by StartProjectVersion
 #[derive(Debug, PartialEq)]
 pub enum StartProjectVersionError {
@@ -5288,23 +5212,21 @@ impl StartProjectVersionError {
 }
 impl fmt::Display for StartProjectVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartProjectVersionError {
-    fn description(&self) -> &str {
         match *self {
-            StartProjectVersionError::AccessDenied(ref cause) => cause,
-            StartProjectVersionError::InternalServerError(ref cause) => cause,
-            StartProjectVersionError::InvalidParameter(ref cause) => cause,
-            StartProjectVersionError::LimitExceeded(ref cause) => cause,
-            StartProjectVersionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartProjectVersionError::ResourceInUse(ref cause) => cause,
-            StartProjectVersionError::ResourceNotFound(ref cause) => cause,
-            StartProjectVersionError::Throttling(ref cause) => cause,
+            StartProjectVersionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartProjectVersionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartProjectVersionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartProjectVersionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartProjectVersionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartProjectVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StartProjectVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartProjectVersionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartProjectVersionError {}
 /// Errors returned by StartStreamProcessor
 #[derive(Debug, PartialEq)]
 pub enum StartStreamProcessorError {
@@ -5366,22 +5288,20 @@ impl StartStreamProcessorError {
 }
 impl fmt::Display for StartStreamProcessorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartStreamProcessorError {
-    fn description(&self) -> &str {
         match *self {
-            StartStreamProcessorError::AccessDenied(ref cause) => cause,
-            StartStreamProcessorError::InternalServerError(ref cause) => cause,
-            StartStreamProcessorError::InvalidParameter(ref cause) => cause,
-            StartStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartStreamProcessorError::ResourceInUse(ref cause) => cause,
-            StartStreamProcessorError::ResourceNotFound(ref cause) => cause,
-            StartStreamProcessorError::Throttling(ref cause) => cause,
+            StartStreamProcessorError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartStreamProcessorError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartStreamProcessorError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartStreamProcessorError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StartStreamProcessorError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartStreamProcessorError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartStreamProcessorError {}
 /// Errors returned by StopProjectVersion
 #[derive(Debug, PartialEq)]
 pub enum StopProjectVersionError {
@@ -5439,22 +5359,20 @@ impl StopProjectVersionError {
 }
 impl fmt::Display for StopProjectVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopProjectVersionError {
-    fn description(&self) -> &str {
         match *self {
-            StopProjectVersionError::AccessDenied(ref cause) => cause,
-            StopProjectVersionError::InternalServerError(ref cause) => cause,
-            StopProjectVersionError::InvalidParameter(ref cause) => cause,
-            StopProjectVersionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StopProjectVersionError::ResourceInUse(ref cause) => cause,
-            StopProjectVersionError::ResourceNotFound(ref cause) => cause,
-            StopProjectVersionError::Throttling(ref cause) => cause,
+            StopProjectVersionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StopProjectVersionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StopProjectVersionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopProjectVersionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopProjectVersionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StopProjectVersionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopProjectVersionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopProjectVersionError {}
 /// Errors returned by StopStreamProcessor
 #[derive(Debug, PartialEq)]
 pub enum StopStreamProcessorError {
@@ -5516,22 +5434,20 @@ impl StopStreamProcessorError {
 }
 impl fmt::Display for StopStreamProcessorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopStreamProcessorError {
-    fn description(&self) -> &str {
         match *self {
-            StopStreamProcessorError::AccessDenied(ref cause) => cause,
-            StopStreamProcessorError::InternalServerError(ref cause) => cause,
-            StopStreamProcessorError::InvalidParameter(ref cause) => cause,
-            StopStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StopStreamProcessorError::ResourceInUse(ref cause) => cause,
-            StopStreamProcessorError::ResourceNotFound(ref cause) => cause,
-            StopStreamProcessorError::Throttling(ref cause) => cause,
+            StopStreamProcessorError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StopStreamProcessorError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StopStreamProcessorError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopStreamProcessorError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopStreamProcessorError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            StopStreamProcessorError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopStreamProcessorError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopStreamProcessorError {}
 /// Trait representing the capabilities of the Amazon Rekognition API. Amazon Rekognition clients implement this trait.
 pub trait Rekognition {
     /// <p>Compares a face in the <i>source</i> input image with each of the 100 largest faces detected in the <i>target</i> input image. </p> <note> <p> If the source image contains multiple faces, the service detects the largest face and compares it with each face detected in the target image. </p> </note> <p>You pass the input and target images either as base64-encoded image bytes or as references to images in an Amazon S3 bucket. If you use the AWS CLI to call Amazon Rekognition operations, passing image bytes isn't supported. The image must be formatted as a PNG or JPEG file. </p> <p>In response, the operation returns an array of face matches ordered by similarity score in descending order. For each face match, the response provides a bounding box of the face, facial landmarks, pose details (pitch, role, and yaw), quality (brightness and sharpness), and confidence value (indicating the level of confidence that the bounding box contains a face). The response also provides a similarity score, which indicates how closely the faces match. </p> <note> <p>By default, only faces with a similarity score of greater than or equal to 80% are returned in the response. You can change this value by specifying the <code>SimilarityThreshold</code> parameter.</p> </note> <p> <code>CompareFaces</code> also returns an array of faces that don't match the source image. For each face, it returns a bounding box, confidence value, landmarks, pose details, and quality. The response also returns information about the face in the source image, including the bounding box of the face and confidence value.</p> <p>The <code>QualityFilter</code> input parameter allows you to filter out detected faces that don’t meet a required quality bar. The quality bar is based on a variety of common use cases. Use <code>QualityFilter</code> to set the quality bar by specifying <code>LOW</code>, <code>MEDIUM</code>, or <code>HIGH</code>. If you do not want to filter detected faces, specify <code>NONE</code>. The default value is <code>NONE</code>. </p> <note> <p>To use quality filtering, you need a collection associated with version 3 of the face model or higher. To get the version of the face model associated with a collection, call <a>DescribeCollection</a>. </p> </note> <p>If the image doesn't contain Exif metadata, <code>CompareFaces</code> returns orientation information for the source and target images. Use these values to display the images with the correct image orientation.</p> <p>If no faces are detected in the source or target images, <code>CompareFaces</code> returns an <code>InvalidParameterException</code> error. </p> <note> <p> This is a stateless API operation. That is, data returned by this operation doesn't persist.</p> </note> <p>For an example, see Comparing Faces in Images in the Amazon Rekognition Developer Guide.</p> <p>This operation requires permissions to perform the <code>rekognition:CompareFaces</code> action.</p>

--- a/rusoto/services/resource-groups/src/generated.rs
+++ b/rusoto/services/resource-groups/src/generated.rs
@@ -455,20 +455,16 @@ impl CreateGroupError {
 }
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupError::BadRequest(ref cause) => cause,
-            CreateGroupError::Forbidden(ref cause) => cause,
-            CreateGroupError::InternalServerError(ref cause) => cause,
-            CreateGroupError::MethodNotAllowed(ref cause) => cause,
-            CreateGroupError::TooManyRequests(ref cause) => cause,
+            CreateGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGroupError {}
 /// Errors returned by DeleteGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteGroupError {
@@ -517,21 +513,17 @@ impl DeleteGroupError {
 }
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGroupError::BadRequest(ref cause) => cause,
-            DeleteGroupError::Forbidden(ref cause) => cause,
-            DeleteGroupError::InternalServerError(ref cause) => cause,
-            DeleteGroupError::MethodNotAllowed(ref cause) => cause,
-            DeleteGroupError::NotFound(ref cause) => cause,
-            DeleteGroupError::TooManyRequests(ref cause) => cause,
+            DeleteGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGroupError {}
 /// Errors returned by GetGroup
 #[derive(Debug, PartialEq)]
 pub enum GetGroupError {
@@ -580,21 +572,17 @@ impl GetGroupError {
 }
 impl fmt::Display for GetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupError::BadRequest(ref cause) => cause,
-            GetGroupError::Forbidden(ref cause) => cause,
-            GetGroupError::InternalServerError(ref cause) => cause,
-            GetGroupError::MethodNotAllowed(ref cause) => cause,
-            GetGroupError::NotFound(ref cause) => cause,
-            GetGroupError::TooManyRequests(ref cause) => cause,
+            GetGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetGroupError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            GetGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupError {}
 /// Errors returned by GetGroupQuery
 #[derive(Debug, PartialEq)]
 pub enum GetGroupQueryError {
@@ -643,21 +631,17 @@ impl GetGroupQueryError {
 }
 impl fmt::Display for GetGroupQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupQueryError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupQueryError::BadRequest(ref cause) => cause,
-            GetGroupQueryError::Forbidden(ref cause) => cause,
-            GetGroupQueryError::InternalServerError(ref cause) => cause,
-            GetGroupQueryError::MethodNotAllowed(ref cause) => cause,
-            GetGroupQueryError::NotFound(ref cause) => cause,
-            GetGroupQueryError::TooManyRequests(ref cause) => cause,
+            GetGroupQueryError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetGroupQueryError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetGroupQueryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetGroupQueryError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            GetGroupQueryError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetGroupQueryError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupQueryError {}
 /// Errors returned by GetTags
 #[derive(Debug, PartialEq)]
 pub enum GetTagsError {
@@ -706,21 +690,17 @@ impl GetTagsError {
 }
 impl fmt::Display for GetTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTagsError {
-    fn description(&self) -> &str {
         match *self {
-            GetTagsError::BadRequest(ref cause) => cause,
-            GetTagsError::Forbidden(ref cause) => cause,
-            GetTagsError::InternalServerError(ref cause) => cause,
-            GetTagsError::MethodNotAllowed(ref cause) => cause,
-            GetTagsError::NotFound(ref cause) => cause,
-            GetTagsError::TooManyRequests(ref cause) => cause,
+            GetTagsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetTagsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetTagsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetTagsError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            GetTagsError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetTagsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTagsError {}
 /// Errors returned by ListGroupResources
 #[derive(Debug, PartialEq)]
 pub enum ListGroupResourcesError {
@@ -776,22 +756,18 @@ impl ListGroupResourcesError {
 }
 impl fmt::Display for ListGroupResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupResourcesError::BadRequest(ref cause) => cause,
-            ListGroupResourcesError::Forbidden(ref cause) => cause,
-            ListGroupResourcesError::InternalServerError(ref cause) => cause,
-            ListGroupResourcesError::MethodNotAllowed(ref cause) => cause,
-            ListGroupResourcesError::NotFound(ref cause) => cause,
-            ListGroupResourcesError::TooManyRequests(ref cause) => cause,
-            ListGroupResourcesError::Unauthorized(ref cause) => cause,
+            ListGroupResourcesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListGroupResourcesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListGroupResourcesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListGroupResourcesError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            ListGroupResourcesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListGroupResourcesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListGroupResourcesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupResourcesError {}
 /// Errors returned by ListGroups
 #[derive(Debug, PartialEq)]
 pub enum ListGroupsError {
@@ -835,20 +811,16 @@ impl ListGroupsError {
 }
 impl fmt::Display for ListGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupsError::BadRequest(ref cause) => cause,
-            ListGroupsError::Forbidden(ref cause) => cause,
-            ListGroupsError::InternalServerError(ref cause) => cause,
-            ListGroupsError::MethodNotAllowed(ref cause) => cause,
-            ListGroupsError::TooManyRequests(ref cause) => cause,
+            ListGroupsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupsError {}
 /// Errors returned by SearchResources
 #[derive(Debug, PartialEq)]
 pub enum SearchResourcesError {
@@ -897,21 +869,17 @@ impl SearchResourcesError {
 }
 impl fmt::Display for SearchResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            SearchResourcesError::BadRequest(ref cause) => cause,
-            SearchResourcesError::Forbidden(ref cause) => cause,
-            SearchResourcesError::InternalServerError(ref cause) => cause,
-            SearchResourcesError::MethodNotAllowed(ref cause) => cause,
-            SearchResourcesError::TooManyRequests(ref cause) => cause,
-            SearchResourcesError::Unauthorized(ref cause) => cause,
+            SearchResourcesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            SearchResourcesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            SearchResourcesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SearchResourcesError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            SearchResourcesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            SearchResourcesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchResourcesError {}
 /// Errors returned by Tag
 #[derive(Debug, PartialEq)]
 pub enum TagError {
@@ -956,21 +924,17 @@ impl TagError {
 }
 impl fmt::Display for TagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagError {
-    fn description(&self) -> &str {
         match *self {
-            TagError::BadRequest(ref cause) => cause,
-            TagError::Forbidden(ref cause) => cause,
-            TagError::InternalServerError(ref cause) => cause,
-            TagError::MethodNotAllowed(ref cause) => cause,
-            TagError::NotFound(ref cause) => cause,
-            TagError::TooManyRequests(ref cause) => cause,
+            TagError::BadRequest(ref cause) => write!(f, "{}", cause),
+            TagError::Forbidden(ref cause) => write!(f, "{}", cause),
+            TagError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            TagError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            TagError::NotFound(ref cause) => write!(f, "{}", cause),
+            TagError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagError {}
 /// Errors returned by Untag
 #[derive(Debug, PartialEq)]
 pub enum UntagError {
@@ -1017,21 +981,17 @@ impl UntagError {
 }
 impl fmt::Display for UntagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagError {
-    fn description(&self) -> &str {
         match *self {
-            UntagError::BadRequest(ref cause) => cause,
-            UntagError::Forbidden(ref cause) => cause,
-            UntagError::InternalServerError(ref cause) => cause,
-            UntagError::MethodNotAllowed(ref cause) => cause,
-            UntagError::NotFound(ref cause) => cause,
-            UntagError::TooManyRequests(ref cause) => cause,
+            UntagError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UntagError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UntagError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UntagError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            UntagError::NotFound(ref cause) => write!(f, "{}", cause),
+            UntagError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagError {}
 /// Errors returned by UpdateGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateGroupError {
@@ -1080,21 +1040,17 @@ impl UpdateGroupError {
 }
 impl fmt::Display for UpdateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGroupError::BadRequest(ref cause) => cause,
-            UpdateGroupError::Forbidden(ref cause) => cause,
-            UpdateGroupError::InternalServerError(ref cause) => cause,
-            UpdateGroupError::MethodNotAllowed(ref cause) => cause,
-            UpdateGroupError::NotFound(ref cause) => cause,
-            UpdateGroupError::TooManyRequests(ref cause) => cause,
+            UpdateGroupError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGroupError {}
 /// Errors returned by UpdateGroupQuery
 #[derive(Debug, PartialEq)]
 pub enum UpdateGroupQueryError {
@@ -1145,21 +1101,17 @@ impl UpdateGroupQueryError {
 }
 impl fmt::Display for UpdateGroupQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGroupQueryError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGroupQueryError::BadRequest(ref cause) => cause,
-            UpdateGroupQueryError::Forbidden(ref cause) => cause,
-            UpdateGroupQueryError::InternalServerError(ref cause) => cause,
-            UpdateGroupQueryError::MethodNotAllowed(ref cause) => cause,
-            UpdateGroupQueryError::NotFound(ref cause) => cause,
-            UpdateGroupQueryError::TooManyRequests(ref cause) => cause,
+            UpdateGroupQueryError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGroupQueryError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateGroupQueryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateGroupQueryError::MethodNotAllowed(ref cause) => write!(f, "{}", cause),
+            UpdateGroupQueryError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateGroupQueryError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGroupQueryError {}
 /// Trait representing the capabilities of the Resource Groups API. Resource Groups clients implement this trait.
 pub trait ResourceGroups {
     /// <p>Creates a group with a specified name, description, and resource query.</p>

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -380,19 +380,15 @@ impl DescribeReportCreationError {
 }
 impl fmt::Display for DescribeReportCreationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReportCreationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReportCreationError::ConstraintViolation(ref cause) => cause,
-            DescribeReportCreationError::InternalService(ref cause) => cause,
-            DescribeReportCreationError::InvalidParameter(ref cause) => cause,
-            DescribeReportCreationError::Throttled(ref cause) => cause,
+            DescribeReportCreationError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            DescribeReportCreationError::InternalService(ref cause) => write!(f, "{}", cause),
+            DescribeReportCreationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeReportCreationError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeReportCreationError {}
 /// Errors returned by GetComplianceSummary
 #[derive(Debug, PartialEq)]
 pub enum GetComplianceSummaryError {
@@ -437,19 +433,15 @@ impl GetComplianceSummaryError {
 }
 impl fmt::Display for GetComplianceSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetComplianceSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            GetComplianceSummaryError::ConstraintViolation(ref cause) => cause,
-            GetComplianceSummaryError::InternalService(ref cause) => cause,
-            GetComplianceSummaryError::InvalidParameter(ref cause) => cause,
-            GetComplianceSummaryError::Throttled(ref cause) => cause,
+            GetComplianceSummaryError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            GetComplianceSummaryError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetComplianceSummaryError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetComplianceSummaryError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetComplianceSummaryError {}
 /// Errors returned by GetResources
 #[derive(Debug, PartialEq)]
 pub enum GetResourcesError {
@@ -488,19 +480,15 @@ impl GetResourcesError {
 }
 impl fmt::Display for GetResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourcesError::InternalService(ref cause) => cause,
-            GetResourcesError::InvalidParameter(ref cause) => cause,
-            GetResourcesError::PaginationTokenExpired(ref cause) => cause,
-            GetResourcesError::Throttled(ref cause) => cause,
+            GetResourcesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::PaginationTokenExpired(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourcesError {}
 /// Errors returned by GetTagKeys
 #[derive(Debug, PartialEq)]
 pub enum GetTagKeysError {
@@ -539,19 +527,15 @@ impl GetTagKeysError {
 }
 impl fmt::Display for GetTagKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTagKeysError {
-    fn description(&self) -> &str {
         match *self {
-            GetTagKeysError::InternalService(ref cause) => cause,
-            GetTagKeysError::InvalidParameter(ref cause) => cause,
-            GetTagKeysError::PaginationTokenExpired(ref cause) => cause,
-            GetTagKeysError::Throttled(ref cause) => cause,
+            GetTagKeysError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTagKeysError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetTagKeysError::PaginationTokenExpired(ref cause) => write!(f, "{}", cause),
+            GetTagKeysError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTagKeysError {}
 /// Errors returned by GetTagValues
 #[derive(Debug, PartialEq)]
 pub enum GetTagValuesError {
@@ -590,19 +574,15 @@ impl GetTagValuesError {
 }
 impl fmt::Display for GetTagValuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTagValuesError {
-    fn description(&self) -> &str {
         match *self {
-            GetTagValuesError::InternalService(ref cause) => cause,
-            GetTagValuesError::InvalidParameter(ref cause) => cause,
-            GetTagValuesError::PaginationTokenExpired(ref cause) => cause,
-            GetTagValuesError::Throttled(ref cause) => cause,
+            GetTagValuesError::InternalService(ref cause) => write!(f, "{}", cause),
+            GetTagValuesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetTagValuesError::PaginationTokenExpired(ref cause) => write!(f, "{}", cause),
+            GetTagValuesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTagValuesError {}
 /// Errors returned by StartReportCreation
 #[derive(Debug, PartialEq)]
 pub enum StartReportCreationError {
@@ -652,20 +632,16 @@ impl StartReportCreationError {
 }
 impl fmt::Display for StartReportCreationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartReportCreationError {
-    fn description(&self) -> &str {
         match *self {
-            StartReportCreationError::ConcurrentModification(ref cause) => cause,
-            StartReportCreationError::ConstraintViolation(ref cause) => cause,
-            StartReportCreationError::InternalService(ref cause) => cause,
-            StartReportCreationError::InvalidParameter(ref cause) => cause,
-            StartReportCreationError::Throttled(ref cause) => cause,
+            StartReportCreationError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            StartReportCreationError::ConstraintViolation(ref cause) => write!(f, "{}", cause),
+            StartReportCreationError::InternalService(ref cause) => write!(f, "{}", cause),
+            StartReportCreationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartReportCreationError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartReportCreationError {}
 /// Errors returned by TagResources
 #[derive(Debug, PartialEq)]
 pub enum TagResourcesError {
@@ -699,18 +675,14 @@ impl TagResourcesError {
 }
 impl fmt::Display for TagResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourcesError::InternalService(ref cause) => cause,
-            TagResourcesError::InvalidParameter(ref cause) => cause,
-            TagResourcesError::Throttled(ref cause) => cause,
+            TagResourcesError::InternalService(ref cause) => write!(f, "{}", cause),
+            TagResourcesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourcesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourcesError {}
 /// Errors returned by UntagResources
 #[derive(Debug, PartialEq)]
 pub enum UntagResourcesError {
@@ -744,18 +716,14 @@ impl UntagResourcesError {
 }
 impl fmt::Display for UntagResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourcesError::InternalService(ref cause) => cause,
-            UntagResourcesError::InvalidParameter(ref cause) => cause,
-            UntagResourcesError::Throttled(ref cause) => cause,
+            UntagResourcesError::InternalService(ref cause) => write!(f, "{}", cause),
+            UntagResourcesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourcesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourcesError {}
 /// Trait representing the capabilities of the AWS Resource Groups Tagging API API. AWS Resource Groups Tagging API clients implement this trait.
 pub trait ResourceGroupsTaggingApi {
     /// <p>Describes the status of the <code>StartReportCreation</code> operation. </p> <p>You can call this operation only from the organization's master account and from the us-east-1 Region.</p>

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -7848,22 +7848,22 @@ impl AssociateVPCWithHostedZoneError {
 }
 impl fmt::Display for AssociateVPCWithHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateVPCWithHostedZoneError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateVPCWithHostedZoneError::ConflictingDomainExists(ref cause) => cause,
-            AssociateVPCWithHostedZoneError::InvalidInput(ref cause) => cause,
-            AssociateVPCWithHostedZoneError::InvalidVPCId(ref cause) => cause,
-            AssociateVPCWithHostedZoneError::LimitsExceeded(ref cause) => cause,
-            AssociateVPCWithHostedZoneError::NoSuchHostedZone(ref cause) => cause,
-            AssociateVPCWithHostedZoneError::NotAuthorized(ref cause) => cause,
-            AssociateVPCWithHostedZoneError::PublicZoneVPCAssociation(ref cause) => cause,
+            AssociateVPCWithHostedZoneError::ConflictingDomainExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateVPCWithHostedZoneError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AssociateVPCWithHostedZoneError::InvalidVPCId(ref cause) => write!(f, "{}", cause),
+            AssociateVPCWithHostedZoneError::LimitsExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateVPCWithHostedZoneError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            AssociateVPCWithHostedZoneError::NotAuthorized(ref cause) => write!(f, "{}", cause),
+            AssociateVPCWithHostedZoneError::PublicZoneVPCAssociation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateVPCWithHostedZoneError {}
 /// Errors returned by ChangeResourceRecordSets
 #[derive(Debug, PartialEq)]
 pub enum ChangeResourceRecordSetsError {
@@ -7931,20 +7931,18 @@ impl ChangeResourceRecordSetsError {
 }
 impl fmt::Display for ChangeResourceRecordSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ChangeResourceRecordSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ChangeResourceRecordSetsError::InvalidChangeBatch(ref cause) => cause,
-            ChangeResourceRecordSetsError::InvalidInput(ref cause) => cause,
-            ChangeResourceRecordSetsError::NoSuchHealthCheck(ref cause) => cause,
-            ChangeResourceRecordSetsError::NoSuchHostedZone(ref cause) => cause,
-            ChangeResourceRecordSetsError::PriorRequestNotComplete(ref cause) => cause,
+            ChangeResourceRecordSetsError::InvalidChangeBatch(ref cause) => write!(f, "{}", cause),
+            ChangeResourceRecordSetsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ChangeResourceRecordSetsError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
+            ChangeResourceRecordSetsError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            ChangeResourceRecordSetsError::PriorRequestNotComplete(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ChangeResourceRecordSetsError {}
 /// Errors returned by ChangeTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ChangeTagsForResourceError {
@@ -8012,20 +8010,18 @@ impl ChangeTagsForResourceError {
 }
 impl fmt::Display for ChangeTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ChangeTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ChangeTagsForResourceError::InvalidInput(ref cause) => cause,
-            ChangeTagsForResourceError::NoSuchHealthCheck(ref cause) => cause,
-            ChangeTagsForResourceError::NoSuchHostedZone(ref cause) => cause,
-            ChangeTagsForResourceError::PriorRequestNotComplete(ref cause) => cause,
-            ChangeTagsForResourceError::Throttling(ref cause) => cause,
+            ChangeTagsForResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ChangeTagsForResourceError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
+            ChangeTagsForResourceError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            ChangeTagsForResourceError::PriorRequestNotComplete(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ChangeTagsForResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ChangeTagsForResourceError {}
 /// Errors returned by CreateHealthCheck
 #[derive(Debug, PartialEq)]
 pub enum CreateHealthCheckError {
@@ -8077,18 +8073,14 @@ impl CreateHealthCheckError {
 }
 impl fmt::Display for CreateHealthCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHealthCheckError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHealthCheckError::HealthCheckAlreadyExists(ref cause) => cause,
-            CreateHealthCheckError::InvalidInput(ref cause) => cause,
-            CreateHealthCheckError::TooManyHealthChecks(ref cause) => cause,
+            CreateHealthCheckError::HealthCheckAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateHealthCheckError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateHealthCheckError::TooManyHealthChecks(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHealthCheckError {}
 /// Errors returned by CreateHostedZone
 #[derive(Debug, PartialEq)]
 pub enum CreateHostedZoneError {
@@ -8182,24 +8174,20 @@ impl CreateHostedZoneError {
 }
 impl fmt::Display for CreateHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHostedZoneError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHostedZoneError::ConflictingDomainExists(ref cause) => cause,
-            CreateHostedZoneError::DelegationSetNotAvailable(ref cause) => cause,
-            CreateHostedZoneError::DelegationSetNotReusable(ref cause) => cause,
-            CreateHostedZoneError::HostedZoneAlreadyExists(ref cause) => cause,
-            CreateHostedZoneError::InvalidDomainName(ref cause) => cause,
-            CreateHostedZoneError::InvalidInput(ref cause) => cause,
-            CreateHostedZoneError::InvalidVPCId(ref cause) => cause,
-            CreateHostedZoneError::NoSuchDelegationSet(ref cause) => cause,
-            CreateHostedZoneError::TooManyHostedZones(ref cause) => cause,
+            CreateHostedZoneError::ConflictingDomainExists(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::DelegationSetNotAvailable(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::DelegationSetNotReusable(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::HostedZoneAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::InvalidDomainName(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::InvalidVPCId(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::NoSuchDelegationSet(ref cause) => write!(f, "{}", cause),
+            CreateHostedZoneError::TooManyHostedZones(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHostedZoneError {}
 /// Errors returned by CreateQueryLoggingConfig
 #[derive(Debug, PartialEq)]
 pub enum CreateQueryLoggingConfigError {
@@ -8280,23 +8268,25 @@ impl CreateQueryLoggingConfigError {
 }
 impl fmt::Display for CreateQueryLoggingConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateQueryLoggingConfigError {
-    fn description(&self) -> &str {
         match *self {
-            CreateQueryLoggingConfigError::ConcurrentModification(ref cause) => cause,
-            CreateQueryLoggingConfigError::InsufficientCloudWatchLogsResourcePolicy(ref cause) => {
-                cause
+            CreateQueryLoggingConfigError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
             }
-            CreateQueryLoggingConfigError::InvalidInput(ref cause) => cause,
-            CreateQueryLoggingConfigError::NoSuchCloudWatchLogsLogGroup(ref cause) => cause,
-            CreateQueryLoggingConfigError::NoSuchHostedZone(ref cause) => cause,
-            CreateQueryLoggingConfigError::QueryLoggingConfigAlreadyExists(ref cause) => cause,
+            CreateQueryLoggingConfigError::InsufficientCloudWatchLogsResourcePolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateQueryLoggingConfigError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateQueryLoggingConfigError::NoSuchCloudWatchLogsLogGroup(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateQueryLoggingConfigError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            CreateQueryLoggingConfigError::QueryLoggingConfigAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateQueryLoggingConfigError {}
 /// Errors returned by CreateReusableDelegationSet
 #[derive(Debug, PartialEq)]
 pub enum CreateReusableDelegationSetError {
@@ -8386,22 +8376,26 @@ impl CreateReusableDelegationSetError {
 }
 impl fmt::Display for CreateReusableDelegationSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReusableDelegationSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReusableDelegationSetError::DelegationSetAlreadyCreated(ref cause) => cause,
-            CreateReusableDelegationSetError::DelegationSetAlreadyReusable(ref cause) => cause,
-            CreateReusableDelegationSetError::DelegationSetNotAvailable(ref cause) => cause,
-            CreateReusableDelegationSetError::HostedZoneNotFound(ref cause) => cause,
-            CreateReusableDelegationSetError::InvalidArgument(ref cause) => cause,
-            CreateReusableDelegationSetError::InvalidInput(ref cause) => cause,
-            CreateReusableDelegationSetError::LimitsExceeded(ref cause) => cause,
+            CreateReusableDelegationSetError::DelegationSetAlreadyCreated(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReusableDelegationSetError::DelegationSetAlreadyReusable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReusableDelegationSetError::DelegationSetNotAvailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReusableDelegationSetError::HostedZoneNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReusableDelegationSetError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            CreateReusableDelegationSetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateReusableDelegationSetError::LimitsExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateReusableDelegationSetError {}
 /// Errors returned by CreateTrafficPolicy
 #[derive(Debug, PartialEq)]
 pub enum CreateTrafficPolicyError {
@@ -8464,19 +8458,19 @@ impl CreateTrafficPolicyError {
 }
 impl fmt::Display for CreateTrafficPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrafficPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrafficPolicyError::InvalidInput(ref cause) => cause,
-            CreateTrafficPolicyError::InvalidTrafficPolicyDocument(ref cause) => cause,
-            CreateTrafficPolicyError::TooManyTrafficPolicies(ref cause) => cause,
-            CreateTrafficPolicyError::TrafficPolicyAlreadyExists(ref cause) => cause,
+            CreateTrafficPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateTrafficPolicyError::InvalidTrafficPolicyDocument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTrafficPolicyError::TooManyTrafficPolicies(ref cause) => write!(f, "{}", cause),
+            CreateTrafficPolicyError::TrafficPolicyAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateTrafficPolicyError {}
 /// Errors returned by CreateTrafficPolicyInstance
 #[derive(Debug, PartialEq)]
 pub enum CreateTrafficPolicyInstanceError {
@@ -8552,22 +8546,22 @@ impl CreateTrafficPolicyInstanceError {
 }
 impl fmt::Display for CreateTrafficPolicyInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrafficPolicyInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrafficPolicyInstanceError::InvalidInput(ref cause) => cause,
-            CreateTrafficPolicyInstanceError::NoSuchHostedZone(ref cause) => cause,
-            CreateTrafficPolicyInstanceError::NoSuchTrafficPolicy(ref cause) => cause,
-            CreateTrafficPolicyInstanceError::TooManyTrafficPolicyInstances(ref cause) => cause,
+            CreateTrafficPolicyInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateTrafficPolicyInstanceError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            CreateTrafficPolicyInstanceError::NoSuchTrafficPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTrafficPolicyInstanceError::TooManyTrafficPolicyInstances(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateTrafficPolicyInstanceError::TrafficPolicyInstanceAlreadyExists(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CreateTrafficPolicyInstanceError {}
 /// Errors returned by CreateTrafficPolicyVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateTrafficPolicyVersionError {
@@ -8610,22 +8604,24 @@ impl CreateTrafficPolicyVersionError {
 }
 impl fmt::Display for CreateTrafficPolicyVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrafficPolicyVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrafficPolicyVersionError::ConcurrentModification(ref cause) => cause,
-            CreateTrafficPolicyVersionError::InvalidInput(ref cause) => cause,
-            CreateTrafficPolicyVersionError::InvalidTrafficPolicyDocument(ref cause) => cause,
-            CreateTrafficPolicyVersionError::NoSuchTrafficPolicy(ref cause) => cause,
+            CreateTrafficPolicyVersionError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTrafficPolicyVersionError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateTrafficPolicyVersionError::InvalidTrafficPolicyDocument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateTrafficPolicyVersionError::NoSuchTrafficPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateTrafficPolicyVersionError::TooManyTrafficPolicyVersionsForCurrentPolicy(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTrafficPolicyVersionError {}
 /// Errors returned by CreateVPCAssociationAuthorization
 #[derive(Debug, PartialEq)]
 pub enum CreateVPCAssociationAuthorizationError {
@@ -8701,22 +8697,26 @@ impl CreateVPCAssociationAuthorizationError {
 }
 impl fmt::Display for CreateVPCAssociationAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVPCAssociationAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVPCAssociationAuthorizationError::ConcurrentModification(ref cause) => cause,
-            CreateVPCAssociationAuthorizationError::InvalidInput(ref cause) => cause,
-            CreateVPCAssociationAuthorizationError::InvalidVPCId(ref cause) => cause,
-            CreateVPCAssociationAuthorizationError::NoSuchHostedZone(ref cause) => cause,
+            CreateVPCAssociationAuthorizationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateVPCAssociationAuthorizationError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateVPCAssociationAuthorizationError::InvalidVPCId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateVPCAssociationAuthorizationError::NoSuchHostedZone(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateVPCAssociationAuthorizationError::TooManyVPCAssociationAuthorizations(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVPCAssociationAuthorizationError {}
 /// Errors returned by DeleteHealthCheck
 #[derive(Debug, PartialEq)]
 pub enum DeleteHealthCheckError {
@@ -8768,18 +8768,14 @@ impl DeleteHealthCheckError {
 }
 impl fmt::Display for DeleteHealthCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHealthCheckError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHealthCheckError::HealthCheckInUse(ref cause) => cause,
-            DeleteHealthCheckError::InvalidInput(ref cause) => cause,
-            DeleteHealthCheckError::NoSuchHealthCheck(ref cause) => cause,
+            DeleteHealthCheckError::HealthCheckInUse(ref cause) => write!(f, "{}", cause),
+            DeleteHealthCheckError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteHealthCheckError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteHealthCheckError {}
 /// Errors returned by DeleteHostedZone
 #[derive(Debug, PartialEq)]
 pub enum DeleteHostedZoneError {
@@ -8845,20 +8841,16 @@ impl DeleteHostedZoneError {
 }
 impl fmt::Display for DeleteHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteHostedZoneError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteHostedZoneError::HostedZoneNotEmpty(ref cause) => cause,
-            DeleteHostedZoneError::InvalidDomainName(ref cause) => cause,
-            DeleteHostedZoneError::InvalidInput(ref cause) => cause,
-            DeleteHostedZoneError::NoSuchHostedZone(ref cause) => cause,
-            DeleteHostedZoneError::PriorRequestNotComplete(ref cause) => cause,
+            DeleteHostedZoneError::HostedZoneNotEmpty(ref cause) => write!(f, "{}", cause),
+            DeleteHostedZoneError::InvalidDomainName(ref cause) => write!(f, "{}", cause),
+            DeleteHostedZoneError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteHostedZoneError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            DeleteHostedZoneError::PriorRequestNotComplete(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteHostedZoneError {}
 /// Errors returned by DeleteQueryLoggingConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteQueryLoggingConfigError {
@@ -8914,18 +8906,18 @@ impl DeleteQueryLoggingConfigError {
 }
 impl fmt::Display for DeleteQueryLoggingConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteQueryLoggingConfigError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteQueryLoggingConfigError::ConcurrentModification(ref cause) => cause,
-            DeleteQueryLoggingConfigError::InvalidInput(ref cause) => cause,
-            DeleteQueryLoggingConfigError::NoSuchQueryLoggingConfig(ref cause) => cause,
+            DeleteQueryLoggingConfigError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteQueryLoggingConfigError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteQueryLoggingConfigError::NoSuchQueryLoggingConfig(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteQueryLoggingConfigError {}
 /// Errors returned by DeleteReusableDelegationSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteReusableDelegationSetError {
@@ -8992,19 +8984,21 @@ impl DeleteReusableDelegationSetError {
 }
 impl fmt::Display for DeleteReusableDelegationSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReusableDelegationSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReusableDelegationSetError::DelegationSetInUse(ref cause) => cause,
-            DeleteReusableDelegationSetError::DelegationSetNotReusable(ref cause) => cause,
-            DeleteReusableDelegationSetError::InvalidInput(ref cause) => cause,
-            DeleteReusableDelegationSetError::NoSuchDelegationSet(ref cause) => cause,
+            DeleteReusableDelegationSetError::DelegationSetInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReusableDelegationSetError::DelegationSetNotReusable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReusableDelegationSetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteReusableDelegationSetError::NoSuchDelegationSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteReusableDelegationSetError {}
 /// Errors returned by DeleteTrafficPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteTrafficPolicyError {
@@ -9063,19 +9057,15 @@ impl DeleteTrafficPolicyError {
 }
 impl fmt::Display for DeleteTrafficPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTrafficPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTrafficPolicyError::ConcurrentModification(ref cause) => cause,
-            DeleteTrafficPolicyError::InvalidInput(ref cause) => cause,
-            DeleteTrafficPolicyError::NoSuchTrafficPolicy(ref cause) => cause,
-            DeleteTrafficPolicyError::TrafficPolicyInUse(ref cause) => cause,
+            DeleteTrafficPolicyError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteTrafficPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteTrafficPolicyError::NoSuchTrafficPolicy(ref cause) => write!(f, "{}", cause),
+            DeleteTrafficPolicyError::TrafficPolicyInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTrafficPolicyError {}
 /// Errors returned by DeleteTrafficPolicyInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteTrafficPolicyInstanceError {
@@ -9133,18 +9123,18 @@ impl DeleteTrafficPolicyInstanceError {
 }
 impl fmt::Display for DeleteTrafficPolicyInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTrafficPolicyInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTrafficPolicyInstanceError::InvalidInput(ref cause) => cause,
-            DeleteTrafficPolicyInstanceError::NoSuchTrafficPolicyInstance(ref cause) => cause,
-            DeleteTrafficPolicyInstanceError::PriorRequestNotComplete(ref cause) => cause,
+            DeleteTrafficPolicyInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteTrafficPolicyInstanceError::NoSuchTrafficPolicyInstance(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteTrafficPolicyInstanceError::PriorRequestNotComplete(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteTrafficPolicyInstanceError {}
 /// Errors returned by DeleteVPCAssociationAuthorization
 #[derive(Debug, PartialEq)]
 pub enum DeleteVPCAssociationAuthorizationError {
@@ -9220,22 +9210,26 @@ impl DeleteVPCAssociationAuthorizationError {
 }
 impl fmt::Display for DeleteVPCAssociationAuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVPCAssociationAuthorizationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVPCAssociationAuthorizationError::ConcurrentModification(ref cause) => cause,
-            DeleteVPCAssociationAuthorizationError::InvalidInput(ref cause) => cause,
-            DeleteVPCAssociationAuthorizationError::InvalidVPCId(ref cause) => cause,
-            DeleteVPCAssociationAuthorizationError::NoSuchHostedZone(ref cause) => cause,
+            DeleteVPCAssociationAuthorizationError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVPCAssociationAuthorizationError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVPCAssociationAuthorizationError::InvalidVPCId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteVPCAssociationAuthorizationError::NoSuchHostedZone(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DeleteVPCAssociationAuthorizationError::VPCAssociationAuthorizationNotFound(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVPCAssociationAuthorizationError {}
 /// Errors returned by DisassociateVPCFromHostedZone
 #[derive(Debug, PartialEq)]
 pub enum DisassociateVPCFromHostedZoneError {
@@ -9309,20 +9303,22 @@ impl DisassociateVPCFromHostedZoneError {
 }
 impl fmt::Display for DisassociateVPCFromHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateVPCFromHostedZoneError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateVPCFromHostedZoneError::InvalidInput(ref cause) => cause,
-            DisassociateVPCFromHostedZoneError::InvalidVPCId(ref cause) => cause,
-            DisassociateVPCFromHostedZoneError::LastVPCAssociation(ref cause) => cause,
-            DisassociateVPCFromHostedZoneError::NoSuchHostedZone(ref cause) => cause,
-            DisassociateVPCFromHostedZoneError::VPCAssociationNotFound(ref cause) => cause,
+            DisassociateVPCFromHostedZoneError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisassociateVPCFromHostedZoneError::InvalidVPCId(ref cause) => write!(f, "{}", cause),
+            DisassociateVPCFromHostedZoneError::LastVPCAssociation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateVPCFromHostedZoneError::NoSuchHostedZone(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateVPCFromHostedZoneError::VPCAssociationNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateVPCFromHostedZoneError {}
 /// Errors returned by GetAccountLimit
 #[derive(Debug, PartialEq)]
 pub enum GetAccountLimitError {
@@ -9360,16 +9356,12 @@ impl GetAccountLimitError {
 }
 impl fmt::Display for GetAccountLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountLimitError {
-    fn description(&self) -> &str {
         match *self {
-            GetAccountLimitError::InvalidInput(ref cause) => cause,
+            GetAccountLimitError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAccountLimitError {}
 /// Errors returned by GetChange
 #[derive(Debug, PartialEq)]
 pub enum GetChangeError {
@@ -9414,17 +9406,13 @@ impl GetChangeError {
 }
 impl fmt::Display for GetChangeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetChangeError {
-    fn description(&self) -> &str {
         match *self {
-            GetChangeError::InvalidInput(ref cause) => cause,
-            GetChangeError::NoSuchChange(ref cause) => cause,
+            GetChangeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetChangeError::NoSuchChange(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetChangeError {}
 /// Errors returned by GetCheckerIpRanges
 #[derive(Debug, PartialEq)]
 pub enum GetCheckerIpRangesError {}
@@ -9454,14 +9442,10 @@ impl GetCheckerIpRangesError {
 }
 impl fmt::Display for GetCheckerIpRangesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCheckerIpRangesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetCheckerIpRangesError {}
 /// Errors returned by GetGeoLocation
 #[derive(Debug, PartialEq)]
 pub enum GetGeoLocationError {
@@ -9506,17 +9490,13 @@ impl GetGeoLocationError {
 }
 impl fmt::Display for GetGeoLocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGeoLocationError {
-    fn description(&self) -> &str {
         match *self {
-            GetGeoLocationError::InvalidInput(ref cause) => cause,
-            GetGeoLocationError::NoSuchGeoLocation(ref cause) => cause,
+            GetGeoLocationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetGeoLocationError::NoSuchGeoLocation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGeoLocationError {}
 /// Errors returned by GetHealthCheck
 #[derive(Debug, PartialEq)]
 pub enum GetHealthCheckError {
@@ -9568,18 +9548,14 @@ impl GetHealthCheckError {
 }
 impl fmt::Display for GetHealthCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHealthCheckError {
-    fn description(&self) -> &str {
         match *self {
-            GetHealthCheckError::IncompatibleVersion(ref cause) => cause,
-            GetHealthCheckError::InvalidInput(ref cause) => cause,
-            GetHealthCheckError::NoSuchHealthCheck(ref cause) => cause,
+            GetHealthCheckError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            GetHealthCheckError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetHealthCheckError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetHealthCheckError {}
 /// Errors returned by GetHealthCheckCount
 #[derive(Debug, PartialEq)]
 pub enum GetHealthCheckCountError {}
@@ -9609,14 +9585,10 @@ impl GetHealthCheckCountError {
 }
 impl fmt::Display for GetHealthCheckCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHealthCheckCountError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetHealthCheckCountError {}
 /// Errors returned by GetHealthCheckLastFailureReason
 #[derive(Debug, PartialEq)]
 pub enum GetHealthCheckLastFailureReasonError {
@@ -9667,17 +9639,15 @@ impl GetHealthCheckLastFailureReasonError {
 }
 impl fmt::Display for GetHealthCheckLastFailureReasonError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHealthCheckLastFailureReasonError {
-    fn description(&self) -> &str {
         match *self {
-            GetHealthCheckLastFailureReasonError::InvalidInput(ref cause) => cause,
-            GetHealthCheckLastFailureReasonError::NoSuchHealthCheck(ref cause) => cause,
+            GetHealthCheckLastFailureReasonError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetHealthCheckLastFailureReasonError::NoSuchHealthCheck(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetHealthCheckLastFailureReasonError {}
 /// Errors returned by GetHealthCheckStatus
 #[derive(Debug, PartialEq)]
 pub enum GetHealthCheckStatusError {
@@ -9722,17 +9692,13 @@ impl GetHealthCheckStatusError {
 }
 impl fmt::Display for GetHealthCheckStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHealthCheckStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetHealthCheckStatusError::InvalidInput(ref cause) => cause,
-            GetHealthCheckStatusError::NoSuchHealthCheck(ref cause) => cause,
+            GetHealthCheckStatusError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetHealthCheckStatusError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetHealthCheckStatusError {}
 /// Errors returned by GetHostedZone
 #[derive(Debug, PartialEq)]
 pub enum GetHostedZoneError {
@@ -9777,17 +9743,13 @@ impl GetHostedZoneError {
 }
 impl fmt::Display for GetHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHostedZoneError {
-    fn description(&self) -> &str {
         match *self {
-            GetHostedZoneError::InvalidInput(ref cause) => cause,
-            GetHostedZoneError::NoSuchHostedZone(ref cause) => cause,
+            GetHostedZoneError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetHostedZoneError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetHostedZoneError {}
 /// Errors returned by GetHostedZoneCount
 #[derive(Debug, PartialEq)]
 pub enum GetHostedZoneCountError {
@@ -9825,16 +9787,12 @@ impl GetHostedZoneCountError {
 }
 impl fmt::Display for GetHostedZoneCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHostedZoneCountError {
-    fn description(&self) -> &str {
         match *self {
-            GetHostedZoneCountError::InvalidInput(ref cause) => cause,
+            GetHostedZoneCountError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetHostedZoneCountError {}
 /// Errors returned by GetHostedZoneLimit
 #[derive(Debug, PartialEq)]
 pub enum GetHostedZoneLimitError {
@@ -9886,18 +9844,14 @@ impl GetHostedZoneLimitError {
 }
 impl fmt::Display for GetHostedZoneLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetHostedZoneLimitError {
-    fn description(&self) -> &str {
         match *self {
-            GetHostedZoneLimitError::HostedZoneNotPrivate(ref cause) => cause,
-            GetHostedZoneLimitError::InvalidInput(ref cause) => cause,
-            GetHostedZoneLimitError::NoSuchHostedZone(ref cause) => cause,
+            GetHostedZoneLimitError::HostedZoneNotPrivate(ref cause) => write!(f, "{}", cause),
+            GetHostedZoneLimitError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetHostedZoneLimitError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetHostedZoneLimitError {}
 /// Errors returned by GetQueryLoggingConfig
 #[derive(Debug, PartialEq)]
 pub enum GetQueryLoggingConfigError {
@@ -9944,17 +9898,15 @@ impl GetQueryLoggingConfigError {
 }
 impl fmt::Display for GetQueryLoggingConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQueryLoggingConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetQueryLoggingConfigError::InvalidInput(ref cause) => cause,
-            GetQueryLoggingConfigError::NoSuchQueryLoggingConfig(ref cause) => cause,
+            GetQueryLoggingConfigError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetQueryLoggingConfigError::NoSuchQueryLoggingConfig(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetQueryLoggingConfigError {}
 /// Errors returned by GetReusableDelegationSet
 #[derive(Debug, PartialEq)]
 pub enum GetReusableDelegationSetError {
@@ -10010,18 +9962,16 @@ impl GetReusableDelegationSetError {
 }
 impl fmt::Display for GetReusableDelegationSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReusableDelegationSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetReusableDelegationSetError::DelegationSetNotReusable(ref cause) => cause,
-            GetReusableDelegationSetError::InvalidInput(ref cause) => cause,
-            GetReusableDelegationSetError::NoSuchDelegationSet(ref cause) => cause,
+            GetReusableDelegationSetError::DelegationSetNotReusable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetReusableDelegationSetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetReusableDelegationSetError::NoSuchDelegationSet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetReusableDelegationSetError {}
 /// Errors returned by GetReusableDelegationSetLimit
 #[derive(Debug, PartialEq)]
 pub enum GetReusableDelegationSetLimitError {
@@ -10070,17 +10020,15 @@ impl GetReusableDelegationSetLimitError {
 }
 impl fmt::Display for GetReusableDelegationSetLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReusableDelegationSetLimitError {
-    fn description(&self) -> &str {
         match *self {
-            GetReusableDelegationSetLimitError::InvalidInput(ref cause) => cause,
-            GetReusableDelegationSetLimitError::NoSuchDelegationSet(ref cause) => cause,
+            GetReusableDelegationSetLimitError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetReusableDelegationSetLimitError::NoSuchDelegationSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetReusableDelegationSetLimitError {}
 /// Errors returned by GetTrafficPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetTrafficPolicyError {
@@ -10125,17 +10073,13 @@ impl GetTrafficPolicyError {
 }
 impl fmt::Display for GetTrafficPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTrafficPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetTrafficPolicyError::InvalidInput(ref cause) => cause,
-            GetTrafficPolicyError::NoSuchTrafficPolicy(ref cause) => cause,
+            GetTrafficPolicyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTrafficPolicyError::NoSuchTrafficPolicy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTrafficPolicyError {}
 /// Errors returned by GetTrafficPolicyInstance
 #[derive(Debug, PartialEq)]
 pub enum GetTrafficPolicyInstanceError {
@@ -10182,17 +10126,15 @@ impl GetTrafficPolicyInstanceError {
 }
 impl fmt::Display for GetTrafficPolicyInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTrafficPolicyInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetTrafficPolicyInstanceError::InvalidInput(ref cause) => cause,
-            GetTrafficPolicyInstanceError::NoSuchTrafficPolicyInstance(ref cause) => cause,
+            GetTrafficPolicyInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetTrafficPolicyInstanceError::NoSuchTrafficPolicyInstance(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetTrafficPolicyInstanceError {}
 /// Errors returned by GetTrafficPolicyInstanceCount
 #[derive(Debug, PartialEq)]
 pub enum GetTrafficPolicyInstanceCountError {}
@@ -10224,14 +10166,10 @@ impl GetTrafficPolicyInstanceCountError {
 }
 impl fmt::Display for GetTrafficPolicyInstanceCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTrafficPolicyInstanceCountError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetTrafficPolicyInstanceCountError {}
 /// Errors returned by ListGeoLocations
 #[derive(Debug, PartialEq)]
 pub enum ListGeoLocationsError {
@@ -10269,16 +10207,12 @@ impl ListGeoLocationsError {
 }
 impl fmt::Display for ListGeoLocationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGeoLocationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGeoLocationsError::InvalidInput(ref cause) => cause,
+            ListGeoLocationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGeoLocationsError {}
 /// Errors returned by ListHealthChecks
 #[derive(Debug, PartialEq)]
 pub enum ListHealthChecksError {
@@ -10323,17 +10257,13 @@ impl ListHealthChecksError {
 }
 impl fmt::Display for ListHealthChecksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHealthChecksError {
-    fn description(&self) -> &str {
         match *self {
-            ListHealthChecksError::IncompatibleVersion(ref cause) => cause,
-            ListHealthChecksError::InvalidInput(ref cause) => cause,
+            ListHealthChecksError::IncompatibleVersion(ref cause) => write!(f, "{}", cause),
+            ListHealthChecksError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHealthChecksError {}
 /// Errors returned by ListHostedZones
 #[derive(Debug, PartialEq)]
 pub enum ListHostedZonesError {
@@ -10385,18 +10315,14 @@ impl ListHostedZonesError {
 }
 impl fmt::Display for ListHostedZonesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHostedZonesError {
-    fn description(&self) -> &str {
         match *self {
-            ListHostedZonesError::DelegationSetNotReusable(ref cause) => cause,
-            ListHostedZonesError::InvalidInput(ref cause) => cause,
-            ListHostedZonesError::NoSuchDelegationSet(ref cause) => cause,
+            ListHostedZonesError::DelegationSetNotReusable(ref cause) => write!(f, "{}", cause),
+            ListHostedZonesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListHostedZonesError::NoSuchDelegationSet(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHostedZonesError {}
 /// Errors returned by ListHostedZonesByName
 #[derive(Debug, PartialEq)]
 pub enum ListHostedZonesByNameError {
@@ -10441,17 +10367,13 @@ impl ListHostedZonesByNameError {
 }
 impl fmt::Display for ListHostedZonesByNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHostedZonesByNameError {
-    fn description(&self) -> &str {
         match *self {
-            ListHostedZonesByNameError::InvalidDomainName(ref cause) => cause,
-            ListHostedZonesByNameError::InvalidInput(ref cause) => cause,
+            ListHostedZonesByNameError::InvalidDomainName(ref cause) => write!(f, "{}", cause),
+            ListHostedZonesByNameError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListHostedZonesByNameError {}
 /// Errors returned by ListQueryLoggingConfigs
 #[derive(Debug, PartialEq)]
 pub enum ListQueryLoggingConfigsError {
@@ -10505,18 +10427,16 @@ impl ListQueryLoggingConfigsError {
 }
 impl fmt::Display for ListQueryLoggingConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQueryLoggingConfigsError {
-    fn description(&self) -> &str {
         match *self {
-            ListQueryLoggingConfigsError::InvalidInput(ref cause) => cause,
-            ListQueryLoggingConfigsError::InvalidPaginationToken(ref cause) => cause,
-            ListQueryLoggingConfigsError::NoSuchHostedZone(ref cause) => cause,
+            ListQueryLoggingConfigsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListQueryLoggingConfigsError::InvalidPaginationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListQueryLoggingConfigsError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListQueryLoggingConfigsError {}
 /// Errors returned by ListResourceRecordSets
 #[derive(Debug, PartialEq)]
 pub enum ListResourceRecordSetsError {
@@ -10561,17 +10481,13 @@ impl ListResourceRecordSetsError {
 }
 impl fmt::Display for ListResourceRecordSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceRecordSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceRecordSetsError::InvalidInput(ref cause) => cause,
-            ListResourceRecordSetsError::NoSuchHostedZone(ref cause) => cause,
+            ListResourceRecordSetsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListResourceRecordSetsError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourceRecordSetsError {}
 /// Errors returned by ListReusableDelegationSets
 #[derive(Debug, PartialEq)]
 pub enum ListReusableDelegationSetsError {
@@ -10611,16 +10527,12 @@ impl ListReusableDelegationSetsError {
 }
 impl fmt::Display for ListReusableDelegationSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReusableDelegationSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListReusableDelegationSetsError::InvalidInput(ref cause) => cause,
+            ListReusableDelegationSetsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListReusableDelegationSetsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -10686,20 +10598,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InvalidInput(ref cause) => cause,
-            ListTagsForResourceError::NoSuchHealthCheck(ref cause) => cause,
-            ListTagsForResourceError::NoSuchHostedZone(ref cause) => cause,
-            ListTagsForResourceError::PriorRequestNotComplete(ref cause) => cause,
-            ListTagsForResourceError::Throttling(ref cause) => cause,
+            ListTagsForResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::PriorRequestNotComplete(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTagsForResources
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourcesError {
@@ -10767,20 +10675,16 @@ impl ListTagsForResourcesError {
 }
 impl fmt::Display for ListTagsForResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourcesError::InvalidInput(ref cause) => cause,
-            ListTagsForResourcesError::NoSuchHealthCheck(ref cause) => cause,
-            ListTagsForResourcesError::NoSuchHostedZone(ref cause) => cause,
-            ListTagsForResourcesError::PriorRequestNotComplete(ref cause) => cause,
-            ListTagsForResourcesError::Throttling(ref cause) => cause,
+            ListTagsForResourcesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourcesError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourcesError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourcesError::PriorRequestNotComplete(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourcesError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourcesError {}
 /// Errors returned by ListTrafficPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListTrafficPoliciesError {
@@ -10818,16 +10722,12 @@ impl ListTrafficPoliciesError {
 }
 impl fmt::Display for ListTrafficPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrafficPoliciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTrafficPoliciesError::InvalidInput(ref cause) => cause,
+            ListTrafficPoliciesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTrafficPoliciesError {}
 /// Errors returned by ListTrafficPolicyInstances
 #[derive(Debug, PartialEq)]
 pub enum ListTrafficPolicyInstancesError {
@@ -10876,17 +10776,15 @@ impl ListTrafficPolicyInstancesError {
 }
 impl fmt::Display for ListTrafficPolicyInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrafficPolicyInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTrafficPolicyInstancesError::InvalidInput(ref cause) => cause,
-            ListTrafficPolicyInstancesError::NoSuchTrafficPolicyInstance(ref cause) => cause,
+            ListTrafficPolicyInstancesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTrafficPolicyInstancesError::NoSuchTrafficPolicyInstance(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListTrafficPolicyInstancesError {}
 /// Errors returned by ListTrafficPolicyInstancesByHostedZone
 #[derive(Debug, PartialEq)]
 pub enum ListTrafficPolicyInstancesByHostedZoneError {
@@ -10944,20 +10842,20 @@ impl ListTrafficPolicyInstancesByHostedZoneError {
 }
 impl fmt::Display for ListTrafficPolicyInstancesByHostedZoneError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrafficPolicyInstancesByHostedZoneError {
-    fn description(&self) -> &str {
         match *self {
-            ListTrafficPolicyInstancesByHostedZoneError::InvalidInput(ref cause) => cause,
-            ListTrafficPolicyInstancesByHostedZoneError::NoSuchHostedZone(ref cause) => cause,
+            ListTrafficPolicyInstancesByHostedZoneError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTrafficPolicyInstancesByHostedZoneError::NoSuchHostedZone(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ListTrafficPolicyInstancesByHostedZoneError::NoSuchTrafficPolicyInstance(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ListTrafficPolicyInstancesByHostedZoneError {}
 /// Errors returned by ListTrafficPolicyInstancesByPolicy
 #[derive(Debug, PartialEq)]
 pub enum ListTrafficPolicyInstancesByPolicyError {
@@ -11017,20 +10915,20 @@ impl ListTrafficPolicyInstancesByPolicyError {
 }
 impl fmt::Display for ListTrafficPolicyInstancesByPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrafficPolicyInstancesByPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            ListTrafficPolicyInstancesByPolicyError::InvalidInput(ref cause) => cause,
-            ListTrafficPolicyInstancesByPolicyError::NoSuchTrafficPolicy(ref cause) => cause,
+            ListTrafficPolicyInstancesByPolicyError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTrafficPolicyInstancesByPolicyError::NoSuchTrafficPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
             ListTrafficPolicyInstancesByPolicyError::NoSuchTrafficPolicyInstance(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for ListTrafficPolicyInstancesByPolicyError {}
 /// Errors returned by ListTrafficPolicyVersions
 #[derive(Debug, PartialEq)]
 pub enum ListTrafficPolicyVersionsError {
@@ -11077,17 +10975,15 @@ impl ListTrafficPolicyVersionsError {
 }
 impl fmt::Display for ListTrafficPolicyVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrafficPolicyVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTrafficPolicyVersionsError::InvalidInput(ref cause) => cause,
-            ListTrafficPolicyVersionsError::NoSuchTrafficPolicy(ref cause) => cause,
+            ListTrafficPolicyVersionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTrafficPolicyVersionsError::NoSuchTrafficPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListTrafficPolicyVersionsError {}
 /// Errors returned by ListVPCAssociationAuthorizations
 #[derive(Debug, PartialEq)]
 pub enum ListVPCAssociationAuthorizationsError {
@@ -11147,18 +11043,20 @@ impl ListVPCAssociationAuthorizationsError {
 }
 impl fmt::Display for ListVPCAssociationAuthorizationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVPCAssociationAuthorizationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVPCAssociationAuthorizationsError::InvalidInput(ref cause) => cause,
-            ListVPCAssociationAuthorizationsError::InvalidPaginationToken(ref cause) => cause,
-            ListVPCAssociationAuthorizationsError::NoSuchHostedZone(ref cause) => cause,
+            ListVPCAssociationAuthorizationsError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVPCAssociationAuthorizationsError::InvalidPaginationToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListVPCAssociationAuthorizationsError::NoSuchHostedZone(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListVPCAssociationAuthorizationsError {}
 /// Errors returned by TestDNSAnswer
 #[derive(Debug, PartialEq)]
 pub enum TestDNSAnswerError {
@@ -11203,17 +11101,13 @@ impl TestDNSAnswerError {
 }
 impl fmt::Display for TestDNSAnswerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestDNSAnswerError {
-    fn description(&self) -> &str {
         match *self {
-            TestDNSAnswerError::InvalidInput(ref cause) => cause,
-            TestDNSAnswerError::NoSuchHostedZone(ref cause) => cause,
+            TestDNSAnswerError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TestDNSAnswerError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestDNSAnswerError {}
 /// Errors returned by UpdateHealthCheck
 #[derive(Debug, PartialEq)]
 pub enum UpdateHealthCheckError {
@@ -11267,18 +11161,14 @@ impl UpdateHealthCheckError {
 }
 impl fmt::Display for UpdateHealthCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateHealthCheckError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateHealthCheckError::HealthCheckVersionMismatch(ref cause) => cause,
-            UpdateHealthCheckError::InvalidInput(ref cause) => cause,
-            UpdateHealthCheckError::NoSuchHealthCheck(ref cause) => cause,
+            UpdateHealthCheckError::HealthCheckVersionMismatch(ref cause) => write!(f, "{}", cause),
+            UpdateHealthCheckError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateHealthCheckError::NoSuchHealthCheck(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateHealthCheckError {}
 /// Errors returned by UpdateHostedZoneComment
 #[derive(Debug, PartialEq)]
 pub enum UpdateHostedZoneCommentError {
@@ -11323,17 +11213,13 @@ impl UpdateHostedZoneCommentError {
 }
 impl fmt::Display for UpdateHostedZoneCommentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateHostedZoneCommentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateHostedZoneCommentError::InvalidInput(ref cause) => cause,
-            UpdateHostedZoneCommentError::NoSuchHostedZone(ref cause) => cause,
+            UpdateHostedZoneCommentError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateHostedZoneCommentError::NoSuchHostedZone(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateHostedZoneCommentError {}
 /// Errors returned by UpdateTrafficPolicyComment
 #[derive(Debug, PartialEq)]
 pub enum UpdateTrafficPolicyCommentError {
@@ -11391,18 +11277,18 @@ impl UpdateTrafficPolicyCommentError {
 }
 impl fmt::Display for UpdateTrafficPolicyCommentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTrafficPolicyCommentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTrafficPolicyCommentError::ConcurrentModification(ref cause) => cause,
-            UpdateTrafficPolicyCommentError::InvalidInput(ref cause) => cause,
-            UpdateTrafficPolicyCommentError::NoSuchTrafficPolicy(ref cause) => cause,
+            UpdateTrafficPolicyCommentError::ConcurrentModification(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTrafficPolicyCommentError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateTrafficPolicyCommentError::NoSuchTrafficPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateTrafficPolicyCommentError {}
 /// Errors returned by UpdateTrafficPolicyInstance
 #[derive(Debug, PartialEq)]
 pub enum UpdateTrafficPolicyInstanceError {
@@ -11478,20 +11364,22 @@ impl UpdateTrafficPolicyInstanceError {
 }
 impl fmt::Display for UpdateTrafficPolicyInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTrafficPolicyInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTrafficPolicyInstanceError::ConflictingTypes(ref cause) => cause,
-            UpdateTrafficPolicyInstanceError::InvalidInput(ref cause) => cause,
-            UpdateTrafficPolicyInstanceError::NoSuchTrafficPolicy(ref cause) => cause,
-            UpdateTrafficPolicyInstanceError::NoSuchTrafficPolicyInstance(ref cause) => cause,
-            UpdateTrafficPolicyInstanceError::PriorRequestNotComplete(ref cause) => cause,
+            UpdateTrafficPolicyInstanceError::ConflictingTypes(ref cause) => write!(f, "{}", cause),
+            UpdateTrafficPolicyInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateTrafficPolicyInstanceError::NoSuchTrafficPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTrafficPolicyInstanceError::NoSuchTrafficPolicyInstance(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateTrafficPolicyInstanceError::PriorRequestNotComplete(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateTrafficPolicyInstanceError {}
 /// Trait representing the capabilities of the Route 53 API. Route 53 clients implement this trait.
 pub trait Route53 {
     /// <p><p>Associates an Amazon VPC with a private hosted zone. </p> <important> <p>To perform the association, the VPC and the private hosted zone must already exist. You can&#39;t convert a public hosted zone into a private hosted zone.</p> </important> <note> <p>If you want to associate a VPC that was created by using one AWS account with a private hosted zone that was created by using a different account, the AWS account that created the private hosted zone must first submit a <code>CreateVPCAssociationAuthorization</code> request. Then the account that created the VPC must submit an <code>AssociateVPCWithHostedZone</code> request.</p> </note></p>

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -900,17 +900,13 @@ impl CheckDomainAvailabilityError {
 }
 impl fmt::Display for CheckDomainAvailabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CheckDomainAvailabilityError {
-    fn description(&self) -> &str {
         match *self {
-            CheckDomainAvailabilityError::InvalidInput(ref cause) => cause,
-            CheckDomainAvailabilityError::UnsupportedTLD(ref cause) => cause,
+            CheckDomainAvailabilityError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CheckDomainAvailabilityError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CheckDomainAvailabilityError {}
 /// Errors returned by CheckDomainTransferability
 #[derive(Debug, PartialEq)]
 pub enum CheckDomainTransferabilityError {
@@ -945,17 +941,13 @@ impl CheckDomainTransferabilityError {
 }
 impl fmt::Display for CheckDomainTransferabilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CheckDomainTransferabilityError {
-    fn description(&self) -> &str {
         match *self {
-            CheckDomainTransferabilityError::InvalidInput(ref cause) => cause,
-            CheckDomainTransferabilityError::UnsupportedTLD(ref cause) => cause,
+            CheckDomainTransferabilityError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CheckDomainTransferabilityError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CheckDomainTransferabilityError {}
 /// Errors returned by DeleteTagsForDomain
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsForDomainError {
@@ -991,18 +983,14 @@ impl DeleteTagsForDomainError {
 }
 impl fmt::Display for DeleteTagsForDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsForDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsForDomainError::InvalidInput(ref cause) => cause,
-            DeleteTagsForDomainError::OperationLimitExceeded(ref cause) => cause,
-            DeleteTagsForDomainError::UnsupportedTLD(ref cause) => cause,
+            DeleteTagsForDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteTagsForDomainError::OperationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteTagsForDomainError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsForDomainError {}
 /// Errors returned by DisableDomainAutoRenew
 #[derive(Debug, PartialEq)]
 pub enum DisableDomainAutoRenewError {
@@ -1033,17 +1021,13 @@ impl DisableDomainAutoRenewError {
 }
 impl fmt::Display for DisableDomainAutoRenewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableDomainAutoRenewError {
-    fn description(&self) -> &str {
         match *self {
-            DisableDomainAutoRenewError::InvalidInput(ref cause) => cause,
-            DisableDomainAutoRenewError::UnsupportedTLD(ref cause) => cause,
+            DisableDomainAutoRenewError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisableDomainAutoRenewError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableDomainAutoRenewError {}
 /// Errors returned by DisableDomainTransferLock
 #[derive(Debug, PartialEq)]
 pub enum DisableDomainTransferLockError {
@@ -1097,20 +1081,18 @@ impl DisableDomainTransferLockError {
 }
 impl fmt::Display for DisableDomainTransferLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableDomainTransferLockError {
-    fn description(&self) -> &str {
         match *self {
-            DisableDomainTransferLockError::DuplicateRequest(ref cause) => cause,
-            DisableDomainTransferLockError::InvalidInput(ref cause) => cause,
-            DisableDomainTransferLockError::OperationLimitExceeded(ref cause) => cause,
-            DisableDomainTransferLockError::TLDRulesViolation(ref cause) => cause,
-            DisableDomainTransferLockError::UnsupportedTLD(ref cause) => cause,
+            DisableDomainTransferLockError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            DisableDomainTransferLockError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisableDomainTransferLockError::OperationLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisableDomainTransferLockError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            DisableDomainTransferLockError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableDomainTransferLockError {}
 /// Errors returned by EnableDomainAutoRenew
 #[derive(Debug, PartialEq)]
 pub enum EnableDomainAutoRenewError {
@@ -1148,18 +1130,14 @@ impl EnableDomainAutoRenewError {
 }
 impl fmt::Display for EnableDomainAutoRenewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableDomainAutoRenewError {
-    fn description(&self) -> &str {
         match *self {
-            EnableDomainAutoRenewError::InvalidInput(ref cause) => cause,
-            EnableDomainAutoRenewError::TLDRulesViolation(ref cause) => cause,
-            EnableDomainAutoRenewError::UnsupportedTLD(ref cause) => cause,
+            EnableDomainAutoRenewError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            EnableDomainAutoRenewError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            EnableDomainAutoRenewError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableDomainAutoRenewError {}
 /// Errors returned by EnableDomainTransferLock
 #[derive(Debug, PartialEq)]
 pub enum EnableDomainTransferLockError {
@@ -1213,20 +1191,18 @@ impl EnableDomainTransferLockError {
 }
 impl fmt::Display for EnableDomainTransferLockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableDomainTransferLockError {
-    fn description(&self) -> &str {
         match *self {
-            EnableDomainTransferLockError::DuplicateRequest(ref cause) => cause,
-            EnableDomainTransferLockError::InvalidInput(ref cause) => cause,
-            EnableDomainTransferLockError::OperationLimitExceeded(ref cause) => cause,
-            EnableDomainTransferLockError::TLDRulesViolation(ref cause) => cause,
-            EnableDomainTransferLockError::UnsupportedTLD(ref cause) => cause,
+            EnableDomainTransferLockError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            EnableDomainTransferLockError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            EnableDomainTransferLockError::OperationLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableDomainTransferLockError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            EnableDomainTransferLockError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableDomainTransferLockError {}
 /// Errors returned by GetContactReachabilityStatus
 #[derive(Debug, PartialEq)]
 pub enum GetContactReachabilityStatusError {
@@ -1268,18 +1244,16 @@ impl GetContactReachabilityStatusError {
 }
 impl fmt::Display for GetContactReachabilityStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetContactReachabilityStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetContactReachabilityStatusError::InvalidInput(ref cause) => cause,
-            GetContactReachabilityStatusError::OperationLimitExceeded(ref cause) => cause,
-            GetContactReachabilityStatusError::UnsupportedTLD(ref cause) => cause,
+            GetContactReachabilityStatusError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetContactReachabilityStatusError::OperationLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetContactReachabilityStatusError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetContactReachabilityStatusError {}
 /// Errors returned by GetDomainDetail
 #[derive(Debug, PartialEq)]
 pub enum GetDomainDetailError {
@@ -1308,17 +1282,13 @@ impl GetDomainDetailError {
 }
 impl fmt::Display for GetDomainDetailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainDetailError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainDetailError::InvalidInput(ref cause) => cause,
-            GetDomainDetailError::UnsupportedTLD(ref cause) => cause,
+            GetDomainDetailError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDomainDetailError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainDetailError {}
 /// Errors returned by GetDomainSuggestions
 #[derive(Debug, PartialEq)]
 pub enum GetDomainSuggestionsError {
@@ -1347,17 +1317,13 @@ impl GetDomainSuggestionsError {
 }
 impl fmt::Display for GetDomainSuggestionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDomainSuggestionsError {
-    fn description(&self) -> &str {
         match *self {
-            GetDomainSuggestionsError::InvalidInput(ref cause) => cause,
-            GetDomainSuggestionsError::UnsupportedTLD(ref cause) => cause,
+            GetDomainSuggestionsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetDomainSuggestionsError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDomainSuggestionsError {}
 /// Errors returned by GetOperationDetail
 #[derive(Debug, PartialEq)]
 pub enum GetOperationDetailError {
@@ -1381,16 +1347,12 @@ impl GetOperationDetailError {
 }
 impl fmt::Display for GetOperationDetailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOperationDetailError {
-    fn description(&self) -> &str {
         match *self {
-            GetOperationDetailError::InvalidInput(ref cause) => cause,
+            GetOperationDetailError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOperationDetailError {}
 /// Errors returned by ListDomains
 #[derive(Debug, PartialEq)]
 pub enum ListDomainsError {
@@ -1414,16 +1376,12 @@ impl ListDomainsError {
 }
 impl fmt::Display for ListDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDomainsError::InvalidInput(ref cause) => cause,
+            ListDomainsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDomainsError {}
 /// Errors returned by ListOperations
 #[derive(Debug, PartialEq)]
 pub enum ListOperationsError {
@@ -1447,16 +1405,12 @@ impl ListOperationsError {
 }
 impl fmt::Display for ListOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOperationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOperationsError::InvalidInput(ref cause) => cause,
+            ListOperationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOperationsError {}
 /// Errors returned by ListTagsForDomain
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForDomainError {
@@ -1492,18 +1446,14 @@ impl ListTagsForDomainError {
 }
 impl fmt::Display for ListTagsForDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForDomainError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForDomainError::InvalidInput(ref cause) => cause,
-            ListTagsForDomainError::OperationLimitExceeded(ref cause) => cause,
-            ListTagsForDomainError::UnsupportedTLD(ref cause) => cause,
+            ListTagsForDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTagsForDomainError::OperationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ListTagsForDomainError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForDomainError {}
 /// Errors returned by RegisterDomain
 #[derive(Debug, PartialEq)]
 pub enum RegisterDomainError {
@@ -1554,21 +1504,17 @@ impl RegisterDomainError {
 }
 impl fmt::Display for RegisterDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterDomainError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterDomainError::DomainLimitExceeded(ref cause) => cause,
-            RegisterDomainError::DuplicateRequest(ref cause) => cause,
-            RegisterDomainError::InvalidInput(ref cause) => cause,
-            RegisterDomainError::OperationLimitExceeded(ref cause) => cause,
-            RegisterDomainError::TLDRulesViolation(ref cause) => cause,
-            RegisterDomainError::UnsupportedTLD(ref cause) => cause,
+            RegisterDomainError::DomainLimitExceeded(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::OperationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterDomainError {}
 /// Errors returned by RenewDomain
 #[derive(Debug, PartialEq)]
 pub enum RenewDomainError {
@@ -1612,20 +1558,16 @@ impl RenewDomainError {
 }
 impl fmt::Display for RenewDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RenewDomainError {
-    fn description(&self) -> &str {
         match *self {
-            RenewDomainError::DuplicateRequest(ref cause) => cause,
-            RenewDomainError::InvalidInput(ref cause) => cause,
-            RenewDomainError::OperationLimitExceeded(ref cause) => cause,
-            RenewDomainError::TLDRulesViolation(ref cause) => cause,
-            RenewDomainError::UnsupportedTLD(ref cause) => cause,
+            RenewDomainError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            RenewDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RenewDomainError::OperationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            RenewDomainError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            RenewDomainError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RenewDomainError {}
 /// Errors returned by ResendContactReachabilityEmail
 #[derive(Debug, PartialEq)]
 pub enum ResendContactReachabilityEmailError {
@@ -1667,18 +1609,18 @@ impl ResendContactReachabilityEmailError {
 }
 impl fmt::Display for ResendContactReachabilityEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResendContactReachabilityEmailError {
-    fn description(&self) -> &str {
         match *self {
-            ResendContactReachabilityEmailError::InvalidInput(ref cause) => cause,
-            ResendContactReachabilityEmailError::OperationLimitExceeded(ref cause) => cause,
-            ResendContactReachabilityEmailError::UnsupportedTLD(ref cause) => cause,
+            ResendContactReachabilityEmailError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ResendContactReachabilityEmailError::OperationLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResendContactReachabilityEmailError::UnsupportedTLD(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ResendContactReachabilityEmailError {}
 /// Errors returned by RetrieveDomainAuthCode
 #[derive(Debug, PartialEq)]
 pub enum RetrieveDomainAuthCodeError {
@@ -1709,17 +1651,13 @@ impl RetrieveDomainAuthCodeError {
 }
 impl fmt::Display for RetrieveDomainAuthCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RetrieveDomainAuthCodeError {
-    fn description(&self) -> &str {
         match *self {
-            RetrieveDomainAuthCodeError::InvalidInput(ref cause) => cause,
-            RetrieveDomainAuthCodeError::UnsupportedTLD(ref cause) => cause,
+            RetrieveDomainAuthCodeError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RetrieveDomainAuthCodeError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RetrieveDomainAuthCodeError {}
 /// Errors returned by TransferDomain
 #[derive(Debug, PartialEq)]
 pub enum TransferDomainError {
@@ -1770,21 +1708,17 @@ impl TransferDomainError {
 }
 impl fmt::Display for TransferDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TransferDomainError {
-    fn description(&self) -> &str {
         match *self {
-            TransferDomainError::DomainLimitExceeded(ref cause) => cause,
-            TransferDomainError::DuplicateRequest(ref cause) => cause,
-            TransferDomainError::InvalidInput(ref cause) => cause,
-            TransferDomainError::OperationLimitExceeded(ref cause) => cause,
-            TransferDomainError::TLDRulesViolation(ref cause) => cause,
-            TransferDomainError::UnsupportedTLD(ref cause) => cause,
+            TransferDomainError::DomainLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TransferDomainError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            TransferDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TransferDomainError::OperationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TransferDomainError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            TransferDomainError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TransferDomainError {}
 /// Errors returned by UpdateDomainContact
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainContactError {
@@ -1834,20 +1768,16 @@ impl UpdateDomainContactError {
 }
 impl fmt::Display for UpdateDomainContactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainContactError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainContactError::DuplicateRequest(ref cause) => cause,
-            UpdateDomainContactError::InvalidInput(ref cause) => cause,
-            UpdateDomainContactError::OperationLimitExceeded(ref cause) => cause,
-            UpdateDomainContactError::TLDRulesViolation(ref cause) => cause,
-            UpdateDomainContactError::UnsupportedTLD(ref cause) => cause,
+            UpdateDomainContactError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainContactError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDomainContactError::OperationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDomainContactError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            UpdateDomainContactError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainContactError {}
 /// Errors returned by UpdateDomainContactPrivacy
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainContactPrivacyError {
@@ -1903,20 +1833,18 @@ impl UpdateDomainContactPrivacyError {
 }
 impl fmt::Display for UpdateDomainContactPrivacyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainContactPrivacyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainContactPrivacyError::DuplicateRequest(ref cause) => cause,
-            UpdateDomainContactPrivacyError::InvalidInput(ref cause) => cause,
-            UpdateDomainContactPrivacyError::OperationLimitExceeded(ref cause) => cause,
-            UpdateDomainContactPrivacyError::TLDRulesViolation(ref cause) => cause,
-            UpdateDomainContactPrivacyError::UnsupportedTLD(ref cause) => cause,
+            UpdateDomainContactPrivacyError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainContactPrivacyError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDomainContactPrivacyError::OperationLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDomainContactPrivacyError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            UpdateDomainContactPrivacyError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainContactPrivacyError {}
 /// Errors returned by UpdateDomainNameservers
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainNameserversError {
@@ -1970,20 +1898,18 @@ impl UpdateDomainNameserversError {
 }
 impl fmt::Display for UpdateDomainNameserversError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainNameserversError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainNameserversError::DuplicateRequest(ref cause) => cause,
-            UpdateDomainNameserversError::InvalidInput(ref cause) => cause,
-            UpdateDomainNameserversError::OperationLimitExceeded(ref cause) => cause,
-            UpdateDomainNameserversError::TLDRulesViolation(ref cause) => cause,
-            UpdateDomainNameserversError::UnsupportedTLD(ref cause) => cause,
+            UpdateDomainNameserversError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameserversError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameserversError::OperationLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDomainNameserversError::TLDRulesViolation(ref cause) => write!(f, "{}", cause),
+            UpdateDomainNameserversError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainNameserversError {}
 /// Errors returned by UpdateTagsForDomain
 #[derive(Debug, PartialEq)]
 pub enum UpdateTagsForDomainError {
@@ -2019,18 +1945,14 @@ impl UpdateTagsForDomainError {
 }
 impl fmt::Display for UpdateTagsForDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTagsForDomainError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTagsForDomainError::InvalidInput(ref cause) => cause,
-            UpdateTagsForDomainError::OperationLimitExceeded(ref cause) => cause,
-            UpdateTagsForDomainError::UnsupportedTLD(ref cause) => cause,
+            UpdateTagsForDomainError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateTagsForDomainError::OperationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateTagsForDomainError::UnsupportedTLD(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTagsForDomainError {}
 /// Errors returned by ViewBilling
 #[derive(Debug, PartialEq)]
 pub enum ViewBillingError {
@@ -2054,16 +1976,12 @@ impl ViewBillingError {
 }
 impl fmt::Display for ViewBillingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ViewBillingError {
-    fn description(&self) -> &str {
         match *self {
-            ViewBillingError::InvalidInput(ref cause) => cause,
+            ViewBillingError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ViewBillingError {}
 /// Trait representing the capabilities of the Amazon Route 53 Domains API. Amazon Route 53 Domains clients implement this trait.
 pub trait Route53Domains {
     /// <p>This operation checks the availability of one domain name. Note that if the availability status of a domain is pending, you must submit another request to determine the availability of the domain name.</p>

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -15478,16 +15478,12 @@ impl AbortMultipartUploadError {
 }
 impl fmt::Display for AbortMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AbortMultipartUploadError {
-    fn description(&self) -> &str {
         match *self {
-            AbortMultipartUploadError::NoSuchUpload(ref cause) => cause,
+            AbortMultipartUploadError::NoSuchUpload(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AbortMultipartUploadError {}
 /// Errors returned by CompleteMultipartUpload
 #[derive(Debug, PartialEq)]
 pub enum CompleteMultipartUploadError {}
@@ -15516,14 +15512,10 @@ impl CompleteMultipartUploadError {
 }
 impl fmt::Display for CompleteMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CompleteMultipartUploadError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CompleteMultipartUploadError {}
 /// Errors returned by CopyObject
 #[derive(Debug, PartialEq)]
 pub enum CopyObjectError {
@@ -15560,16 +15552,12 @@ impl CopyObjectError {
 }
 impl fmt::Display for CopyObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyObjectError {
-    fn description(&self) -> &str {
         match *self {
-            CopyObjectError::ObjectNotInActiveTierError(ref cause) => cause,
+            CopyObjectError::ObjectNotInActiveTierError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopyObjectError {}
 /// Errors returned by CreateBucket
 #[derive(Debug, PartialEq)]
 pub enum CreateBucketError {
@@ -15613,17 +15601,13 @@ impl CreateBucketError {
 }
 impl fmt::Display for CreateBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateBucketError {
-    fn description(&self) -> &str {
         match *self {
-            CreateBucketError::BucketAlreadyExists(ref cause) => cause,
-            CreateBucketError::BucketAlreadyOwnedByYou(ref cause) => cause,
+            CreateBucketError::BucketAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateBucketError::BucketAlreadyOwnedByYou(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateBucketError {}
 /// Errors returned by CreateMultipartUpload
 #[derive(Debug, PartialEq)]
 pub enum CreateMultipartUploadError {}
@@ -15652,14 +15636,10 @@ impl CreateMultipartUploadError {
 }
 impl fmt::Display for CreateMultipartUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMultipartUploadError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreateMultipartUploadError {}
 /// Errors returned by DeleteBucket
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketError {}
@@ -15688,14 +15668,10 @@ impl DeleteBucketError {
 }
 impl fmt::Display for DeleteBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketError {}
 /// Errors returned by DeleteBucketAnalyticsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketAnalyticsConfigurationError {}
@@ -15726,14 +15702,10 @@ impl DeleteBucketAnalyticsConfigurationError {
 }
 impl fmt::Display for DeleteBucketAnalyticsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketAnalyticsConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketAnalyticsConfigurationError {}
 /// Errors returned by DeleteBucketCors
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketCorsError {}
@@ -15762,14 +15734,10 @@ impl DeleteBucketCorsError {
 }
 impl fmt::Display for DeleteBucketCorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketCorsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketCorsError {}
 /// Errors returned by DeleteBucketEncryption
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketEncryptionError {}
@@ -15798,14 +15766,10 @@ impl DeleteBucketEncryptionError {
 }
 impl fmt::Display for DeleteBucketEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketEncryptionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketEncryptionError {}
 /// Errors returned by DeleteBucketInventoryConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketInventoryConfigurationError {}
@@ -15836,14 +15800,10 @@ impl DeleteBucketInventoryConfigurationError {
 }
 impl fmt::Display for DeleteBucketInventoryConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketInventoryConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketInventoryConfigurationError {}
 /// Errors returned by DeleteBucketLifecycle
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketLifecycleError {}
@@ -15872,14 +15832,10 @@ impl DeleteBucketLifecycleError {
 }
 impl fmt::Display for DeleteBucketLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketLifecycleError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketLifecycleError {}
 /// Errors returned by DeleteBucketMetricsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketMetricsConfigurationError {}
@@ -15910,14 +15866,10 @@ impl DeleteBucketMetricsConfigurationError {
 }
 impl fmt::Display for DeleteBucketMetricsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketMetricsConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketMetricsConfigurationError {}
 /// Errors returned by DeleteBucketPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketPolicyError {}
@@ -15946,14 +15898,10 @@ impl DeleteBucketPolicyError {
 }
 impl fmt::Display for DeleteBucketPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketPolicyError {}
 /// Errors returned by DeleteBucketReplication
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketReplicationError {}
@@ -15982,14 +15930,10 @@ impl DeleteBucketReplicationError {
 }
 impl fmt::Display for DeleteBucketReplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketReplicationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketReplicationError {}
 /// Errors returned by DeleteBucketTagging
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketTaggingError {}
@@ -16018,14 +15962,10 @@ impl DeleteBucketTaggingError {
 }
 impl fmt::Display for DeleteBucketTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketTaggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketTaggingError {}
 /// Errors returned by DeleteBucketWebsite
 #[derive(Debug, PartialEq)]
 pub enum DeleteBucketWebsiteError {}
@@ -16054,14 +15994,10 @@ impl DeleteBucketWebsiteError {
 }
 impl fmt::Display for DeleteBucketWebsiteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBucketWebsiteError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteBucketWebsiteError {}
 /// Errors returned by DeleteObject
 #[derive(Debug, PartialEq)]
 pub enum DeleteObjectError {}
@@ -16090,14 +16026,10 @@ impl DeleteObjectError {
 }
 impl fmt::Display for DeleteObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteObjectError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteObjectError {}
 /// Errors returned by DeleteObjectTagging
 #[derive(Debug, PartialEq)]
 pub enum DeleteObjectTaggingError {}
@@ -16126,14 +16058,10 @@ impl DeleteObjectTaggingError {
 }
 impl fmt::Display for DeleteObjectTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteObjectTaggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteObjectTaggingError {}
 /// Errors returned by DeleteObjects
 #[derive(Debug, PartialEq)]
 pub enum DeleteObjectsError {}
@@ -16162,14 +16090,10 @@ impl DeleteObjectsError {
 }
 impl fmt::Display for DeleteObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteObjectsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteObjectsError {}
 /// Errors returned by DeletePublicAccessBlock
 #[derive(Debug, PartialEq)]
 pub enum DeletePublicAccessBlockError {}
@@ -16198,14 +16122,10 @@ impl DeletePublicAccessBlockError {
 }
 impl fmt::Display for DeletePublicAccessBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePublicAccessBlockError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeletePublicAccessBlockError {}
 /// Errors returned by GetBucketAccelerateConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetBucketAccelerateConfigurationError {}
@@ -16236,14 +16156,10 @@ impl GetBucketAccelerateConfigurationError {
 }
 impl fmt::Display for GetBucketAccelerateConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketAccelerateConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketAccelerateConfigurationError {}
 /// Errors returned by GetBucketAcl
 #[derive(Debug, PartialEq)]
 pub enum GetBucketAclError {}
@@ -16272,14 +16188,10 @@ impl GetBucketAclError {
 }
 impl fmt::Display for GetBucketAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketAclError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketAclError {}
 /// Errors returned by GetBucketAnalyticsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetBucketAnalyticsConfigurationError {}
@@ -16310,14 +16222,10 @@ impl GetBucketAnalyticsConfigurationError {
 }
 impl fmt::Display for GetBucketAnalyticsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketAnalyticsConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketAnalyticsConfigurationError {}
 /// Errors returned by GetBucketCors
 #[derive(Debug, PartialEq)]
 pub enum GetBucketCorsError {}
@@ -16346,14 +16254,10 @@ impl GetBucketCorsError {
 }
 impl fmt::Display for GetBucketCorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketCorsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketCorsError {}
 /// Errors returned by GetBucketEncryption
 #[derive(Debug, PartialEq)]
 pub enum GetBucketEncryptionError {}
@@ -16382,14 +16286,10 @@ impl GetBucketEncryptionError {
 }
 impl fmt::Display for GetBucketEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketEncryptionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketEncryptionError {}
 /// Errors returned by GetBucketInventoryConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetBucketInventoryConfigurationError {}
@@ -16420,14 +16320,10 @@ impl GetBucketInventoryConfigurationError {
 }
 impl fmt::Display for GetBucketInventoryConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketInventoryConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketInventoryConfigurationError {}
 /// Errors returned by GetBucketLifecycle
 #[derive(Debug, PartialEq)]
 pub enum GetBucketLifecycleError {}
@@ -16456,14 +16352,10 @@ impl GetBucketLifecycleError {
 }
 impl fmt::Display for GetBucketLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketLifecycleError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketLifecycleError {}
 /// Errors returned by GetBucketLifecycleConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetBucketLifecycleConfigurationError {}
@@ -16494,14 +16386,10 @@ impl GetBucketLifecycleConfigurationError {
 }
 impl fmt::Display for GetBucketLifecycleConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketLifecycleConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketLifecycleConfigurationError {}
 /// Errors returned by GetBucketLocation
 #[derive(Debug, PartialEq)]
 pub enum GetBucketLocationError {}
@@ -16530,14 +16418,10 @@ impl GetBucketLocationError {
 }
 impl fmt::Display for GetBucketLocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketLocationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketLocationError {}
 /// Errors returned by GetBucketLogging
 #[derive(Debug, PartialEq)]
 pub enum GetBucketLoggingError {}
@@ -16566,14 +16450,10 @@ impl GetBucketLoggingError {
 }
 impl fmt::Display for GetBucketLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketLoggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketLoggingError {}
 /// Errors returned by GetBucketMetricsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetBucketMetricsConfigurationError {}
@@ -16604,14 +16484,10 @@ impl GetBucketMetricsConfigurationError {
 }
 impl fmt::Display for GetBucketMetricsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketMetricsConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketMetricsConfigurationError {}
 /// Errors returned by GetBucketNotification
 #[derive(Debug, PartialEq)]
 pub enum GetBucketNotificationError {}
@@ -16640,14 +16516,10 @@ impl GetBucketNotificationError {
 }
 impl fmt::Display for GetBucketNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketNotificationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketNotificationError {}
 /// Errors returned by GetBucketNotificationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetBucketNotificationConfigurationError {}
@@ -16678,14 +16550,10 @@ impl GetBucketNotificationConfigurationError {
 }
 impl fmt::Display for GetBucketNotificationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketNotificationConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketNotificationConfigurationError {}
 /// Errors returned by GetBucketPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetBucketPolicyError {}
@@ -16714,14 +16582,10 @@ impl GetBucketPolicyError {
 }
 impl fmt::Display for GetBucketPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketPolicyError {}
 /// Errors returned by GetBucketPolicyStatus
 #[derive(Debug, PartialEq)]
 pub enum GetBucketPolicyStatusError {}
@@ -16750,14 +16614,10 @@ impl GetBucketPolicyStatusError {
 }
 impl fmt::Display for GetBucketPolicyStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketPolicyStatusError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketPolicyStatusError {}
 /// Errors returned by GetBucketReplication
 #[derive(Debug, PartialEq)]
 pub enum GetBucketReplicationError {}
@@ -16786,14 +16646,10 @@ impl GetBucketReplicationError {
 }
 impl fmt::Display for GetBucketReplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketReplicationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketReplicationError {}
 /// Errors returned by GetBucketRequestPayment
 #[derive(Debug, PartialEq)]
 pub enum GetBucketRequestPaymentError {}
@@ -16822,14 +16678,10 @@ impl GetBucketRequestPaymentError {
 }
 impl fmt::Display for GetBucketRequestPaymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketRequestPaymentError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketRequestPaymentError {}
 /// Errors returned by GetBucketTagging
 #[derive(Debug, PartialEq)]
 pub enum GetBucketTaggingError {}
@@ -16858,14 +16710,10 @@ impl GetBucketTaggingError {
 }
 impl fmt::Display for GetBucketTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketTaggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketTaggingError {}
 /// Errors returned by GetBucketVersioning
 #[derive(Debug, PartialEq)]
 pub enum GetBucketVersioningError {}
@@ -16894,14 +16742,10 @@ impl GetBucketVersioningError {
 }
 impl fmt::Display for GetBucketVersioningError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketVersioningError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketVersioningError {}
 /// Errors returned by GetBucketWebsite
 #[derive(Debug, PartialEq)]
 pub enum GetBucketWebsiteError {}
@@ -16930,14 +16774,10 @@ impl GetBucketWebsiteError {
 }
 impl fmt::Display for GetBucketWebsiteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetBucketWebsiteError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetBucketWebsiteError {}
 /// Errors returned by GetObject
 #[derive(Debug, PartialEq)]
 pub enum GetObjectError {
@@ -16974,16 +16814,12 @@ impl GetObjectError {
 }
 impl fmt::Display for GetObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectError {
-    fn description(&self) -> &str {
         match *self {
-            GetObjectError::NoSuchKey(ref cause) => cause,
+            GetObjectError::NoSuchKey(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetObjectError {}
 /// Errors returned by GetObjectAcl
 #[derive(Debug, PartialEq)]
 pub enum GetObjectAclError {
@@ -17020,16 +16856,12 @@ impl GetObjectAclError {
 }
 impl fmt::Display for GetObjectAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectAclError {
-    fn description(&self) -> &str {
         match *self {
-            GetObjectAclError::NoSuchKey(ref cause) => cause,
+            GetObjectAclError::NoSuchKey(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetObjectAclError {}
 /// Errors returned by GetObjectLegalHold
 #[derive(Debug, PartialEq)]
 pub enum GetObjectLegalHoldError {}
@@ -17058,14 +16890,10 @@ impl GetObjectLegalHoldError {
 }
 impl fmt::Display for GetObjectLegalHoldError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectLegalHoldError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetObjectLegalHoldError {}
 /// Errors returned by GetObjectLockConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetObjectLockConfigurationError {}
@@ -17096,14 +16924,10 @@ impl GetObjectLockConfigurationError {
 }
 impl fmt::Display for GetObjectLockConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectLockConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetObjectLockConfigurationError {}
 /// Errors returned by GetObjectRetention
 #[derive(Debug, PartialEq)]
 pub enum GetObjectRetentionError {}
@@ -17132,14 +16956,10 @@ impl GetObjectRetentionError {
 }
 impl fmt::Display for GetObjectRetentionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectRetentionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetObjectRetentionError {}
 /// Errors returned by GetObjectTagging
 #[derive(Debug, PartialEq)]
 pub enum GetObjectTaggingError {}
@@ -17168,14 +16988,10 @@ impl GetObjectTaggingError {
 }
 impl fmt::Display for GetObjectTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectTaggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetObjectTaggingError {}
 /// Errors returned by GetObjectTorrent
 #[derive(Debug, PartialEq)]
 pub enum GetObjectTorrentError {}
@@ -17204,14 +17020,10 @@ impl GetObjectTorrentError {
 }
 impl fmt::Display for GetObjectTorrentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetObjectTorrentError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetObjectTorrentError {}
 /// Errors returned by GetPublicAccessBlock
 #[derive(Debug, PartialEq)]
 pub enum GetPublicAccessBlockError {}
@@ -17240,14 +17052,10 @@ impl GetPublicAccessBlockError {
 }
 impl fmt::Display for GetPublicAccessBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPublicAccessBlockError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetPublicAccessBlockError {}
 /// Errors returned by HeadBucket
 #[derive(Debug, PartialEq)]
 pub enum HeadBucketError {
@@ -17284,16 +17092,12 @@ impl HeadBucketError {
 }
 impl fmt::Display for HeadBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for HeadBucketError {
-    fn description(&self) -> &str {
         match *self {
-            HeadBucketError::NoSuchBucket(ref cause) => cause,
+            HeadBucketError::NoSuchBucket(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for HeadBucketError {}
 /// Errors returned by HeadObject
 #[derive(Debug, PartialEq)]
 pub enum HeadObjectError {
@@ -17330,16 +17134,12 @@ impl HeadObjectError {
 }
 impl fmt::Display for HeadObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for HeadObjectError {
-    fn description(&self) -> &str {
         match *self {
-            HeadObjectError::NoSuchKey(ref cause) => cause,
+            HeadObjectError::NoSuchKey(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for HeadObjectError {}
 /// Errors returned by ListBucketAnalyticsConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListBucketAnalyticsConfigurationsError {}
@@ -17370,14 +17170,10 @@ impl ListBucketAnalyticsConfigurationsError {
 }
 impl fmt::Display for ListBucketAnalyticsConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBucketAnalyticsConfigurationsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListBucketAnalyticsConfigurationsError {}
 /// Errors returned by ListBucketInventoryConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListBucketInventoryConfigurationsError {}
@@ -17408,14 +17204,10 @@ impl ListBucketInventoryConfigurationsError {
 }
 impl fmt::Display for ListBucketInventoryConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBucketInventoryConfigurationsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListBucketInventoryConfigurationsError {}
 /// Errors returned by ListBucketMetricsConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListBucketMetricsConfigurationsError {}
@@ -17446,14 +17238,10 @@ impl ListBucketMetricsConfigurationsError {
 }
 impl fmt::Display for ListBucketMetricsConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBucketMetricsConfigurationsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListBucketMetricsConfigurationsError {}
 /// Errors returned by ListBuckets
 #[derive(Debug, PartialEq)]
 pub enum ListBucketsError {}
@@ -17482,14 +17270,10 @@ impl ListBucketsError {
 }
 impl fmt::Display for ListBucketsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBucketsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListBucketsError {}
 /// Errors returned by ListMultipartUploads
 #[derive(Debug, PartialEq)]
 pub enum ListMultipartUploadsError {}
@@ -17518,14 +17302,10 @@ impl ListMultipartUploadsError {
 }
 impl fmt::Display for ListMultipartUploadsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMultipartUploadsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListMultipartUploadsError {}
 /// Errors returned by ListObjectVersions
 #[derive(Debug, PartialEq)]
 pub enum ListObjectVersionsError {}
@@ -17554,14 +17334,10 @@ impl ListObjectVersionsError {
 }
 impl fmt::Display for ListObjectVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectVersionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListObjectVersionsError {}
 /// Errors returned by ListObjects
 #[derive(Debug, PartialEq)]
 pub enum ListObjectsError {
@@ -17598,16 +17374,12 @@ impl ListObjectsError {
 }
 impl fmt::Display for ListObjectsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectsError {
-    fn description(&self) -> &str {
         match *self {
-            ListObjectsError::NoSuchBucket(ref cause) => cause,
+            ListObjectsError::NoSuchBucket(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListObjectsError {}
 /// Errors returned by ListObjectsV2
 #[derive(Debug, PartialEq)]
 pub enum ListObjectsV2Error {
@@ -17644,16 +17416,12 @@ impl ListObjectsV2Error {
 }
 impl fmt::Display for ListObjectsV2Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListObjectsV2Error {
-    fn description(&self) -> &str {
         match *self {
-            ListObjectsV2Error::NoSuchBucket(ref cause) => cause,
+            ListObjectsV2Error::NoSuchBucket(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListObjectsV2Error {}
 /// Errors returned by ListParts
 #[derive(Debug, PartialEq)]
 pub enum ListPartsError {}
@@ -17682,14 +17450,10 @@ impl ListPartsError {
 }
 impl fmt::Display for ListPartsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPartsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListPartsError {}
 /// Errors returned by PutBucketAccelerateConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutBucketAccelerateConfigurationError {}
@@ -17720,14 +17484,10 @@ impl PutBucketAccelerateConfigurationError {
 }
 impl fmt::Display for PutBucketAccelerateConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketAccelerateConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketAccelerateConfigurationError {}
 /// Errors returned by PutBucketAcl
 #[derive(Debug, PartialEq)]
 pub enum PutBucketAclError {}
@@ -17756,14 +17516,10 @@ impl PutBucketAclError {
 }
 impl fmt::Display for PutBucketAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketAclError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketAclError {}
 /// Errors returned by PutBucketAnalyticsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutBucketAnalyticsConfigurationError {}
@@ -17794,14 +17550,10 @@ impl PutBucketAnalyticsConfigurationError {
 }
 impl fmt::Display for PutBucketAnalyticsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketAnalyticsConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketAnalyticsConfigurationError {}
 /// Errors returned by PutBucketCors
 #[derive(Debug, PartialEq)]
 pub enum PutBucketCorsError {}
@@ -17830,14 +17582,10 @@ impl PutBucketCorsError {
 }
 impl fmt::Display for PutBucketCorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketCorsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketCorsError {}
 /// Errors returned by PutBucketEncryption
 #[derive(Debug, PartialEq)]
 pub enum PutBucketEncryptionError {}
@@ -17866,14 +17614,10 @@ impl PutBucketEncryptionError {
 }
 impl fmt::Display for PutBucketEncryptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketEncryptionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketEncryptionError {}
 /// Errors returned by PutBucketInventoryConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutBucketInventoryConfigurationError {}
@@ -17904,14 +17648,10 @@ impl PutBucketInventoryConfigurationError {
 }
 impl fmt::Display for PutBucketInventoryConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketInventoryConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketInventoryConfigurationError {}
 /// Errors returned by PutBucketLifecycle
 #[derive(Debug, PartialEq)]
 pub enum PutBucketLifecycleError {}
@@ -17940,14 +17680,10 @@ impl PutBucketLifecycleError {
 }
 impl fmt::Display for PutBucketLifecycleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketLifecycleError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketLifecycleError {}
 /// Errors returned by PutBucketLifecycleConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutBucketLifecycleConfigurationError {}
@@ -17978,14 +17714,10 @@ impl PutBucketLifecycleConfigurationError {
 }
 impl fmt::Display for PutBucketLifecycleConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketLifecycleConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketLifecycleConfigurationError {}
 /// Errors returned by PutBucketLogging
 #[derive(Debug, PartialEq)]
 pub enum PutBucketLoggingError {}
@@ -18014,14 +17746,10 @@ impl PutBucketLoggingError {
 }
 impl fmt::Display for PutBucketLoggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketLoggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketLoggingError {}
 /// Errors returned by PutBucketMetricsConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutBucketMetricsConfigurationError {}
@@ -18052,14 +17780,10 @@ impl PutBucketMetricsConfigurationError {
 }
 impl fmt::Display for PutBucketMetricsConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketMetricsConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketMetricsConfigurationError {}
 /// Errors returned by PutBucketNotification
 #[derive(Debug, PartialEq)]
 pub enum PutBucketNotificationError {}
@@ -18088,14 +17812,10 @@ impl PutBucketNotificationError {
 }
 impl fmt::Display for PutBucketNotificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketNotificationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketNotificationError {}
 /// Errors returned by PutBucketNotificationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutBucketNotificationConfigurationError {}
@@ -18126,14 +17846,10 @@ impl PutBucketNotificationConfigurationError {
 }
 impl fmt::Display for PutBucketNotificationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketNotificationConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketNotificationConfigurationError {}
 /// Errors returned by PutBucketPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutBucketPolicyError {}
@@ -18162,14 +17878,10 @@ impl PutBucketPolicyError {
 }
 impl fmt::Display for PutBucketPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketPolicyError {}
 /// Errors returned by PutBucketReplication
 #[derive(Debug, PartialEq)]
 pub enum PutBucketReplicationError {}
@@ -18198,14 +17910,10 @@ impl PutBucketReplicationError {
 }
 impl fmt::Display for PutBucketReplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketReplicationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketReplicationError {}
 /// Errors returned by PutBucketRequestPayment
 #[derive(Debug, PartialEq)]
 pub enum PutBucketRequestPaymentError {}
@@ -18234,14 +17942,10 @@ impl PutBucketRequestPaymentError {
 }
 impl fmt::Display for PutBucketRequestPaymentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketRequestPaymentError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketRequestPaymentError {}
 /// Errors returned by PutBucketTagging
 #[derive(Debug, PartialEq)]
 pub enum PutBucketTaggingError {}
@@ -18270,14 +17974,10 @@ impl PutBucketTaggingError {
 }
 impl fmt::Display for PutBucketTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketTaggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketTaggingError {}
 /// Errors returned by PutBucketVersioning
 #[derive(Debug, PartialEq)]
 pub enum PutBucketVersioningError {}
@@ -18306,14 +18006,10 @@ impl PutBucketVersioningError {
 }
 impl fmt::Display for PutBucketVersioningError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketVersioningError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketVersioningError {}
 /// Errors returned by PutBucketWebsite
 #[derive(Debug, PartialEq)]
 pub enum PutBucketWebsiteError {}
@@ -18342,14 +18038,10 @@ impl PutBucketWebsiteError {
 }
 impl fmt::Display for PutBucketWebsiteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutBucketWebsiteError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutBucketWebsiteError {}
 /// Errors returned by PutObject
 #[derive(Debug, PartialEq)]
 pub enum PutObjectError {}
@@ -18378,14 +18070,10 @@ impl PutObjectError {
 }
 impl fmt::Display for PutObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutObjectError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutObjectError {}
 /// Errors returned by PutObjectAcl
 #[derive(Debug, PartialEq)]
 pub enum PutObjectAclError {
@@ -18422,16 +18110,12 @@ impl PutObjectAclError {
 }
 impl fmt::Display for PutObjectAclError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutObjectAclError {
-    fn description(&self) -> &str {
         match *self {
-            PutObjectAclError::NoSuchKey(ref cause) => cause,
+            PutObjectAclError::NoSuchKey(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutObjectAclError {}
 /// Errors returned by PutObjectLegalHold
 #[derive(Debug, PartialEq)]
 pub enum PutObjectLegalHoldError {}
@@ -18460,14 +18144,10 @@ impl PutObjectLegalHoldError {
 }
 impl fmt::Display for PutObjectLegalHoldError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutObjectLegalHoldError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutObjectLegalHoldError {}
 /// Errors returned by PutObjectLockConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutObjectLockConfigurationError {}
@@ -18498,14 +18178,10 @@ impl PutObjectLockConfigurationError {
 }
 impl fmt::Display for PutObjectLockConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutObjectLockConfigurationError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutObjectLockConfigurationError {}
 /// Errors returned by PutObjectRetention
 #[derive(Debug, PartialEq)]
 pub enum PutObjectRetentionError {}
@@ -18534,14 +18210,10 @@ impl PutObjectRetentionError {
 }
 impl fmt::Display for PutObjectRetentionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutObjectRetentionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutObjectRetentionError {}
 /// Errors returned by PutObjectTagging
 #[derive(Debug, PartialEq)]
 pub enum PutObjectTaggingError {}
@@ -18570,14 +18242,10 @@ impl PutObjectTaggingError {
 }
 impl fmt::Display for PutObjectTaggingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutObjectTaggingError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutObjectTaggingError {}
 /// Errors returned by PutPublicAccessBlock
 #[derive(Debug, PartialEq)]
 pub enum PutPublicAccessBlockError {}
@@ -18606,14 +18274,10 @@ impl PutPublicAccessBlockError {
 }
 impl fmt::Display for PutPublicAccessBlockError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPublicAccessBlockError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for PutPublicAccessBlockError {}
 /// Errors returned by RestoreObject
 #[derive(Debug, PartialEq)]
 pub enum RestoreObjectError {
@@ -18652,16 +18316,12 @@ impl RestoreObjectError {
 }
 impl fmt::Display for RestoreObjectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreObjectError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreObjectError::ObjectAlreadyInActiveTierError(ref cause) => cause,
+            RestoreObjectError::ObjectAlreadyInActiveTierError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreObjectError {}
 /// Errors returned by SelectObjectContent
 #[derive(Debug, PartialEq)]
 pub enum SelectObjectContentError {}
@@ -18690,14 +18350,10 @@ impl SelectObjectContentError {
 }
 impl fmt::Display for SelectObjectContentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SelectObjectContentError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SelectObjectContentError {}
 /// Errors returned by UploadPart
 #[derive(Debug, PartialEq)]
 pub enum UploadPartError {}
@@ -18726,14 +18382,10 @@ impl UploadPartError {
 }
 impl fmt::Display for UploadPartError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadPartError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UploadPartError {}
 /// Errors returned by UploadPartCopy
 #[derive(Debug, PartialEq)]
 pub enum UploadPartCopyError {}
@@ -18762,14 +18414,10 @@ impl UploadPartCopyError {
 }
 impl fmt::Display for UploadPartCopyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UploadPartCopyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UploadPartCopyError {}
 /// Trait representing the capabilities of the Amazon S3 API. Amazon S3 clients implement this trait.
 pub trait S3 {
     /// <p><p>This operation aborts a multipart upload. After a multipart upload is aborted, no additional parts can be uploaded using that upload ID. The storage consumed by any previously uploaded parts will be freed. However, if any part uploads are currently in progress, those part uploads might or might not succeed. As a result, it might be necessary to abort a given multipart upload multiple times in order to completely free all storage consumed by all parts. </p> <p>To verify that all parts have been removed, so you don&#39;t get charged for the part storage, you should call the <a>ListParts</a> operation and ensure that the parts list is empty.</p> <p>For information about permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload API and Permissions</a>.</p> <p>The following operations are related to <code>AbortMultipartUpload</code>:</p> <ul> <li> <p> <a>CreateMultipartUpload</a> </p> </li> <li> <p> <a>UploadPart</a> </p> </li> <li> <p> <a>CompleteMultipartUpload</a> </p> </li> <li> <p> <a>ListParts</a> </p> </li> <li> <p> <a>ListMultipartUploads</a> </p> </li> </ul></p>

--- a/rusoto/services/sagemaker-runtime/src/generated.rs
+++ b/rusoto/services/sagemaker-runtime/src/generated.rs
@@ -103,19 +103,15 @@ impl InvokeEndpointError {
 }
 impl fmt::Display for InvokeEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InvokeEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            InvokeEndpointError::InternalFailure(ref cause) => cause,
-            InvokeEndpointError::ModelError(ref cause) => cause,
-            InvokeEndpointError::ServiceUnavailable(ref cause) => cause,
-            InvokeEndpointError::ValidationError(ref cause) => cause,
+            InvokeEndpointError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            InvokeEndpointError::ModelError(ref cause) => write!(f, "{}", cause),
+            InvokeEndpointError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            InvokeEndpointError::ValidationError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InvokeEndpointError {}
 /// Trait representing the capabilities of the Amazon SageMaker Runtime API. Amazon SageMaker Runtime clients implement this trait.
 pub trait SageMakerRuntime {
     /// <p><p>After you deploy a model into production using Amazon SageMaker hosting services, your client applications use this API to get inferences from the model hosted at the specified endpoint. </p> <p>For an overview of Amazon SageMaker, see <a href="https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works.html">How It Works</a>. </p> <p>Amazon SageMaker strips all POST headers except those supported by the API. Amazon SageMaker might add additional headers. You should not rely on the behavior of headers outside those enumerated in the request syntax. </p> <p>Calls to <code>InvokeEndpoint</code> are authenticated by using AWS Signature Version 4. For information, see <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating Requests (AWS Signature Version 4)</a> in the <i>Amazon S3 API Reference</i>.</p> <p>A customer&#39;s model containers must respond to requests within 60 seconds. The model itself can have a maximum processing time of 60 seconds before responding to the /invocations. If your model is going to take 50-60 seconds of processing time, the SDK socket timeout should be set to be 70 seconds.</p> <note> <p>Endpoints are scoped to an individual account, and are not public. The URL does not contain the account ID, but Amazon SageMaker determines the account ID from the authentication token that is supplied by the caller.</p> </note></p>

--- a/rusoto/services/sagemaker/src/generated.rs
+++ b/rusoto/services/sagemaker/src/generated.rs
@@ -8443,14 +8443,10 @@ impl AddTagsError {
 }
 impl fmt::Display for AddTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for AddTagsError {}
 /// Errors returned by AssociateTrialComponent
 #[derive(Debug, PartialEq)]
 pub enum AssociateTrialComponentError {
@@ -8483,17 +8479,15 @@ impl AssociateTrialComponentError {
 }
 impl fmt::Display for AssociateTrialComponentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateTrialComponentError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateTrialComponentError::ResourceLimitExceeded(ref cause) => cause,
-            AssociateTrialComponentError::ResourceNotFound(ref cause) => cause,
+            AssociateTrialComponentError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateTrialComponentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateTrialComponentError {}
 /// Errors returned by CreateAlgorithm
 #[derive(Debug, PartialEq)]
 pub enum CreateAlgorithmError {}
@@ -8511,14 +8505,10 @@ impl CreateAlgorithmError {
 }
 impl fmt::Display for CreateAlgorithmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAlgorithmError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreateAlgorithmError {}
 /// Errors returned by CreateApp
 #[derive(Debug, PartialEq)]
 pub enum CreateAppError {
@@ -8547,17 +8537,13 @@ impl CreateAppError {
 }
 impl fmt::Display for CreateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAppError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAppError::ResourceInUse(ref cause) => cause,
-            CreateAppError::ResourceLimitExceeded(ref cause) => cause,
+            CreateAppError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateAppError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAppError {}
 /// Errors returned by CreateAutoMLJob
 #[derive(Debug, PartialEq)]
 pub enum CreateAutoMLJobError {
@@ -8588,17 +8574,13 @@ impl CreateAutoMLJobError {
 }
 impl fmt::Display for CreateAutoMLJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAutoMLJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAutoMLJobError::ResourceInUse(ref cause) => cause,
-            CreateAutoMLJobError::ResourceLimitExceeded(ref cause) => cause,
+            CreateAutoMLJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateAutoMLJobError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAutoMLJobError {}
 /// Errors returned by CreateCodeRepository
 #[derive(Debug, PartialEq)]
 pub enum CreateCodeRepositoryError {}
@@ -8616,14 +8598,10 @@ impl CreateCodeRepositoryError {
 }
 impl fmt::Display for CreateCodeRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCodeRepositoryError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreateCodeRepositoryError {}
 /// Errors returned by CreateCompilationJob
 #[derive(Debug, PartialEq)]
 pub enum CreateCompilationJobError {
@@ -8654,17 +8632,13 @@ impl CreateCompilationJobError {
 }
 impl fmt::Display for CreateCompilationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCompilationJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCompilationJobError::ResourceInUse(ref cause) => cause,
-            CreateCompilationJobError::ResourceLimitExceeded(ref cause) => cause,
+            CreateCompilationJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateCompilationJobError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCompilationJobError {}
 /// Errors returned by CreateDomain
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainError {
@@ -8693,17 +8667,13 @@ impl CreateDomainError {
 }
 impl fmt::Display for CreateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainError::ResourceInUse(ref cause) => cause,
-            CreateDomainError::ResourceLimitExceeded(ref cause) => cause,
+            CreateDomainError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainError {}
 /// Errors returned by CreateEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateEndpointError {
@@ -8729,16 +8699,12 @@ impl CreateEndpointError {
 }
 impl fmt::Display for CreateEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEndpointError::ResourceLimitExceeded(ref cause) => cause,
+            CreateEndpointError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEndpointError {}
 /// Errors returned by CreateEndpointConfig
 #[derive(Debug, PartialEq)]
 pub enum CreateEndpointConfigError {
@@ -8764,16 +8730,12 @@ impl CreateEndpointConfigError {
 }
 impl fmt::Display for CreateEndpointConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateEndpointConfigError {
-    fn description(&self) -> &str {
         match *self {
-            CreateEndpointConfigError::ResourceLimitExceeded(ref cause) => cause,
+            CreateEndpointConfigError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateEndpointConfigError {}
 /// Errors returned by CreateExperiment
 #[derive(Debug, PartialEq)]
 pub enum CreateExperimentError {
@@ -8799,16 +8761,12 @@ impl CreateExperimentError {
 }
 impl fmt::Display for CreateExperimentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateExperimentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateExperimentError::ResourceLimitExceeded(ref cause) => cause,
+            CreateExperimentError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateExperimentError {}
 /// Errors returned by CreateFlowDefinition
 #[derive(Debug, PartialEq)]
 pub enum CreateFlowDefinitionError {
@@ -8839,17 +8797,13 @@ impl CreateFlowDefinitionError {
 }
 impl fmt::Display for CreateFlowDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFlowDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFlowDefinitionError::ResourceInUse(ref cause) => cause,
-            CreateFlowDefinitionError::ResourceLimitExceeded(ref cause) => cause,
+            CreateFlowDefinitionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateFlowDefinitionError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFlowDefinitionError {}
 /// Errors returned by CreateHumanTaskUi
 #[derive(Debug, PartialEq)]
 pub enum CreateHumanTaskUiError {
@@ -8880,17 +8834,13 @@ impl CreateHumanTaskUiError {
 }
 impl fmt::Display for CreateHumanTaskUiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHumanTaskUiError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHumanTaskUiError::ResourceInUse(ref cause) => cause,
-            CreateHumanTaskUiError::ResourceLimitExceeded(ref cause) => cause,
+            CreateHumanTaskUiError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateHumanTaskUiError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHumanTaskUiError {}
 /// Errors returned by CreateHyperParameterTuningJob
 #[derive(Debug, PartialEq)]
 pub enum CreateHyperParameterTuningJobError {
@@ -8925,17 +8875,15 @@ impl CreateHyperParameterTuningJobError {
 }
 impl fmt::Display for CreateHyperParameterTuningJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHyperParameterTuningJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHyperParameterTuningJobError::ResourceInUse(ref cause) => cause,
-            CreateHyperParameterTuningJobError::ResourceLimitExceeded(ref cause) => cause,
+            CreateHyperParameterTuningJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateHyperParameterTuningJobError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateHyperParameterTuningJobError {}
 /// Errors returned by CreateLabelingJob
 #[derive(Debug, PartialEq)]
 pub enum CreateLabelingJobError {
@@ -8966,17 +8914,13 @@ impl CreateLabelingJobError {
 }
 impl fmt::Display for CreateLabelingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLabelingJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLabelingJobError::ResourceInUse(ref cause) => cause,
-            CreateLabelingJobError::ResourceLimitExceeded(ref cause) => cause,
+            CreateLabelingJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateLabelingJobError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLabelingJobError {}
 /// Errors returned by CreateModel
 #[derive(Debug, PartialEq)]
 pub enum CreateModelError {
@@ -9000,16 +8944,12 @@ impl CreateModelError {
 }
 impl fmt::Display for CreateModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateModelError {
-    fn description(&self) -> &str {
         match *self {
-            CreateModelError::ResourceLimitExceeded(ref cause) => cause,
+            CreateModelError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateModelError {}
 /// Errors returned by CreateModelPackage
 #[derive(Debug, PartialEq)]
 pub enum CreateModelPackageError {}
@@ -9027,14 +8967,10 @@ impl CreateModelPackageError {
 }
 impl fmt::Display for CreateModelPackageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateModelPackageError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreateModelPackageError {}
 /// Errors returned by CreateMonitoringSchedule
 #[derive(Debug, PartialEq)]
 pub enum CreateMonitoringScheduleError {
@@ -9067,17 +9003,15 @@ impl CreateMonitoringScheduleError {
 }
 impl fmt::Display for CreateMonitoringScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMonitoringScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMonitoringScheduleError::ResourceInUse(ref cause) => cause,
-            CreateMonitoringScheduleError::ResourceLimitExceeded(ref cause) => cause,
+            CreateMonitoringScheduleError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateMonitoringScheduleError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateMonitoringScheduleError {}
 /// Errors returned by CreateNotebookInstance
 #[derive(Debug, PartialEq)]
 pub enum CreateNotebookInstanceError {
@@ -9103,16 +9037,12 @@ impl CreateNotebookInstanceError {
 }
 impl fmt::Display for CreateNotebookInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNotebookInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNotebookInstanceError::ResourceLimitExceeded(ref cause) => cause,
+            CreateNotebookInstanceError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateNotebookInstanceError {}
 /// Errors returned by CreateNotebookInstanceLifecycleConfig
 #[derive(Debug, PartialEq)]
 pub enum CreateNotebookInstanceLifecycleConfigError {
@@ -9140,16 +9070,14 @@ impl CreateNotebookInstanceLifecycleConfigError {
 }
 impl fmt::Display for CreateNotebookInstanceLifecycleConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNotebookInstanceLifecycleConfigError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNotebookInstanceLifecycleConfigError::ResourceLimitExceeded(ref cause) => cause,
+            CreateNotebookInstanceLifecycleConfigError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateNotebookInstanceLifecycleConfigError {}
 /// Errors returned by CreatePresignedDomainUrl
 #[derive(Debug, PartialEq)]
 pub enum CreatePresignedDomainUrlError {}
@@ -9167,14 +9095,10 @@ impl CreatePresignedDomainUrlError {
 }
 impl fmt::Display for CreatePresignedDomainUrlError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePresignedDomainUrlError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreatePresignedDomainUrlError {}
 /// Errors returned by CreatePresignedNotebookInstanceUrl
 #[derive(Debug, PartialEq)]
 pub enum CreatePresignedNotebookInstanceUrlError {}
@@ -9194,14 +9118,10 @@ impl CreatePresignedNotebookInstanceUrlError {
 }
 impl fmt::Display for CreatePresignedNotebookInstanceUrlError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePresignedNotebookInstanceUrlError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for CreatePresignedNotebookInstanceUrlError {}
 /// Errors returned by CreateProcessingJob
 #[derive(Debug, PartialEq)]
 pub enum CreateProcessingJobError {
@@ -9239,18 +9159,14 @@ impl CreateProcessingJobError {
 }
 impl fmt::Display for CreateProcessingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProcessingJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProcessingJobError::ResourceInUse(ref cause) => cause,
-            CreateProcessingJobError::ResourceLimitExceeded(ref cause) => cause,
-            CreateProcessingJobError::ResourceNotFound(ref cause) => cause,
+            CreateProcessingJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateProcessingJobError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProcessingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProcessingJobError {}
 /// Errors returned by CreateTrainingJob
 #[derive(Debug, PartialEq)]
 pub enum CreateTrainingJobError {
@@ -9286,18 +9202,14 @@ impl CreateTrainingJobError {
 }
 impl fmt::Display for CreateTrainingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrainingJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrainingJobError::ResourceInUse(ref cause) => cause,
-            CreateTrainingJobError::ResourceLimitExceeded(ref cause) => cause,
-            CreateTrainingJobError::ResourceNotFound(ref cause) => cause,
+            CreateTrainingJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateTrainingJobError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTrainingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTrainingJobError {}
 /// Errors returned by CreateTransformJob
 #[derive(Debug, PartialEq)]
 pub enum CreateTransformJobError {
@@ -9333,18 +9245,14 @@ impl CreateTransformJobError {
 }
 impl fmt::Display for CreateTransformJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTransformJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTransformJobError::ResourceInUse(ref cause) => cause,
-            CreateTransformJobError::ResourceLimitExceeded(ref cause) => cause,
-            CreateTransformJobError::ResourceNotFound(ref cause) => cause,
+            CreateTransformJobError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateTransformJobError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTransformJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTransformJobError {}
 /// Errors returned by CreateTrial
 #[derive(Debug, PartialEq)]
 pub enum CreateTrialError {
@@ -9373,17 +9281,13 @@ impl CreateTrialError {
 }
 impl fmt::Display for CreateTrialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrialError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrialError::ResourceLimitExceeded(ref cause) => cause,
-            CreateTrialError::ResourceNotFound(ref cause) => cause,
+            CreateTrialError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTrialError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTrialError {}
 /// Errors returned by CreateTrialComponent
 #[derive(Debug, PartialEq)]
 pub enum CreateTrialComponentError {
@@ -9409,16 +9313,12 @@ impl CreateTrialComponentError {
 }
 impl fmt::Display for CreateTrialComponentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTrialComponentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTrialComponentError::ResourceLimitExceeded(ref cause) => cause,
+            CreateTrialComponentError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTrialComponentError {}
 /// Errors returned by CreateUserProfile
 #[derive(Debug, PartialEq)]
 pub enum CreateUserProfileError {
@@ -9449,17 +9349,13 @@ impl CreateUserProfileError {
 }
 impl fmt::Display for CreateUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserProfileError::ResourceInUse(ref cause) => cause,
-            CreateUserProfileError::ResourceLimitExceeded(ref cause) => cause,
+            CreateUserProfileError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateUserProfileError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserProfileError {}
 /// Errors returned by CreateWorkteam
 #[derive(Debug, PartialEq)]
 pub enum CreateWorkteamError {
@@ -9490,17 +9386,13 @@ impl CreateWorkteamError {
 }
 impl fmt::Display for CreateWorkteamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWorkteamError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWorkteamError::ResourceInUse(ref cause) => cause,
-            CreateWorkteamError::ResourceLimitExceeded(ref cause) => cause,
+            CreateWorkteamError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            CreateWorkteamError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWorkteamError {}
 /// Errors returned by DeleteAlgorithm
 #[derive(Debug, PartialEq)]
 pub enum DeleteAlgorithmError {}
@@ -9518,14 +9410,10 @@ impl DeleteAlgorithmError {
 }
 impl fmt::Display for DeleteAlgorithmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAlgorithmError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteAlgorithmError {}
 /// Errors returned by DeleteApp
 #[derive(Debug, PartialEq)]
 pub enum DeleteAppError {
@@ -9554,17 +9442,13 @@ impl DeleteAppError {
 }
 impl fmt::Display for DeleteAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAppError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAppError::ResourceInUse(ref cause) => cause,
-            DeleteAppError::ResourceNotFound(ref cause) => cause,
+            DeleteAppError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAppError {}
 /// Errors returned by DeleteCodeRepository
 #[derive(Debug, PartialEq)]
 pub enum DeleteCodeRepositoryError {}
@@ -9582,14 +9466,10 @@ impl DeleteCodeRepositoryError {
 }
 impl fmt::Display for DeleteCodeRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCodeRepositoryError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteCodeRepositoryError {}
 /// Errors returned by DeleteDomain
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainError {
@@ -9618,17 +9498,13 @@ impl DeleteDomainError {
 }
 impl fmt::Display for DeleteDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainError::ResourceInUse(ref cause) => cause,
-            DeleteDomainError::ResourceNotFound(ref cause) => cause,
+            DeleteDomainError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainError {}
 /// Errors returned by DeleteEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteEndpointError {}
@@ -9646,14 +9522,10 @@ impl DeleteEndpointError {
 }
 impl fmt::Display for DeleteEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEndpointError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteEndpointError {}
 /// Errors returned by DeleteEndpointConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteEndpointConfigError {}
@@ -9671,14 +9543,10 @@ impl DeleteEndpointConfigError {
 }
 impl fmt::Display for DeleteEndpointConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEndpointConfigError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteEndpointConfigError {}
 /// Errors returned by DeleteExperiment
 #[derive(Debug, PartialEq)]
 pub enum DeleteExperimentError {
@@ -9702,16 +9570,12 @@ impl DeleteExperimentError {
 }
 impl fmt::Display for DeleteExperimentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteExperimentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteExperimentError::ResourceNotFound(ref cause) => cause,
+            DeleteExperimentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteExperimentError {}
 /// Errors returned by DeleteFlowDefinition
 #[derive(Debug, PartialEq)]
 pub enum DeleteFlowDefinitionError {
@@ -9737,16 +9601,12 @@ impl DeleteFlowDefinitionError {
 }
 impl fmt::Display for DeleteFlowDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFlowDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFlowDefinitionError::ResourceNotFound(ref cause) => cause,
+            DeleteFlowDefinitionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFlowDefinitionError {}
 /// Errors returned by DeleteModel
 #[derive(Debug, PartialEq)]
 pub enum DeleteModelError {}
@@ -9764,14 +9624,10 @@ impl DeleteModelError {
 }
 impl fmt::Display for DeleteModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteModelError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteModelError {}
 /// Errors returned by DeleteModelPackage
 #[derive(Debug, PartialEq)]
 pub enum DeleteModelPackageError {}
@@ -9789,14 +9645,10 @@ impl DeleteModelPackageError {
 }
 impl fmt::Display for DeleteModelPackageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteModelPackageError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteModelPackageError {}
 /// Errors returned by DeleteMonitoringSchedule
 #[derive(Debug, PartialEq)]
 pub enum DeleteMonitoringScheduleError {
@@ -9822,16 +9674,12 @@ impl DeleteMonitoringScheduleError {
 }
 impl fmt::Display for DeleteMonitoringScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMonitoringScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMonitoringScheduleError::ResourceNotFound(ref cause) => cause,
+            DeleteMonitoringScheduleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMonitoringScheduleError {}
 /// Errors returned by DeleteNotebookInstance
 #[derive(Debug, PartialEq)]
 pub enum DeleteNotebookInstanceError {}
@@ -9849,14 +9697,10 @@ impl DeleteNotebookInstanceError {
 }
 impl fmt::Display for DeleteNotebookInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNotebookInstanceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteNotebookInstanceError {}
 /// Errors returned by DeleteNotebookInstanceLifecycleConfig
 #[derive(Debug, PartialEq)]
 pub enum DeleteNotebookInstanceLifecycleConfigError {}
@@ -9876,14 +9720,10 @@ impl DeleteNotebookInstanceLifecycleConfigError {
 }
 impl fmt::Display for DeleteNotebookInstanceLifecycleConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNotebookInstanceLifecycleConfigError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteNotebookInstanceLifecycleConfigError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {}
@@ -9901,14 +9741,10 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DeleteTrial
 #[derive(Debug, PartialEq)]
 pub enum DeleteTrialError {
@@ -9932,16 +9768,12 @@ impl DeleteTrialError {
 }
 impl fmt::Display for DeleteTrialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTrialError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTrialError::ResourceNotFound(ref cause) => cause,
+            DeleteTrialError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTrialError {}
 /// Errors returned by DeleteTrialComponent
 #[derive(Debug, PartialEq)]
 pub enum DeleteTrialComponentError {
@@ -9967,16 +9799,12 @@ impl DeleteTrialComponentError {
 }
 impl fmt::Display for DeleteTrialComponentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTrialComponentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTrialComponentError::ResourceNotFound(ref cause) => cause,
+            DeleteTrialComponentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTrialComponentError {}
 /// Errors returned by DeleteUserProfile
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserProfileError {
@@ -10005,17 +9833,13 @@ impl DeleteUserProfileError {
 }
 impl fmt::Display for DeleteUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserProfileError::ResourceInUse(ref cause) => cause,
-            DeleteUserProfileError::ResourceNotFound(ref cause) => cause,
+            DeleteUserProfileError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteUserProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserProfileError {}
 /// Errors returned by DeleteWorkteam
 #[derive(Debug, PartialEq)]
 pub enum DeleteWorkteamError {
@@ -10041,16 +9865,12 @@ impl DeleteWorkteamError {
 }
 impl fmt::Display for DeleteWorkteamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWorkteamError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWorkteamError::ResourceLimitExceeded(ref cause) => cause,
+            DeleteWorkteamError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWorkteamError {}
 /// Errors returned by DescribeAlgorithm
 #[derive(Debug, PartialEq)]
 pub enum DescribeAlgorithmError {}
@@ -10068,14 +9888,10 @@ impl DescribeAlgorithmError {
 }
 impl fmt::Display for DescribeAlgorithmError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAlgorithmError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeAlgorithmError {}
 /// Errors returned by DescribeApp
 #[derive(Debug, PartialEq)]
 pub enum DescribeAppError {
@@ -10099,16 +9915,12 @@ impl DescribeAppError {
 }
 impl fmt::Display for DescribeAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAppError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAppError::ResourceNotFound(ref cause) => cause,
+            DescribeAppError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAppError {}
 /// Errors returned by DescribeAutoMLJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeAutoMLJobError {
@@ -10132,16 +9944,12 @@ impl DescribeAutoMLJobError {
 }
 impl fmt::Display for DescribeAutoMLJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAutoMLJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAutoMLJobError::ResourceNotFound(ref cause) => cause,
+            DescribeAutoMLJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAutoMLJobError {}
 /// Errors returned by DescribeCodeRepository
 #[derive(Debug, PartialEq)]
 pub enum DescribeCodeRepositoryError {}
@@ -10159,14 +9967,10 @@ impl DescribeCodeRepositoryError {
 }
 impl fmt::Display for DescribeCodeRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCodeRepositoryError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeCodeRepositoryError {}
 /// Errors returned by DescribeCompilationJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeCompilationJobError {
@@ -10192,16 +9996,12 @@ impl DescribeCompilationJobError {
 }
 impl fmt::Display for DescribeCompilationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCompilationJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCompilationJobError::ResourceNotFound(ref cause) => cause,
+            DescribeCompilationJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCompilationJobError {}
 /// Errors returned by DescribeDomain
 #[derive(Debug, PartialEq)]
 pub enum DescribeDomainError {
@@ -10225,16 +10025,12 @@ impl DescribeDomainError {
 }
 impl fmt::Display for DescribeDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDomainError::ResourceNotFound(ref cause) => cause,
+            DescribeDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDomainError {}
 /// Errors returned by DescribeEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointError {}
@@ -10252,14 +10048,10 @@ impl DescribeEndpointError {
 }
 impl fmt::Display for DescribeEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEndpointError {}
 /// Errors returned by DescribeEndpointConfig
 #[derive(Debug, PartialEq)]
 pub enum DescribeEndpointConfigError {}
@@ -10277,14 +10069,10 @@ impl DescribeEndpointConfigError {
 }
 impl fmt::Display for DescribeEndpointConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEndpointConfigError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeEndpointConfigError {}
 /// Errors returned by DescribeExperiment
 #[derive(Debug, PartialEq)]
 pub enum DescribeExperimentError {
@@ -10308,16 +10096,12 @@ impl DescribeExperimentError {
 }
 impl fmt::Display for DescribeExperimentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeExperimentError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeExperimentError::ResourceNotFound(ref cause) => cause,
+            DescribeExperimentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeExperimentError {}
 /// Errors returned by DescribeFlowDefinition
 #[derive(Debug, PartialEq)]
 pub enum DescribeFlowDefinitionError {
@@ -10343,16 +10127,12 @@ impl DescribeFlowDefinitionError {
 }
 impl fmt::Display for DescribeFlowDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFlowDefinitionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFlowDefinitionError::ResourceNotFound(ref cause) => cause,
+            DescribeFlowDefinitionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFlowDefinitionError {}
 /// Errors returned by DescribeHumanTaskUi
 #[derive(Debug, PartialEq)]
 pub enum DescribeHumanTaskUiError {
@@ -10378,16 +10158,12 @@ impl DescribeHumanTaskUiError {
 }
 impl fmt::Display for DescribeHumanTaskUiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHumanTaskUiError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHumanTaskUiError::ResourceNotFound(ref cause) => cause,
+            DescribeHumanTaskUiError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeHumanTaskUiError {}
 /// Errors returned by DescribeHyperParameterTuningJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeHyperParameterTuningJobError {
@@ -10415,16 +10191,14 @@ impl DescribeHyperParameterTuningJobError {
 }
 impl fmt::Display for DescribeHyperParameterTuningJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHyperParameterTuningJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHyperParameterTuningJobError::ResourceNotFound(ref cause) => cause,
+            DescribeHyperParameterTuningJobError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeHyperParameterTuningJobError {}
 /// Errors returned by DescribeLabelingJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeLabelingJobError {
@@ -10450,16 +10224,12 @@ impl DescribeLabelingJobError {
 }
 impl fmt::Display for DescribeLabelingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeLabelingJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeLabelingJobError::ResourceNotFound(ref cause) => cause,
+            DescribeLabelingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeLabelingJobError {}
 /// Errors returned by DescribeModel
 #[derive(Debug, PartialEq)]
 pub enum DescribeModelError {}
@@ -10477,14 +10247,10 @@ impl DescribeModelError {
 }
 impl fmt::Display for DescribeModelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeModelError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeModelError {}
 /// Errors returned by DescribeModelPackage
 #[derive(Debug, PartialEq)]
 pub enum DescribeModelPackageError {}
@@ -10502,14 +10268,10 @@ impl DescribeModelPackageError {
 }
 impl fmt::Display for DescribeModelPackageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeModelPackageError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeModelPackageError {}
 /// Errors returned by DescribeMonitoringSchedule
 #[derive(Debug, PartialEq)]
 pub enum DescribeMonitoringScheduleError {
@@ -10537,16 +10299,12 @@ impl DescribeMonitoringScheduleError {
 }
 impl fmt::Display for DescribeMonitoringScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMonitoringScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMonitoringScheduleError::ResourceNotFound(ref cause) => cause,
+            DescribeMonitoringScheduleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMonitoringScheduleError {}
 /// Errors returned by DescribeNotebookInstance
 #[derive(Debug, PartialEq)]
 pub enum DescribeNotebookInstanceError {}
@@ -10564,14 +10322,10 @@ impl DescribeNotebookInstanceError {
 }
 impl fmt::Display for DescribeNotebookInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNotebookInstanceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeNotebookInstanceError {}
 /// Errors returned by DescribeNotebookInstanceLifecycleConfig
 #[derive(Debug, PartialEq)]
 pub enum DescribeNotebookInstanceLifecycleConfigError {}
@@ -10591,14 +10345,10 @@ impl DescribeNotebookInstanceLifecycleConfigError {
 }
 impl fmt::Display for DescribeNotebookInstanceLifecycleConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNotebookInstanceLifecycleConfigError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeNotebookInstanceLifecycleConfigError {}
 /// Errors returned by DescribeProcessingJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeProcessingJobError {
@@ -10624,16 +10374,12 @@ impl DescribeProcessingJobError {
 }
 impl fmt::Display for DescribeProcessingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProcessingJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProcessingJobError::ResourceNotFound(ref cause) => cause,
+            DescribeProcessingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProcessingJobError {}
 /// Errors returned by DescribeSubscribedWorkteam
 #[derive(Debug, PartialEq)]
 pub enum DescribeSubscribedWorkteamError {}
@@ -10653,14 +10399,10 @@ impl DescribeSubscribedWorkteamError {
 }
 impl fmt::Display for DescribeSubscribedWorkteamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSubscribedWorkteamError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeSubscribedWorkteamError {}
 /// Errors returned by DescribeTrainingJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrainingJobError {
@@ -10686,16 +10428,12 @@ impl DescribeTrainingJobError {
 }
 impl fmt::Display for DescribeTrainingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrainingJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrainingJobError::ResourceNotFound(ref cause) => cause,
+            DescribeTrainingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTrainingJobError {}
 /// Errors returned by DescribeTransformJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeTransformJobError {
@@ -10721,16 +10459,12 @@ impl DescribeTransformJobError {
 }
 impl fmt::Display for DescribeTransformJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTransformJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTransformJobError::ResourceNotFound(ref cause) => cause,
+            DescribeTransformJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTransformJobError {}
 /// Errors returned by DescribeTrial
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrialError {
@@ -10754,16 +10488,12 @@ impl DescribeTrialError {
 }
 impl fmt::Display for DescribeTrialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrialError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrialError::ResourceNotFound(ref cause) => cause,
+            DescribeTrialError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTrialError {}
 /// Errors returned by DescribeTrialComponent
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrialComponentError {
@@ -10789,16 +10519,12 @@ impl DescribeTrialComponentError {
 }
 impl fmt::Display for DescribeTrialComponentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrialComponentError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrialComponentError::ResourceNotFound(ref cause) => cause,
+            DescribeTrialComponentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTrialComponentError {}
 /// Errors returned by DescribeUserProfile
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserProfileError {
@@ -10824,16 +10550,12 @@ impl DescribeUserProfileError {
 }
 impl fmt::Display for DescribeUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserProfileError::ResourceNotFound(ref cause) => cause,
+            DescribeUserProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserProfileError {}
 /// Errors returned by DescribeWorkteam
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkteamError {}
@@ -10851,14 +10573,10 @@ impl DescribeWorkteamError {
 }
 impl fmt::Display for DescribeWorkteamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkteamError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeWorkteamError {}
 /// Errors returned by DisassociateTrialComponent
 #[derive(Debug, PartialEq)]
 pub enum DisassociateTrialComponentError {
@@ -10886,16 +10604,12 @@ impl DisassociateTrialComponentError {
 }
 impl fmt::Display for DisassociateTrialComponentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateTrialComponentError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateTrialComponentError::ResourceNotFound(ref cause) => cause,
+            DisassociateTrialComponentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateTrialComponentError {}
 /// Errors returned by GetSearchSuggestions
 #[derive(Debug, PartialEq)]
 pub enum GetSearchSuggestionsError {}
@@ -10913,14 +10627,10 @@ impl GetSearchSuggestionsError {
 }
 impl fmt::Display for GetSearchSuggestionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSearchSuggestionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetSearchSuggestionsError {}
 /// Errors returned by ListAlgorithms
 #[derive(Debug, PartialEq)]
 pub enum ListAlgorithmsError {}
@@ -10938,14 +10648,10 @@ impl ListAlgorithmsError {
 }
 impl fmt::Display for ListAlgorithmsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAlgorithmsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListAlgorithmsError {}
 /// Errors returned by ListApps
 #[derive(Debug, PartialEq)]
 pub enum ListAppsError {}
@@ -10963,14 +10669,10 @@ impl ListAppsError {
 }
 impl fmt::Display for ListAppsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAppsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListAppsError {}
 /// Errors returned by ListAutoMLJobs
 #[derive(Debug, PartialEq)]
 pub enum ListAutoMLJobsError {}
@@ -10988,14 +10690,10 @@ impl ListAutoMLJobsError {
 }
 impl fmt::Display for ListAutoMLJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAutoMLJobsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListAutoMLJobsError {}
 /// Errors returned by ListCandidatesForAutoMLJob
 #[derive(Debug, PartialEq)]
 pub enum ListCandidatesForAutoMLJobError {
@@ -11023,16 +10721,12 @@ impl ListCandidatesForAutoMLJobError {
 }
 impl fmt::Display for ListCandidatesForAutoMLJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCandidatesForAutoMLJobError {
-    fn description(&self) -> &str {
         match *self {
-            ListCandidatesForAutoMLJobError::ResourceNotFound(ref cause) => cause,
+            ListCandidatesForAutoMLJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCandidatesForAutoMLJobError {}
 /// Errors returned by ListCodeRepositories
 #[derive(Debug, PartialEq)]
 pub enum ListCodeRepositoriesError {}
@@ -11050,14 +10744,10 @@ impl ListCodeRepositoriesError {
 }
 impl fmt::Display for ListCodeRepositoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCodeRepositoriesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListCodeRepositoriesError {}
 /// Errors returned by ListCompilationJobs
 #[derive(Debug, PartialEq)]
 pub enum ListCompilationJobsError {}
@@ -11075,14 +10765,10 @@ impl ListCompilationJobsError {
 }
 impl fmt::Display for ListCompilationJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCompilationJobsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListCompilationJobsError {}
 /// Errors returned by ListDomains
 #[derive(Debug, PartialEq)]
 pub enum ListDomainsError {}
@@ -11100,14 +10786,10 @@ impl ListDomainsError {
 }
 impl fmt::Display for ListDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListDomainsError {}
 /// Errors returned by ListEndpointConfigs
 #[derive(Debug, PartialEq)]
 pub enum ListEndpointConfigsError {}
@@ -11125,14 +10807,10 @@ impl ListEndpointConfigsError {
 }
 impl fmt::Display for ListEndpointConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEndpointConfigsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListEndpointConfigsError {}
 /// Errors returned by ListEndpoints
 #[derive(Debug, PartialEq)]
 pub enum ListEndpointsError {}
@@ -11150,14 +10828,10 @@ impl ListEndpointsError {
 }
 impl fmt::Display for ListEndpointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEndpointsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListEndpointsError {}
 /// Errors returned by ListExperiments
 #[derive(Debug, PartialEq)]
 pub enum ListExperimentsError {}
@@ -11175,14 +10849,10 @@ impl ListExperimentsError {
 }
 impl fmt::Display for ListExperimentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListExperimentsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListExperimentsError {}
 /// Errors returned by ListFlowDefinitions
 #[derive(Debug, PartialEq)]
 pub enum ListFlowDefinitionsError {}
@@ -11200,14 +10870,10 @@ impl ListFlowDefinitionsError {
 }
 impl fmt::Display for ListFlowDefinitionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFlowDefinitionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListFlowDefinitionsError {}
 /// Errors returned by ListHumanTaskUis
 #[derive(Debug, PartialEq)]
 pub enum ListHumanTaskUisError {}
@@ -11225,14 +10891,10 @@ impl ListHumanTaskUisError {
 }
 impl fmt::Display for ListHumanTaskUisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHumanTaskUisError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListHumanTaskUisError {}
 /// Errors returned by ListHyperParameterTuningJobs
 #[derive(Debug, PartialEq)]
 pub enum ListHyperParameterTuningJobsError {}
@@ -11252,14 +10914,10 @@ impl ListHyperParameterTuningJobsError {
 }
 impl fmt::Display for ListHyperParameterTuningJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListHyperParameterTuningJobsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListHyperParameterTuningJobsError {}
 /// Errors returned by ListLabelingJobs
 #[derive(Debug, PartialEq)]
 pub enum ListLabelingJobsError {}
@@ -11277,14 +10935,10 @@ impl ListLabelingJobsError {
 }
 impl fmt::Display for ListLabelingJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLabelingJobsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListLabelingJobsError {}
 /// Errors returned by ListLabelingJobsForWorkteam
 #[derive(Debug, PartialEq)]
 pub enum ListLabelingJobsForWorkteamError {
@@ -11312,16 +10966,12 @@ impl ListLabelingJobsForWorkteamError {
 }
 impl fmt::Display for ListLabelingJobsForWorkteamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLabelingJobsForWorkteamError {
-    fn description(&self) -> &str {
         match *self {
-            ListLabelingJobsForWorkteamError::ResourceNotFound(ref cause) => cause,
+            ListLabelingJobsForWorkteamError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLabelingJobsForWorkteamError {}
 /// Errors returned by ListModelPackages
 #[derive(Debug, PartialEq)]
 pub enum ListModelPackagesError {}
@@ -11339,14 +10989,10 @@ impl ListModelPackagesError {
 }
 impl fmt::Display for ListModelPackagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListModelPackagesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListModelPackagesError {}
 /// Errors returned by ListModels
 #[derive(Debug, PartialEq)]
 pub enum ListModelsError {}
@@ -11364,14 +11010,10 @@ impl ListModelsError {
 }
 impl fmt::Display for ListModelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListModelsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListModelsError {}
 /// Errors returned by ListMonitoringExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListMonitoringExecutionsError {}
@@ -11389,14 +11031,10 @@ impl ListMonitoringExecutionsError {
 }
 impl fmt::Display for ListMonitoringExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMonitoringExecutionsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListMonitoringExecutionsError {}
 /// Errors returned by ListMonitoringSchedules
 #[derive(Debug, PartialEq)]
 pub enum ListMonitoringSchedulesError {}
@@ -11414,14 +11052,10 @@ impl ListMonitoringSchedulesError {
 }
 impl fmt::Display for ListMonitoringSchedulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMonitoringSchedulesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListMonitoringSchedulesError {}
 /// Errors returned by ListNotebookInstanceLifecycleConfigs
 #[derive(Debug, PartialEq)]
 pub enum ListNotebookInstanceLifecycleConfigsError {}
@@ -11441,14 +11075,10 @@ impl ListNotebookInstanceLifecycleConfigsError {
 }
 impl fmt::Display for ListNotebookInstanceLifecycleConfigsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListNotebookInstanceLifecycleConfigsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListNotebookInstanceLifecycleConfigsError {}
 /// Errors returned by ListNotebookInstances
 #[derive(Debug, PartialEq)]
 pub enum ListNotebookInstancesError {}
@@ -11466,14 +11096,10 @@ impl ListNotebookInstancesError {
 }
 impl fmt::Display for ListNotebookInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListNotebookInstancesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListNotebookInstancesError {}
 /// Errors returned by ListProcessingJobs
 #[derive(Debug, PartialEq)]
 pub enum ListProcessingJobsError {}
@@ -11491,14 +11117,10 @@ impl ListProcessingJobsError {
 }
 impl fmt::Display for ListProcessingJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProcessingJobsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListProcessingJobsError {}
 /// Errors returned by ListSubscribedWorkteams
 #[derive(Debug, PartialEq)]
 pub enum ListSubscribedWorkteamsError {}
@@ -11516,14 +11138,10 @@ impl ListSubscribedWorkteamsError {
 }
 impl fmt::Display for ListSubscribedWorkteamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSubscribedWorkteamsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListSubscribedWorkteamsError {}
 /// Errors returned by ListTags
 #[derive(Debug, PartialEq)]
 pub enum ListTagsError {}
@@ -11541,14 +11159,10 @@ impl ListTagsError {
 }
 impl fmt::Display for ListTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListTagsError {}
 /// Errors returned by ListTrainingJobs
 #[derive(Debug, PartialEq)]
 pub enum ListTrainingJobsError {}
@@ -11566,14 +11180,10 @@ impl ListTrainingJobsError {
 }
 impl fmt::Display for ListTrainingJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrainingJobsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListTrainingJobsError {}
 /// Errors returned by ListTrainingJobsForHyperParameterTuningJob
 #[derive(Debug, PartialEq)]
 pub enum ListTrainingJobsForHyperParameterTuningJobError {
@@ -11601,16 +11211,14 @@ impl ListTrainingJobsForHyperParameterTuningJobError {
 }
 impl fmt::Display for ListTrainingJobsForHyperParameterTuningJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrainingJobsForHyperParameterTuningJobError {
-    fn description(&self) -> &str {
         match *self {
-            ListTrainingJobsForHyperParameterTuningJobError::ResourceNotFound(ref cause) => cause,
+            ListTrainingJobsForHyperParameterTuningJobError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListTrainingJobsForHyperParameterTuningJobError {}
 /// Errors returned by ListTransformJobs
 #[derive(Debug, PartialEq)]
 pub enum ListTransformJobsError {}
@@ -11628,14 +11236,10 @@ impl ListTransformJobsError {
 }
 impl fmt::Display for ListTransformJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTransformJobsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListTransformJobsError {}
 /// Errors returned by ListTrialComponents
 #[derive(Debug, PartialEq)]
 pub enum ListTrialComponentsError {}
@@ -11653,14 +11257,10 @@ impl ListTrialComponentsError {
 }
 impl fmt::Display for ListTrialComponentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrialComponentsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListTrialComponentsError {}
 /// Errors returned by ListTrials
 #[derive(Debug, PartialEq)]
 pub enum ListTrialsError {}
@@ -11678,14 +11278,10 @@ impl ListTrialsError {
 }
 impl fmt::Display for ListTrialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTrialsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListTrialsError {}
 /// Errors returned by ListUserProfiles
 #[derive(Debug, PartialEq)]
 pub enum ListUserProfilesError {}
@@ -11703,14 +11299,10 @@ impl ListUserProfilesError {
 }
 impl fmt::Display for ListUserProfilesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUserProfilesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListUserProfilesError {}
 /// Errors returned by ListWorkteams
 #[derive(Debug, PartialEq)]
 pub enum ListWorkteamsError {}
@@ -11728,14 +11320,10 @@ impl ListWorkteamsError {
 }
 impl fmt::Display for ListWorkteamsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWorkteamsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListWorkteamsError {}
 /// Errors returned by RenderUiTemplate
 #[derive(Debug, PartialEq)]
 pub enum RenderUiTemplateError {}
@@ -11753,14 +11341,10 @@ impl RenderUiTemplateError {
 }
 impl fmt::Display for RenderUiTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RenderUiTemplateError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RenderUiTemplateError {}
 /// Errors returned by Search
 #[derive(Debug, PartialEq)]
 pub enum SearchError {}
@@ -11778,14 +11362,10 @@ impl SearchError {
 }
 impl fmt::Display for SearchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SearchError {}
 /// Errors returned by StartMonitoringSchedule
 #[derive(Debug, PartialEq)]
 pub enum StartMonitoringScheduleError {
@@ -11811,16 +11391,12 @@ impl StartMonitoringScheduleError {
 }
 impl fmt::Display for StartMonitoringScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartMonitoringScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            StartMonitoringScheduleError::ResourceNotFound(ref cause) => cause,
+            StartMonitoringScheduleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartMonitoringScheduleError {}
 /// Errors returned by StartNotebookInstance
 #[derive(Debug, PartialEq)]
 pub enum StartNotebookInstanceError {
@@ -11846,16 +11422,12 @@ impl StartNotebookInstanceError {
 }
 impl fmt::Display for StartNotebookInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartNotebookInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            StartNotebookInstanceError::ResourceLimitExceeded(ref cause) => cause,
+            StartNotebookInstanceError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartNotebookInstanceError {}
 /// Errors returned by StopAutoMLJob
 #[derive(Debug, PartialEq)]
 pub enum StopAutoMLJobError {
@@ -11879,16 +11451,12 @@ impl StopAutoMLJobError {
 }
 impl fmt::Display for StopAutoMLJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopAutoMLJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopAutoMLJobError::ResourceNotFound(ref cause) => cause,
+            StopAutoMLJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopAutoMLJobError {}
 /// Errors returned by StopCompilationJob
 #[derive(Debug, PartialEq)]
 pub enum StopCompilationJobError {
@@ -11912,16 +11480,12 @@ impl StopCompilationJobError {
 }
 impl fmt::Display for StopCompilationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopCompilationJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopCompilationJobError::ResourceNotFound(ref cause) => cause,
+            StopCompilationJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopCompilationJobError {}
 /// Errors returned by StopHyperParameterTuningJob
 #[derive(Debug, PartialEq)]
 pub enum StopHyperParameterTuningJobError {
@@ -11949,16 +11513,12 @@ impl StopHyperParameterTuningJobError {
 }
 impl fmt::Display for StopHyperParameterTuningJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopHyperParameterTuningJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopHyperParameterTuningJobError::ResourceNotFound(ref cause) => cause,
+            StopHyperParameterTuningJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopHyperParameterTuningJobError {}
 /// Errors returned by StopLabelingJob
 #[derive(Debug, PartialEq)]
 pub enum StopLabelingJobError {
@@ -11982,16 +11542,12 @@ impl StopLabelingJobError {
 }
 impl fmt::Display for StopLabelingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopLabelingJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopLabelingJobError::ResourceNotFound(ref cause) => cause,
+            StopLabelingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopLabelingJobError {}
 /// Errors returned by StopMonitoringSchedule
 #[derive(Debug, PartialEq)]
 pub enum StopMonitoringScheduleError {
@@ -12017,16 +11573,12 @@ impl StopMonitoringScheduleError {
 }
 impl fmt::Display for StopMonitoringScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopMonitoringScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            StopMonitoringScheduleError::ResourceNotFound(ref cause) => cause,
+            StopMonitoringScheduleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopMonitoringScheduleError {}
 /// Errors returned by StopNotebookInstance
 #[derive(Debug, PartialEq)]
 pub enum StopNotebookInstanceError {}
@@ -12044,14 +11596,10 @@ impl StopNotebookInstanceError {
 }
 impl fmt::Display for StopNotebookInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopNotebookInstanceError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for StopNotebookInstanceError {}
 /// Errors returned by StopProcessingJob
 #[derive(Debug, PartialEq)]
 pub enum StopProcessingJobError {
@@ -12075,16 +11623,12 @@ impl StopProcessingJobError {
 }
 impl fmt::Display for StopProcessingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopProcessingJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopProcessingJobError::ResourceNotFound(ref cause) => cause,
+            StopProcessingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopProcessingJobError {}
 /// Errors returned by StopTrainingJob
 #[derive(Debug, PartialEq)]
 pub enum StopTrainingJobError {
@@ -12108,16 +11652,12 @@ impl StopTrainingJobError {
 }
 impl fmt::Display for StopTrainingJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopTrainingJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopTrainingJobError::ResourceNotFound(ref cause) => cause,
+            StopTrainingJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopTrainingJobError {}
 /// Errors returned by StopTransformJob
 #[derive(Debug, PartialEq)]
 pub enum StopTransformJobError {
@@ -12141,16 +11681,12 @@ impl StopTransformJobError {
 }
 impl fmt::Display for StopTransformJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopTransformJobError {
-    fn description(&self) -> &str {
         match *self {
-            StopTransformJobError::ResourceNotFound(ref cause) => cause,
+            StopTransformJobError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopTransformJobError {}
 /// Errors returned by UpdateCodeRepository
 #[derive(Debug, PartialEq)]
 pub enum UpdateCodeRepositoryError {}
@@ -12168,14 +11704,10 @@ impl UpdateCodeRepositoryError {
 }
 impl fmt::Display for UpdateCodeRepositoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCodeRepositoryError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UpdateCodeRepositoryError {}
 /// Errors returned by UpdateDomain
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainError {
@@ -12209,18 +11741,14 @@ impl UpdateDomainError {
 }
 impl fmt::Display for UpdateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainError::ResourceInUse(ref cause) => cause,
-            UpdateDomainError::ResourceLimitExceeded(ref cause) => cause,
-            UpdateDomainError::ResourceNotFound(ref cause) => cause,
+            UpdateDomainError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateDomainError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainError {}
 /// Errors returned by UpdateEndpoint
 #[derive(Debug, PartialEq)]
 pub enum UpdateEndpointError {
@@ -12246,16 +11774,12 @@ impl UpdateEndpointError {
 }
 impl fmt::Display for UpdateEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEndpointError::ResourceLimitExceeded(ref cause) => cause,
+            UpdateEndpointError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateEndpointError {}
 /// Errors returned by UpdateEndpointWeightsAndCapacities
 #[derive(Debug, PartialEq)]
 pub enum UpdateEndpointWeightsAndCapacitiesError {
@@ -12283,16 +11807,14 @@ impl UpdateEndpointWeightsAndCapacitiesError {
 }
 impl fmt::Display for UpdateEndpointWeightsAndCapacitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEndpointWeightsAndCapacitiesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEndpointWeightsAndCapacitiesError::ResourceLimitExceeded(ref cause) => cause,
+            UpdateEndpointWeightsAndCapacitiesError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateEndpointWeightsAndCapacitiesError {}
 /// Errors returned by UpdateExperiment
 #[derive(Debug, PartialEq)]
 pub enum UpdateExperimentError {
@@ -12321,17 +11843,13 @@ impl UpdateExperimentError {
 }
 impl fmt::Display for UpdateExperimentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateExperimentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateExperimentError::Conflict(ref cause) => cause,
-            UpdateExperimentError::ResourceNotFound(ref cause) => cause,
+            UpdateExperimentError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateExperimentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateExperimentError {}
 /// Errors returned by UpdateMonitoringSchedule
 #[derive(Debug, PartialEq)]
 pub enum UpdateMonitoringScheduleError {
@@ -12364,17 +11882,15 @@ impl UpdateMonitoringScheduleError {
 }
 impl fmt::Display for UpdateMonitoringScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMonitoringScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMonitoringScheduleError::ResourceLimitExceeded(ref cause) => cause,
-            UpdateMonitoringScheduleError::ResourceNotFound(ref cause) => cause,
+            UpdateMonitoringScheduleError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateMonitoringScheduleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMonitoringScheduleError {}
 /// Errors returned by UpdateNotebookInstance
 #[derive(Debug, PartialEq)]
 pub enum UpdateNotebookInstanceError {
@@ -12400,16 +11916,12 @@ impl UpdateNotebookInstanceError {
 }
 impl fmt::Display for UpdateNotebookInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNotebookInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNotebookInstanceError::ResourceLimitExceeded(ref cause) => cause,
+            UpdateNotebookInstanceError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNotebookInstanceError {}
 /// Errors returned by UpdateNotebookInstanceLifecycleConfig
 #[derive(Debug, PartialEq)]
 pub enum UpdateNotebookInstanceLifecycleConfigError {
@@ -12437,16 +11949,14 @@ impl UpdateNotebookInstanceLifecycleConfigError {
 }
 impl fmt::Display for UpdateNotebookInstanceLifecycleConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNotebookInstanceLifecycleConfigError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNotebookInstanceLifecycleConfigError::ResourceLimitExceeded(ref cause) => cause,
+            UpdateNotebookInstanceLifecycleConfigError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateNotebookInstanceLifecycleConfigError {}
 /// Errors returned by UpdateTrial
 #[derive(Debug, PartialEq)]
 pub enum UpdateTrialError {
@@ -12475,17 +11985,13 @@ impl UpdateTrialError {
 }
 impl fmt::Display for UpdateTrialError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTrialError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTrialError::Conflict(ref cause) => cause,
-            UpdateTrialError::ResourceNotFound(ref cause) => cause,
+            UpdateTrialError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateTrialError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTrialError {}
 /// Errors returned by UpdateTrialComponent
 #[derive(Debug, PartialEq)]
 pub enum UpdateTrialComponentError {
@@ -12516,17 +12022,13 @@ impl UpdateTrialComponentError {
 }
 impl fmt::Display for UpdateTrialComponentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTrialComponentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTrialComponentError::Conflict(ref cause) => cause,
-            UpdateTrialComponentError::ResourceNotFound(ref cause) => cause,
+            UpdateTrialComponentError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateTrialComponentError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTrialComponentError {}
 /// Errors returned by UpdateUserProfile
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserProfileError {
@@ -12562,18 +12064,14 @@ impl UpdateUserProfileError {
 }
 impl fmt::Display for UpdateUserProfileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserProfileError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserProfileError::ResourceInUse(ref cause) => cause,
-            UpdateUserProfileError::ResourceLimitExceeded(ref cause) => cause,
-            UpdateUserProfileError::ResourceNotFound(ref cause) => cause,
+            UpdateUserProfileError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            UpdateUserProfileError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateUserProfileError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserProfileError {}
 /// Errors returned by UpdateWorkteam
 #[derive(Debug, PartialEq)]
 pub enum UpdateWorkteamError {
@@ -12599,16 +12097,12 @@ impl UpdateWorkteamError {
 }
 impl fmt::Display for UpdateWorkteamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateWorkteamError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateWorkteamError::ResourceLimitExceeded(ref cause) => cause,
+            UpdateWorkteamError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateWorkteamError {}
 /// Trait representing the capabilities of the SageMaker API. SageMaker clients implement this trait.
 pub trait SageMaker {
     /// <p><p>Adds or overwrites one or more tags for the specified Amazon SageMaker resource. You can add tags to notebook instances, training jobs, hyperparameter tuning jobs, batch transform jobs, models, labeling jobs, work teams, endpoint configurations, and endpoints.</p> <p>Each tag consists of a key and an optional value. Tag keys must be unique per resource. For more information about tags, see For more information, see <a href="https://aws.amazon.com/answers/account-management/aws-tagging-strategies/">AWS Tagging Strategies</a>.</p> <note> <p>Tags that you add to a hyperparameter tuning job by calling this API are also added to any training jobs that the hyperparameter tuning job launches after you call this API, but not to training jobs that the hyperparameter tuning job launched before you called this API. To make sure that the tags associated with a hyperparameter tuning job are also added to all training jobs that the hyperparameter tuning job launches, add the tags when you first create the tuning job by specifying them in the <code>Tags</code> parameter of <a>CreateHyperParameterTuningJob</a> </p> </note></p>

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -890,14 +890,10 @@ impl BatchDeleteAttributesError {
 }
 impl fmt::Display for BatchDeleteAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDeleteAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for BatchDeleteAttributesError {}
 /// Errors returned by BatchPutAttributes
 #[derive(Debug, PartialEq)]
 pub enum BatchPutAttributesError {
@@ -1001,24 +997,28 @@ impl BatchPutAttributesError {
 }
 impl fmt::Display for BatchPutAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchPutAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            BatchPutAttributesError::DuplicateItemName(ref cause) => cause,
-            BatchPutAttributesError::InvalidParameterValue(ref cause) => cause,
-            BatchPutAttributesError::MissingParameter(ref cause) => cause,
-            BatchPutAttributesError::NoSuchDomain(ref cause) => cause,
-            BatchPutAttributesError::NumberDomainAttributesExceeded(ref cause) => cause,
-            BatchPutAttributesError::NumberDomainBytesExceeded(ref cause) => cause,
-            BatchPutAttributesError::NumberItemAttributesExceeded(ref cause) => cause,
-            BatchPutAttributesError::NumberSubmittedAttributesExceeded(ref cause) => cause,
-            BatchPutAttributesError::NumberSubmittedItemsExceeded(ref cause) => cause,
+            BatchPutAttributesError::DuplicateItemName(ref cause) => write!(f, "{}", cause),
+            BatchPutAttributesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            BatchPutAttributesError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            BatchPutAttributesError::NoSuchDomain(ref cause) => write!(f, "{}", cause),
+            BatchPutAttributesError::NumberDomainAttributesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchPutAttributesError::NumberDomainBytesExceeded(ref cause) => write!(f, "{}", cause),
+            BatchPutAttributesError::NumberItemAttributesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchPutAttributesError::NumberSubmittedAttributesExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            BatchPutAttributesError::NumberSubmittedItemsExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for BatchPutAttributesError {}
 /// Errors returned by CreateDomain
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainError {
@@ -1070,18 +1070,14 @@ impl CreateDomainError {
 }
 impl fmt::Display for CreateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDomainError::InvalidParameterValue(ref cause) => cause,
-            CreateDomainError::MissingParameter(ref cause) => cause,
-            CreateDomainError::NumberDomainsExceeded(ref cause) => cause,
+            CreateDomainError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            CreateDomainError::NumberDomainsExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDomainError {}
 /// Errors returned by DeleteAttributes
 #[derive(Debug, PartialEq)]
 pub enum DeleteAttributesError {
@@ -1140,19 +1136,15 @@ impl DeleteAttributesError {
 }
 impl fmt::Display for DeleteAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAttributesError::AttributeDoesNotExist(ref cause) => cause,
-            DeleteAttributesError::InvalidParameterValue(ref cause) => cause,
-            DeleteAttributesError::MissingParameter(ref cause) => cause,
-            DeleteAttributesError::NoSuchDomain(ref cause) => cause,
+            DeleteAttributesError::AttributeDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteAttributesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            DeleteAttributesError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            DeleteAttributesError::NoSuchDomain(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAttributesError {}
 /// Errors returned by DeleteDomain
 #[derive(Debug, PartialEq)]
 pub enum DeleteDomainError {
@@ -1190,16 +1182,12 @@ impl DeleteDomainError {
 }
 impl fmt::Display for DeleteDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDomainError::MissingParameter(ref cause) => cause,
+            DeleteDomainError::MissingParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDomainError {}
 /// Errors returned by DomainMetadata
 #[derive(Debug, PartialEq)]
 pub enum DomainMetadataError {
@@ -1244,17 +1232,13 @@ impl DomainMetadataError {
 }
 impl fmt::Display for DomainMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DomainMetadataError {
-    fn description(&self) -> &str {
         match *self {
-            DomainMetadataError::MissingParameter(ref cause) => cause,
-            DomainMetadataError::NoSuchDomain(ref cause) => cause,
+            DomainMetadataError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            DomainMetadataError::NoSuchDomain(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DomainMetadataError {}
 /// Errors returned by GetAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetAttributesError {
@@ -1306,18 +1290,14 @@ impl GetAttributesError {
 }
 impl fmt::Display for GetAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetAttributesError::InvalidParameterValue(ref cause) => cause,
-            GetAttributesError::MissingParameter(ref cause) => cause,
-            GetAttributesError::NoSuchDomain(ref cause) => cause,
+            GetAttributesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetAttributesError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            GetAttributesError::NoSuchDomain(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAttributesError {}
 /// Errors returned by ListDomains
 #[derive(Debug, PartialEq)]
 pub enum ListDomainsError {
@@ -1362,17 +1342,13 @@ impl ListDomainsError {
 }
 impl fmt::Display for ListDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDomainsError::InvalidNextToken(ref cause) => cause,
-            ListDomainsError::InvalidParameterValue(ref cause) => cause,
+            ListDomainsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListDomainsError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDomainsError {}
 /// Errors returned by PutAttributes
 #[derive(Debug, PartialEq)]
 pub enum PutAttributesError {
@@ -1454,22 +1430,18 @@ impl PutAttributesError {
 }
 impl fmt::Display for PutAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            PutAttributesError::AttributeDoesNotExist(ref cause) => cause,
-            PutAttributesError::InvalidParameterValue(ref cause) => cause,
-            PutAttributesError::MissingParameter(ref cause) => cause,
-            PutAttributesError::NoSuchDomain(ref cause) => cause,
-            PutAttributesError::NumberDomainAttributesExceeded(ref cause) => cause,
-            PutAttributesError::NumberDomainBytesExceeded(ref cause) => cause,
-            PutAttributesError::NumberItemAttributesExceeded(ref cause) => cause,
+            PutAttributesError::AttributeDoesNotExist(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::NoSuchDomain(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::NumberDomainAttributesExceeded(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::NumberDomainBytesExceeded(ref cause) => write!(f, "{}", cause),
+            PutAttributesError::NumberItemAttributesExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutAttributesError {}
 /// Errors returned by Select
 #[derive(Debug, PartialEq)]
 pub enum SelectError {
@@ -1563,24 +1535,20 @@ impl SelectError {
 }
 impl fmt::Display for SelectError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SelectError {
-    fn description(&self) -> &str {
         match *self {
-            SelectError::InvalidNextToken(ref cause) => cause,
-            SelectError::InvalidNumberPredicates(ref cause) => cause,
-            SelectError::InvalidNumberValueTests(ref cause) => cause,
-            SelectError::InvalidParameterValue(ref cause) => cause,
-            SelectError::InvalidQueryExpression(ref cause) => cause,
-            SelectError::MissingParameter(ref cause) => cause,
-            SelectError::NoSuchDomain(ref cause) => cause,
-            SelectError::RequestTimeout(ref cause) => cause,
-            SelectError::TooManyRequestedAttributes(ref cause) => cause,
+            SelectError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            SelectError::InvalidNumberPredicates(ref cause) => write!(f, "{}", cause),
+            SelectError::InvalidNumberValueTests(ref cause) => write!(f, "{}", cause),
+            SelectError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            SelectError::InvalidQueryExpression(ref cause) => write!(f, "{}", cause),
+            SelectError::MissingParameter(ref cause) => write!(f, "{}", cause),
+            SelectError::NoSuchDomain(ref cause) => write!(f, "{}", cause),
+            SelectError::RequestTimeout(ref cause) => write!(f, "{}", cause),
+            SelectError::TooManyRequestedAttributes(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SelectError {}
 /// Trait representing the capabilities of the Amazon SimpleDB API. Amazon SimpleDB clients implement this trait.
 pub trait SimpleDb {
     /// <p> Performs multiple DeleteAttributes operations in a single call, which reduces round trips and latencies. This enables Amazon SimpleDB to optimize requests, which generally yields better throughput. </p> <p> The following limitations are enforced for this operation: <ul> <li>1 MB request size</li> <li>25 item limit per BatchDeleteAttributes operation</li> </ul> </p>

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -779,19 +779,15 @@ impl CancelRotateSecretError {
 }
 impl fmt::Display for CancelRotateSecretError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelRotateSecretError {
-    fn description(&self) -> &str {
         match *self {
-            CancelRotateSecretError::InternalServiceError(ref cause) => cause,
-            CancelRotateSecretError::InvalidParameter(ref cause) => cause,
-            CancelRotateSecretError::InvalidRequest(ref cause) => cause,
-            CancelRotateSecretError::ResourceNotFound(ref cause) => cause,
+            CancelRotateSecretError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            CancelRotateSecretError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CancelRotateSecretError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CancelRotateSecretError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelRotateSecretError {}
 /// Errors returned by CreateSecret
 #[derive(Debug, PartialEq)]
 pub enum CreateSecretError {
@@ -857,24 +853,20 @@ impl CreateSecretError {
 }
 impl fmt::Display for CreateSecretError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSecretError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSecretError::EncryptionFailure(ref cause) => cause,
-            CreateSecretError::InternalServiceError(ref cause) => cause,
-            CreateSecretError::InvalidParameter(ref cause) => cause,
-            CreateSecretError::InvalidRequest(ref cause) => cause,
-            CreateSecretError::LimitExceeded(ref cause) => cause,
-            CreateSecretError::MalformedPolicyDocument(ref cause) => cause,
-            CreateSecretError::PreconditionNotMet(ref cause) => cause,
-            CreateSecretError::ResourceExists(ref cause) => cause,
-            CreateSecretError::ResourceNotFound(ref cause) => cause,
+            CreateSecretError::EncryptionFailure(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::PreconditionNotMet(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::ResourceExists(ref cause) => write!(f, "{}", cause),
+            CreateSecretError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSecretError {}
 /// Errors returned by DeleteResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourcePolicyError {
@@ -912,18 +904,14 @@ impl DeleteResourcePolicyError {
 }
 impl fmt::Display for DeleteResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourcePolicyError::InternalServiceError(ref cause) => cause,
-            DeleteResourcePolicyError::InvalidRequest(ref cause) => cause,
-            DeleteResourcePolicyError::ResourceNotFound(ref cause) => cause,
+            DeleteResourcePolicyError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteResourcePolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourcePolicyError {}
 /// Errors returned by DeleteSecret
 #[derive(Debug, PartialEq)]
 pub enum DeleteSecretError {
@@ -962,19 +950,15 @@ impl DeleteSecretError {
 }
 impl fmt::Display for DeleteSecretError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSecretError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSecretError::InternalServiceError(ref cause) => cause,
-            DeleteSecretError::InvalidParameter(ref cause) => cause,
-            DeleteSecretError::InvalidRequest(ref cause) => cause,
-            DeleteSecretError::ResourceNotFound(ref cause) => cause,
+            DeleteSecretError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DeleteSecretError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteSecretError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteSecretError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSecretError {}
 /// Errors returned by DescribeSecret
 #[derive(Debug, PartialEq)]
 pub enum DescribeSecretError {
@@ -1003,17 +987,13 @@ impl DescribeSecretError {
 }
 impl fmt::Display for DescribeSecretError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSecretError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSecretError::InternalServiceError(ref cause) => cause,
-            DescribeSecretError::ResourceNotFound(ref cause) => cause,
+            DescribeSecretError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DescribeSecretError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSecretError {}
 /// Errors returned by GetRandomPassword
 #[derive(Debug, PartialEq)]
 pub enum GetRandomPasswordError {
@@ -1049,18 +1029,14 @@ impl GetRandomPasswordError {
 }
 impl fmt::Display for GetRandomPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRandomPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            GetRandomPasswordError::InternalServiceError(ref cause) => cause,
-            GetRandomPasswordError::InvalidParameter(ref cause) => cause,
-            GetRandomPasswordError::InvalidRequest(ref cause) => cause,
+            GetRandomPasswordError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            GetRandomPasswordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetRandomPasswordError::InvalidRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRandomPasswordError {}
 /// Errors returned by GetResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum GetResourcePolicyError {
@@ -1096,18 +1072,14 @@ impl GetResourcePolicyError {
 }
 impl fmt::Display for GetResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourcePolicyError::InternalServiceError(ref cause) => cause,
-            GetResourcePolicyError::InvalidRequest(ref cause) => cause,
-            GetResourcePolicyError::ResourceNotFound(ref cause) => cause,
+            GetResourcePolicyError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            GetResourcePolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetResourcePolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourcePolicyError {}
 /// Errors returned by GetSecretValue
 #[derive(Debug, PartialEq)]
 pub enum GetSecretValueError {
@@ -1151,20 +1123,16 @@ impl GetSecretValueError {
 }
 impl fmt::Display for GetSecretValueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSecretValueError {
-    fn description(&self) -> &str {
         match *self {
-            GetSecretValueError::DecryptionFailure(ref cause) => cause,
-            GetSecretValueError::InternalServiceError(ref cause) => cause,
-            GetSecretValueError::InvalidParameter(ref cause) => cause,
-            GetSecretValueError::InvalidRequest(ref cause) => cause,
-            GetSecretValueError::ResourceNotFound(ref cause) => cause,
+            GetSecretValueError::DecryptionFailure(ref cause) => write!(f, "{}", cause),
+            GetSecretValueError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            GetSecretValueError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetSecretValueError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetSecretValueError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSecretValueError {}
 /// Errors returned by ListSecretVersionIds
 #[derive(Debug, PartialEq)]
 pub enum ListSecretVersionIdsError {
@@ -1204,18 +1172,14 @@ impl ListSecretVersionIdsError {
 }
 impl fmt::Display for ListSecretVersionIdsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSecretVersionIdsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSecretVersionIdsError::InternalServiceError(ref cause) => cause,
-            ListSecretVersionIdsError::InvalidNextToken(ref cause) => cause,
-            ListSecretVersionIdsError::ResourceNotFound(ref cause) => cause,
+            ListSecretVersionIdsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ListSecretVersionIdsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListSecretVersionIdsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSecretVersionIdsError {}
 /// Errors returned by ListSecrets
 #[derive(Debug, PartialEq)]
 pub enum ListSecretsError {
@@ -1249,18 +1213,14 @@ impl ListSecretsError {
 }
 impl fmt::Display for ListSecretsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSecretsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSecretsError::InternalServiceError(ref cause) => cause,
-            ListSecretsError::InvalidNextToken(ref cause) => cause,
-            ListSecretsError::InvalidParameter(ref cause) => cause,
+            ListSecretsError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ListSecretsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListSecretsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSecretsError {}
 /// Errors returned by PutResourcePolicy
 #[derive(Debug, PartialEq)]
 pub enum PutResourcePolicyError {
@@ -1308,20 +1268,16 @@ impl PutResourcePolicyError {
 }
 impl fmt::Display for PutResourcePolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutResourcePolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutResourcePolicyError::InternalServiceError(ref cause) => cause,
-            PutResourcePolicyError::InvalidParameter(ref cause) => cause,
-            PutResourcePolicyError::InvalidRequest(ref cause) => cause,
-            PutResourcePolicyError::MalformedPolicyDocument(ref cause) => cause,
-            PutResourcePolicyError::ResourceNotFound(ref cause) => cause,
+            PutResourcePolicyError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            PutResourcePolicyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutResourcePolicyError {}
 /// Errors returned by PutSecretValue
 #[derive(Debug, PartialEq)]
 pub enum PutSecretValueError {
@@ -1375,22 +1331,18 @@ impl PutSecretValueError {
 }
 impl fmt::Display for PutSecretValueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutSecretValueError {
-    fn description(&self) -> &str {
         match *self {
-            PutSecretValueError::EncryptionFailure(ref cause) => cause,
-            PutSecretValueError::InternalServiceError(ref cause) => cause,
-            PutSecretValueError::InvalidParameter(ref cause) => cause,
-            PutSecretValueError::InvalidRequest(ref cause) => cause,
-            PutSecretValueError::LimitExceeded(ref cause) => cause,
-            PutSecretValueError::ResourceExists(ref cause) => cause,
-            PutSecretValueError::ResourceNotFound(ref cause) => cause,
+            PutSecretValueError::EncryptionFailure(ref cause) => write!(f, "{}", cause),
+            PutSecretValueError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            PutSecretValueError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutSecretValueError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutSecretValueError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutSecretValueError::ResourceExists(ref cause) => write!(f, "{}", cause),
+            PutSecretValueError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutSecretValueError {}
 /// Errors returned by RestoreSecret
 #[derive(Debug, PartialEq)]
 pub enum RestoreSecretError {
@@ -1429,19 +1381,15 @@ impl RestoreSecretError {
 }
 impl fmt::Display for RestoreSecretError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreSecretError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreSecretError::InternalServiceError(ref cause) => cause,
-            RestoreSecretError::InvalidParameter(ref cause) => cause,
-            RestoreSecretError::InvalidRequest(ref cause) => cause,
-            RestoreSecretError::ResourceNotFound(ref cause) => cause,
+            RestoreSecretError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            RestoreSecretError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RestoreSecretError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RestoreSecretError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreSecretError {}
 /// Errors returned by RotateSecret
 #[derive(Debug, PartialEq)]
 pub enum RotateSecretError {
@@ -1480,19 +1428,15 @@ impl RotateSecretError {
 }
 impl fmt::Display for RotateSecretError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RotateSecretError {
-    fn description(&self) -> &str {
         match *self {
-            RotateSecretError::InternalServiceError(ref cause) => cause,
-            RotateSecretError::InvalidParameter(ref cause) => cause,
-            RotateSecretError::InvalidRequest(ref cause) => cause,
-            RotateSecretError::ResourceNotFound(ref cause) => cause,
+            RotateSecretError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            RotateSecretError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RotateSecretError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RotateSecretError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RotateSecretError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1531,19 +1475,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalServiceError(ref cause) => cause,
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1582,19 +1522,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalServiceError(ref cause) => cause,
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateSecret
 #[derive(Debug, PartialEq)]
 pub enum UpdateSecretError {
@@ -1660,24 +1596,20 @@ impl UpdateSecretError {
 }
 impl fmt::Display for UpdateSecretError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSecretError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSecretError::EncryptionFailure(ref cause) => cause,
-            UpdateSecretError::InternalServiceError(ref cause) => cause,
-            UpdateSecretError::InvalidParameter(ref cause) => cause,
-            UpdateSecretError::InvalidRequest(ref cause) => cause,
-            UpdateSecretError::LimitExceeded(ref cause) => cause,
-            UpdateSecretError::MalformedPolicyDocument(ref cause) => cause,
-            UpdateSecretError::PreconditionNotMet(ref cause) => cause,
-            UpdateSecretError::ResourceExists(ref cause) => cause,
-            UpdateSecretError::ResourceNotFound(ref cause) => cause,
+            UpdateSecretError::EncryptionFailure(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::PreconditionNotMet(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::ResourceExists(ref cause) => write!(f, "{}", cause),
+            UpdateSecretError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSecretError {}
 /// Errors returned by UpdateSecretVersionStage
 #[derive(Debug, PartialEq)]
 pub enum UpdateSecretVersionStageError {
@@ -1731,20 +1663,18 @@ impl UpdateSecretVersionStageError {
 }
 impl fmt::Display for UpdateSecretVersionStageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSecretVersionStageError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSecretVersionStageError::InternalServiceError(ref cause) => cause,
-            UpdateSecretVersionStageError::InvalidParameter(ref cause) => cause,
-            UpdateSecretVersionStageError::InvalidRequest(ref cause) => cause,
-            UpdateSecretVersionStageError::LimitExceeded(ref cause) => cause,
-            UpdateSecretVersionStageError::ResourceNotFound(ref cause) => cause,
+            UpdateSecretVersionStageError::InternalServiceError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSecretVersionStageError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateSecretVersionStageError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateSecretVersionStageError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSecretVersionStageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSecretVersionStageError {}
 /// Trait representing the capabilities of the AWS Secrets Manager API. AWS Secrets Manager clients implement this trait.
 pub trait SecretsManager {
     /// <p><p>Disables automatic scheduled rotation and cancels the rotation of a secret if one is currently in progress.</p> <p>To re-enable scheduled rotation, call <a>RotateSecret</a> with <code>AutomaticallyRotateAfterDays</code> set to a value greater than 0. This will immediately rotate your secret and then enable the automatic schedule.</p> <note> <p>If you cancel a rotation that is in progress, it can leave the <code>VersionStage</code> labels in an unexpected state. Depending on what step of the rotation was in progress, you might need to remove the staging label <code>AWSPENDING</code> from the partially created version, specified by the <code>VersionId</code> response value. You should also evaluate the partially rotated new version to see if it should be deleted, which you can do by removing all staging labels from the new version&#39;s <code>VersionStage</code> field.</p> </note> <p>To successfully start a rotation, the staging label <code>AWSPENDING</code> must be in one of the following states:</p> <ul> <li> <p>Not be attached to any version at all</p> </li> <li> <p>Attached to the same version as the staging label <code>AWSCURRENT</code> </p> </li> </ul> <p>If the staging label <code>AWSPENDING</code> is attached to a different version than the version with <code>AWSCURRENT</code> then the attempt to rotate fails.</p> <p> <b>Minimum permissions</b> </p> <p>To run this command, you must have the following permissions:</p> <ul> <li> <p>secretsmanager:CancelRotateSecret</p> </li> </ul> <p> <b>Related operations</b> </p> <ul> <li> <p>To configure rotation for a secret or to manually trigger a rotation, use <a>RotateSecret</a>.</p> </li> <li> <p>To get the rotation configuration details for a secret, use <a>DescribeSecret</a>.</p> </li> <li> <p>To list all of the currently available secrets, use <a>ListSecrets</a>.</p> </li> <li> <p>To list all of the versions currently associated with a secret, use <a>ListSecretVersionIds</a>.</p> </li> </ul></p>

--- a/rusoto/services/securityhub/src/generated.rs
+++ b/rusoto/services/securityhub/src/generated.rs
@@ -1889,20 +1889,16 @@ impl AcceptInvitationError {
 }
 impl fmt::Display for AcceptInvitationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptInvitationError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptInvitationError::Internal(ref cause) => cause,
-            AcceptInvitationError::InvalidAccess(ref cause) => cause,
-            AcceptInvitationError::InvalidInput(ref cause) => cause,
-            AcceptInvitationError::LimitExceeded(ref cause) => cause,
-            AcceptInvitationError::ResourceNotFound(ref cause) => cause,
+            AcceptInvitationError::Internal(ref cause) => write!(f, "{}", cause),
+            AcceptInvitationError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            AcceptInvitationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            AcceptInvitationError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AcceptInvitationError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptInvitationError {}
 /// Errors returned by BatchDisableStandards
 #[derive(Debug, PartialEq)]
 pub enum BatchDisableStandardsError {
@@ -1941,19 +1937,15 @@ impl BatchDisableStandardsError {
 }
 impl fmt::Display for BatchDisableStandardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDisableStandardsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchDisableStandardsError::Internal(ref cause) => cause,
-            BatchDisableStandardsError::InvalidAccess(ref cause) => cause,
-            BatchDisableStandardsError::InvalidInput(ref cause) => cause,
-            BatchDisableStandardsError::LimitExceeded(ref cause) => cause,
+            BatchDisableStandardsError::Internal(ref cause) => write!(f, "{}", cause),
+            BatchDisableStandardsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            BatchDisableStandardsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchDisableStandardsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDisableStandardsError {}
 /// Errors returned by BatchEnableStandards
 #[derive(Debug, PartialEq)]
 pub enum BatchEnableStandardsError {
@@ -1992,19 +1984,15 @@ impl BatchEnableStandardsError {
 }
 impl fmt::Display for BatchEnableStandardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchEnableStandardsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchEnableStandardsError::Internal(ref cause) => cause,
-            BatchEnableStandardsError::InvalidAccess(ref cause) => cause,
-            BatchEnableStandardsError::InvalidInput(ref cause) => cause,
-            BatchEnableStandardsError::LimitExceeded(ref cause) => cause,
+            BatchEnableStandardsError::Internal(ref cause) => write!(f, "{}", cause),
+            BatchEnableStandardsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            BatchEnableStandardsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchEnableStandardsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchEnableStandardsError {}
 /// Errors returned by BatchImportFindings
 #[derive(Debug, PartialEq)]
 pub enum BatchImportFindingsError {
@@ -2043,19 +2031,15 @@ impl BatchImportFindingsError {
 }
 impl fmt::Display for BatchImportFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchImportFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            BatchImportFindingsError::Internal(ref cause) => cause,
-            BatchImportFindingsError::InvalidAccess(ref cause) => cause,
-            BatchImportFindingsError::InvalidInput(ref cause) => cause,
-            BatchImportFindingsError::LimitExceeded(ref cause) => cause,
+            BatchImportFindingsError::Internal(ref cause) => write!(f, "{}", cause),
+            BatchImportFindingsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            BatchImportFindingsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            BatchImportFindingsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchImportFindingsError {}
 /// Errors returned by CreateActionTarget
 #[derive(Debug, PartialEq)]
 pub enum CreateActionTargetError {
@@ -2099,20 +2083,16 @@ impl CreateActionTargetError {
 }
 impl fmt::Display for CreateActionTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateActionTargetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateActionTargetError::Internal(ref cause) => cause,
-            CreateActionTargetError::InvalidAccess(ref cause) => cause,
-            CreateActionTargetError::InvalidInput(ref cause) => cause,
-            CreateActionTargetError::LimitExceeded(ref cause) => cause,
-            CreateActionTargetError::ResourceConflict(ref cause) => cause,
+            CreateActionTargetError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateActionTargetError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            CreateActionTargetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateActionTargetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateActionTargetError::ResourceConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateActionTargetError {}
 /// Errors returned by CreateInsight
 #[derive(Debug, PartialEq)]
 pub enum CreateInsightError {
@@ -2156,20 +2136,16 @@ impl CreateInsightError {
 }
 impl fmt::Display for CreateInsightError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateInsightError {
-    fn description(&self) -> &str {
         match *self {
-            CreateInsightError::Internal(ref cause) => cause,
-            CreateInsightError::InvalidAccess(ref cause) => cause,
-            CreateInsightError::InvalidInput(ref cause) => cause,
-            CreateInsightError::LimitExceeded(ref cause) => cause,
-            CreateInsightError::ResourceConflict(ref cause) => cause,
+            CreateInsightError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateInsightError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            CreateInsightError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateInsightError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateInsightError::ResourceConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateInsightError {}
 /// Errors returned by CreateMembers
 #[derive(Debug, PartialEq)]
 pub enum CreateMembersError {
@@ -2213,20 +2189,16 @@ impl CreateMembersError {
 }
 impl fmt::Display for CreateMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMembersError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMembersError::Internal(ref cause) => cause,
-            CreateMembersError::InvalidAccess(ref cause) => cause,
-            CreateMembersError::InvalidInput(ref cause) => cause,
-            CreateMembersError::LimitExceeded(ref cause) => cause,
-            CreateMembersError::ResourceConflict(ref cause) => cause,
+            CreateMembersError::Internal(ref cause) => write!(f, "{}", cause),
+            CreateMembersError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            CreateMembersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateMembersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateMembersError::ResourceConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateMembersError {}
 /// Errors returned by DeclineInvitations
 #[derive(Debug, PartialEq)]
 pub enum DeclineInvitationsError {
@@ -2265,19 +2237,15 @@ impl DeclineInvitationsError {
 }
 impl fmt::Display for DeclineInvitationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeclineInvitationsError {
-    fn description(&self) -> &str {
         match *self {
-            DeclineInvitationsError::Internal(ref cause) => cause,
-            DeclineInvitationsError::InvalidAccess(ref cause) => cause,
-            DeclineInvitationsError::InvalidInput(ref cause) => cause,
-            DeclineInvitationsError::ResourceNotFound(ref cause) => cause,
+            DeclineInvitationsError::Internal(ref cause) => write!(f, "{}", cause),
+            DeclineInvitationsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DeclineInvitationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeclineInvitationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeclineInvitationsError {}
 /// Errors returned by DeleteActionTarget
 #[derive(Debug, PartialEq)]
 pub enum DeleteActionTargetError {
@@ -2316,19 +2284,15 @@ impl DeleteActionTargetError {
 }
 impl fmt::Display for DeleteActionTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteActionTargetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteActionTargetError::Internal(ref cause) => cause,
-            DeleteActionTargetError::InvalidAccess(ref cause) => cause,
-            DeleteActionTargetError::InvalidInput(ref cause) => cause,
-            DeleteActionTargetError::ResourceNotFound(ref cause) => cause,
+            DeleteActionTargetError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteActionTargetError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DeleteActionTargetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteActionTargetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteActionTargetError {}
 /// Errors returned by DeleteInsight
 #[derive(Debug, PartialEq)]
 pub enum DeleteInsightError {
@@ -2372,20 +2336,16 @@ impl DeleteInsightError {
 }
 impl fmt::Display for DeleteInsightError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInsightError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInsightError::Internal(ref cause) => cause,
-            DeleteInsightError::InvalidAccess(ref cause) => cause,
-            DeleteInsightError::InvalidInput(ref cause) => cause,
-            DeleteInsightError::LimitExceeded(ref cause) => cause,
-            DeleteInsightError::ResourceNotFound(ref cause) => cause,
+            DeleteInsightError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteInsightError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DeleteInsightError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteInsightError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteInsightError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInsightError {}
 /// Errors returned by DeleteInvitations
 #[derive(Debug, PartialEq)]
 pub enum DeleteInvitationsError {
@@ -2429,20 +2389,16 @@ impl DeleteInvitationsError {
 }
 impl fmt::Display for DeleteInvitationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInvitationsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInvitationsError::Internal(ref cause) => cause,
-            DeleteInvitationsError::InvalidAccess(ref cause) => cause,
-            DeleteInvitationsError::InvalidInput(ref cause) => cause,
-            DeleteInvitationsError::LimitExceeded(ref cause) => cause,
-            DeleteInvitationsError::ResourceNotFound(ref cause) => cause,
+            DeleteInvitationsError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteInvitationsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DeleteInvitationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteInvitationsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteInvitationsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInvitationsError {}
 /// Errors returned by DeleteMembers
 #[derive(Debug, PartialEq)]
 pub enum DeleteMembersError {
@@ -2486,20 +2442,16 @@ impl DeleteMembersError {
 }
 impl fmt::Display for DeleteMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMembersError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMembersError::Internal(ref cause) => cause,
-            DeleteMembersError::InvalidAccess(ref cause) => cause,
-            DeleteMembersError::InvalidInput(ref cause) => cause,
-            DeleteMembersError::LimitExceeded(ref cause) => cause,
-            DeleteMembersError::ResourceNotFound(ref cause) => cause,
+            DeleteMembersError::Internal(ref cause) => write!(f, "{}", cause),
+            DeleteMembersError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DeleteMembersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteMembersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteMembersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMembersError {}
 /// Errors returned by DescribeActionTargets
 #[derive(Debug, PartialEq)]
 pub enum DescribeActionTargetsError {
@@ -2540,19 +2492,15 @@ impl DescribeActionTargetsError {
 }
 impl fmt::Display for DescribeActionTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeActionTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeActionTargetsError::Internal(ref cause) => cause,
-            DescribeActionTargetsError::InvalidAccess(ref cause) => cause,
-            DescribeActionTargetsError::InvalidInput(ref cause) => cause,
-            DescribeActionTargetsError::ResourceNotFound(ref cause) => cause,
+            DescribeActionTargetsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeActionTargetsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DescribeActionTargetsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeActionTargetsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeActionTargetsError {}
 /// Errors returned by DescribeHub
 #[derive(Debug, PartialEq)]
 pub enum DescribeHubError {
@@ -2596,20 +2544,16 @@ impl DescribeHubError {
 }
 impl fmt::Display for DescribeHubError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeHubError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeHubError::Internal(ref cause) => cause,
-            DescribeHubError::InvalidAccess(ref cause) => cause,
-            DescribeHubError::InvalidInput(ref cause) => cause,
-            DescribeHubError::LimitExceeded(ref cause) => cause,
-            DescribeHubError::ResourceNotFound(ref cause) => cause,
+            DescribeHubError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeHubError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DescribeHubError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeHubError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DescribeHubError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeHubError {}
 /// Errors returned by DescribeProducts
 #[derive(Debug, PartialEq)]
 pub enum DescribeProductsError {
@@ -2648,19 +2592,15 @@ impl DescribeProductsError {
 }
 impl fmt::Display for DescribeProductsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProductsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProductsError::Internal(ref cause) => cause,
-            DescribeProductsError::InvalidAccess(ref cause) => cause,
-            DescribeProductsError::InvalidInput(ref cause) => cause,
-            DescribeProductsError::LimitExceeded(ref cause) => cause,
+            DescribeProductsError::Internal(ref cause) => write!(f, "{}", cause),
+            DescribeProductsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DescribeProductsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DescribeProductsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProductsError {}
 /// Errors returned by DisableImportFindingsForProduct
 #[derive(Debug, PartialEq)]
 pub enum DisableImportFindingsForProductError {
@@ -2716,20 +2656,22 @@ impl DisableImportFindingsForProductError {
 }
 impl fmt::Display for DisableImportFindingsForProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableImportFindingsForProductError {
-    fn description(&self) -> &str {
         match *self {
-            DisableImportFindingsForProductError::Internal(ref cause) => cause,
-            DisableImportFindingsForProductError::InvalidAccess(ref cause) => cause,
-            DisableImportFindingsForProductError::InvalidInput(ref cause) => cause,
-            DisableImportFindingsForProductError::LimitExceeded(ref cause) => cause,
-            DisableImportFindingsForProductError::ResourceNotFound(ref cause) => cause,
+            DisableImportFindingsForProductError::Internal(ref cause) => write!(f, "{}", cause),
+            DisableImportFindingsForProductError::InvalidAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisableImportFindingsForProductError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisableImportFindingsForProductError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisableImportFindingsForProductError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisableImportFindingsForProductError {}
 /// Errors returned by DisableSecurityHub
 #[derive(Debug, PartialEq)]
 pub enum DisableSecurityHubError {
@@ -2768,19 +2710,15 @@ impl DisableSecurityHubError {
 }
 impl fmt::Display for DisableSecurityHubError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableSecurityHubError {
-    fn description(&self) -> &str {
         match *self {
-            DisableSecurityHubError::Internal(ref cause) => cause,
-            DisableSecurityHubError::InvalidAccess(ref cause) => cause,
-            DisableSecurityHubError::LimitExceeded(ref cause) => cause,
-            DisableSecurityHubError::ResourceNotFound(ref cause) => cause,
+            DisableSecurityHubError::Internal(ref cause) => write!(f, "{}", cause),
+            DisableSecurityHubError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DisableSecurityHubError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DisableSecurityHubError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableSecurityHubError {}
 /// Errors returned by DisassociateFromMasterAccount
 #[derive(Debug, PartialEq)]
 pub enum DisassociateFromMasterAccountError {
@@ -2836,20 +2774,18 @@ impl DisassociateFromMasterAccountError {
 }
 impl fmt::Display for DisassociateFromMasterAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateFromMasterAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateFromMasterAccountError::Internal(ref cause) => cause,
-            DisassociateFromMasterAccountError::InvalidAccess(ref cause) => cause,
-            DisassociateFromMasterAccountError::InvalidInput(ref cause) => cause,
-            DisassociateFromMasterAccountError::LimitExceeded(ref cause) => cause,
-            DisassociateFromMasterAccountError::ResourceNotFound(ref cause) => cause,
+            DisassociateFromMasterAccountError::Internal(ref cause) => write!(f, "{}", cause),
+            DisassociateFromMasterAccountError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DisassociateFromMasterAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisassociateFromMasterAccountError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DisassociateFromMasterAccountError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateFromMasterAccountError {}
 /// Errors returned by DisassociateMembers
 #[derive(Debug, PartialEq)]
 pub enum DisassociateMembersError {
@@ -2895,20 +2831,16 @@ impl DisassociateMembersError {
 }
 impl fmt::Display for DisassociateMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateMembersError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateMembersError::Internal(ref cause) => cause,
-            DisassociateMembersError::InvalidAccess(ref cause) => cause,
-            DisassociateMembersError::InvalidInput(ref cause) => cause,
-            DisassociateMembersError::LimitExceeded(ref cause) => cause,
-            DisassociateMembersError::ResourceNotFound(ref cause) => cause,
+            DisassociateMembersError::Internal(ref cause) => write!(f, "{}", cause),
+            DisassociateMembersError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            DisassociateMembersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DisassociateMembersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DisassociateMembersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateMembersError {}
 /// Errors returned by EnableImportFindingsForProduct
 #[derive(Debug, PartialEq)]
 pub enum EnableImportFindingsForProductError {
@@ -2964,20 +2896,18 @@ impl EnableImportFindingsForProductError {
 }
 impl fmt::Display for EnableImportFindingsForProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableImportFindingsForProductError {
-    fn description(&self) -> &str {
         match *self {
-            EnableImportFindingsForProductError::Internal(ref cause) => cause,
-            EnableImportFindingsForProductError::InvalidAccess(ref cause) => cause,
-            EnableImportFindingsForProductError::InvalidInput(ref cause) => cause,
-            EnableImportFindingsForProductError::LimitExceeded(ref cause) => cause,
-            EnableImportFindingsForProductError::ResourceConflict(ref cause) => cause,
+            EnableImportFindingsForProductError::Internal(ref cause) => write!(f, "{}", cause),
+            EnableImportFindingsForProductError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            EnableImportFindingsForProductError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            EnableImportFindingsForProductError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            EnableImportFindingsForProductError::ResourceConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for EnableImportFindingsForProductError {}
 /// Errors returned by EnableSecurityHub
 #[derive(Debug, PartialEq)]
 pub enum EnableSecurityHubError {
@@ -3021,20 +2951,16 @@ impl EnableSecurityHubError {
 }
 impl fmt::Display for EnableSecurityHubError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableSecurityHubError {
-    fn description(&self) -> &str {
         match *self {
-            EnableSecurityHubError::AccessDenied(ref cause) => cause,
-            EnableSecurityHubError::Internal(ref cause) => cause,
-            EnableSecurityHubError::InvalidAccess(ref cause) => cause,
-            EnableSecurityHubError::LimitExceeded(ref cause) => cause,
-            EnableSecurityHubError::ResourceConflict(ref cause) => cause,
+            EnableSecurityHubError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            EnableSecurityHubError::Internal(ref cause) => write!(f, "{}", cause),
+            EnableSecurityHubError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            EnableSecurityHubError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            EnableSecurityHubError::ResourceConflict(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for EnableSecurityHubError {}
 /// Errors returned by GetEnabledStandards
 #[derive(Debug, PartialEq)]
 pub enum GetEnabledStandardsError {
@@ -3073,19 +2999,15 @@ impl GetEnabledStandardsError {
 }
 impl fmt::Display for GetEnabledStandardsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEnabledStandardsError {
-    fn description(&self) -> &str {
         match *self {
-            GetEnabledStandardsError::Internal(ref cause) => cause,
-            GetEnabledStandardsError::InvalidAccess(ref cause) => cause,
-            GetEnabledStandardsError::InvalidInput(ref cause) => cause,
-            GetEnabledStandardsError::LimitExceeded(ref cause) => cause,
+            GetEnabledStandardsError::Internal(ref cause) => write!(f, "{}", cause),
+            GetEnabledStandardsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            GetEnabledStandardsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetEnabledStandardsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEnabledStandardsError {}
 /// Errors returned by GetFindings
 #[derive(Debug, PartialEq)]
 pub enum GetFindingsError {
@@ -3124,19 +3046,15 @@ impl GetFindingsError {
 }
 impl fmt::Display for GetFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            GetFindingsError::Internal(ref cause) => cause,
-            GetFindingsError::InvalidAccess(ref cause) => cause,
-            GetFindingsError::InvalidInput(ref cause) => cause,
-            GetFindingsError::LimitExceeded(ref cause) => cause,
+            GetFindingsError::Internal(ref cause) => write!(f, "{}", cause),
+            GetFindingsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            GetFindingsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetFindingsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFindingsError {}
 /// Errors returned by GetInsightResults
 #[derive(Debug, PartialEq)]
 pub enum GetInsightResultsError {
@@ -3180,20 +3098,16 @@ impl GetInsightResultsError {
 }
 impl fmt::Display for GetInsightResultsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInsightResultsError {
-    fn description(&self) -> &str {
         match *self {
-            GetInsightResultsError::Internal(ref cause) => cause,
-            GetInsightResultsError::InvalidAccess(ref cause) => cause,
-            GetInsightResultsError::InvalidInput(ref cause) => cause,
-            GetInsightResultsError::LimitExceeded(ref cause) => cause,
-            GetInsightResultsError::ResourceNotFound(ref cause) => cause,
+            GetInsightResultsError::Internal(ref cause) => write!(f, "{}", cause),
+            GetInsightResultsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            GetInsightResultsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInsightResultsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetInsightResultsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInsightResultsError {}
 /// Errors returned by GetInsights
 #[derive(Debug, PartialEq)]
 pub enum GetInsightsError {
@@ -3237,20 +3151,16 @@ impl GetInsightsError {
 }
 impl fmt::Display for GetInsightsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInsightsError {
-    fn description(&self) -> &str {
         match *self {
-            GetInsightsError::Internal(ref cause) => cause,
-            GetInsightsError::InvalidAccess(ref cause) => cause,
-            GetInsightsError::InvalidInput(ref cause) => cause,
-            GetInsightsError::LimitExceeded(ref cause) => cause,
-            GetInsightsError::ResourceNotFound(ref cause) => cause,
+            GetInsightsError::Internal(ref cause) => write!(f, "{}", cause),
+            GetInsightsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            GetInsightsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInsightsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetInsightsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInsightsError {}
 /// Errors returned by GetInvitationsCount
 #[derive(Debug, PartialEq)]
 pub enum GetInvitationsCountError {
@@ -3289,19 +3199,15 @@ impl GetInvitationsCountError {
 }
 impl fmt::Display for GetInvitationsCountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInvitationsCountError {
-    fn description(&self) -> &str {
         match *self {
-            GetInvitationsCountError::Internal(ref cause) => cause,
-            GetInvitationsCountError::InvalidAccess(ref cause) => cause,
-            GetInvitationsCountError::InvalidInput(ref cause) => cause,
-            GetInvitationsCountError::LimitExceeded(ref cause) => cause,
+            GetInvitationsCountError::Internal(ref cause) => write!(f, "{}", cause),
+            GetInvitationsCountError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            GetInvitationsCountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInvitationsCountError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInvitationsCountError {}
 /// Errors returned by GetMasterAccount
 #[derive(Debug, PartialEq)]
 pub enum GetMasterAccountError {
@@ -3345,20 +3251,16 @@ impl GetMasterAccountError {
 }
 impl fmt::Display for GetMasterAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMasterAccountError {
-    fn description(&self) -> &str {
         match *self {
-            GetMasterAccountError::Internal(ref cause) => cause,
-            GetMasterAccountError::InvalidAccess(ref cause) => cause,
-            GetMasterAccountError::InvalidInput(ref cause) => cause,
-            GetMasterAccountError::LimitExceeded(ref cause) => cause,
-            GetMasterAccountError::ResourceNotFound(ref cause) => cause,
+            GetMasterAccountError::Internal(ref cause) => write!(f, "{}", cause),
+            GetMasterAccountError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            GetMasterAccountError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMasterAccountError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetMasterAccountError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMasterAccountError {}
 /// Errors returned by GetMembers
 #[derive(Debug, PartialEq)]
 pub enum GetMembersError {
@@ -3402,20 +3304,16 @@ impl GetMembersError {
 }
 impl fmt::Display for GetMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMembersError {
-    fn description(&self) -> &str {
         match *self {
-            GetMembersError::Internal(ref cause) => cause,
-            GetMembersError::InvalidAccess(ref cause) => cause,
-            GetMembersError::InvalidInput(ref cause) => cause,
-            GetMembersError::LimitExceeded(ref cause) => cause,
-            GetMembersError::ResourceNotFound(ref cause) => cause,
+            GetMembersError::Internal(ref cause) => write!(f, "{}", cause),
+            GetMembersError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            GetMembersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetMembersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetMembersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMembersError {}
 /// Errors returned by InviteMembers
 #[derive(Debug, PartialEq)]
 pub enum InviteMembersError {
@@ -3459,20 +3357,16 @@ impl InviteMembersError {
 }
 impl fmt::Display for InviteMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InviteMembersError {
-    fn description(&self) -> &str {
         match *self {
-            InviteMembersError::Internal(ref cause) => cause,
-            InviteMembersError::InvalidAccess(ref cause) => cause,
-            InviteMembersError::InvalidInput(ref cause) => cause,
-            InviteMembersError::LimitExceeded(ref cause) => cause,
-            InviteMembersError::ResourceNotFound(ref cause) => cause,
+            InviteMembersError::Internal(ref cause) => write!(f, "{}", cause),
+            InviteMembersError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            InviteMembersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            InviteMembersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            InviteMembersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for InviteMembersError {}
 /// Errors returned by ListEnabledProductsForImport
 #[derive(Debug, PartialEq)]
 pub enum ListEnabledProductsForImportError {
@@ -3514,18 +3408,14 @@ impl ListEnabledProductsForImportError {
 }
 impl fmt::Display for ListEnabledProductsForImportError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEnabledProductsForImportError {
-    fn description(&self) -> &str {
         match *self {
-            ListEnabledProductsForImportError::Internal(ref cause) => cause,
-            ListEnabledProductsForImportError::InvalidAccess(ref cause) => cause,
-            ListEnabledProductsForImportError::LimitExceeded(ref cause) => cause,
+            ListEnabledProductsForImportError::Internal(ref cause) => write!(f, "{}", cause),
+            ListEnabledProductsForImportError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            ListEnabledProductsForImportError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEnabledProductsForImportError {}
 /// Errors returned by ListInvitations
 #[derive(Debug, PartialEq)]
 pub enum ListInvitationsError {
@@ -3564,19 +3454,15 @@ impl ListInvitationsError {
 }
 impl fmt::Display for ListInvitationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInvitationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListInvitationsError::Internal(ref cause) => cause,
-            ListInvitationsError::InvalidAccess(ref cause) => cause,
-            ListInvitationsError::InvalidInput(ref cause) => cause,
-            ListInvitationsError::LimitExceeded(ref cause) => cause,
+            ListInvitationsError::Internal(ref cause) => write!(f, "{}", cause),
+            ListInvitationsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            ListInvitationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListInvitationsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInvitationsError {}
 /// Errors returned by ListMembers
 #[derive(Debug, PartialEq)]
 pub enum ListMembersError {
@@ -3615,19 +3501,15 @@ impl ListMembersError {
 }
 impl fmt::Display for ListMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMembersError {
-    fn description(&self) -> &str {
         match *self {
-            ListMembersError::Internal(ref cause) => cause,
-            ListMembersError::InvalidAccess(ref cause) => cause,
-            ListMembersError::InvalidInput(ref cause) => cause,
-            ListMembersError::LimitExceeded(ref cause) => cause,
+            ListMembersError::Internal(ref cause) => write!(f, "{}", cause),
+            ListMembersError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            ListMembersError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListMembersError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMembersError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3663,18 +3545,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::Internal(ref cause) => cause,
-            ListTagsForResourceError::InvalidInput(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -3708,18 +3586,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::Internal(ref cause) => cause,
-            TagResourceError::InvalidInput(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
+            TagResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -3753,18 +3627,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::Internal(ref cause) => cause,
-            UntagResourceError::InvalidInput(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::Internal(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateActionTarget
 #[derive(Debug, PartialEq)]
 pub enum UpdateActionTargetError {
@@ -3803,19 +3673,15 @@ impl UpdateActionTargetError {
 }
 impl fmt::Display for UpdateActionTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateActionTargetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateActionTargetError::Internal(ref cause) => cause,
-            UpdateActionTargetError::InvalidAccess(ref cause) => cause,
-            UpdateActionTargetError::InvalidInput(ref cause) => cause,
-            UpdateActionTargetError::ResourceNotFound(ref cause) => cause,
+            UpdateActionTargetError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateActionTargetError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            UpdateActionTargetError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateActionTargetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateActionTargetError {}
 /// Errors returned by UpdateFindings
 #[derive(Debug, PartialEq)]
 pub enum UpdateFindingsError {
@@ -3859,20 +3725,16 @@ impl UpdateFindingsError {
 }
 impl fmt::Display for UpdateFindingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFindingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFindingsError::Internal(ref cause) => cause,
-            UpdateFindingsError::InvalidAccess(ref cause) => cause,
-            UpdateFindingsError::InvalidInput(ref cause) => cause,
-            UpdateFindingsError::LimitExceeded(ref cause) => cause,
-            UpdateFindingsError::ResourceNotFound(ref cause) => cause,
+            UpdateFindingsError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateFindingsError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            UpdateFindingsError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateFindingsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFindingsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFindingsError {}
 /// Errors returned by UpdateInsight
 #[derive(Debug, PartialEq)]
 pub enum UpdateInsightError {
@@ -3916,20 +3778,16 @@ impl UpdateInsightError {
 }
 impl fmt::Display for UpdateInsightError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateInsightError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateInsightError::Internal(ref cause) => cause,
-            UpdateInsightError::InvalidAccess(ref cause) => cause,
-            UpdateInsightError::InvalidInput(ref cause) => cause,
-            UpdateInsightError::LimitExceeded(ref cause) => cause,
-            UpdateInsightError::ResourceNotFound(ref cause) => cause,
+            UpdateInsightError::Internal(ref cause) => write!(f, "{}", cause),
+            UpdateInsightError::InvalidAccess(ref cause) => write!(f, "{}", cause),
+            UpdateInsightError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateInsightError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateInsightError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateInsightError {}
 /// Trait representing the capabilities of the AWS SecurityHub API. AWS SecurityHub clients implement this trait.
 pub trait SecurityHub {
     /// <p>Accepts the invitation to be a member account and be monitored by the Security Hub master account that the invitation was sent from. When the member account accepts the invitation, permission is granted to the master account to view findings generated in the member account.</p>

--- a/rusoto/services/serverlessrepo/src/generated.rs
+++ b/rusoto/services/serverlessrepo/src/generated.rs
@@ -1049,20 +1049,16 @@ impl CreateApplicationError {
 }
 impl fmt::Display for CreateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApplicationError::BadRequest(ref cause) => cause,
-            CreateApplicationError::Conflict(ref cause) => cause,
-            CreateApplicationError::Forbidden(ref cause) => cause,
-            CreateApplicationError::InternalServerError(ref cause) => cause,
-            CreateApplicationError::TooManyRequests(ref cause) => cause,
+            CreateApplicationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateApplicationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApplicationError {}
 /// Errors returned by CreateApplicationVersion
 #[derive(Debug, PartialEq)]
 pub enum CreateApplicationVersionError {
@@ -1110,20 +1106,16 @@ impl CreateApplicationVersionError {
 }
 impl fmt::Display for CreateApplicationVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateApplicationVersionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateApplicationVersionError::BadRequest(ref cause) => cause,
-            CreateApplicationVersionError::Conflict(ref cause) => cause,
-            CreateApplicationVersionError::Forbidden(ref cause) => cause,
-            CreateApplicationVersionError::InternalServerError(ref cause) => cause,
-            CreateApplicationVersionError::TooManyRequests(ref cause) => cause,
+            CreateApplicationVersionError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateApplicationVersionError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateApplicationVersionError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateApplicationVersionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateApplicationVersionError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateApplicationVersionError {}
 /// Errors returned by CreateCloudFormationChangeSet
 #[derive(Debug, PartialEq)]
 pub enum CreateCloudFormationChangeSetError {
@@ -1172,19 +1164,19 @@ impl CreateCloudFormationChangeSetError {
 }
 impl fmt::Display for CreateCloudFormationChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCloudFormationChangeSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCloudFormationChangeSetError::BadRequest(ref cause) => cause,
-            CreateCloudFormationChangeSetError::Forbidden(ref cause) => cause,
-            CreateCloudFormationChangeSetError::InternalServerError(ref cause) => cause,
-            CreateCloudFormationChangeSetError::TooManyRequests(ref cause) => cause,
+            CreateCloudFormationChangeSetError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationChangeSetError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationChangeSetError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCloudFormationChangeSetError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCloudFormationChangeSetError {}
 /// Errors returned by CreateCloudFormationTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateCloudFormationTemplateError {
@@ -1240,20 +1232,18 @@ impl CreateCloudFormationTemplateError {
 }
 impl fmt::Display for CreateCloudFormationTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCloudFormationTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCloudFormationTemplateError::BadRequest(ref cause) => cause,
-            CreateCloudFormationTemplateError::Forbidden(ref cause) => cause,
-            CreateCloudFormationTemplateError::InternalServerError(ref cause) => cause,
-            CreateCloudFormationTemplateError::NotFound(ref cause) => cause,
-            CreateCloudFormationTemplateError::TooManyRequests(ref cause) => cause,
+            CreateCloudFormationTemplateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationTemplateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationTemplateError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCloudFormationTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            CreateCloudFormationTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCloudFormationTemplateError {}
 /// Errors returned by DeleteApplication
 #[derive(Debug, PartialEq)]
 pub enum DeleteApplicationError {
@@ -1304,21 +1294,17 @@ impl DeleteApplicationError {
 }
 impl fmt::Display for DeleteApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteApplicationError::BadRequest(ref cause) => cause,
-            DeleteApplicationError::Conflict(ref cause) => cause,
-            DeleteApplicationError::Forbidden(ref cause) => cause,
-            DeleteApplicationError::InternalServerError(ref cause) => cause,
-            DeleteApplicationError::NotFound(ref cause) => cause,
-            DeleteApplicationError::TooManyRequests(ref cause) => cause,
+            DeleteApplicationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::Conflict(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteApplicationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteApplicationError {}
 /// Errors returned by GetApplication
 #[derive(Debug, PartialEq)]
 pub enum GetApplicationError {
@@ -1362,20 +1348,16 @@ impl GetApplicationError {
 }
 impl fmt::Display for GetApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            GetApplicationError::BadRequest(ref cause) => cause,
-            GetApplicationError::Forbidden(ref cause) => cause,
-            GetApplicationError::InternalServerError(ref cause) => cause,
-            GetApplicationError::NotFound(ref cause) => cause,
-            GetApplicationError::TooManyRequests(ref cause) => cause,
+            GetApplicationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetApplicationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetApplicationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetApplicationError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApplicationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApplicationError {}
 /// Errors returned by GetApplicationPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetApplicationPolicyError {
@@ -1423,20 +1405,16 @@ impl GetApplicationPolicyError {
 }
 impl fmt::Display for GetApplicationPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetApplicationPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetApplicationPolicyError::BadRequest(ref cause) => cause,
-            GetApplicationPolicyError::Forbidden(ref cause) => cause,
-            GetApplicationPolicyError::InternalServerError(ref cause) => cause,
-            GetApplicationPolicyError::NotFound(ref cause) => cause,
-            GetApplicationPolicyError::TooManyRequests(ref cause) => cause,
+            GetApplicationPolicyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetApplicationPolicyError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetApplicationPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetApplicationPolicyError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetApplicationPolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetApplicationPolicyError {}
 /// Errors returned by GetCloudFormationTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetCloudFormationTemplateError {
@@ -1486,20 +1464,18 @@ impl GetCloudFormationTemplateError {
 }
 impl fmt::Display for GetCloudFormationTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCloudFormationTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GetCloudFormationTemplateError::BadRequest(ref cause) => cause,
-            GetCloudFormationTemplateError::Forbidden(ref cause) => cause,
-            GetCloudFormationTemplateError::InternalServerError(ref cause) => cause,
-            GetCloudFormationTemplateError::NotFound(ref cause) => cause,
-            GetCloudFormationTemplateError::TooManyRequests(ref cause) => cause,
+            GetCloudFormationTemplateError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetCloudFormationTemplateError::Forbidden(ref cause) => write!(f, "{}", cause),
+            GetCloudFormationTemplateError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetCloudFormationTemplateError::NotFound(ref cause) => write!(f, "{}", cause),
+            GetCloudFormationTemplateError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCloudFormationTemplateError {}
 /// Errors returned by ListApplicationDependencies
 #[derive(Debug, PartialEq)]
 pub enum ListApplicationDependenciesError {
@@ -1555,20 +1531,18 @@ impl ListApplicationDependenciesError {
 }
 impl fmt::Display for ListApplicationDependenciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApplicationDependenciesError {
-    fn description(&self) -> &str {
         match *self {
-            ListApplicationDependenciesError::BadRequest(ref cause) => cause,
-            ListApplicationDependenciesError::Forbidden(ref cause) => cause,
-            ListApplicationDependenciesError::InternalServerError(ref cause) => cause,
-            ListApplicationDependenciesError::NotFound(ref cause) => cause,
-            ListApplicationDependenciesError::TooManyRequests(ref cause) => cause,
+            ListApplicationDependenciesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListApplicationDependenciesError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListApplicationDependenciesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListApplicationDependenciesError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListApplicationDependenciesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListApplicationDependenciesError {}
 /// Errors returned by ListApplicationVersions
 #[derive(Debug, PartialEq)]
 pub enum ListApplicationVersionsError {
@@ -1616,20 +1590,16 @@ impl ListApplicationVersionsError {
 }
 impl fmt::Display for ListApplicationVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApplicationVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListApplicationVersionsError::BadRequest(ref cause) => cause,
-            ListApplicationVersionsError::Forbidden(ref cause) => cause,
-            ListApplicationVersionsError::InternalServerError(ref cause) => cause,
-            ListApplicationVersionsError::NotFound(ref cause) => cause,
-            ListApplicationVersionsError::TooManyRequests(ref cause) => cause,
+            ListApplicationVersionsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListApplicationVersionsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListApplicationVersionsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListApplicationVersionsError::NotFound(ref cause) => write!(f, "{}", cause),
+            ListApplicationVersionsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListApplicationVersionsError {}
 /// Errors returned by ListApplications
 #[derive(Debug, PartialEq)]
 pub enum ListApplicationsError {
@@ -1670,19 +1640,15 @@ impl ListApplicationsError {
 }
 impl fmt::Display for ListApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListApplicationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListApplicationsError::BadRequest(ref cause) => cause,
-            ListApplicationsError::Forbidden(ref cause) => cause,
-            ListApplicationsError::InternalServerError(ref cause) => cause,
-            ListApplicationsError::NotFound(ref cause) => cause,
+            ListApplicationsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListApplicationsError::Forbidden(ref cause) => write!(f, "{}", cause),
+            ListApplicationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListApplicationsError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListApplicationsError {}
 /// Errors returned by PutApplicationPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutApplicationPolicyError {
@@ -1730,20 +1696,16 @@ impl PutApplicationPolicyError {
 }
 impl fmt::Display for PutApplicationPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutApplicationPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutApplicationPolicyError::BadRequest(ref cause) => cause,
-            PutApplicationPolicyError::Forbidden(ref cause) => cause,
-            PutApplicationPolicyError::InternalServerError(ref cause) => cause,
-            PutApplicationPolicyError::NotFound(ref cause) => cause,
-            PutApplicationPolicyError::TooManyRequests(ref cause) => cause,
+            PutApplicationPolicyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            PutApplicationPolicyError::Forbidden(ref cause) => write!(f, "{}", cause),
+            PutApplicationPolicyError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            PutApplicationPolicyError::NotFound(ref cause) => write!(f, "{}", cause),
+            PutApplicationPolicyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutApplicationPolicyError {}
 /// Errors returned by UpdateApplication
 #[derive(Debug, PartialEq)]
 pub enum UpdateApplicationError {
@@ -1794,21 +1756,17 @@ impl UpdateApplicationError {
 }
 impl fmt::Display for UpdateApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateApplicationError::BadRequest(ref cause) => cause,
-            UpdateApplicationError::Conflict(ref cause) => cause,
-            UpdateApplicationError::Forbidden(ref cause) => cause,
-            UpdateApplicationError::InternalServerError(ref cause) => cause,
-            UpdateApplicationError::NotFound(ref cause) => cause,
-            UpdateApplicationError::TooManyRequests(ref cause) => cause,
+            UpdateApplicationError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::Forbidden(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::NotFound(ref cause) => write!(f, "{}", cause),
+            UpdateApplicationError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateApplicationError {}
 /// Trait representing the capabilities of the AWSServerlessApplicationRepository API. AWSServerlessApplicationRepository clients implement this trait.
 pub trait ServerlessRepo {
     /// <p>Creates an application, optionally including an AWS SAM file to create the first application version in the same call.</p>

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -3643,18 +3643,14 @@ impl AcceptPortfolioShareError {
 }
 impl fmt::Display for AcceptPortfolioShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AcceptPortfolioShareError {
-    fn description(&self) -> &str {
         match *self {
-            AcceptPortfolioShareError::InvalidParameters(ref cause) => cause,
-            AcceptPortfolioShareError::LimitExceeded(ref cause) => cause,
-            AcceptPortfolioShareError::ResourceNotFound(ref cause) => cause,
+            AcceptPortfolioShareError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            AcceptPortfolioShareError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AcceptPortfolioShareError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AcceptPortfolioShareError {}
 /// Errors returned by AssociateBudgetWithResource
 #[derive(Debug, PartialEq)]
 pub enum AssociateBudgetWithResourceError {
@@ -3703,19 +3699,19 @@ impl AssociateBudgetWithResourceError {
 }
 impl fmt::Display for AssociateBudgetWithResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateBudgetWithResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateBudgetWithResourceError::DuplicateResource(ref cause) => cause,
-            AssociateBudgetWithResourceError::InvalidParameters(ref cause) => cause,
-            AssociateBudgetWithResourceError::LimitExceeded(ref cause) => cause,
-            AssociateBudgetWithResourceError::ResourceNotFound(ref cause) => cause,
+            AssociateBudgetWithResourceError::DuplicateResource(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateBudgetWithResourceError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateBudgetWithResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateBudgetWithResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateBudgetWithResourceError {}
 /// Errors returned by AssociatePrincipalWithPortfolio
 #[derive(Debug, PartialEq)]
 pub enum AssociatePrincipalWithPortfolioError {
@@ -3757,18 +3753,20 @@ impl AssociatePrincipalWithPortfolioError {
 }
 impl fmt::Display for AssociatePrincipalWithPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociatePrincipalWithPortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            AssociatePrincipalWithPortfolioError::InvalidParameters(ref cause) => cause,
-            AssociatePrincipalWithPortfolioError::LimitExceeded(ref cause) => cause,
-            AssociatePrincipalWithPortfolioError::ResourceNotFound(ref cause) => cause,
+            AssociatePrincipalWithPortfolioError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePrincipalWithPortfolioError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociatePrincipalWithPortfolioError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociatePrincipalWithPortfolioError {}
 /// Errors returned by AssociateProductWithPortfolio
 #[derive(Debug, PartialEq)]
 pub enum AssociateProductWithPortfolioError {
@@ -3810,18 +3808,18 @@ impl AssociateProductWithPortfolioError {
 }
 impl fmt::Display for AssociateProductWithPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateProductWithPortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateProductWithPortfolioError::InvalidParameters(ref cause) => cause,
-            AssociateProductWithPortfolioError::LimitExceeded(ref cause) => cause,
-            AssociateProductWithPortfolioError::ResourceNotFound(ref cause) => cause,
+            AssociateProductWithPortfolioError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateProductWithPortfolioError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateProductWithPortfolioError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateProductWithPortfolioError {}
 /// Errors returned by AssociateServiceActionWithProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum AssociateServiceActionWithProvisioningArtifactError {
@@ -3867,22 +3865,20 @@ impl AssociateServiceActionWithProvisioningArtifactError {
 }
 impl fmt::Display for AssociateServiceActionWithProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateServiceActionWithProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
             AssociateServiceActionWithProvisioningArtifactError::DuplicateResource(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            AssociateServiceActionWithProvisioningArtifactError::LimitExceeded(ref cause) => cause,
+            AssociateServiceActionWithProvisioningArtifactError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
             AssociateServiceActionWithProvisioningArtifactError::ResourceNotFound(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for AssociateServiceActionWithProvisioningArtifactError {}
 /// Errors returned by AssociateTagOptionWithResource
 #[derive(Debug, PartialEq)]
 pub enum AssociateTagOptionWithResourceError {
@@ -3945,21 +3941,25 @@ impl AssociateTagOptionWithResourceError {
 }
 impl fmt::Display for AssociateTagOptionWithResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateTagOptionWithResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateTagOptionWithResourceError::DuplicateResource(ref cause) => cause,
-            AssociateTagOptionWithResourceError::InvalidParameters(ref cause) => cause,
-            AssociateTagOptionWithResourceError::InvalidState(ref cause) => cause,
-            AssociateTagOptionWithResourceError::LimitExceeded(ref cause) => cause,
-            AssociateTagOptionWithResourceError::ResourceNotFound(ref cause) => cause,
-            AssociateTagOptionWithResourceError::TagOptionNotMigrated(ref cause) => cause,
+            AssociateTagOptionWithResourceError::DuplicateResource(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateTagOptionWithResourceError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateTagOptionWithResourceError::InvalidState(ref cause) => write!(f, "{}", cause),
+            AssociateTagOptionWithResourceError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateTagOptionWithResourceError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateTagOptionWithResourceError::TagOptionNotMigrated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateTagOptionWithResourceError {}
 /// Errors returned by BatchAssociateServiceActionWithProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum BatchAssociateServiceActionWithProvisioningArtifactError {
@@ -3989,18 +3989,14 @@ impl BatchAssociateServiceActionWithProvisioningArtifactError {
 }
 impl fmt::Display for BatchAssociateServiceActionWithProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchAssociateServiceActionWithProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
             BatchAssociateServiceActionWithProvisioningArtifactError::InvalidParameters(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchAssociateServiceActionWithProvisioningArtifactError {}
 /// Errors returned by BatchDisassociateServiceActionFromProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum BatchDisassociateServiceActionFromProvisioningArtifactError {
@@ -4028,18 +4024,14 @@ impl BatchDisassociateServiceActionFromProvisioningArtifactError {
 }
 impl fmt::Display for BatchDisassociateServiceActionFromProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchDisassociateServiceActionFromProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
             BatchDisassociateServiceActionFromProvisioningArtifactError::InvalidParameters(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchDisassociateServiceActionFromProvisioningArtifactError {}
 /// Errors returned by CopyProduct
 #[derive(Debug, PartialEq)]
 pub enum CopyProductError {
@@ -4068,17 +4060,13 @@ impl CopyProductError {
 }
 impl fmt::Display for CopyProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyProductError {
-    fn description(&self) -> &str {
         match *self {
-            CopyProductError::InvalidParameters(ref cause) => cause,
-            CopyProductError::ResourceNotFound(ref cause) => cause,
+            CopyProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CopyProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopyProductError {}
 /// Errors returned by CreateConstraint
 #[derive(Debug, PartialEq)]
 pub enum CreateConstraintError {
@@ -4117,19 +4105,15 @@ impl CreateConstraintError {
 }
 impl fmt::Display for CreateConstraintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConstraintError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConstraintError::DuplicateResource(ref cause) => cause,
-            CreateConstraintError::InvalidParameters(ref cause) => cause,
-            CreateConstraintError::LimitExceeded(ref cause) => cause,
-            CreateConstraintError::ResourceNotFound(ref cause) => cause,
+            CreateConstraintError::DuplicateResource(ref cause) => write!(f, "{}", cause),
+            CreateConstraintError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreateConstraintError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateConstraintError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConstraintError {}
 /// Errors returned by CreatePortfolio
 #[derive(Debug, PartialEq)]
 pub enum CreatePortfolioError {
@@ -4165,18 +4149,14 @@ impl CreatePortfolioError {
 }
 impl fmt::Display for CreatePortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePortfolioError::InvalidParameters(ref cause) => cause,
-            CreatePortfolioError::LimitExceeded(ref cause) => cause,
-            CreatePortfolioError::TagOptionNotMigrated(ref cause) => cause,
+            CreatePortfolioError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreatePortfolioError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePortfolioError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePortfolioError {}
 /// Errors returned by CreatePortfolioShare
 #[derive(Debug, PartialEq)]
 pub enum CreatePortfolioShareError {
@@ -4226,20 +4206,16 @@ impl CreatePortfolioShareError {
 }
 impl fmt::Display for CreatePortfolioShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePortfolioShareError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePortfolioShareError::InvalidParameters(ref cause) => cause,
-            CreatePortfolioShareError::InvalidState(ref cause) => cause,
-            CreatePortfolioShareError::LimitExceeded(ref cause) => cause,
-            CreatePortfolioShareError::OperationNotSupported(ref cause) => cause,
-            CreatePortfolioShareError::ResourceNotFound(ref cause) => cause,
+            CreatePortfolioShareError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreatePortfolioShareError::InvalidState(ref cause) => write!(f, "{}", cause),
+            CreatePortfolioShareError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreatePortfolioShareError::OperationNotSupported(ref cause) => write!(f, "{}", cause),
+            CreatePortfolioShareError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePortfolioShareError {}
 /// Errors returned by CreateProduct
 #[derive(Debug, PartialEq)]
 pub enum CreateProductError {
@@ -4273,18 +4249,14 @@ impl CreateProductError {
 }
 impl fmt::Display for CreateProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProductError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProductError::InvalidParameters(ref cause) => cause,
-            CreateProductError::LimitExceeded(ref cause) => cause,
-            CreateProductError::TagOptionNotMigrated(ref cause) => cause,
+            CreateProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreateProductError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProductError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProductError {}
 /// Errors returned by CreateProvisionedProductPlan
 #[derive(Debug, PartialEq)]
 pub enum CreateProvisionedProductPlanError {
@@ -4326,18 +4298,18 @@ impl CreateProvisionedProductPlanError {
 }
 impl fmt::Display for CreateProvisionedProductPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProvisionedProductPlanError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProvisionedProductPlanError::InvalidParameters(ref cause) => cause,
-            CreateProvisionedProductPlanError::InvalidState(ref cause) => cause,
-            CreateProvisionedProductPlanError::ResourceNotFound(ref cause) => cause,
+            CreateProvisionedProductPlanError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateProvisionedProductPlanError::InvalidState(ref cause) => write!(f, "{}", cause),
+            CreateProvisionedProductPlanError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateProvisionedProductPlanError {}
 /// Errors returned by CreateProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum CreateProvisioningArtifactError {
@@ -4379,18 +4351,14 @@ impl CreateProvisioningArtifactError {
 }
 impl fmt::Display for CreateProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProvisioningArtifactError::InvalidParameters(ref cause) => cause,
-            CreateProvisioningArtifactError::LimitExceeded(ref cause) => cause,
-            CreateProvisioningArtifactError::ResourceNotFound(ref cause) => cause,
+            CreateProvisioningArtifactError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningArtifactError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProvisioningArtifactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProvisioningArtifactError {}
 /// Errors returned by CreateServiceAction
 #[derive(Debug, PartialEq)]
 pub enum CreateServiceActionError {
@@ -4421,17 +4389,13 @@ impl CreateServiceActionError {
 }
 impl fmt::Display for CreateServiceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateServiceActionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateServiceActionError::InvalidParameters(ref cause) => cause,
-            CreateServiceActionError::LimitExceeded(ref cause) => cause,
+            CreateServiceActionError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreateServiceActionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateServiceActionError {}
 /// Errors returned by CreateTagOption
 #[derive(Debug, PartialEq)]
 pub enum CreateTagOptionError {
@@ -4467,18 +4431,14 @@ impl CreateTagOptionError {
 }
 impl fmt::Display for CreateTagOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTagOptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTagOptionError::DuplicateResource(ref cause) => cause,
-            CreateTagOptionError::LimitExceeded(ref cause) => cause,
-            CreateTagOptionError::TagOptionNotMigrated(ref cause) => cause,
+            CreateTagOptionError::DuplicateResource(ref cause) => write!(f, "{}", cause),
+            CreateTagOptionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTagOptionError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTagOptionError {}
 /// Errors returned by DeleteConstraint
 #[derive(Debug, PartialEq)]
 pub enum DeleteConstraintError {
@@ -4507,17 +4467,13 @@ impl DeleteConstraintError {
 }
 impl fmt::Display for DeleteConstraintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConstraintError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConstraintError::InvalidParameters(ref cause) => cause,
-            DeleteConstraintError::ResourceNotFound(ref cause) => cause,
+            DeleteConstraintError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            DeleteConstraintError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConstraintError {}
 /// Errors returned by DeletePortfolio
 #[derive(Debug, PartialEq)]
 pub enum DeletePortfolioError {
@@ -4558,19 +4514,15 @@ impl DeletePortfolioError {
 }
 impl fmt::Display for DeletePortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePortfolioError::InvalidParameters(ref cause) => cause,
-            DeletePortfolioError::ResourceInUse(ref cause) => cause,
-            DeletePortfolioError::ResourceNotFound(ref cause) => cause,
-            DeletePortfolioError::TagOptionNotMigrated(ref cause) => cause,
+            DeletePortfolioError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            DeletePortfolioError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeletePortfolioError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeletePortfolioError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePortfolioError {}
 /// Errors returned by DeletePortfolioShare
 #[derive(Debug, PartialEq)]
 pub enum DeletePortfolioShareError {
@@ -4615,19 +4567,15 @@ impl DeletePortfolioShareError {
 }
 impl fmt::Display for DeletePortfolioShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePortfolioShareError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePortfolioShareError::InvalidParameters(ref cause) => cause,
-            DeletePortfolioShareError::InvalidState(ref cause) => cause,
-            DeletePortfolioShareError::OperationNotSupported(ref cause) => cause,
-            DeletePortfolioShareError::ResourceNotFound(ref cause) => cause,
+            DeletePortfolioShareError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            DeletePortfolioShareError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DeletePortfolioShareError::OperationNotSupported(ref cause) => write!(f, "{}", cause),
+            DeletePortfolioShareError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePortfolioShareError {}
 /// Errors returned by DeleteProduct
 #[derive(Debug, PartialEq)]
 pub enum DeleteProductError {
@@ -4666,19 +4614,15 @@ impl DeleteProductError {
 }
 impl fmt::Display for DeleteProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProductError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProductError::InvalidParameters(ref cause) => cause,
-            DeleteProductError::ResourceInUse(ref cause) => cause,
-            DeleteProductError::ResourceNotFound(ref cause) => cause,
-            DeleteProductError::TagOptionNotMigrated(ref cause) => cause,
+            DeleteProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            DeleteProductError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteProductError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProductError {}
 /// Errors returned by DeleteProvisionedProductPlan
 #[derive(Debug, PartialEq)]
 pub enum DeleteProvisionedProductPlanError {
@@ -4713,17 +4657,17 @@ impl DeleteProvisionedProductPlanError {
 }
 impl fmt::Display for DeleteProvisionedProductPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProvisionedProductPlanError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProvisionedProductPlanError::InvalidParameters(ref cause) => cause,
-            DeleteProvisionedProductPlanError::ResourceNotFound(ref cause) => cause,
+            DeleteProvisionedProductPlanError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteProvisionedProductPlanError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteProvisionedProductPlanError {}
 /// Errors returned by DeleteProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum DeleteProvisioningArtifactError {
@@ -4765,18 +4709,14 @@ impl DeleteProvisioningArtifactError {
 }
 impl fmt::Display for DeleteProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProvisioningArtifactError::InvalidParameters(ref cause) => cause,
-            DeleteProvisioningArtifactError::ResourceInUse(ref cause) => cause,
-            DeleteProvisioningArtifactError::ResourceNotFound(ref cause) => cause,
+            DeleteProvisioningArtifactError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningArtifactError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteProvisioningArtifactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProvisioningArtifactError {}
 /// Errors returned by DeleteServiceAction
 #[derive(Debug, PartialEq)]
 pub enum DeleteServiceActionError {
@@ -4807,17 +4747,13 @@ impl DeleteServiceActionError {
 }
 impl fmt::Display for DeleteServiceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServiceActionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServiceActionError::ResourceInUse(ref cause) => cause,
-            DeleteServiceActionError::ResourceNotFound(ref cause) => cause,
+            DeleteServiceActionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteServiceActionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServiceActionError {}
 /// Errors returned by DeleteTagOption
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagOptionError {
@@ -4853,18 +4789,14 @@ impl DeleteTagOptionError {
 }
 impl fmt::Display for DeleteTagOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagOptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagOptionError::ResourceInUse(ref cause) => cause,
-            DeleteTagOptionError::ResourceNotFound(ref cause) => cause,
-            DeleteTagOptionError::TagOptionNotMigrated(ref cause) => cause,
+            DeleteTagOptionError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteTagOptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTagOptionError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagOptionError {}
 /// Errors returned by DescribeConstraint
 #[derive(Debug, PartialEq)]
 pub enum DescribeConstraintError {
@@ -4888,16 +4820,12 @@ impl DescribeConstraintError {
 }
 impl fmt::Display for DescribeConstraintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConstraintError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConstraintError::ResourceNotFound(ref cause) => cause,
+            DescribeConstraintError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeConstraintError {}
 /// Errors returned by DescribeCopyProductStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeCopyProductStatusError {
@@ -4923,16 +4851,12 @@ impl DescribeCopyProductStatusError {
 }
 impl fmt::Display for DescribeCopyProductStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCopyProductStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCopyProductStatusError::ResourceNotFound(ref cause) => cause,
+            DescribeCopyProductStatusError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCopyProductStatusError {}
 /// Errors returned by DescribePortfolio
 #[derive(Debug, PartialEq)]
 pub enum DescribePortfolioError {
@@ -4956,16 +4880,12 @@ impl DescribePortfolioError {
 }
 impl fmt::Display for DescribePortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePortfolioError::ResourceNotFound(ref cause) => cause,
+            DescribePortfolioError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePortfolioError {}
 /// Errors returned by DescribePortfolioShareStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribePortfolioShareStatusError {
@@ -5007,18 +4927,20 @@ impl DescribePortfolioShareStatusError {
 }
 impl fmt::Display for DescribePortfolioShareStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePortfolioShareStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePortfolioShareStatusError::InvalidParameters(ref cause) => cause,
-            DescribePortfolioShareStatusError::OperationNotSupported(ref cause) => cause,
-            DescribePortfolioShareStatusError::ResourceNotFound(ref cause) => cause,
+            DescribePortfolioShareStatusError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePortfolioShareStatusError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribePortfolioShareStatusError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribePortfolioShareStatusError {}
 /// Errors returned by DescribeProduct
 #[derive(Debug, PartialEq)]
 pub enum DescribeProductError {
@@ -5047,17 +4969,13 @@ impl DescribeProductError {
 }
 impl fmt::Display for DescribeProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProductError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProductError::InvalidParameters(ref cause) => cause,
-            DescribeProductError::ResourceNotFound(ref cause) => cause,
+            DescribeProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            DescribeProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProductError {}
 /// Errors returned by DescribeProductAsAdmin
 #[derive(Debug, PartialEq)]
 pub enum DescribeProductAsAdminError {
@@ -5083,16 +5001,12 @@ impl DescribeProductAsAdminError {
 }
 impl fmt::Display for DescribeProductAsAdminError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProductAsAdminError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProductAsAdminError::ResourceNotFound(ref cause) => cause,
+            DescribeProductAsAdminError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProductAsAdminError {}
 /// Errors returned by DescribeProductView
 #[derive(Debug, PartialEq)]
 pub enum DescribeProductViewError {
@@ -5125,17 +5039,13 @@ impl DescribeProductViewError {
 }
 impl fmt::Display for DescribeProductViewError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProductViewError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProductViewError::InvalidParameters(ref cause) => cause,
-            DescribeProductViewError::ResourceNotFound(ref cause) => cause,
+            DescribeProductViewError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            DescribeProductViewError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProductViewError {}
 /// Errors returned by DescribeProvisionedProduct
 #[derive(Debug, PartialEq)]
 pub enum DescribeProvisionedProductError {
@@ -5163,16 +5073,12 @@ impl DescribeProvisionedProductError {
 }
 impl fmt::Display for DescribeProvisionedProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProvisionedProductError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProvisionedProductError::ResourceNotFound(ref cause) => cause,
+            DescribeProvisionedProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProvisionedProductError {}
 /// Errors returned by DescribeProvisionedProductPlan
 #[derive(Debug, PartialEq)]
 pub enum DescribeProvisionedProductPlanError {
@@ -5207,17 +5113,17 @@ impl DescribeProvisionedProductPlanError {
 }
 impl fmt::Display for DescribeProvisionedProductPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProvisionedProductPlanError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProvisionedProductPlanError::InvalidParameters(ref cause) => cause,
-            DescribeProvisionedProductPlanError::ResourceNotFound(ref cause) => cause,
+            DescribeProvisionedProductPlanError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProvisionedProductPlanError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeProvisionedProductPlanError {}
 /// Errors returned by DescribeProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum DescribeProvisioningArtifactError {
@@ -5245,16 +5151,14 @@ impl DescribeProvisioningArtifactError {
 }
 impl fmt::Display for DescribeProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProvisioningArtifactError::ResourceNotFound(ref cause) => cause,
+            DescribeProvisioningArtifactError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeProvisioningArtifactError {}
 /// Errors returned by DescribeProvisioningParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeProvisioningParametersError {
@@ -5289,17 +5193,17 @@ impl DescribeProvisioningParametersError {
 }
 impl fmt::Display for DescribeProvisioningParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProvisioningParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProvisioningParametersError::InvalidParameters(ref cause) => cause,
-            DescribeProvisioningParametersError::ResourceNotFound(ref cause) => cause,
+            DescribeProvisioningParametersError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeProvisioningParametersError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeProvisioningParametersError {}
 /// Errors returned by DescribeRecord
 #[derive(Debug, PartialEq)]
 pub enum DescribeRecordError {
@@ -5323,16 +5227,12 @@ impl DescribeRecordError {
 }
 impl fmt::Display for DescribeRecordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRecordError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRecordError::ResourceNotFound(ref cause) => cause,
+            DescribeRecordError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeRecordError {}
 /// Errors returned by DescribeServiceAction
 #[derive(Debug, PartialEq)]
 pub enum DescribeServiceActionError {
@@ -5358,16 +5258,12 @@ impl DescribeServiceActionError {
 }
 impl fmt::Display for DescribeServiceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServiceActionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServiceActionError::ResourceNotFound(ref cause) => cause,
+            DescribeServiceActionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeServiceActionError {}
 /// Errors returned by DescribeServiceActionExecutionParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeServiceActionExecutionParametersError {
@@ -5402,17 +5298,17 @@ impl DescribeServiceActionExecutionParametersError {
 }
 impl fmt::Display for DescribeServiceActionExecutionParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServiceActionExecutionParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServiceActionExecutionParametersError::InvalidParameters(ref cause) => cause,
-            DescribeServiceActionExecutionParametersError::ResourceNotFound(ref cause) => cause,
+            DescribeServiceActionExecutionParametersError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeServiceActionExecutionParametersError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeServiceActionExecutionParametersError {}
 /// Errors returned by DescribeTagOption
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagOptionError {
@@ -5443,17 +5339,13 @@ impl DescribeTagOptionError {
 }
 impl fmt::Display for DescribeTagOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagOptionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagOptionError::ResourceNotFound(ref cause) => cause,
-            DescribeTagOptionError::TagOptionNotMigrated(ref cause) => cause,
+            DescribeTagOptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeTagOptionError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagOptionError {}
 /// Errors returned by DisableAWSOrganizationsAccess
 #[derive(Debug, PartialEq)]
 pub enum DisableAWSOrganizationsAccessError {
@@ -5495,18 +5387,18 @@ impl DisableAWSOrganizationsAccessError {
 }
 impl fmt::Display for DisableAWSOrganizationsAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableAWSOrganizationsAccessError {
-    fn description(&self) -> &str {
         match *self {
-            DisableAWSOrganizationsAccessError::InvalidState(ref cause) => cause,
-            DisableAWSOrganizationsAccessError::OperationNotSupported(ref cause) => cause,
-            DisableAWSOrganizationsAccessError::ResourceNotFound(ref cause) => cause,
+            DisableAWSOrganizationsAccessError::InvalidState(ref cause) => write!(f, "{}", cause),
+            DisableAWSOrganizationsAccessError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisableAWSOrganizationsAccessError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisableAWSOrganizationsAccessError {}
 /// Errors returned by DisassociateBudgetFromResource
 #[derive(Debug, PartialEq)]
 pub enum DisassociateBudgetFromResourceError {
@@ -5534,16 +5426,14 @@ impl DisassociateBudgetFromResourceError {
 }
 impl fmt::Display for DisassociateBudgetFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateBudgetFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateBudgetFromResourceError::ResourceNotFound(ref cause) => cause,
+            DisassociateBudgetFromResourceError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateBudgetFromResourceError {}
 /// Errors returned by DisassociatePrincipalFromPortfolio
 #[derive(Debug, PartialEq)]
 pub enum DisassociatePrincipalFromPortfolioError {
@@ -5578,17 +5468,17 @@ impl DisassociatePrincipalFromPortfolioError {
 }
 impl fmt::Display for DisassociatePrincipalFromPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociatePrincipalFromPortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociatePrincipalFromPortfolioError::InvalidParameters(ref cause) => cause,
-            DisassociatePrincipalFromPortfolioError::ResourceNotFound(ref cause) => cause,
+            DisassociatePrincipalFromPortfolioError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociatePrincipalFromPortfolioError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociatePrincipalFromPortfolioError {}
 /// Errors returned by DisassociateProductFromPortfolio
 #[derive(Debug, PartialEq)]
 pub enum DisassociateProductFromPortfolioError {
@@ -5630,18 +5520,20 @@ impl DisassociateProductFromPortfolioError {
 }
 impl fmt::Display for DisassociateProductFromPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateProductFromPortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateProductFromPortfolioError::InvalidParameters(ref cause) => cause,
-            DisassociateProductFromPortfolioError::ResourceInUse(ref cause) => cause,
-            DisassociateProductFromPortfolioError::ResourceNotFound(ref cause) => cause,
+            DisassociateProductFromPortfolioError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateProductFromPortfolioError::ResourceInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateProductFromPortfolioError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateProductFromPortfolioError {}
 /// Errors returned by DisassociateServiceActionFromProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum DisassociateServiceActionFromProvisioningArtifactError {
@@ -5671,18 +5563,14 @@ impl DisassociateServiceActionFromProvisioningArtifactError {
 }
 impl fmt::Display for DisassociateServiceActionFromProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateServiceActionFromProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
             DisassociateServiceActionFromProvisioningArtifactError::ResourceNotFound(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DisassociateServiceActionFromProvisioningArtifactError {}
 /// Errors returned by DisassociateTagOptionFromResource
 #[derive(Debug, PartialEq)]
 pub enum DisassociateTagOptionFromResourceError {
@@ -5717,17 +5605,17 @@ impl DisassociateTagOptionFromResourceError {
 }
 impl fmt::Display for DisassociateTagOptionFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateTagOptionFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateTagOptionFromResourceError::ResourceNotFound(ref cause) => cause,
-            DisassociateTagOptionFromResourceError::TagOptionNotMigrated(ref cause) => cause,
+            DisassociateTagOptionFromResourceError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateTagOptionFromResourceError::TagOptionNotMigrated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateTagOptionFromResourceError {}
 /// Errors returned by EnableAWSOrganizationsAccess
 #[derive(Debug, PartialEq)]
 pub enum EnableAWSOrganizationsAccessError {
@@ -5769,18 +5657,18 @@ impl EnableAWSOrganizationsAccessError {
 }
 impl fmt::Display for EnableAWSOrganizationsAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for EnableAWSOrganizationsAccessError {
-    fn description(&self) -> &str {
         match *self {
-            EnableAWSOrganizationsAccessError::InvalidState(ref cause) => cause,
-            EnableAWSOrganizationsAccessError::OperationNotSupported(ref cause) => cause,
-            EnableAWSOrganizationsAccessError::ResourceNotFound(ref cause) => cause,
+            EnableAWSOrganizationsAccessError::InvalidState(ref cause) => write!(f, "{}", cause),
+            EnableAWSOrganizationsAccessError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            EnableAWSOrganizationsAccessError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for EnableAWSOrganizationsAccessError {}
 /// Errors returned by ExecuteProvisionedProductPlan
 #[derive(Debug, PartialEq)]
 pub enum ExecuteProvisionedProductPlanError {
@@ -5822,18 +5710,18 @@ impl ExecuteProvisionedProductPlanError {
 }
 impl fmt::Display for ExecuteProvisionedProductPlanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExecuteProvisionedProductPlanError {
-    fn description(&self) -> &str {
         match *self {
-            ExecuteProvisionedProductPlanError::InvalidParameters(ref cause) => cause,
-            ExecuteProvisionedProductPlanError::InvalidState(ref cause) => cause,
-            ExecuteProvisionedProductPlanError::ResourceNotFound(ref cause) => cause,
+            ExecuteProvisionedProductPlanError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ExecuteProvisionedProductPlanError::InvalidState(ref cause) => write!(f, "{}", cause),
+            ExecuteProvisionedProductPlanError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ExecuteProvisionedProductPlanError {}
 /// Errors returned by ExecuteProvisionedProductServiceAction
 #[derive(Debug, PartialEq)]
 pub enum ExecuteProvisionedProductServiceActionError {
@@ -5875,18 +5763,20 @@ impl ExecuteProvisionedProductServiceActionError {
 }
 impl fmt::Display for ExecuteProvisionedProductServiceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ExecuteProvisionedProductServiceActionError {
-    fn description(&self) -> &str {
         match *self {
-            ExecuteProvisionedProductServiceActionError::InvalidParameters(ref cause) => cause,
-            ExecuteProvisionedProductServiceActionError::InvalidState(ref cause) => cause,
-            ExecuteProvisionedProductServiceActionError::ResourceNotFound(ref cause) => cause,
+            ExecuteProvisionedProductServiceActionError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ExecuteProvisionedProductServiceActionError::InvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ExecuteProvisionedProductServiceActionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ExecuteProvisionedProductServiceActionError {}
 /// Errors returned by GetAWSOrganizationsAccessStatus
 #[derive(Debug, PartialEq)]
 pub enum GetAWSOrganizationsAccessStatusError {
@@ -5921,17 +5811,17 @@ impl GetAWSOrganizationsAccessStatusError {
 }
 impl fmt::Display for GetAWSOrganizationsAccessStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAWSOrganizationsAccessStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetAWSOrganizationsAccessStatusError::OperationNotSupported(ref cause) => cause,
-            GetAWSOrganizationsAccessStatusError::ResourceNotFound(ref cause) => cause,
+            GetAWSOrganizationsAccessStatusError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAWSOrganizationsAccessStatusError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetAWSOrganizationsAccessStatusError {}
 /// Errors returned by ListAcceptedPortfolioShares
 #[derive(Debug, PartialEq)]
 pub enum ListAcceptedPortfolioSharesError {
@@ -5966,17 +5856,17 @@ impl ListAcceptedPortfolioSharesError {
 }
 impl fmt::Display for ListAcceptedPortfolioSharesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAcceptedPortfolioSharesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAcceptedPortfolioSharesError::InvalidParameters(ref cause) => cause,
-            ListAcceptedPortfolioSharesError::OperationNotSupported(ref cause) => cause,
+            ListAcceptedPortfolioSharesError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAcceptedPortfolioSharesError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListAcceptedPortfolioSharesError {}
 /// Errors returned by ListBudgetsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListBudgetsForResourceError {
@@ -6009,17 +5899,13 @@ impl ListBudgetsForResourceError {
 }
 impl fmt::Display for ListBudgetsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListBudgetsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListBudgetsForResourceError::InvalidParameters(ref cause) => cause,
-            ListBudgetsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListBudgetsForResourceError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ListBudgetsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListBudgetsForResourceError {}
 /// Errors returned by ListConstraintsForPortfolio
 #[derive(Debug, PartialEq)]
 pub enum ListConstraintsForPortfolioError {
@@ -6054,17 +5940,15 @@ impl ListConstraintsForPortfolioError {
 }
 impl fmt::Display for ListConstraintsForPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConstraintsForPortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            ListConstraintsForPortfolioError::InvalidParameters(ref cause) => cause,
-            ListConstraintsForPortfolioError::ResourceNotFound(ref cause) => cause,
+            ListConstraintsForPortfolioError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListConstraintsForPortfolioError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListConstraintsForPortfolioError {}
 /// Errors returned by ListLaunchPaths
 #[derive(Debug, PartialEq)]
 pub enum ListLaunchPathsError {
@@ -6093,17 +5977,13 @@ impl ListLaunchPathsError {
 }
 impl fmt::Display for ListLaunchPathsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLaunchPathsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLaunchPathsError::InvalidParameters(ref cause) => cause,
-            ListLaunchPathsError::ResourceNotFound(ref cause) => cause,
+            ListLaunchPathsError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ListLaunchPathsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLaunchPathsError {}
 /// Errors returned by ListOrganizationPortfolioAccess
 #[derive(Debug, PartialEq)]
 pub enum ListOrganizationPortfolioAccessError {
@@ -6145,18 +6025,20 @@ impl ListOrganizationPortfolioAccessError {
 }
 impl fmt::Display for ListOrganizationPortfolioAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOrganizationPortfolioAccessError {
-    fn description(&self) -> &str {
         match *self {
-            ListOrganizationPortfolioAccessError::InvalidParameters(ref cause) => cause,
-            ListOrganizationPortfolioAccessError::OperationNotSupported(ref cause) => cause,
-            ListOrganizationPortfolioAccessError::ResourceNotFound(ref cause) => cause,
+            ListOrganizationPortfolioAccessError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOrganizationPortfolioAccessError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOrganizationPortfolioAccessError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListOrganizationPortfolioAccessError {}
 /// Errors returned by ListPortfolioAccess
 #[derive(Debug, PartialEq)]
 pub enum ListPortfolioAccessError {
@@ -6182,16 +6064,12 @@ impl ListPortfolioAccessError {
 }
 impl fmt::Display for ListPortfolioAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPortfolioAccessError {
-    fn description(&self) -> &str {
         match *self {
-            ListPortfolioAccessError::ResourceNotFound(ref cause) => cause,
+            ListPortfolioAccessError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPortfolioAccessError {}
 /// Errors returned by ListPortfolios
 #[derive(Debug, PartialEq)]
 pub enum ListPortfoliosError {
@@ -6215,16 +6093,12 @@ impl ListPortfoliosError {
 }
 impl fmt::Display for ListPortfoliosError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPortfoliosError {
-    fn description(&self) -> &str {
         match *self {
-            ListPortfoliosError::InvalidParameters(ref cause) => cause,
+            ListPortfoliosError::InvalidParameters(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPortfoliosError {}
 /// Errors returned by ListPortfoliosForProduct
 #[derive(Debug, PartialEq)]
 pub enum ListPortfoliosForProductError {
@@ -6257,17 +6131,13 @@ impl ListPortfoliosForProductError {
 }
 impl fmt::Display for ListPortfoliosForProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPortfoliosForProductError {
-    fn description(&self) -> &str {
         match *self {
-            ListPortfoliosForProductError::InvalidParameters(ref cause) => cause,
-            ListPortfoliosForProductError::ResourceNotFound(ref cause) => cause,
+            ListPortfoliosForProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ListPortfoliosForProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPortfoliosForProductError {}
 /// Errors returned by ListPrincipalsForPortfolio
 #[derive(Debug, PartialEq)]
 pub enum ListPrincipalsForPortfolioError {
@@ -6302,17 +6172,13 @@ impl ListPrincipalsForPortfolioError {
 }
 impl fmt::Display for ListPrincipalsForPortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPrincipalsForPortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            ListPrincipalsForPortfolioError::InvalidParameters(ref cause) => cause,
-            ListPrincipalsForPortfolioError::ResourceNotFound(ref cause) => cause,
+            ListPrincipalsForPortfolioError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ListPrincipalsForPortfolioError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPrincipalsForPortfolioError {}
 /// Errors returned by ListProvisionedProductPlans
 #[derive(Debug, PartialEq)]
 pub enum ListProvisionedProductPlansError {
@@ -6347,17 +6213,15 @@ impl ListProvisionedProductPlansError {
 }
 impl fmt::Display for ListProvisionedProductPlansError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProvisionedProductPlansError {
-    fn description(&self) -> &str {
         match *self {
-            ListProvisionedProductPlansError::InvalidParameters(ref cause) => cause,
-            ListProvisionedProductPlansError::ResourceNotFound(ref cause) => cause,
+            ListProvisionedProductPlansError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisionedProductPlansError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProvisionedProductPlansError {}
 /// Errors returned by ListProvisioningArtifacts
 #[derive(Debug, PartialEq)]
 pub enum ListProvisioningArtifactsError {
@@ -6390,17 +6254,13 @@ impl ListProvisioningArtifactsError {
 }
 impl fmt::Display for ListProvisioningArtifactsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProvisioningArtifactsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProvisioningArtifactsError::InvalidParameters(ref cause) => cause,
-            ListProvisioningArtifactsError::ResourceNotFound(ref cause) => cause,
+            ListProvisioningArtifactsError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ListProvisioningArtifactsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProvisioningArtifactsError {}
 /// Errors returned by ListProvisioningArtifactsForServiceAction
 #[derive(Debug, PartialEq)]
 pub enum ListProvisioningArtifactsForServiceActionError {
@@ -6435,17 +6295,17 @@ impl ListProvisioningArtifactsForServiceActionError {
 }
 impl fmt::Display for ListProvisioningArtifactsForServiceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProvisioningArtifactsForServiceActionError {
-    fn description(&self) -> &str {
         match *self {
-            ListProvisioningArtifactsForServiceActionError::InvalidParameters(ref cause) => cause,
-            ListProvisioningArtifactsForServiceActionError::ResourceNotFound(ref cause) => cause,
+            ListProvisioningArtifactsForServiceActionError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListProvisioningArtifactsForServiceActionError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListProvisioningArtifactsForServiceActionError {}
 /// Errors returned by ListRecordHistory
 #[derive(Debug, PartialEq)]
 pub enum ListRecordHistoryError {
@@ -6469,16 +6329,12 @@ impl ListRecordHistoryError {
 }
 impl fmt::Display for ListRecordHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRecordHistoryError {
-    fn description(&self) -> &str {
         match *self {
-            ListRecordHistoryError::InvalidParameters(ref cause) => cause,
+            ListRecordHistoryError::InvalidParameters(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRecordHistoryError {}
 /// Errors returned by ListResourcesForTagOption
 #[derive(Debug, PartialEq)]
 pub enum ListResourcesForTagOptionError {
@@ -6518,18 +6374,16 @@ impl ListResourcesForTagOptionError {
 }
 impl fmt::Display for ListResourcesForTagOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourcesForTagOptionError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourcesForTagOptionError::InvalidParameters(ref cause) => cause,
-            ListResourcesForTagOptionError::ResourceNotFound(ref cause) => cause,
-            ListResourcesForTagOptionError::TagOptionNotMigrated(ref cause) => cause,
+            ListResourcesForTagOptionError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ListResourcesForTagOptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListResourcesForTagOptionError::TagOptionNotMigrated(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListResourcesForTagOptionError {}
 /// Errors returned by ListServiceActions
 #[derive(Debug, PartialEq)]
 pub enum ListServiceActionsError {
@@ -6555,16 +6409,12 @@ impl ListServiceActionsError {
 }
 impl fmt::Display for ListServiceActionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServiceActionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListServiceActionsError::InvalidParameters(ref cause) => cause,
+            ListServiceActionsError::InvalidParameters(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListServiceActionsError {}
 /// Errors returned by ListServiceActionsForProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum ListServiceActionsForProvisioningArtifactError {
@@ -6599,17 +6449,17 @@ impl ListServiceActionsForProvisioningArtifactError {
 }
 impl fmt::Display for ListServiceActionsForProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServiceActionsForProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
-            ListServiceActionsForProvisioningArtifactError::InvalidParameters(ref cause) => cause,
-            ListServiceActionsForProvisioningArtifactError::ResourceNotFound(ref cause) => cause,
+            ListServiceActionsForProvisioningArtifactError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListServiceActionsForProvisioningArtifactError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListServiceActionsForProvisioningArtifactError {}
 /// Errors returned by ListStackInstancesForProvisionedProduct
 #[derive(Debug, PartialEq)]
 pub enum ListStackInstancesForProvisionedProductError {
@@ -6644,17 +6494,17 @@ impl ListStackInstancesForProvisionedProductError {
 }
 impl fmt::Display for ListStackInstancesForProvisionedProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStackInstancesForProvisionedProductError {
-    fn description(&self) -> &str {
         match *self {
-            ListStackInstancesForProvisionedProductError::InvalidParameters(ref cause) => cause,
-            ListStackInstancesForProvisionedProductError::ResourceNotFound(ref cause) => cause,
+            ListStackInstancesForProvisionedProductError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListStackInstancesForProvisionedProductError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListStackInstancesForProvisionedProductError {}
 /// Errors returned by ListTagOptions
 #[derive(Debug, PartialEq)]
 pub enum ListTagOptionsError {
@@ -6683,17 +6533,13 @@ impl ListTagOptionsError {
 }
 impl fmt::Display for ListTagOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagOptionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagOptionsError::InvalidParameters(ref cause) => cause,
-            ListTagOptionsError::TagOptionNotMigrated(ref cause) => cause,
+            ListTagOptionsError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ListTagOptionsError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagOptionsError {}
 /// Errors returned by ProvisionProduct
 #[derive(Debug, PartialEq)]
 pub enum ProvisionProductError {
@@ -6727,18 +6573,14 @@ impl ProvisionProductError {
 }
 impl fmt::Display for ProvisionProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ProvisionProductError {
-    fn description(&self) -> &str {
         match *self {
-            ProvisionProductError::DuplicateResource(ref cause) => cause,
-            ProvisionProductError::InvalidParameters(ref cause) => cause,
-            ProvisionProductError::ResourceNotFound(ref cause) => cause,
+            ProvisionProductError::DuplicateResource(ref cause) => write!(f, "{}", cause),
+            ProvisionProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            ProvisionProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ProvisionProductError {}
 /// Errors returned by RejectPortfolioShare
 #[derive(Debug, PartialEq)]
 pub enum RejectPortfolioShareError {
@@ -6764,16 +6606,12 @@ impl RejectPortfolioShareError {
 }
 impl fmt::Display for RejectPortfolioShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RejectPortfolioShareError {
-    fn description(&self) -> &str {
         match *self {
-            RejectPortfolioShareError::ResourceNotFound(ref cause) => cause,
+            RejectPortfolioShareError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RejectPortfolioShareError {}
 /// Errors returned by ScanProvisionedProducts
 #[derive(Debug, PartialEq)]
 pub enum ScanProvisionedProductsError {
@@ -6799,16 +6637,12 @@ impl ScanProvisionedProductsError {
 }
 impl fmt::Display for ScanProvisionedProductsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ScanProvisionedProductsError {
-    fn description(&self) -> &str {
         match *self {
-            ScanProvisionedProductsError::InvalidParameters(ref cause) => cause,
+            ScanProvisionedProductsError::InvalidParameters(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ScanProvisionedProductsError {}
 /// Errors returned by SearchProducts
 #[derive(Debug, PartialEq)]
 pub enum SearchProductsError {
@@ -6832,16 +6666,12 @@ impl SearchProductsError {
 }
 impl fmt::Display for SearchProductsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchProductsError {
-    fn description(&self) -> &str {
         match *self {
-            SearchProductsError::InvalidParameters(ref cause) => cause,
+            SearchProductsError::InvalidParameters(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchProductsError {}
 /// Errors returned by SearchProductsAsAdmin
 #[derive(Debug, PartialEq)]
 pub enum SearchProductsAsAdminError {
@@ -6874,17 +6704,13 @@ impl SearchProductsAsAdminError {
 }
 impl fmt::Display for SearchProductsAsAdminError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchProductsAsAdminError {
-    fn description(&self) -> &str {
         match *self {
-            SearchProductsAsAdminError::InvalidParameters(ref cause) => cause,
-            SearchProductsAsAdminError::ResourceNotFound(ref cause) => cause,
+            SearchProductsAsAdminError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            SearchProductsAsAdminError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchProductsAsAdminError {}
 /// Errors returned by SearchProvisionedProducts
 #[derive(Debug, PartialEq)]
 pub enum SearchProvisionedProductsError {
@@ -6910,16 +6736,12 @@ impl SearchProvisionedProductsError {
 }
 impl fmt::Display for SearchProvisionedProductsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SearchProvisionedProductsError {
-    fn description(&self) -> &str {
         match *self {
-            SearchProvisionedProductsError::InvalidParameters(ref cause) => cause,
+            SearchProvisionedProductsError::InvalidParameters(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SearchProvisionedProductsError {}
 /// Errors returned by TerminateProvisionedProduct
 #[derive(Debug, PartialEq)]
 pub enum TerminateProvisionedProductError {
@@ -6947,16 +6769,12 @@ impl TerminateProvisionedProductError {
 }
 impl fmt::Display for TerminateProvisionedProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateProvisionedProductError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateProvisionedProductError::ResourceNotFound(ref cause) => cause,
+            TerminateProvisionedProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TerminateProvisionedProductError {}
 /// Errors returned by UpdateConstraint
 #[derive(Debug, PartialEq)]
 pub enum UpdateConstraintError {
@@ -6985,17 +6803,13 @@ impl UpdateConstraintError {
 }
 impl fmt::Display for UpdateConstraintError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConstraintError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateConstraintError::InvalidParameters(ref cause) => cause,
-            UpdateConstraintError::ResourceNotFound(ref cause) => cause,
+            UpdateConstraintError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdateConstraintError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConstraintError {}
 /// Errors returned by UpdatePortfolio
 #[derive(Debug, PartialEq)]
 pub enum UpdatePortfolioError {
@@ -7036,19 +6850,15 @@ impl UpdatePortfolioError {
 }
 impl fmt::Display for UpdatePortfolioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePortfolioError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePortfolioError::InvalidParameters(ref cause) => cause,
-            UpdatePortfolioError::LimitExceeded(ref cause) => cause,
-            UpdatePortfolioError::ResourceNotFound(ref cause) => cause,
-            UpdatePortfolioError::TagOptionNotMigrated(ref cause) => cause,
+            UpdatePortfolioError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdatePortfolioError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdatePortfolioError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePortfolioError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePortfolioError {}
 /// Errors returned by UpdateProduct
 #[derive(Debug, PartialEq)]
 pub enum UpdateProductError {
@@ -7082,18 +6892,14 @@ impl UpdateProductError {
 }
 impl fmt::Display for UpdateProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProductError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProductError::InvalidParameters(ref cause) => cause,
-            UpdateProductError::ResourceNotFound(ref cause) => cause,
-            UpdateProductError::TagOptionNotMigrated(ref cause) => cause,
+            UpdateProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdateProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateProductError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProductError {}
 /// Errors returned by UpdateProvisionedProduct
 #[derive(Debug, PartialEq)]
 pub enum UpdateProvisionedProductError {
@@ -7126,17 +6932,13 @@ impl UpdateProvisionedProductError {
 }
 impl fmt::Display for UpdateProvisionedProductError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProvisionedProductError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProvisionedProductError::InvalidParameters(ref cause) => cause,
-            UpdateProvisionedProductError::ResourceNotFound(ref cause) => cause,
+            UpdateProvisionedProductError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdateProvisionedProductError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProvisionedProductError {}
 /// Errors returned by UpdateProvisionedProductProperties
 #[derive(Debug, PartialEq)]
 pub enum UpdateProvisionedProductPropertiesError {
@@ -7178,18 +6980,20 @@ impl UpdateProvisionedProductPropertiesError {
 }
 impl fmt::Display for UpdateProvisionedProductPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProvisionedProductPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProvisionedProductPropertiesError::InvalidParameters(ref cause) => cause,
-            UpdateProvisionedProductPropertiesError::InvalidState(ref cause) => cause,
-            UpdateProvisionedProductPropertiesError::ResourceNotFound(ref cause) => cause,
+            UpdateProvisionedProductPropertiesError::InvalidParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateProvisionedProductPropertiesError::InvalidState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateProvisionedProductPropertiesError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateProvisionedProductPropertiesError {}
 /// Errors returned by UpdateProvisioningArtifact
 #[derive(Debug, PartialEq)]
 pub enum UpdateProvisioningArtifactError {
@@ -7224,17 +7028,13 @@ impl UpdateProvisioningArtifactError {
 }
 impl fmt::Display for UpdateProvisioningArtifactError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateProvisioningArtifactError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateProvisioningArtifactError::InvalidParameters(ref cause) => cause,
-            UpdateProvisioningArtifactError::ResourceNotFound(ref cause) => cause,
+            UpdateProvisioningArtifactError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdateProvisioningArtifactError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateProvisioningArtifactError {}
 /// Errors returned by UpdateServiceAction
 #[derive(Debug, PartialEq)]
 pub enum UpdateServiceActionError {
@@ -7267,17 +7067,13 @@ impl UpdateServiceActionError {
 }
 impl fmt::Display for UpdateServiceActionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServiceActionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServiceActionError::InvalidParameters(ref cause) => cause,
-            UpdateServiceActionError::ResourceNotFound(ref cause) => cause,
+            UpdateServiceActionError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdateServiceActionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServiceActionError {}
 /// Errors returned by UpdateTagOption
 #[derive(Debug, PartialEq)]
 pub enum UpdateTagOptionError {
@@ -7318,19 +7114,15 @@ impl UpdateTagOptionError {
 }
 impl fmt::Display for UpdateTagOptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTagOptionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTagOptionError::DuplicateResource(ref cause) => cause,
-            UpdateTagOptionError::InvalidParameters(ref cause) => cause,
-            UpdateTagOptionError::ResourceNotFound(ref cause) => cause,
-            UpdateTagOptionError::TagOptionNotMigrated(ref cause) => cause,
+            UpdateTagOptionError::DuplicateResource(ref cause) => write!(f, "{}", cause),
+            UpdateTagOptionError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdateTagOptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateTagOptionError::TagOptionNotMigrated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTagOptionError {}
 /// Trait representing the capabilities of the AWS Service Catalog API. AWS Service Catalog clients implement this trait.
 pub trait ServiceCatalog {
     /// <p>Accepts an offer to share the specified portfolio.</p>

--- a/rusoto/services/servicediscovery/src/generated.rs
+++ b/rusoto/services/servicediscovery/src/generated.rs
@@ -958,19 +958,15 @@ impl CreateHttpNamespaceError {
 }
 impl fmt::Display for CreateHttpNamespaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateHttpNamespaceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateHttpNamespaceError::DuplicateRequest(ref cause) => cause,
-            CreateHttpNamespaceError::InvalidInput(ref cause) => cause,
-            CreateHttpNamespaceError::NamespaceAlreadyExists(ref cause) => cause,
-            CreateHttpNamespaceError::ResourceLimitExceeded(ref cause) => cause,
+            CreateHttpNamespaceError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            CreateHttpNamespaceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateHttpNamespaceError::NamespaceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateHttpNamespaceError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateHttpNamespaceError {}
 /// Errors returned by CreatePrivateDnsNamespace
 #[derive(Debug, PartialEq)]
 pub enum CreatePrivateDnsNamespaceError {
@@ -1017,19 +1013,19 @@ impl CreatePrivateDnsNamespaceError {
 }
 impl fmt::Display for CreatePrivateDnsNamespaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePrivateDnsNamespaceError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePrivateDnsNamespaceError::DuplicateRequest(ref cause) => cause,
-            CreatePrivateDnsNamespaceError::InvalidInput(ref cause) => cause,
-            CreatePrivateDnsNamespaceError::NamespaceAlreadyExists(ref cause) => cause,
-            CreatePrivateDnsNamespaceError::ResourceLimitExceeded(ref cause) => cause,
+            CreatePrivateDnsNamespaceError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            CreatePrivateDnsNamespaceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreatePrivateDnsNamespaceError::NamespaceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePrivateDnsNamespaceError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreatePrivateDnsNamespaceError {}
 /// Errors returned by CreatePublicDnsNamespace
 #[derive(Debug, PartialEq)]
 pub enum CreatePublicDnsNamespaceError {
@@ -1076,19 +1072,19 @@ impl CreatePublicDnsNamespaceError {
 }
 impl fmt::Display for CreatePublicDnsNamespaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePublicDnsNamespaceError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePublicDnsNamespaceError::DuplicateRequest(ref cause) => cause,
-            CreatePublicDnsNamespaceError::InvalidInput(ref cause) => cause,
-            CreatePublicDnsNamespaceError::NamespaceAlreadyExists(ref cause) => cause,
-            CreatePublicDnsNamespaceError::ResourceLimitExceeded(ref cause) => cause,
+            CreatePublicDnsNamespaceError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            CreatePublicDnsNamespaceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreatePublicDnsNamespaceError::NamespaceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePublicDnsNamespaceError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreatePublicDnsNamespaceError {}
 /// Errors returned by CreateService
 #[derive(Debug, PartialEq)]
 pub enum CreateServiceError {
@@ -1127,19 +1123,15 @@ impl CreateServiceError {
 }
 impl fmt::Display for CreateServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateServiceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateServiceError::InvalidInput(ref cause) => cause,
-            CreateServiceError::NamespaceNotFound(ref cause) => cause,
-            CreateServiceError::ResourceLimitExceeded(ref cause) => cause,
-            CreateServiceError::ServiceAlreadyExists(ref cause) => cause,
+            CreateServiceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::NamespaceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateServiceError::ServiceAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateServiceError {}
 /// Errors returned by DeleteNamespace
 #[derive(Debug, PartialEq)]
 pub enum DeleteNamespaceError {
@@ -1178,19 +1170,15 @@ impl DeleteNamespaceError {
 }
 impl fmt::Display for DeleteNamespaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNamespaceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNamespaceError::DuplicateRequest(ref cause) => cause,
-            DeleteNamespaceError::InvalidInput(ref cause) => cause,
-            DeleteNamespaceError::NamespaceNotFound(ref cause) => cause,
-            DeleteNamespaceError::ResourceInUse(ref cause) => cause,
+            DeleteNamespaceError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            DeleteNamespaceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteNamespaceError::NamespaceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteNamespaceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteNamespaceError {}
 /// Errors returned by DeleteService
 #[derive(Debug, PartialEq)]
 pub enum DeleteServiceError {
@@ -1224,18 +1212,14 @@ impl DeleteServiceError {
 }
 impl fmt::Display for DeleteServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServiceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServiceError::InvalidInput(ref cause) => cause,
-            DeleteServiceError::ResourceInUse(ref cause) => cause,
-            DeleteServiceError::ServiceNotFound(ref cause) => cause,
+            DeleteServiceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeleteServiceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeleteServiceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServiceError {}
 /// Errors returned by DeregisterInstance
 #[derive(Debug, PartialEq)]
 pub enum DeregisterInstanceError {
@@ -1279,20 +1263,16 @@ impl DeregisterInstanceError {
 }
 impl fmt::Display for DeregisterInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterInstanceError::DuplicateRequest(ref cause) => cause,
-            DeregisterInstanceError::InstanceNotFound(ref cause) => cause,
-            DeregisterInstanceError::InvalidInput(ref cause) => cause,
-            DeregisterInstanceError::ResourceInUse(ref cause) => cause,
-            DeregisterInstanceError::ServiceNotFound(ref cause) => cause,
+            DeregisterInstanceError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            DeregisterInstanceError::InstanceNotFound(ref cause) => write!(f, "{}", cause),
+            DeregisterInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DeregisterInstanceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            DeregisterInstanceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterInstanceError {}
 /// Errors returned by DiscoverInstances
 #[derive(Debug, PartialEq)]
 pub enum DiscoverInstancesError {
@@ -1326,18 +1306,14 @@ impl DiscoverInstancesError {
 }
 impl fmt::Display for DiscoverInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DiscoverInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            DiscoverInstancesError::InvalidInput(ref cause) => cause,
-            DiscoverInstancesError::NamespaceNotFound(ref cause) => cause,
-            DiscoverInstancesError::ServiceNotFound(ref cause) => cause,
+            DiscoverInstancesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            DiscoverInstancesError::NamespaceNotFound(ref cause) => write!(f, "{}", cause),
+            DiscoverInstancesError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DiscoverInstancesError {}
 /// Errors returned by GetInstance
 #[derive(Debug, PartialEq)]
 pub enum GetInstanceError {
@@ -1371,18 +1347,14 @@ impl GetInstanceError {
 }
 impl fmt::Display for GetInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstanceError::InstanceNotFound(ref cause) => cause,
-            GetInstanceError::InvalidInput(ref cause) => cause,
-            GetInstanceError::ServiceNotFound(ref cause) => cause,
+            GetInstanceError::InstanceNotFound(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstanceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstanceError {}
 /// Errors returned by GetInstancesHealthStatus
 #[derive(Debug, PartialEq)]
 pub enum GetInstancesHealthStatusError {
@@ -1422,18 +1394,14 @@ impl GetInstancesHealthStatusError {
 }
 impl fmt::Display for GetInstancesHealthStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInstancesHealthStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetInstancesHealthStatusError::InstanceNotFound(ref cause) => cause,
-            GetInstancesHealthStatusError::InvalidInput(ref cause) => cause,
-            GetInstancesHealthStatusError::ServiceNotFound(ref cause) => cause,
+            GetInstancesHealthStatusError::InstanceNotFound(ref cause) => write!(f, "{}", cause),
+            GetInstancesHealthStatusError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetInstancesHealthStatusError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInstancesHealthStatusError {}
 /// Errors returned by GetNamespace
 #[derive(Debug, PartialEq)]
 pub enum GetNamespaceError {
@@ -1462,17 +1430,13 @@ impl GetNamespaceError {
 }
 impl fmt::Display for GetNamespaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetNamespaceError {
-    fn description(&self) -> &str {
         match *self {
-            GetNamespaceError::InvalidInput(ref cause) => cause,
-            GetNamespaceError::NamespaceNotFound(ref cause) => cause,
+            GetNamespaceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetNamespaceError::NamespaceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetNamespaceError {}
 /// Errors returned by GetOperation
 #[derive(Debug, PartialEq)]
 pub enum GetOperationError {
@@ -1501,17 +1465,13 @@ impl GetOperationError {
 }
 impl fmt::Display for GetOperationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOperationError {
-    fn description(&self) -> &str {
         match *self {
-            GetOperationError::InvalidInput(ref cause) => cause,
-            GetOperationError::OperationNotFound(ref cause) => cause,
+            GetOperationError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetOperationError::OperationNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOperationError {}
 /// Errors returned by GetService
 #[derive(Debug, PartialEq)]
 pub enum GetServiceError {
@@ -1540,17 +1500,13 @@ impl GetServiceError {
 }
 impl fmt::Display for GetServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceError::InvalidInput(ref cause) => cause,
-            GetServiceError::ServiceNotFound(ref cause) => cause,
+            GetServiceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            GetServiceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServiceError {}
 /// Errors returned by ListInstances
 #[derive(Debug, PartialEq)]
 pub enum ListInstancesError {
@@ -1579,17 +1535,13 @@ impl ListInstancesError {
 }
 impl fmt::Display for ListInstancesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInstancesError {
-    fn description(&self) -> &str {
         match *self {
-            ListInstancesError::InvalidInput(ref cause) => cause,
-            ListInstancesError::ServiceNotFound(ref cause) => cause,
+            ListInstancesError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            ListInstancesError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInstancesError {}
 /// Errors returned by ListNamespaces
 #[derive(Debug, PartialEq)]
 pub enum ListNamespacesError {
@@ -1613,16 +1565,12 @@ impl ListNamespacesError {
 }
 impl fmt::Display for ListNamespacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListNamespacesError {
-    fn description(&self) -> &str {
         match *self {
-            ListNamespacesError::InvalidInput(ref cause) => cause,
+            ListNamespacesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListNamespacesError {}
 /// Errors returned by ListOperations
 #[derive(Debug, PartialEq)]
 pub enum ListOperationsError {
@@ -1646,16 +1594,12 @@ impl ListOperationsError {
 }
 impl fmt::Display for ListOperationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOperationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOperationsError::InvalidInput(ref cause) => cause,
+            ListOperationsError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOperationsError {}
 /// Errors returned by ListServices
 #[derive(Debug, PartialEq)]
 pub enum ListServicesError {
@@ -1679,16 +1623,12 @@ impl ListServicesError {
 }
 impl fmt::Display for ListServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListServicesError::InvalidInput(ref cause) => cause,
+            ListServicesError::InvalidInput(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListServicesError {}
 /// Errors returned by RegisterInstance
 #[derive(Debug, PartialEq)]
 pub enum RegisterInstanceError {
@@ -1734,20 +1674,16 @@ impl RegisterInstanceError {
 }
 impl fmt::Display for RegisterInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterInstanceError::DuplicateRequest(ref cause) => cause,
-            RegisterInstanceError::InvalidInput(ref cause) => cause,
-            RegisterInstanceError::ResourceInUse(ref cause) => cause,
-            RegisterInstanceError::ResourceLimitExceeded(ref cause) => cause,
-            RegisterInstanceError::ServiceNotFound(ref cause) => cause,
+            RegisterInstanceError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            RegisterInstanceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            RegisterInstanceError::ResourceInUse(ref cause) => write!(f, "{}", cause),
+            RegisterInstanceError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            RegisterInstanceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterInstanceError {}
 /// Errors returned by UpdateInstanceCustomHealthStatus
 #[derive(Debug, PartialEq)]
 pub enum UpdateInstanceCustomHealthStatusError {
@@ -1796,19 +1732,23 @@ impl UpdateInstanceCustomHealthStatusError {
 }
 impl fmt::Display for UpdateInstanceCustomHealthStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateInstanceCustomHealthStatusError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateInstanceCustomHealthStatusError::CustomHealthNotFound(ref cause) => cause,
-            UpdateInstanceCustomHealthStatusError::InstanceNotFound(ref cause) => cause,
-            UpdateInstanceCustomHealthStatusError::InvalidInput(ref cause) => cause,
-            UpdateInstanceCustomHealthStatusError::ServiceNotFound(ref cause) => cause,
+            UpdateInstanceCustomHealthStatusError::CustomHealthNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateInstanceCustomHealthStatusError::InstanceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateInstanceCustomHealthStatusError::InvalidInput(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateInstanceCustomHealthStatusError::ServiceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateInstanceCustomHealthStatusError {}
 /// Errors returned by UpdateService
 #[derive(Debug, PartialEq)]
 pub enum UpdateServiceError {
@@ -1842,18 +1782,14 @@ impl UpdateServiceError {
 }
 impl fmt::Display for UpdateServiceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServiceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServiceError::DuplicateRequest(ref cause) => cause,
-            UpdateServiceError::InvalidInput(ref cause) => cause,
-            UpdateServiceError::ServiceNotFound(ref cause) => cause,
+            UpdateServiceError::DuplicateRequest(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::InvalidInput(ref cause) => write!(f, "{}", cause),
+            UpdateServiceError::ServiceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServiceError {}
 /// Trait representing the capabilities of the ServiceDiscovery API. ServiceDiscovery clients implement this trait.
 pub trait ServiceDiscovery {
     /// <p>Creates an HTTP namespace. Service instances that you register using an HTTP namespace can be discovered using a <code>DiscoverInstances</code> request but can't be discovered using DNS. </p> <p>For the current limit on the number of namespaces that you can create using the same AWS account, see <a href="http://docs.aws.amazon.com/cloud-map/latest/dg/cloud-map-limits.html">AWS Cloud Map Limits</a> in the <i>AWS Cloud Map Developer Guide</i>.</p>

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -6967,18 +6967,14 @@ impl CloneReceiptRuleSetError {
 }
 impl fmt::Display for CloneReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CloneReceiptRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            CloneReceiptRuleSetError::AlreadyExists(ref cause) => cause,
-            CloneReceiptRuleSetError::LimitExceeded(ref cause) => cause,
-            CloneReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => cause,
+            CloneReceiptRuleSetError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CloneReceiptRuleSetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CloneReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CloneReceiptRuleSetError {}
 /// Errors returned by CreateConfigurationSet
 #[derive(Debug, PartialEq)]
 pub enum CreateConfigurationSetError {
@@ -7034,18 +7030,18 @@ impl CreateConfigurationSetError {
 }
 impl fmt::Display for CreateConfigurationSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConfigurationSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateConfigurationSetError::ConfigurationSetAlreadyExists(ref cause) => cause,
-            CreateConfigurationSetError::InvalidConfigurationSet(ref cause) => cause,
-            CreateConfigurationSetError::LimitExceeded(ref cause) => cause,
+            CreateConfigurationSetError::ConfigurationSetAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateConfigurationSetError::InvalidConfigurationSet(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateConfigurationSetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateConfigurationSetError {}
 /// Errors returned by CreateConfigurationSetEventDestination
 #[derive(Debug, PartialEq)]
 pub enum CreateConfigurationSetEventDestinationError {
@@ -7126,29 +7122,29 @@ impl CreateConfigurationSetEventDestinationError {
 }
 impl fmt::Display for CreateConfigurationSetEventDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConfigurationSetEventDestinationError {
-    fn description(&self) -> &str {
         match *self {
             CreateConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateConfigurationSetEventDestinationError::EventDestinationAlreadyExists(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateConfigurationSetEventDestinationError::InvalidCloudWatchDestination(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             CreateConfigurationSetEventDestinationError::InvalidFirehoseDestination(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateConfigurationSetEventDestinationError::InvalidSNSDestination(ref cause) => cause,
-            CreateConfigurationSetEventDestinationError::LimitExceeded(ref cause) => cause,
+            CreateConfigurationSetEventDestinationError::InvalidSNSDestination(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateConfigurationSetEventDestinationError::LimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateConfigurationSetEventDestinationError {}
 /// Errors returned by CreateConfigurationSetTrackingOptions
 #[derive(Debug, PartialEq)]
 pub enum CreateConfigurationSetTrackingOptionsError {
@@ -7204,22 +7200,20 @@ impl CreateConfigurationSetTrackingOptionsError {
 }
 impl fmt::Display for CreateConfigurationSetTrackingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateConfigurationSetTrackingOptionsError {
-    fn description(&self) -> &str {
         match *self {
             CreateConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            CreateConfigurationSetTrackingOptionsError::InvalidTrackingOptions(ref cause) => cause,
+            CreateConfigurationSetTrackingOptionsError::InvalidTrackingOptions(ref cause) => {
+                write!(f, "{}", cause)
+            }
             CreateConfigurationSetTrackingOptionsError::TrackingOptionsAlreadyExists(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for CreateConfigurationSetTrackingOptionsError {}
 /// Errors returned by CreateCustomVerificationEmailTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateCustomVerificationEmailTemplateError {
@@ -7260,19 +7254,15 @@ impl CreateCustomVerificationEmailTemplateError {
 }
 impl fmt::Display for CreateCustomVerificationEmailTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCustomVerificationEmailTemplateError {
-    fn description(&self) -> &str {
         match *self {
-                            CreateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(ref cause) => cause,
-CreateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateAlreadyExists(ref cause) => cause,
-CreateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(ref cause) => cause,
-CreateCustomVerificationEmailTemplateError::LimitExceeded(ref cause) => cause
+                            CreateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(ref cause) => write!(f, "{}", cause),
+CreateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateAlreadyExists(ref cause) => write!(f, "{}", cause),
+CreateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(ref cause) => write!(f, "{}", cause),
+CreateCustomVerificationEmailTemplateError::LimitExceeded(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for CreateCustomVerificationEmailTemplateError {}
 /// Errors returned by CreateReceiptFilter
 #[derive(Debug, PartialEq)]
 pub enum CreateReceiptFilterError {
@@ -7317,17 +7307,13 @@ impl CreateReceiptFilterError {
 }
 impl fmt::Display for CreateReceiptFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReceiptFilterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReceiptFilterError::AlreadyExists(ref cause) => cause,
-            CreateReceiptFilterError::LimitExceeded(ref cause) => cause,
+            CreateReceiptFilterError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateReceiptFilterError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateReceiptFilterError {}
 /// Errors returned by CreateReceiptRule
 #[derive(Debug, PartialEq)]
 pub enum CreateReceiptRuleError {
@@ -7407,22 +7393,18 @@ impl CreateReceiptRuleError {
 }
 impl fmt::Display for CreateReceiptRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReceiptRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReceiptRuleError::AlreadyExists(ref cause) => cause,
-            CreateReceiptRuleError::InvalidLambdaFunction(ref cause) => cause,
-            CreateReceiptRuleError::InvalidS3Configuration(ref cause) => cause,
-            CreateReceiptRuleError::InvalidSnsTopic(ref cause) => cause,
-            CreateReceiptRuleError::LimitExceeded(ref cause) => cause,
-            CreateReceiptRuleError::RuleDoesNotExist(ref cause) => cause,
-            CreateReceiptRuleError::RuleSetDoesNotExist(ref cause) => cause,
+            CreateReceiptRuleError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateReceiptRuleError::InvalidLambdaFunction(ref cause) => write!(f, "{}", cause),
+            CreateReceiptRuleError::InvalidS3Configuration(ref cause) => write!(f, "{}", cause),
+            CreateReceiptRuleError::InvalidSnsTopic(ref cause) => write!(f, "{}", cause),
+            CreateReceiptRuleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateReceiptRuleError::RuleDoesNotExist(ref cause) => write!(f, "{}", cause),
+            CreateReceiptRuleError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateReceiptRuleError {}
 /// Errors returned by CreateReceiptRuleSet
 #[derive(Debug, PartialEq)]
 pub enum CreateReceiptRuleSetError {
@@ -7467,17 +7449,13 @@ impl CreateReceiptRuleSetError {
 }
 impl fmt::Display for CreateReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReceiptRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReceiptRuleSetError::AlreadyExists(ref cause) => cause,
-            CreateReceiptRuleSetError::LimitExceeded(ref cause) => cause,
+            CreateReceiptRuleSetError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateReceiptRuleSetError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateReceiptRuleSetError {}
 /// Errors returned by CreateTemplate
 #[derive(Debug, PartialEq)]
 pub enum CreateTemplateError {
@@ -7529,18 +7507,14 @@ impl CreateTemplateError {
 }
 impl fmt::Display for CreateTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTemplateError::AlreadyExists(ref cause) => cause,
-            CreateTemplateError::InvalidTemplate(ref cause) => cause,
-            CreateTemplateError::LimitExceeded(ref cause) => cause,
+            CreateTemplateError::AlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateTemplateError::InvalidTemplate(ref cause) => write!(f, "{}", cause),
+            CreateTemplateError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTemplateError {}
 /// Errors returned by DeleteConfigurationSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteConfigurationSetError {
@@ -7580,16 +7554,14 @@ impl DeleteConfigurationSetError {
 }
 impl fmt::Display for DeleteConfigurationSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConfigurationSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteConfigurationSetError::ConfigurationSetDoesNotExist(ref cause) => cause,
+            DeleteConfigurationSetError::ConfigurationSetDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteConfigurationSetError {}
 /// Errors returned by DeleteConfigurationSetEventDestination
 #[derive(Debug, PartialEq)]
 pub enum DeleteConfigurationSetEventDestinationError {
@@ -7636,21 +7608,17 @@ impl DeleteConfigurationSetEventDestinationError {
 }
 impl fmt::Display for DeleteConfigurationSetEventDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConfigurationSetEventDestinationError {
-    fn description(&self) -> &str {
         match *self {
             DeleteConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             DeleteConfigurationSetEventDestinationError::EventDestinationDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteConfigurationSetEventDestinationError {}
 /// Errors returned by DeleteConfigurationSetTrackingOptions
 #[derive(Debug, PartialEq)]
 pub enum DeleteConfigurationSetTrackingOptionsError {
@@ -7699,21 +7667,17 @@ impl DeleteConfigurationSetTrackingOptionsError {
 }
 impl fmt::Display for DeleteConfigurationSetTrackingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteConfigurationSetTrackingOptionsError {
-    fn description(&self) -> &str {
         match *self {
             DeleteConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DeleteConfigurationSetTrackingOptionsError::TrackingOptionsDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DeleteConfigurationSetTrackingOptionsError {}
 /// Errors returned by DeleteCustomVerificationEmailTemplate
 #[derive(Debug, PartialEq)]
 pub enum DeleteCustomVerificationEmailTemplateError {}
@@ -7745,14 +7709,10 @@ impl DeleteCustomVerificationEmailTemplateError {
 }
 impl fmt::Display for DeleteCustomVerificationEmailTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCustomVerificationEmailTemplateError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteCustomVerificationEmailTemplateError {}
 /// Errors returned by DeleteIdentity
 #[derive(Debug, PartialEq)]
 pub enum DeleteIdentityError {}
@@ -7782,14 +7742,10 @@ impl DeleteIdentityError {
 }
 impl fmt::Display for DeleteIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIdentityError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteIdentityError {}
 /// Errors returned by DeleteIdentityPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeleteIdentityPolicyError {}
@@ -7819,14 +7775,10 @@ impl DeleteIdentityPolicyError {
 }
 impl fmt::Display for DeleteIdentityPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIdentityPolicyError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteIdentityPolicyError {}
 /// Errors returned by DeleteReceiptFilter
 #[derive(Debug, PartialEq)]
 pub enum DeleteReceiptFilterError {}
@@ -7856,14 +7808,10 @@ impl DeleteReceiptFilterError {
 }
 impl fmt::Display for DeleteReceiptFilterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReceiptFilterError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteReceiptFilterError {}
 /// Errors returned by DeleteReceiptRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteReceiptRuleError {
@@ -7901,16 +7849,12 @@ impl DeleteReceiptRuleError {
 }
 impl fmt::Display for DeleteReceiptRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReceiptRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReceiptRuleError::RuleSetDoesNotExist(ref cause) => cause,
+            DeleteReceiptRuleError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReceiptRuleError {}
 /// Errors returned by DeleteReceiptRuleSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteReceiptRuleSetError {
@@ -7948,16 +7892,12 @@ impl DeleteReceiptRuleSetError {
 }
 impl fmt::Display for DeleteReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReceiptRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReceiptRuleSetError::CannotDelete(ref cause) => cause,
+            DeleteReceiptRuleSetError::CannotDelete(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReceiptRuleSetError {}
 /// Errors returned by DeleteTemplate
 #[derive(Debug, PartialEq)]
 pub enum DeleteTemplateError {}
@@ -7987,14 +7927,10 @@ impl DeleteTemplateError {
 }
 impl fmt::Display for DeleteTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTemplateError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteTemplateError {}
 /// Errors returned by DeleteVerifiedEmailAddress
 #[derive(Debug, PartialEq)]
 pub enum DeleteVerifiedEmailAddressError {}
@@ -8026,14 +7962,10 @@ impl DeleteVerifiedEmailAddressError {
 }
 impl fmt::Display for DeleteVerifiedEmailAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVerifiedEmailAddressError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteVerifiedEmailAddressError {}
 /// Errors returned by DescribeActiveReceiptRuleSet
 #[derive(Debug, PartialEq)]
 pub enum DescribeActiveReceiptRuleSetError {}
@@ -8065,14 +7997,10 @@ impl DescribeActiveReceiptRuleSetError {
 }
 impl fmt::Display for DescribeActiveReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeActiveReceiptRuleSetError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DescribeActiveReceiptRuleSetError {}
 /// Errors returned by DescribeConfigurationSet
 #[derive(Debug, PartialEq)]
 pub enum DescribeConfigurationSetError {
@@ -8112,16 +8040,14 @@ impl DescribeConfigurationSetError {
 }
 impl fmt::Display for DescribeConfigurationSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeConfigurationSetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeConfigurationSetError::ConfigurationSetDoesNotExist(ref cause) => cause,
+            DescribeConfigurationSetError::ConfigurationSetDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeConfigurationSetError {}
 /// Errors returned by DescribeReceiptRule
 #[derive(Debug, PartialEq)]
 pub enum DescribeReceiptRuleError {
@@ -8166,17 +8092,13 @@ impl DescribeReceiptRuleError {
 }
 impl fmt::Display for DescribeReceiptRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReceiptRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReceiptRuleError::RuleDoesNotExist(ref cause) => cause,
-            DescribeReceiptRuleError::RuleSetDoesNotExist(ref cause) => cause,
+            DescribeReceiptRuleError::RuleDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeReceiptRuleError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeReceiptRuleError {}
 /// Errors returned by DescribeReceiptRuleSet
 #[derive(Debug, PartialEq)]
 pub enum DescribeReceiptRuleSetError {
@@ -8214,16 +8136,12 @@ impl DescribeReceiptRuleSetError {
 }
 impl fmt::Display for DescribeReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeReceiptRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => cause,
+            DescribeReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeReceiptRuleSetError {}
 /// Errors returned by GetAccountSendingEnabled
 #[derive(Debug, PartialEq)]
 pub enum GetAccountSendingEnabledError {}
@@ -8253,14 +8171,10 @@ impl GetAccountSendingEnabledError {
 }
 impl fmt::Display for GetAccountSendingEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccountSendingEnabledError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetAccountSendingEnabledError {}
 /// Errors returned by GetCustomVerificationEmailTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetCustomVerificationEmailTemplateError {
@@ -8295,16 +8209,12 @@ impl GetCustomVerificationEmailTemplateError {
 }
 impl fmt::Display for GetCustomVerificationEmailTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCustomVerificationEmailTemplateError {
-    fn description(&self) -> &str {
         match *self {
-                            GetCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(ref cause) => cause
+                            GetCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for GetCustomVerificationEmailTemplateError {}
 /// Errors returned by GetIdentityDkimAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityDkimAttributesError {}
@@ -8334,14 +8244,10 @@ impl GetIdentityDkimAttributesError {
 }
 impl fmt::Display for GetIdentityDkimAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityDkimAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetIdentityDkimAttributesError {}
 /// Errors returned by GetIdentityMailFromDomainAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityMailFromDomainAttributesError {}
@@ -8373,14 +8279,10 @@ impl GetIdentityMailFromDomainAttributesError {
 }
 impl fmt::Display for GetIdentityMailFromDomainAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityMailFromDomainAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetIdentityMailFromDomainAttributesError {}
 /// Errors returned by GetIdentityNotificationAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityNotificationAttributesError {}
@@ -8412,14 +8314,10 @@ impl GetIdentityNotificationAttributesError {
 }
 impl fmt::Display for GetIdentityNotificationAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityNotificationAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetIdentityNotificationAttributesError {}
 /// Errors returned by GetIdentityPolicies
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityPoliciesError {}
@@ -8449,14 +8347,10 @@ impl GetIdentityPoliciesError {
 }
 impl fmt::Display for GetIdentityPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityPoliciesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetIdentityPoliciesError {}
 /// Errors returned by GetIdentityVerificationAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetIdentityVerificationAttributesError {}
@@ -8488,14 +8382,10 @@ impl GetIdentityVerificationAttributesError {
 }
 impl fmt::Display for GetIdentityVerificationAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIdentityVerificationAttributesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetIdentityVerificationAttributesError {}
 /// Errors returned by GetSendQuota
 #[derive(Debug, PartialEq)]
 pub enum GetSendQuotaError {}
@@ -8525,14 +8415,10 @@ impl GetSendQuotaError {
 }
 impl fmt::Display for GetSendQuotaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSendQuotaError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetSendQuotaError {}
 /// Errors returned by GetSendStatistics
 #[derive(Debug, PartialEq)]
 pub enum GetSendStatisticsError {}
@@ -8562,14 +8448,10 @@ impl GetSendStatisticsError {
 }
 impl fmt::Display for GetSendStatisticsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSendStatisticsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetSendStatisticsError {}
 /// Errors returned by GetTemplate
 #[derive(Debug, PartialEq)]
 pub enum GetTemplateError {
@@ -8607,16 +8489,12 @@ impl GetTemplateError {
 }
 impl fmt::Display for GetTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GetTemplateError::TemplateDoesNotExist(ref cause) => cause,
+            GetTemplateError::TemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTemplateError {}
 /// Errors returned by ListConfigurationSets
 #[derive(Debug, PartialEq)]
 pub enum ListConfigurationSetsError {}
@@ -8646,14 +8524,10 @@ impl ListConfigurationSetsError {
 }
 impl fmt::Display for ListConfigurationSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListConfigurationSetsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListConfigurationSetsError {}
 /// Errors returned by ListCustomVerificationEmailTemplates
 #[derive(Debug, PartialEq)]
 pub enum ListCustomVerificationEmailTemplatesError {}
@@ -8685,14 +8559,10 @@ impl ListCustomVerificationEmailTemplatesError {
 }
 impl fmt::Display for ListCustomVerificationEmailTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCustomVerificationEmailTemplatesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListCustomVerificationEmailTemplatesError {}
 /// Errors returned by ListIdentities
 #[derive(Debug, PartialEq)]
 pub enum ListIdentitiesError {}
@@ -8722,14 +8592,10 @@ impl ListIdentitiesError {
 }
 impl fmt::Display for ListIdentitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIdentitiesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListIdentitiesError {}
 /// Errors returned by ListIdentityPolicies
 #[derive(Debug, PartialEq)]
 pub enum ListIdentityPoliciesError {}
@@ -8759,14 +8625,10 @@ impl ListIdentityPoliciesError {
 }
 impl fmt::Display for ListIdentityPoliciesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIdentityPoliciesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListIdentityPoliciesError {}
 /// Errors returned by ListReceiptFilters
 #[derive(Debug, PartialEq)]
 pub enum ListReceiptFiltersError {}
@@ -8796,14 +8658,10 @@ impl ListReceiptFiltersError {
 }
 impl fmt::Display for ListReceiptFiltersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReceiptFiltersError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListReceiptFiltersError {}
 /// Errors returned by ListReceiptRuleSets
 #[derive(Debug, PartialEq)]
 pub enum ListReceiptRuleSetsError {}
@@ -8833,14 +8691,10 @@ impl ListReceiptRuleSetsError {
 }
 impl fmt::Display for ListReceiptRuleSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListReceiptRuleSetsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListReceiptRuleSetsError {}
 /// Errors returned by ListTemplates
 #[derive(Debug, PartialEq)]
 pub enum ListTemplatesError {}
@@ -8870,14 +8724,10 @@ impl ListTemplatesError {
 }
 impl fmt::Display for ListTemplatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTemplatesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListTemplatesError {}
 /// Errors returned by ListVerifiedEmailAddresses
 #[derive(Debug, PartialEq)]
 pub enum ListVerifiedEmailAddressesError {}
@@ -8909,14 +8759,10 @@ impl ListVerifiedEmailAddressesError {
 }
 impl fmt::Display for ListVerifiedEmailAddressesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVerifiedEmailAddressesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListVerifiedEmailAddressesError {}
 /// Errors returned by PutConfigurationSetDeliveryOptions
 #[derive(Debug, PartialEq)]
 pub enum PutConfigurationSetDeliveryOptionsError {
@@ -8967,19 +8813,17 @@ impl PutConfigurationSetDeliveryOptionsError {
 }
 impl fmt::Display for PutConfigurationSetDeliveryOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutConfigurationSetDeliveryOptionsError {
-    fn description(&self) -> &str {
         match *self {
             PutConfigurationSetDeliveryOptionsError::ConfigurationSetDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            PutConfigurationSetDeliveryOptionsError::InvalidDeliveryOptions(ref cause) => cause,
+            PutConfigurationSetDeliveryOptionsError::InvalidDeliveryOptions(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutConfigurationSetDeliveryOptionsError {}
 /// Errors returned by PutIdentityPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutIdentityPolicyError {
@@ -9017,16 +8861,12 @@ impl PutIdentityPolicyError {
 }
 impl fmt::Display for PutIdentityPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutIdentityPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutIdentityPolicyError::InvalidPolicy(ref cause) => cause,
+            PutIdentityPolicyError::InvalidPolicy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutIdentityPolicyError {}
 /// Errors returned by ReorderReceiptRuleSet
 #[derive(Debug, PartialEq)]
 pub enum ReorderReceiptRuleSetError {
@@ -9071,17 +8911,13 @@ impl ReorderReceiptRuleSetError {
 }
 impl fmt::Display for ReorderReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReorderReceiptRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            ReorderReceiptRuleSetError::RuleDoesNotExist(ref cause) => cause,
-            ReorderReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => cause,
+            ReorderReceiptRuleSetError::RuleDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ReorderReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReorderReceiptRuleSetError {}
 /// Errors returned by SendBounce
 #[derive(Debug, PartialEq)]
 pub enum SendBounceError {
@@ -9119,16 +8955,12 @@ impl SendBounceError {
 }
 impl fmt::Display for SendBounceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendBounceError {
-    fn description(&self) -> &str {
         match *self {
-            SendBounceError::MessageRejected(ref cause) => cause,
+            SendBounceError::MessageRejected(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendBounceError {}
 /// Errors returned by SendBulkTemplatedEmail
 #[derive(Debug, PartialEq)]
 pub enum SendBulkTemplatedEmailError {
@@ -9207,21 +9039,23 @@ impl SendBulkTemplatedEmailError {
 }
 impl fmt::Display for SendBulkTemplatedEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendBulkTemplatedEmailError {
-    fn description(&self) -> &str {
         match *self {
-            SendBulkTemplatedEmailError::AccountSendingPaused(ref cause) => cause,
-            SendBulkTemplatedEmailError::ConfigurationSetDoesNotExist(ref cause) => cause,
-            SendBulkTemplatedEmailError::ConfigurationSetSendingPaused(ref cause) => cause,
-            SendBulkTemplatedEmailError::MailFromDomainNotVerified(ref cause) => cause,
-            SendBulkTemplatedEmailError::MessageRejected(ref cause) => cause,
-            SendBulkTemplatedEmailError::TemplateDoesNotExist(ref cause) => cause,
+            SendBulkTemplatedEmailError::AccountSendingPaused(ref cause) => write!(f, "{}", cause),
+            SendBulkTemplatedEmailError::ConfigurationSetDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendBulkTemplatedEmailError::ConfigurationSetSendingPaused(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendBulkTemplatedEmailError::MailFromDomainNotVerified(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendBulkTemplatedEmailError::MessageRejected(ref cause) => write!(f, "{}", cause),
+            SendBulkTemplatedEmailError::TemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendBulkTemplatedEmailError {}
 /// Errors returned by SendCustomVerificationEmail
 #[derive(Debug, PartialEq)]
 pub enum SendCustomVerificationEmailError {
@@ -9264,22 +9098,24 @@ impl SendCustomVerificationEmailError {
 }
 impl fmt::Display for SendCustomVerificationEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendCustomVerificationEmailError {
-    fn description(&self) -> &str {
         match *self {
-            SendCustomVerificationEmailError::ConfigurationSetDoesNotExist(ref cause) => cause,
+            SendCustomVerificationEmailError::ConfigurationSetDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
             SendCustomVerificationEmailError::CustomVerificationEmailTemplateDoesNotExist(
                 ref cause,
-            ) => cause,
-            SendCustomVerificationEmailError::FromEmailAddressNotVerified(ref cause) => cause,
-            SendCustomVerificationEmailError::MessageRejected(ref cause) => cause,
-            SendCustomVerificationEmailError::ProductionAccessNotGranted(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            SendCustomVerificationEmailError::FromEmailAddressNotVerified(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendCustomVerificationEmailError::MessageRejected(ref cause) => write!(f, "{}", cause),
+            SendCustomVerificationEmailError::ProductionAccessNotGranted(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SendCustomVerificationEmailError {}
 /// Errors returned by SendEmail
 #[derive(Debug, PartialEq)]
 pub enum SendEmailError {
@@ -9345,20 +9181,16 @@ impl SendEmailError {
 }
 impl fmt::Display for SendEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendEmailError {
-    fn description(&self) -> &str {
         match *self {
-            SendEmailError::AccountSendingPaused(ref cause) => cause,
-            SendEmailError::ConfigurationSetDoesNotExist(ref cause) => cause,
-            SendEmailError::ConfigurationSetSendingPaused(ref cause) => cause,
-            SendEmailError::MailFromDomainNotVerified(ref cause) => cause,
-            SendEmailError::MessageRejected(ref cause) => cause,
+            SendEmailError::AccountSendingPaused(ref cause) => write!(f, "{}", cause),
+            SendEmailError::ConfigurationSetDoesNotExist(ref cause) => write!(f, "{}", cause),
+            SendEmailError::ConfigurationSetSendingPaused(ref cause) => write!(f, "{}", cause),
+            SendEmailError::MailFromDomainNotVerified(ref cause) => write!(f, "{}", cause),
+            SendEmailError::MessageRejected(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendEmailError {}
 /// Errors returned by SendRawEmail
 #[derive(Debug, PartialEq)]
 pub enum SendRawEmailError {
@@ -9424,20 +9256,16 @@ impl SendRawEmailError {
 }
 impl fmt::Display for SendRawEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendRawEmailError {
-    fn description(&self) -> &str {
         match *self {
-            SendRawEmailError::AccountSendingPaused(ref cause) => cause,
-            SendRawEmailError::ConfigurationSetDoesNotExist(ref cause) => cause,
-            SendRawEmailError::ConfigurationSetSendingPaused(ref cause) => cause,
-            SendRawEmailError::MailFromDomainNotVerified(ref cause) => cause,
-            SendRawEmailError::MessageRejected(ref cause) => cause,
+            SendRawEmailError::AccountSendingPaused(ref cause) => write!(f, "{}", cause),
+            SendRawEmailError::ConfigurationSetDoesNotExist(ref cause) => write!(f, "{}", cause),
+            SendRawEmailError::ConfigurationSetSendingPaused(ref cause) => write!(f, "{}", cause),
+            SendRawEmailError::MailFromDomainNotVerified(ref cause) => write!(f, "{}", cause),
+            SendRawEmailError::MessageRejected(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendRawEmailError {}
 /// Errors returned by SendTemplatedEmail
 #[derive(Debug, PartialEq)]
 pub enum SendTemplatedEmailError {
@@ -9516,21 +9344,21 @@ impl SendTemplatedEmailError {
 }
 impl fmt::Display for SendTemplatedEmailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendTemplatedEmailError {
-    fn description(&self) -> &str {
         match *self {
-            SendTemplatedEmailError::AccountSendingPaused(ref cause) => cause,
-            SendTemplatedEmailError::ConfigurationSetDoesNotExist(ref cause) => cause,
-            SendTemplatedEmailError::ConfigurationSetSendingPaused(ref cause) => cause,
-            SendTemplatedEmailError::MailFromDomainNotVerified(ref cause) => cause,
-            SendTemplatedEmailError::MessageRejected(ref cause) => cause,
-            SendTemplatedEmailError::TemplateDoesNotExist(ref cause) => cause,
+            SendTemplatedEmailError::AccountSendingPaused(ref cause) => write!(f, "{}", cause),
+            SendTemplatedEmailError::ConfigurationSetDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendTemplatedEmailError::ConfigurationSetSendingPaused(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendTemplatedEmailError::MailFromDomainNotVerified(ref cause) => write!(f, "{}", cause),
+            SendTemplatedEmailError::MessageRejected(ref cause) => write!(f, "{}", cause),
+            SendTemplatedEmailError::TemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendTemplatedEmailError {}
 /// Errors returned by SetActiveReceiptRuleSet
 #[derive(Debug, PartialEq)]
 pub enum SetActiveReceiptRuleSetError {
@@ -9568,16 +9396,12 @@ impl SetActiveReceiptRuleSetError {
 }
 impl fmt::Display for SetActiveReceiptRuleSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetActiveReceiptRuleSetError {
-    fn description(&self) -> &str {
         match *self {
-            SetActiveReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => cause,
+            SetActiveReceiptRuleSetError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetActiveReceiptRuleSetError {}
 /// Errors returned by SetIdentityDkimEnabled
 #[derive(Debug, PartialEq)]
 pub enum SetIdentityDkimEnabledError {}
@@ -9607,14 +9431,10 @@ impl SetIdentityDkimEnabledError {
 }
 impl fmt::Display for SetIdentityDkimEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIdentityDkimEnabledError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SetIdentityDkimEnabledError {}
 /// Errors returned by SetIdentityFeedbackForwardingEnabled
 #[derive(Debug, PartialEq)]
 pub enum SetIdentityFeedbackForwardingEnabledError {}
@@ -9646,14 +9466,10 @@ impl SetIdentityFeedbackForwardingEnabledError {
 }
 impl fmt::Display for SetIdentityFeedbackForwardingEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIdentityFeedbackForwardingEnabledError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SetIdentityFeedbackForwardingEnabledError {}
 /// Errors returned by SetIdentityHeadersInNotificationsEnabled
 #[derive(Debug, PartialEq)]
 pub enum SetIdentityHeadersInNotificationsEnabledError {}
@@ -9685,14 +9501,10 @@ impl SetIdentityHeadersInNotificationsEnabledError {
 }
 impl fmt::Display for SetIdentityHeadersInNotificationsEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIdentityHeadersInNotificationsEnabledError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SetIdentityHeadersInNotificationsEnabledError {}
 /// Errors returned by SetIdentityMailFromDomain
 #[derive(Debug, PartialEq)]
 pub enum SetIdentityMailFromDomainError {}
@@ -9722,14 +9534,10 @@ impl SetIdentityMailFromDomainError {
 }
 impl fmt::Display for SetIdentityMailFromDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIdentityMailFromDomainError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SetIdentityMailFromDomainError {}
 /// Errors returned by SetIdentityNotificationTopic
 #[derive(Debug, PartialEq)]
 pub enum SetIdentityNotificationTopicError {}
@@ -9761,14 +9569,10 @@ impl SetIdentityNotificationTopicError {
 }
 impl fmt::Display for SetIdentityNotificationTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetIdentityNotificationTopicError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for SetIdentityNotificationTopicError {}
 /// Errors returned by SetReceiptRulePosition
 #[derive(Debug, PartialEq)]
 pub enum SetReceiptRulePositionError {
@@ -9813,17 +9617,13 @@ impl SetReceiptRulePositionError {
 }
 impl fmt::Display for SetReceiptRulePositionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetReceiptRulePositionError {
-    fn description(&self) -> &str {
         match *self {
-            SetReceiptRulePositionError::RuleDoesNotExist(ref cause) => cause,
-            SetReceiptRulePositionError::RuleSetDoesNotExist(ref cause) => cause,
+            SetReceiptRulePositionError::RuleDoesNotExist(ref cause) => write!(f, "{}", cause),
+            SetReceiptRulePositionError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetReceiptRulePositionError {}
 /// Errors returned by TestRenderTemplate
 #[derive(Debug, PartialEq)]
 pub enum TestRenderTemplateError {
@@ -9879,18 +9679,14 @@ impl TestRenderTemplateError {
 }
 impl fmt::Display for TestRenderTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestRenderTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            TestRenderTemplateError::InvalidRenderingParameter(ref cause) => cause,
-            TestRenderTemplateError::MissingRenderingAttribute(ref cause) => cause,
-            TestRenderTemplateError::TemplateDoesNotExist(ref cause) => cause,
+            TestRenderTemplateError::InvalidRenderingParameter(ref cause) => write!(f, "{}", cause),
+            TestRenderTemplateError::MissingRenderingAttribute(ref cause) => write!(f, "{}", cause),
+            TestRenderTemplateError::TemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestRenderTemplateError {}
 /// Errors returned by UpdateAccountSendingEnabled
 #[derive(Debug, PartialEq)]
 pub enum UpdateAccountSendingEnabledError {}
@@ -9922,14 +9718,10 @@ impl UpdateAccountSendingEnabledError {
 }
 impl fmt::Display for UpdateAccountSendingEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAccountSendingEnabledError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UpdateAccountSendingEnabledError {}
 /// Errors returned by UpdateConfigurationSetEventDestination
 #[derive(Debug, PartialEq)]
 pub enum UpdateConfigurationSetEventDestinationError {
@@ -10001,28 +9793,26 @@ impl UpdateConfigurationSetEventDestinationError {
 }
 impl fmt::Display for UpdateConfigurationSetEventDestinationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConfigurationSetEventDestinationError {
-    fn description(&self) -> &str {
         match *self {
             UpdateConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateConfigurationSetEventDestinationError::EventDestinationDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateConfigurationSetEventDestinationError::InvalidCloudWatchDestination(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
             UpdateConfigurationSetEventDestinationError::InvalidFirehoseDestination(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdateConfigurationSetEventDestinationError::InvalidSNSDestination(ref cause) => cause,
+            UpdateConfigurationSetEventDestinationError::InvalidSNSDestination(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateConfigurationSetEventDestinationError {}
 /// Errors returned by UpdateConfigurationSetReputationMetricsEnabled
 #[derive(Debug, PartialEq)]
 pub enum UpdateConfigurationSetReputationMetricsEnabledError {
@@ -10057,18 +9847,14 @@ impl UpdateConfigurationSetReputationMetricsEnabledError {
 }
 impl fmt::Display for UpdateConfigurationSetReputationMetricsEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConfigurationSetReputationMetricsEnabledError {
-    fn description(&self) -> &str {
         match *self {
             UpdateConfigurationSetReputationMetricsEnabledError::ConfigurationSetDoesNotExist(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateConfigurationSetReputationMetricsEnabledError {}
 /// Errors returned by UpdateConfigurationSetSendingEnabled
 #[derive(Debug, PartialEq)]
 pub enum UpdateConfigurationSetSendingEnabledError {
@@ -10110,18 +9896,14 @@ impl UpdateConfigurationSetSendingEnabledError {
 }
 impl fmt::Display for UpdateConfigurationSetSendingEnabledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConfigurationSetSendingEnabledError {
-    fn description(&self) -> &str {
         match *self {
             UpdateConfigurationSetSendingEnabledError::ConfigurationSetDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for UpdateConfigurationSetSendingEnabledError {}
 /// Errors returned by UpdateConfigurationSetTrackingOptions
 #[derive(Debug, PartialEq)]
 pub enum UpdateConfigurationSetTrackingOptionsError {
@@ -10179,22 +9961,20 @@ impl UpdateConfigurationSetTrackingOptionsError {
 }
 impl fmt::Display for UpdateConfigurationSetTrackingOptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateConfigurationSetTrackingOptionsError {
-    fn description(&self) -> &str {
         match *self {
             UpdateConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdateConfigurationSetTrackingOptionsError::InvalidTrackingOptions(ref cause) => cause,
+            UpdateConfigurationSetTrackingOptionsError::InvalidTrackingOptions(ref cause) => {
+                write!(f, "{}", cause)
+            }
             UpdateConfigurationSetTrackingOptionsError::TrackingOptionsDoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for UpdateConfigurationSetTrackingOptionsError {}
 /// Errors returned by UpdateCustomVerificationEmailTemplate
 #[derive(Debug, PartialEq)]
 pub enum UpdateCustomVerificationEmailTemplateError {
@@ -10233,18 +10013,14 @@ impl UpdateCustomVerificationEmailTemplateError {
 }
 impl fmt::Display for UpdateCustomVerificationEmailTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCustomVerificationEmailTemplateError {
-    fn description(&self) -> &str {
         match *self {
-                            UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(ref cause) => cause,
-UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(ref cause) => cause,
-UpdateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(ref cause) => cause
+                            UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(ref cause) => write!(f, "{}", cause),
+UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
+UpdateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(ref cause) => write!(f, "{}", cause)
                         }
     }
 }
+impl Error for UpdateCustomVerificationEmailTemplateError {}
 /// Errors returned by UpdateReceiptRule
 #[derive(Debug, PartialEq)]
 pub enum UpdateReceiptRuleError {
@@ -10317,21 +10093,17 @@ impl UpdateReceiptRuleError {
 }
 impl fmt::Display for UpdateReceiptRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateReceiptRuleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateReceiptRuleError::InvalidLambdaFunction(ref cause) => cause,
-            UpdateReceiptRuleError::InvalidS3Configuration(ref cause) => cause,
-            UpdateReceiptRuleError::InvalidSnsTopic(ref cause) => cause,
-            UpdateReceiptRuleError::LimitExceeded(ref cause) => cause,
-            UpdateReceiptRuleError::RuleDoesNotExist(ref cause) => cause,
-            UpdateReceiptRuleError::RuleSetDoesNotExist(ref cause) => cause,
+            UpdateReceiptRuleError::InvalidLambdaFunction(ref cause) => write!(f, "{}", cause),
+            UpdateReceiptRuleError::InvalidS3Configuration(ref cause) => write!(f, "{}", cause),
+            UpdateReceiptRuleError::InvalidSnsTopic(ref cause) => write!(f, "{}", cause),
+            UpdateReceiptRuleError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateReceiptRuleError::RuleDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateReceiptRuleError::RuleSetDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateReceiptRuleError {}
 /// Errors returned by UpdateTemplate
 #[derive(Debug, PartialEq)]
 pub enum UpdateTemplateError {
@@ -10376,17 +10148,13 @@ impl UpdateTemplateError {
 }
 impl fmt::Display for UpdateTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateTemplateError::InvalidTemplate(ref cause) => cause,
-            UpdateTemplateError::TemplateDoesNotExist(ref cause) => cause,
+            UpdateTemplateError::InvalidTemplate(ref cause) => write!(f, "{}", cause),
+            UpdateTemplateError::TemplateDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateTemplateError {}
 /// Errors returned by VerifyDomainDkim
 #[derive(Debug, PartialEq)]
 pub enum VerifyDomainDkimError {}
@@ -10416,14 +10184,10 @@ impl VerifyDomainDkimError {
 }
 impl fmt::Display for VerifyDomainDkimError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifyDomainDkimError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for VerifyDomainDkimError {}
 /// Errors returned by VerifyDomainIdentity
 #[derive(Debug, PartialEq)]
 pub enum VerifyDomainIdentityError {}
@@ -10453,14 +10217,10 @@ impl VerifyDomainIdentityError {
 }
 impl fmt::Display for VerifyDomainIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifyDomainIdentityError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for VerifyDomainIdentityError {}
 /// Errors returned by VerifyEmailAddress
 #[derive(Debug, PartialEq)]
 pub enum VerifyEmailAddressError {}
@@ -10490,14 +10250,10 @@ impl VerifyEmailAddressError {
 }
 impl fmt::Display for VerifyEmailAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifyEmailAddressError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for VerifyEmailAddressError {}
 /// Errors returned by VerifyEmailIdentity
 #[derive(Debug, PartialEq)]
 pub enum VerifyEmailIdentityError {}
@@ -10527,14 +10283,10 @@ impl VerifyEmailIdentityError {
 }
 impl fmt::Display for VerifyEmailIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for VerifyEmailIdentityError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for VerifyEmailIdentityError {}
 /// Trait representing the capabilities of the Amazon SES API. Amazon SES clients implement this trait.
 pub trait Ses {
     /// <p>Creates a receipt rule set by cloning an existing one. All receipt rules and configurations are copied to the new receipt rule set and are completely independent of the source rule set.</p> <p>For information about setting up rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -620,23 +620,21 @@ impl AssociateDRTLogBucketError {
 }
 impl fmt::Display for AssociateDRTLogBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDRTLogBucketError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDRTLogBucketError::AccessDeniedForDependency(ref cause) => cause,
-            AssociateDRTLogBucketError::InternalError(ref cause) => cause,
-            AssociateDRTLogBucketError::InvalidOperation(ref cause) => cause,
-            AssociateDRTLogBucketError::InvalidParameter(ref cause) => cause,
-            AssociateDRTLogBucketError::LimitsExceeded(ref cause) => cause,
-            AssociateDRTLogBucketError::NoAssociatedRole(ref cause) => cause,
-            AssociateDRTLogBucketError::OptimisticLock(ref cause) => cause,
-            AssociateDRTLogBucketError::ResourceNotFound(ref cause) => cause,
+            AssociateDRTLogBucketError::AccessDeniedForDependency(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDRTLogBucketError::InternalError(ref cause) => write!(f, "{}", cause),
+            AssociateDRTLogBucketError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            AssociateDRTLogBucketError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateDRTLogBucketError::LimitsExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateDRTLogBucketError::NoAssociatedRole(ref cause) => write!(f, "{}", cause),
+            AssociateDRTLogBucketError::OptimisticLock(ref cause) => write!(f, "{}", cause),
+            AssociateDRTLogBucketError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateDRTLogBucketError {}
 /// Errors returned by AssociateDRTRole
 #[derive(Debug, PartialEq)]
 pub enum AssociateDRTRoleError {
@@ -687,21 +685,17 @@ impl AssociateDRTRoleError {
 }
 impl fmt::Display for AssociateDRTRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDRTRoleError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDRTRoleError::AccessDeniedForDependency(ref cause) => cause,
-            AssociateDRTRoleError::InternalError(ref cause) => cause,
-            AssociateDRTRoleError::InvalidOperation(ref cause) => cause,
-            AssociateDRTRoleError::InvalidParameter(ref cause) => cause,
-            AssociateDRTRoleError::OptimisticLock(ref cause) => cause,
-            AssociateDRTRoleError::ResourceNotFound(ref cause) => cause,
+            AssociateDRTRoleError::AccessDeniedForDependency(ref cause) => write!(f, "{}", cause),
+            AssociateDRTRoleError::InternalError(ref cause) => write!(f, "{}", cause),
+            AssociateDRTRoleError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            AssociateDRTRoleError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateDRTRoleError::OptimisticLock(ref cause) => write!(f, "{}", cause),
+            AssociateDRTRoleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateDRTRoleError {}
 /// Errors returned by CreateProtection
 #[derive(Debug, PartialEq)]
 pub enum CreateProtectionError {
@@ -757,22 +751,18 @@ impl CreateProtectionError {
 }
 impl fmt::Display for CreateProtectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateProtectionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateProtectionError::InternalError(ref cause) => cause,
-            CreateProtectionError::InvalidOperation(ref cause) => cause,
-            CreateProtectionError::InvalidResource(ref cause) => cause,
-            CreateProtectionError::LimitsExceeded(ref cause) => cause,
-            CreateProtectionError::OptimisticLock(ref cause) => cause,
-            CreateProtectionError::ResourceAlreadyExists(ref cause) => cause,
-            CreateProtectionError::ResourceNotFound(ref cause) => cause,
+            CreateProtectionError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateProtectionError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            CreateProtectionError::InvalidResource(ref cause) => write!(f, "{}", cause),
+            CreateProtectionError::LimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateProtectionError::OptimisticLock(ref cause) => write!(f, "{}", cause),
+            CreateProtectionError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateProtectionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateProtectionError {}
 /// Errors returned by CreateSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateSubscriptionError {
@@ -803,17 +793,13 @@ impl CreateSubscriptionError {
 }
 impl fmt::Display for CreateSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSubscriptionError::InternalError(ref cause) => cause,
-            CreateSubscriptionError::ResourceAlreadyExists(ref cause) => cause,
+            CreateSubscriptionError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateSubscriptionError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSubscriptionError {}
 /// Errors returned by DeleteProtection
 #[derive(Debug, PartialEq)]
 pub enum DeleteProtectionError {
@@ -847,18 +833,14 @@ impl DeleteProtectionError {
 }
 impl fmt::Display for DeleteProtectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteProtectionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteProtectionError::InternalError(ref cause) => cause,
-            DeleteProtectionError::OptimisticLock(ref cause) => cause,
-            DeleteProtectionError::ResourceNotFound(ref cause) => cause,
+            DeleteProtectionError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteProtectionError::OptimisticLock(ref cause) => write!(f, "{}", cause),
+            DeleteProtectionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteProtectionError {}
 /// Errors returned by DeleteSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteSubscriptionError {
@@ -894,18 +876,14 @@ impl DeleteSubscriptionError {
 }
 impl fmt::Display for DeleteSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSubscriptionError::InternalError(ref cause) => cause,
-            DeleteSubscriptionError::LockedSubscription(ref cause) => cause,
-            DeleteSubscriptionError::ResourceNotFound(ref cause) => cause,
+            DeleteSubscriptionError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriptionError::LockedSubscription(ref cause) => write!(f, "{}", cause),
+            DeleteSubscriptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSubscriptionError {}
 /// Errors returned by DescribeAttack
 #[derive(Debug, PartialEq)]
 pub enum DescribeAttackError {
@@ -934,17 +912,13 @@ impl DescribeAttackError {
 }
 impl fmt::Display for DescribeAttackError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAttackError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAttackError::AccessDenied(ref cause) => cause,
-            DescribeAttackError::InternalError(ref cause) => cause,
+            DescribeAttackError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeAttackError::InternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAttackError {}
 /// Errors returned by DescribeDRTAccess
 #[derive(Debug, PartialEq)]
 pub enum DescribeDRTAccessError {
@@ -973,17 +947,13 @@ impl DescribeDRTAccessError {
 }
 impl fmt::Display for DescribeDRTAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDRTAccessError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDRTAccessError::InternalError(ref cause) => cause,
-            DescribeDRTAccessError::ResourceNotFound(ref cause) => cause,
+            DescribeDRTAccessError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeDRTAccessError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDRTAccessError {}
 /// Errors returned by DescribeEmergencyContactSettings
 #[derive(Debug, PartialEq)]
 pub enum DescribeEmergencyContactSettingsError {
@@ -1018,17 +988,17 @@ impl DescribeEmergencyContactSettingsError {
 }
 impl fmt::Display for DescribeEmergencyContactSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEmergencyContactSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEmergencyContactSettingsError::InternalError(ref cause) => cause,
-            DescribeEmergencyContactSettingsError::ResourceNotFound(ref cause) => cause,
+            DescribeEmergencyContactSettingsError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEmergencyContactSettingsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEmergencyContactSettingsError {}
 /// Errors returned by DescribeProtection
 #[derive(Debug, PartialEq)]
 pub enum DescribeProtectionError {
@@ -1062,18 +1032,14 @@ impl DescribeProtectionError {
 }
 impl fmt::Display for DescribeProtectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeProtectionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeProtectionError::InternalError(ref cause) => cause,
-            DescribeProtectionError::InvalidParameter(ref cause) => cause,
-            DescribeProtectionError::ResourceNotFound(ref cause) => cause,
+            DescribeProtectionError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeProtectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeProtectionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeProtectionError {}
 /// Errors returned by DescribeSubscription
 #[derive(Debug, PartialEq)]
 pub enum DescribeSubscriptionError {
@@ -1104,17 +1070,13 @@ impl DescribeSubscriptionError {
 }
 impl fmt::Display for DescribeSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSubscriptionError::InternalError(ref cause) => cause,
-            DescribeSubscriptionError::ResourceNotFound(ref cause) => cause,
+            DescribeSubscriptionError::InternalError(ref cause) => write!(f, "{}", cause),
+            DescribeSubscriptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSubscriptionError {}
 /// Errors returned by DisassociateDRTLogBucket
 #[derive(Debug, PartialEq)]
 pub enum DisassociateDRTLogBucketError {
@@ -1175,21 +1137,19 @@ impl DisassociateDRTLogBucketError {
 }
 impl fmt::Display for DisassociateDRTLogBucketError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateDRTLogBucketError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateDRTLogBucketError::AccessDeniedForDependency(ref cause) => cause,
-            DisassociateDRTLogBucketError::InternalError(ref cause) => cause,
-            DisassociateDRTLogBucketError::InvalidOperation(ref cause) => cause,
-            DisassociateDRTLogBucketError::NoAssociatedRole(ref cause) => cause,
-            DisassociateDRTLogBucketError::OptimisticLock(ref cause) => cause,
-            DisassociateDRTLogBucketError::ResourceNotFound(ref cause) => cause,
+            DisassociateDRTLogBucketError::AccessDeniedForDependency(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDRTLogBucketError::InternalError(ref cause) => write!(f, "{}", cause),
+            DisassociateDRTLogBucketError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DisassociateDRTLogBucketError::NoAssociatedRole(ref cause) => write!(f, "{}", cause),
+            DisassociateDRTLogBucketError::OptimisticLock(ref cause) => write!(f, "{}", cause),
+            DisassociateDRTLogBucketError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateDRTLogBucketError {}
 /// Errors returned by DisassociateDRTRole
 #[derive(Debug, PartialEq)]
 pub enum DisassociateDRTRoleError {
@@ -1232,19 +1192,15 @@ impl DisassociateDRTRoleError {
 }
 impl fmt::Display for DisassociateDRTRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateDRTRoleError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateDRTRoleError::InternalError(ref cause) => cause,
-            DisassociateDRTRoleError::InvalidOperation(ref cause) => cause,
-            DisassociateDRTRoleError::OptimisticLock(ref cause) => cause,
-            DisassociateDRTRoleError::ResourceNotFound(ref cause) => cause,
+            DisassociateDRTRoleError::InternalError(ref cause) => write!(f, "{}", cause),
+            DisassociateDRTRoleError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            DisassociateDRTRoleError::OptimisticLock(ref cause) => write!(f, "{}", cause),
+            DisassociateDRTRoleError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateDRTRoleError {}
 /// Errors returned by GetSubscriptionState
 #[derive(Debug, PartialEq)]
 pub enum GetSubscriptionStateError {
@@ -1268,16 +1224,12 @@ impl GetSubscriptionStateError {
 }
 impl fmt::Display for GetSubscriptionStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSubscriptionStateError {
-    fn description(&self) -> &str {
         match *self {
-            GetSubscriptionStateError::InternalError(ref cause) => cause,
+            GetSubscriptionStateError::InternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSubscriptionStateError {}
 /// Errors returned by ListAttacks
 #[derive(Debug, PartialEq)]
 pub enum ListAttacksError {
@@ -1311,18 +1263,14 @@ impl ListAttacksError {
 }
 impl fmt::Display for ListAttacksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAttacksError {
-    fn description(&self) -> &str {
         match *self {
-            ListAttacksError::InternalError(ref cause) => cause,
-            ListAttacksError::InvalidOperation(ref cause) => cause,
-            ListAttacksError::InvalidParameter(ref cause) => cause,
+            ListAttacksError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListAttacksError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            ListAttacksError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAttacksError {}
 /// Errors returned by ListProtections
 #[derive(Debug, PartialEq)]
 pub enum ListProtectionsError {
@@ -1358,18 +1306,14 @@ impl ListProtectionsError {
 }
 impl fmt::Display for ListProtectionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListProtectionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListProtectionsError::InternalError(ref cause) => cause,
-            ListProtectionsError::InvalidPaginationToken(ref cause) => cause,
-            ListProtectionsError::ResourceNotFound(ref cause) => cause,
+            ListProtectionsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListProtectionsError::InvalidPaginationToken(ref cause) => write!(f, "{}", cause),
+            ListProtectionsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListProtectionsError {}
 /// Errors returned by UpdateEmergencyContactSettings
 #[derive(Debug, PartialEq)]
 pub enum UpdateEmergencyContactSettingsError {
@@ -1418,19 +1362,21 @@ impl UpdateEmergencyContactSettingsError {
 }
 impl fmt::Display for UpdateEmergencyContactSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateEmergencyContactSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateEmergencyContactSettingsError::InternalError(ref cause) => cause,
-            UpdateEmergencyContactSettingsError::InvalidParameter(ref cause) => cause,
-            UpdateEmergencyContactSettingsError::OptimisticLock(ref cause) => cause,
-            UpdateEmergencyContactSettingsError::ResourceNotFound(ref cause) => cause,
+            UpdateEmergencyContactSettingsError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateEmergencyContactSettingsError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateEmergencyContactSettingsError::OptimisticLock(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateEmergencyContactSettingsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateEmergencyContactSettingsError {}
 /// Errors returned by UpdateSubscription
 #[derive(Debug, PartialEq)]
 pub enum UpdateSubscriptionError {
@@ -1476,20 +1422,16 @@ impl UpdateSubscriptionError {
 }
 impl fmt::Display for UpdateSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSubscriptionError::InternalError(ref cause) => cause,
-            UpdateSubscriptionError::InvalidParameter(ref cause) => cause,
-            UpdateSubscriptionError::LockedSubscription(ref cause) => cause,
-            UpdateSubscriptionError::OptimisticLock(ref cause) => cause,
-            UpdateSubscriptionError::ResourceNotFound(ref cause) => cause,
+            UpdateSubscriptionError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriptionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriptionError::LockedSubscription(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriptionError::OptimisticLock(ref cause) => write!(f, "{}", cause),
+            UpdateSubscriptionError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSubscriptionError {}
 /// Trait representing the capabilities of the AWS Shield API. AWS Shield clients implement this trait.
 pub trait Shield {
     /// <p>Authorizes the DDoS Response team (DRT) to access the specified Amazon S3 bucket containing your AWS WAF logs. You can associate up to 10 Amazon S3 buckets with your subscription.</p> <p>To use the services of the DRT and make an <code>AssociateDRTLogBucket</code> request, you must be subscribed to the <a href="https://aws.amazon.com/premiumsupport/business-support/">Business Support plan</a> or the <a href="https://aws.amazon.com/premiumsupport/enterprise-support/">Enterprise Support plan</a>.</p>

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -1203,20 +1203,16 @@ impl CreateAppError {
 }
 impl fmt::Display for CreateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAppError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAppError::InternalError(ref cause) => cause,
-            CreateAppError::InvalidParameter(ref cause) => cause,
-            CreateAppError::MissingRequiredParameter(ref cause) => cause,
-            CreateAppError::OperationNotPermitted(ref cause) => cause,
-            CreateAppError::UnauthorizedOperation(ref cause) => cause,
+            CreateAppError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateAppError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateAppError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            CreateAppError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateAppError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAppError {}
 /// Errors returned by CreateReplicationJob
 #[derive(Debug, PartialEq)]
 pub enum CreateReplicationJobError {
@@ -1296,24 +1292,26 @@ impl CreateReplicationJobError {
 }
 impl fmt::Display for CreateReplicationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateReplicationJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateReplicationJobError::InternalError(ref cause) => cause,
-            CreateReplicationJobError::InvalidParameter(ref cause) => cause,
-            CreateReplicationJobError::MissingRequiredParameter(ref cause) => cause,
-            CreateReplicationJobError::NoConnectorsAvailable(ref cause) => cause,
-            CreateReplicationJobError::OperationNotPermitted(ref cause) => cause,
-            CreateReplicationJobError::ReplicationJobAlreadyExists(ref cause) => cause,
-            CreateReplicationJobError::ServerCannotBeReplicated(ref cause) => cause,
-            CreateReplicationJobError::TemporarilyUnavailable(ref cause) => cause,
-            CreateReplicationJobError::UnauthorizedOperation(ref cause) => cause,
+            CreateReplicationJobError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateReplicationJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateReplicationJobError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationJobError::NoConnectorsAvailable(ref cause) => write!(f, "{}", cause),
+            CreateReplicationJobError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            CreateReplicationJobError::ReplicationJobAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationJobError::ServerCannotBeReplicated(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateReplicationJobError::TemporarilyUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateReplicationJobError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateReplicationJobError {}
 /// Errors returned by DeleteApp
 #[derive(Debug, PartialEq)]
 pub enum DeleteAppError {
@@ -1357,20 +1355,16 @@ impl DeleteAppError {
 }
 impl fmt::Display for DeleteAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAppError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAppError::InternalError(ref cause) => cause,
-            DeleteAppError::InvalidParameter(ref cause) => cause,
-            DeleteAppError::MissingRequiredParameter(ref cause) => cause,
-            DeleteAppError::OperationNotPermitted(ref cause) => cause,
-            DeleteAppError::UnauthorizedOperation(ref cause) => cause,
+            DeleteAppError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteAppError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAppError {}
 /// Errors returned by DeleteAppLaunchConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteAppLaunchConfigurationError {
@@ -1426,20 +1420,24 @@ impl DeleteAppLaunchConfigurationError {
 }
 impl fmt::Display for DeleteAppLaunchConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAppLaunchConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAppLaunchConfigurationError::InternalError(ref cause) => cause,
-            DeleteAppLaunchConfigurationError::InvalidParameter(ref cause) => cause,
-            DeleteAppLaunchConfigurationError::MissingRequiredParameter(ref cause) => cause,
-            DeleteAppLaunchConfigurationError::OperationNotPermitted(ref cause) => cause,
-            DeleteAppLaunchConfigurationError::UnauthorizedOperation(ref cause) => cause,
+            DeleteAppLaunchConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteAppLaunchConfigurationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAppLaunchConfigurationError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAppLaunchConfigurationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAppLaunchConfigurationError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteAppLaunchConfigurationError {}
 /// Errors returned by DeleteAppReplicationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteAppReplicationConfigurationError {
@@ -1495,20 +1493,26 @@ impl DeleteAppReplicationConfigurationError {
 }
 impl fmt::Display for DeleteAppReplicationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAppReplicationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAppReplicationConfigurationError::InternalError(ref cause) => cause,
-            DeleteAppReplicationConfigurationError::InvalidParameter(ref cause) => cause,
-            DeleteAppReplicationConfigurationError::MissingRequiredParameter(ref cause) => cause,
-            DeleteAppReplicationConfigurationError::OperationNotPermitted(ref cause) => cause,
-            DeleteAppReplicationConfigurationError::UnauthorizedOperation(ref cause) => cause,
+            DeleteAppReplicationConfigurationError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAppReplicationConfigurationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAppReplicationConfigurationError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAppReplicationConfigurationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteAppReplicationConfigurationError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteAppReplicationConfigurationError {}
 /// Errors returned by DeleteReplicationJob
 #[derive(Debug, PartialEq)]
 pub enum DeleteReplicationJobError {
@@ -1562,20 +1566,18 @@ impl DeleteReplicationJobError {
 }
 impl fmt::Display for DeleteReplicationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteReplicationJobError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteReplicationJobError::InvalidParameter(ref cause) => cause,
-            DeleteReplicationJobError::MissingRequiredParameter(ref cause) => cause,
-            DeleteReplicationJobError::OperationNotPermitted(ref cause) => cause,
-            DeleteReplicationJobError::ReplicationJobNotFound(ref cause) => cause,
-            DeleteReplicationJobError::UnauthorizedOperation(ref cause) => cause,
+            DeleteReplicationJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteReplicationJobError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteReplicationJobError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteReplicationJobError::ReplicationJobNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteReplicationJobError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteReplicationJobError {}
 /// Errors returned by DeleteServerCatalog
 #[derive(Debug, PartialEq)]
 pub enum DeleteServerCatalogError {
@@ -1622,19 +1624,15 @@ impl DeleteServerCatalogError {
 }
 impl fmt::Display for DeleteServerCatalogError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServerCatalogError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServerCatalogError::InvalidParameter(ref cause) => cause,
-            DeleteServerCatalogError::MissingRequiredParameter(ref cause) => cause,
-            DeleteServerCatalogError::OperationNotPermitted(ref cause) => cause,
-            DeleteServerCatalogError::UnauthorizedOperation(ref cause) => cause,
+            DeleteServerCatalogError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteServerCatalogError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            DeleteServerCatalogError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DeleteServerCatalogError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServerCatalogError {}
 /// Errors returned by DisassociateConnector
 #[derive(Debug, PartialEq)]
 pub enum DisassociateConnectorError {
@@ -1681,19 +1679,17 @@ impl DisassociateConnectorError {
 }
 impl fmt::Display for DisassociateConnectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateConnectorError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateConnectorError::InvalidParameter(ref cause) => cause,
-            DisassociateConnectorError::MissingRequiredParameter(ref cause) => cause,
-            DisassociateConnectorError::OperationNotPermitted(ref cause) => cause,
-            DisassociateConnectorError::UnauthorizedOperation(ref cause) => cause,
+            DisassociateConnectorError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DisassociateConnectorError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateConnectorError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            DisassociateConnectorError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateConnectorError {}
 /// Errors returned by GenerateChangeSet
 #[derive(Debug, PartialEq)]
 pub enum GenerateChangeSetError {
@@ -1743,20 +1739,16 @@ impl GenerateChangeSetError {
 }
 impl fmt::Display for GenerateChangeSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateChangeSetError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateChangeSetError::InternalError(ref cause) => cause,
-            GenerateChangeSetError::InvalidParameter(ref cause) => cause,
-            GenerateChangeSetError::MissingRequiredParameter(ref cause) => cause,
-            GenerateChangeSetError::OperationNotPermitted(ref cause) => cause,
-            GenerateChangeSetError::UnauthorizedOperation(ref cause) => cause,
+            GenerateChangeSetError::InternalError(ref cause) => write!(f, "{}", cause),
+            GenerateChangeSetError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GenerateChangeSetError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            GenerateChangeSetError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GenerateChangeSetError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateChangeSetError {}
 /// Errors returned by GenerateTemplate
 #[derive(Debug, PartialEq)]
 pub enum GenerateTemplateError {
@@ -1806,20 +1798,16 @@ impl GenerateTemplateError {
 }
 impl fmt::Display for GenerateTemplateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GenerateTemplateError {
-    fn description(&self) -> &str {
         match *self {
-            GenerateTemplateError::InternalError(ref cause) => cause,
-            GenerateTemplateError::InvalidParameter(ref cause) => cause,
-            GenerateTemplateError::MissingRequiredParameter(ref cause) => cause,
-            GenerateTemplateError::OperationNotPermitted(ref cause) => cause,
-            GenerateTemplateError::UnauthorizedOperation(ref cause) => cause,
+            GenerateTemplateError::InternalError(ref cause) => write!(f, "{}", cause),
+            GenerateTemplateError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GenerateTemplateError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            GenerateTemplateError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GenerateTemplateError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GenerateTemplateError {}
 /// Errors returned by GetApp
 #[derive(Debug, PartialEq)]
 pub enum GetAppError {
@@ -1863,20 +1851,16 @@ impl GetAppError {
 }
 impl fmt::Display for GetAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAppError {
-    fn description(&self) -> &str {
         match *self {
-            GetAppError::InternalError(ref cause) => cause,
-            GetAppError::InvalidParameter(ref cause) => cause,
-            GetAppError::MissingRequiredParameter(ref cause) => cause,
-            GetAppError::OperationNotPermitted(ref cause) => cause,
-            GetAppError::UnauthorizedOperation(ref cause) => cause,
+            GetAppError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetAppError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetAppError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            GetAppError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            GetAppError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAppError {}
 /// Errors returned by GetAppLaunchConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetAppLaunchConfigurationError {
@@ -1930,20 +1914,22 @@ impl GetAppLaunchConfigurationError {
 }
 impl fmt::Display for GetAppLaunchConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAppLaunchConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetAppLaunchConfigurationError::InternalError(ref cause) => cause,
-            GetAppLaunchConfigurationError::InvalidParameter(ref cause) => cause,
-            GetAppLaunchConfigurationError::MissingRequiredParameter(ref cause) => cause,
-            GetAppLaunchConfigurationError::OperationNotPermitted(ref cause) => cause,
-            GetAppLaunchConfigurationError::UnauthorizedOperation(ref cause) => cause,
+            GetAppLaunchConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetAppLaunchConfigurationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetAppLaunchConfigurationError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAppLaunchConfigurationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAppLaunchConfigurationError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetAppLaunchConfigurationError {}
 /// Errors returned by GetAppReplicationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetAppReplicationConfigurationError {
@@ -1999,20 +1985,24 @@ impl GetAppReplicationConfigurationError {
 }
 impl fmt::Display for GetAppReplicationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAppReplicationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetAppReplicationConfigurationError::InternalError(ref cause) => cause,
-            GetAppReplicationConfigurationError::InvalidParameter(ref cause) => cause,
-            GetAppReplicationConfigurationError::MissingRequiredParameter(ref cause) => cause,
-            GetAppReplicationConfigurationError::OperationNotPermitted(ref cause) => cause,
-            GetAppReplicationConfigurationError::UnauthorizedOperation(ref cause) => cause,
+            GetAppReplicationConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetAppReplicationConfigurationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAppReplicationConfigurationError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAppReplicationConfigurationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAppReplicationConfigurationError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetAppReplicationConfigurationError {}
 /// Errors returned by GetConnectors
 #[derive(Debug, PartialEq)]
 pub enum GetConnectorsError {
@@ -2036,16 +2026,12 @@ impl GetConnectorsError {
 }
 impl fmt::Display for GetConnectorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectorsError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectorsError::UnauthorizedOperation(ref cause) => cause,
+            GetConnectorsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectorsError {}
 /// Errors returned by GetReplicationJobs
 #[derive(Debug, PartialEq)]
 pub enum GetReplicationJobsError {
@@ -2083,18 +2069,14 @@ impl GetReplicationJobsError {
 }
 impl fmt::Display for GetReplicationJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReplicationJobsError {
-    fn description(&self) -> &str {
         match *self {
-            GetReplicationJobsError::InvalidParameter(ref cause) => cause,
-            GetReplicationJobsError::MissingRequiredParameter(ref cause) => cause,
-            GetReplicationJobsError::UnauthorizedOperation(ref cause) => cause,
+            GetReplicationJobsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetReplicationJobsError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            GetReplicationJobsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetReplicationJobsError {}
 /// Errors returned by GetReplicationRuns
 #[derive(Debug, PartialEq)]
 pub enum GetReplicationRunsError {
@@ -2132,18 +2114,14 @@ impl GetReplicationRunsError {
 }
 impl fmt::Display for GetReplicationRunsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetReplicationRunsError {
-    fn description(&self) -> &str {
         match *self {
-            GetReplicationRunsError::InvalidParameter(ref cause) => cause,
-            GetReplicationRunsError::MissingRequiredParameter(ref cause) => cause,
-            GetReplicationRunsError::UnauthorizedOperation(ref cause) => cause,
+            GetReplicationRunsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetReplicationRunsError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            GetReplicationRunsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetReplicationRunsError {}
 /// Errors returned by GetServers
 #[derive(Debug, PartialEq)]
 pub enum GetServersError {
@@ -2167,16 +2145,12 @@ impl GetServersError {
 }
 impl fmt::Display for GetServersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServersError {
-    fn description(&self) -> &str {
         match *self {
-            GetServersError::UnauthorizedOperation(ref cause) => cause,
+            GetServersError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServersError {}
 /// Errors returned by ImportServerCatalog
 #[derive(Debug, PartialEq)]
 pub enum ImportServerCatalogError {
@@ -2230,20 +2204,16 @@ impl ImportServerCatalogError {
 }
 impl fmt::Display for ImportServerCatalogError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportServerCatalogError {
-    fn description(&self) -> &str {
         match *self {
-            ImportServerCatalogError::InvalidParameter(ref cause) => cause,
-            ImportServerCatalogError::MissingRequiredParameter(ref cause) => cause,
-            ImportServerCatalogError::NoConnectorsAvailable(ref cause) => cause,
-            ImportServerCatalogError::OperationNotPermitted(ref cause) => cause,
-            ImportServerCatalogError::UnauthorizedOperation(ref cause) => cause,
+            ImportServerCatalogError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ImportServerCatalogError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            ImportServerCatalogError::NoConnectorsAvailable(ref cause) => write!(f, "{}", cause),
+            ImportServerCatalogError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ImportServerCatalogError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportServerCatalogError {}
 /// Errors returned by LaunchApp
 #[derive(Debug, PartialEq)]
 pub enum LaunchAppError {
@@ -2287,20 +2257,16 @@ impl LaunchAppError {
 }
 impl fmt::Display for LaunchAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for LaunchAppError {
-    fn description(&self) -> &str {
         match *self {
-            LaunchAppError::InternalError(ref cause) => cause,
-            LaunchAppError::InvalidParameter(ref cause) => cause,
-            LaunchAppError::MissingRequiredParameter(ref cause) => cause,
-            LaunchAppError::OperationNotPermitted(ref cause) => cause,
-            LaunchAppError::UnauthorizedOperation(ref cause) => cause,
+            LaunchAppError::InternalError(ref cause) => write!(f, "{}", cause),
+            LaunchAppError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            LaunchAppError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            LaunchAppError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            LaunchAppError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for LaunchAppError {}
 /// Errors returned by ListApps
 #[derive(Debug, PartialEq)]
 pub enum ListAppsError {
@@ -2344,20 +2310,16 @@ impl ListAppsError {
 }
 impl fmt::Display for ListAppsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAppsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAppsError::InternalError(ref cause) => cause,
-            ListAppsError::InvalidParameter(ref cause) => cause,
-            ListAppsError::MissingRequiredParameter(ref cause) => cause,
-            ListAppsError::OperationNotPermitted(ref cause) => cause,
-            ListAppsError::UnauthorizedOperation(ref cause) => cause,
+            ListAppsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListAppsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListAppsError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            ListAppsError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            ListAppsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAppsError {}
 /// Errors returned by PutAppLaunchConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutAppLaunchConfigurationError {
@@ -2411,20 +2373,22 @@ impl PutAppLaunchConfigurationError {
 }
 impl fmt::Display for PutAppLaunchConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAppLaunchConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutAppLaunchConfigurationError::InternalError(ref cause) => cause,
-            PutAppLaunchConfigurationError::InvalidParameter(ref cause) => cause,
-            PutAppLaunchConfigurationError::MissingRequiredParameter(ref cause) => cause,
-            PutAppLaunchConfigurationError::OperationNotPermitted(ref cause) => cause,
-            PutAppLaunchConfigurationError::UnauthorizedOperation(ref cause) => cause,
+            PutAppLaunchConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            PutAppLaunchConfigurationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutAppLaunchConfigurationError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutAppLaunchConfigurationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutAppLaunchConfigurationError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutAppLaunchConfigurationError {}
 /// Errors returned by PutAppReplicationConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutAppReplicationConfigurationError {
@@ -2480,20 +2444,24 @@ impl PutAppReplicationConfigurationError {
 }
 impl fmt::Display for PutAppReplicationConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutAppReplicationConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutAppReplicationConfigurationError::InternalError(ref cause) => cause,
-            PutAppReplicationConfigurationError::InvalidParameter(ref cause) => cause,
-            PutAppReplicationConfigurationError::MissingRequiredParameter(ref cause) => cause,
-            PutAppReplicationConfigurationError::OperationNotPermitted(ref cause) => cause,
-            PutAppReplicationConfigurationError::UnauthorizedOperation(ref cause) => cause,
+            PutAppReplicationConfigurationError::InternalError(ref cause) => write!(f, "{}", cause),
+            PutAppReplicationConfigurationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutAppReplicationConfigurationError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutAppReplicationConfigurationError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutAppReplicationConfigurationError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutAppReplicationConfigurationError {}
 /// Errors returned by StartAppReplication
 #[derive(Debug, PartialEq)]
 pub enum StartAppReplicationError {
@@ -2545,20 +2513,16 @@ impl StartAppReplicationError {
 }
 impl fmt::Display for StartAppReplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartAppReplicationError {
-    fn description(&self) -> &str {
         match *self {
-            StartAppReplicationError::InternalError(ref cause) => cause,
-            StartAppReplicationError::InvalidParameter(ref cause) => cause,
-            StartAppReplicationError::MissingRequiredParameter(ref cause) => cause,
-            StartAppReplicationError::OperationNotPermitted(ref cause) => cause,
-            StartAppReplicationError::UnauthorizedOperation(ref cause) => cause,
+            StartAppReplicationError::InternalError(ref cause) => write!(f, "{}", cause),
+            StartAppReplicationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartAppReplicationError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            StartAppReplicationError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StartAppReplicationError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartAppReplicationError {}
 /// Errors returned by StartOnDemandReplicationRun
 #[derive(Debug, PartialEq)]
 pub enum StartOnDemandReplicationRunError {
@@ -2614,20 +2578,24 @@ impl StartOnDemandReplicationRunError {
 }
 impl fmt::Display for StartOnDemandReplicationRunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartOnDemandReplicationRunError {
-    fn description(&self) -> &str {
         match *self {
-            StartOnDemandReplicationRunError::InvalidParameter(ref cause) => cause,
-            StartOnDemandReplicationRunError::MissingRequiredParameter(ref cause) => cause,
-            StartOnDemandReplicationRunError::OperationNotPermitted(ref cause) => cause,
-            StartOnDemandReplicationRunError::ReplicationRunLimitExceeded(ref cause) => cause,
-            StartOnDemandReplicationRunError::UnauthorizedOperation(ref cause) => cause,
+            StartOnDemandReplicationRunError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartOnDemandReplicationRunError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartOnDemandReplicationRunError::OperationNotPermitted(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartOnDemandReplicationRunError::ReplicationRunLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartOnDemandReplicationRunError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartOnDemandReplicationRunError {}
 /// Errors returned by StopAppReplication
 #[derive(Debug, PartialEq)]
 pub enum StopAppReplicationError {
@@ -2677,20 +2645,16 @@ impl StopAppReplicationError {
 }
 impl fmt::Display for StopAppReplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopAppReplicationError {
-    fn description(&self) -> &str {
         match *self {
-            StopAppReplicationError::InternalError(ref cause) => cause,
-            StopAppReplicationError::InvalidParameter(ref cause) => cause,
-            StopAppReplicationError::MissingRequiredParameter(ref cause) => cause,
-            StopAppReplicationError::OperationNotPermitted(ref cause) => cause,
-            StopAppReplicationError::UnauthorizedOperation(ref cause) => cause,
+            StopAppReplicationError::InternalError(ref cause) => write!(f, "{}", cause),
+            StopAppReplicationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StopAppReplicationError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            StopAppReplicationError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            StopAppReplicationError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopAppReplicationError {}
 /// Errors returned by TerminateApp
 #[derive(Debug, PartialEq)]
 pub enum TerminateAppError {
@@ -2736,20 +2700,16 @@ impl TerminateAppError {
 }
 impl fmt::Display for TerminateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateAppError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateAppError::InternalError(ref cause) => cause,
-            TerminateAppError::InvalidParameter(ref cause) => cause,
-            TerminateAppError::MissingRequiredParameter(ref cause) => cause,
-            TerminateAppError::OperationNotPermitted(ref cause) => cause,
-            TerminateAppError::UnauthorizedOperation(ref cause) => cause,
+            TerminateAppError::InternalError(ref cause) => write!(f, "{}", cause),
+            TerminateAppError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TerminateAppError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            TerminateAppError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            TerminateAppError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TerminateAppError {}
 /// Errors returned by UpdateApp
 #[derive(Debug, PartialEq)]
 pub enum UpdateAppError {
@@ -2793,20 +2753,16 @@ impl UpdateAppError {
 }
 impl fmt::Display for UpdateAppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAppError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAppError::InternalError(ref cause) => cause,
-            UpdateAppError::InvalidParameter(ref cause) => cause,
-            UpdateAppError::MissingRequiredParameter(ref cause) => cause,
-            UpdateAppError::OperationNotPermitted(ref cause) => cause,
-            UpdateAppError::UnauthorizedOperation(ref cause) => cause,
+            UpdateAppError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateAppError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateAppError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            UpdateAppError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            UpdateAppError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAppError {}
 /// Errors returned by UpdateReplicationJob
 #[derive(Debug, PartialEq)]
 pub enum UpdateReplicationJobError {
@@ -2879,23 +2835,23 @@ impl UpdateReplicationJobError {
 }
 impl fmt::Display for UpdateReplicationJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateReplicationJobError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateReplicationJobError::InternalError(ref cause) => cause,
-            UpdateReplicationJobError::InvalidParameter(ref cause) => cause,
-            UpdateReplicationJobError::MissingRequiredParameter(ref cause) => cause,
-            UpdateReplicationJobError::OperationNotPermitted(ref cause) => cause,
-            UpdateReplicationJobError::ReplicationJobNotFound(ref cause) => cause,
-            UpdateReplicationJobError::ServerCannotBeReplicated(ref cause) => cause,
-            UpdateReplicationJobError::TemporarilyUnavailable(ref cause) => cause,
-            UpdateReplicationJobError::UnauthorizedOperation(ref cause) => cause,
+            UpdateReplicationJobError::InternalError(ref cause) => write!(f, "{}", cause),
+            UpdateReplicationJobError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateReplicationJobError::MissingRequiredParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateReplicationJobError::OperationNotPermitted(ref cause) => write!(f, "{}", cause),
+            UpdateReplicationJobError::ReplicationJobNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateReplicationJobError::ServerCannotBeReplicated(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateReplicationJobError::TemporarilyUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateReplicationJobError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateReplicationJobError {}
 /// Trait representing the capabilities of the SMS API. SMS clients implement this trait.
 pub trait ServerMigrationService {
     /// <p>Creates an application. An application consists of one or more server groups. Each server group contain one or more servers.</p>

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -958,18 +958,14 @@ impl CancelClusterError {
 }
 impl fmt::Display for CancelClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CancelClusterError::InvalidJobState(ref cause) => cause,
-            CancelClusterError::InvalidResource(ref cause) => cause,
-            CancelClusterError::KMSRequestFailed(ref cause) => cause,
+            CancelClusterError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            CancelClusterError::InvalidResource(ref cause) => write!(f, "{}", cause),
+            CancelClusterError::KMSRequestFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelClusterError {}
 /// Errors returned by CancelJob
 #[derive(Debug, PartialEq)]
 pub enum CancelJobError {
@@ -1003,18 +999,14 @@ impl CancelJobError {
 }
 impl fmt::Display for CancelJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelJobError {
-    fn description(&self) -> &str {
         match *self {
-            CancelJobError::InvalidJobState(ref cause) => cause,
-            CancelJobError::InvalidResource(ref cause) => cause,
-            CancelJobError::KMSRequestFailed(ref cause) => cause,
+            CancelJobError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            CancelJobError::InvalidResource(ref cause) => write!(f, "{}", cause),
+            CancelJobError::KMSRequestFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelJobError {}
 /// Errors returned by CreateAddress
 #[derive(Debug, PartialEq)]
 pub enum CreateAddressError {
@@ -1043,17 +1035,13 @@ impl CreateAddressError {
 }
 impl fmt::Display for CreateAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAddressError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAddressError::InvalidAddress(ref cause) => cause,
-            CreateAddressError::UnsupportedAddress(ref cause) => cause,
+            CreateAddressError::InvalidAddress(ref cause) => write!(f, "{}", cause),
+            CreateAddressError::UnsupportedAddress(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAddressError {}
 /// Errors returned by CreateCluster
 #[derive(Debug, PartialEq)]
 pub enum CreateClusterError {
@@ -1094,19 +1082,15 @@ impl CreateClusterError {
 }
 impl fmt::Display for CreateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            CreateClusterError::Ec2RequestFailed(ref cause) => cause,
-            CreateClusterError::InvalidInputCombination(ref cause) => cause,
-            CreateClusterError::InvalidResource(ref cause) => cause,
-            CreateClusterError::KMSRequestFailed(ref cause) => cause,
+            CreateClusterError::Ec2RequestFailed(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidInputCombination(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::InvalidResource(ref cause) => write!(f, "{}", cause),
+            CreateClusterError::KMSRequestFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateClusterError {}
 /// Errors returned by CreateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateJobError {
@@ -1150,20 +1134,16 @@ impl CreateJobError {
 }
 impl fmt::Display for CreateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateJobError {
-    fn description(&self) -> &str {
         match *self {
-            CreateJobError::ClusterLimitExceeded(ref cause) => cause,
-            CreateJobError::Ec2RequestFailed(ref cause) => cause,
-            CreateJobError::InvalidInputCombination(ref cause) => cause,
-            CreateJobError::InvalidResource(ref cause) => cause,
-            CreateJobError::KMSRequestFailed(ref cause) => cause,
+            CreateJobError::ClusterLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateJobError::Ec2RequestFailed(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidInputCombination(ref cause) => write!(f, "{}", cause),
+            CreateJobError::InvalidResource(ref cause) => write!(f, "{}", cause),
+            CreateJobError::KMSRequestFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateJobError {}
 /// Errors returned by DescribeAddress
 #[derive(Debug, PartialEq)]
 pub enum DescribeAddressError {
@@ -1187,16 +1167,12 @@ impl DescribeAddressError {
 }
 impl fmt::Display for DescribeAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAddressError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAddressError::InvalidResource(ref cause) => cause,
+            DescribeAddressError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAddressError {}
 /// Errors returned by DescribeAddresses
 #[derive(Debug, PartialEq)]
 pub enum DescribeAddressesError {
@@ -1225,17 +1201,13 @@ impl DescribeAddressesError {
 }
 impl fmt::Display for DescribeAddressesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAddressesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAddressesError::InvalidNextToken(ref cause) => cause,
-            DescribeAddressesError::InvalidResource(ref cause) => cause,
+            DescribeAddressesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            DescribeAddressesError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAddressesError {}
 /// Errors returned by DescribeCluster
 #[derive(Debug, PartialEq)]
 pub enum DescribeClusterError {
@@ -1259,16 +1231,12 @@ impl DescribeClusterError {
 }
 impl fmt::Display for DescribeClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClusterError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClusterError::InvalidResource(ref cause) => cause,
+            DescribeClusterError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClusterError {}
 /// Errors returned by DescribeJob
 #[derive(Debug, PartialEq)]
 pub enum DescribeJobError {
@@ -1292,16 +1260,12 @@ impl DescribeJobError {
 }
 impl fmt::Display for DescribeJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeJobError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeJobError::InvalidResource(ref cause) => cause,
+            DescribeJobError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeJobError {}
 /// Errors returned by GetJobManifest
 #[derive(Debug, PartialEq)]
 pub enum GetJobManifestError {
@@ -1330,17 +1294,13 @@ impl GetJobManifestError {
 }
 impl fmt::Display for GetJobManifestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobManifestError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobManifestError::InvalidJobState(ref cause) => cause,
-            GetJobManifestError::InvalidResource(ref cause) => cause,
+            GetJobManifestError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            GetJobManifestError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobManifestError {}
 /// Errors returned by GetJobUnlockCode
 #[derive(Debug, PartialEq)]
 pub enum GetJobUnlockCodeError {
@@ -1369,17 +1329,13 @@ impl GetJobUnlockCodeError {
 }
 impl fmt::Display for GetJobUnlockCodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetJobUnlockCodeError {
-    fn description(&self) -> &str {
         match *self {
-            GetJobUnlockCodeError::InvalidJobState(ref cause) => cause,
-            GetJobUnlockCodeError::InvalidResource(ref cause) => cause,
+            GetJobUnlockCodeError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            GetJobUnlockCodeError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetJobUnlockCodeError {}
 /// Errors returned by GetSnowballUsage
 #[derive(Debug, PartialEq)]
 pub enum GetSnowballUsageError {}
@@ -1397,14 +1353,10 @@ impl GetSnowballUsageError {
 }
 impl fmt::Display for GetSnowballUsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSnowballUsageError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetSnowballUsageError {}
 /// Errors returned by GetSoftwareUpdates
 #[derive(Debug, PartialEq)]
 pub enum GetSoftwareUpdatesError {
@@ -1433,17 +1385,13 @@ impl GetSoftwareUpdatesError {
 }
 impl fmt::Display for GetSoftwareUpdatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSoftwareUpdatesError {
-    fn description(&self) -> &str {
         match *self {
-            GetSoftwareUpdatesError::InvalidJobState(ref cause) => cause,
-            GetSoftwareUpdatesError::InvalidResource(ref cause) => cause,
+            GetSoftwareUpdatesError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            GetSoftwareUpdatesError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSoftwareUpdatesError {}
 /// Errors returned by ListClusterJobs
 #[derive(Debug, PartialEq)]
 pub enum ListClusterJobsError {
@@ -1472,17 +1420,13 @@ impl ListClusterJobsError {
 }
 impl fmt::Display for ListClusterJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClusterJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListClusterJobsError::InvalidNextToken(ref cause) => cause,
-            ListClusterJobsError::InvalidResource(ref cause) => cause,
+            ListClusterJobsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListClusterJobsError::InvalidResource(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListClusterJobsError {}
 /// Errors returned by ListClusters
 #[derive(Debug, PartialEq)]
 pub enum ListClustersError {
@@ -1506,16 +1450,12 @@ impl ListClustersError {
 }
 impl fmt::Display for ListClustersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClustersError {
-    fn description(&self) -> &str {
         match *self {
-            ListClustersError::InvalidNextToken(ref cause) => cause,
+            ListClustersError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListClustersError {}
 /// Errors returned by ListCompatibleImages
 #[derive(Debug, PartialEq)]
 pub enum ListCompatibleImagesError {
@@ -1548,17 +1488,13 @@ impl ListCompatibleImagesError {
 }
 impl fmt::Display for ListCompatibleImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCompatibleImagesError {
-    fn description(&self) -> &str {
         match *self {
-            ListCompatibleImagesError::Ec2RequestFailed(ref cause) => cause,
-            ListCompatibleImagesError::InvalidNextToken(ref cause) => cause,
+            ListCompatibleImagesError::Ec2RequestFailed(ref cause) => write!(f, "{}", cause),
+            ListCompatibleImagesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCompatibleImagesError {}
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
@@ -1582,16 +1518,12 @@ impl ListJobsError {
 }
 impl fmt::Display for ListJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListJobsError::InvalidNextToken(ref cause) => cause,
+            ListJobsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListJobsError {}
 /// Errors returned by UpdateCluster
 #[derive(Debug, PartialEq)]
 pub enum UpdateClusterError {
@@ -1637,20 +1569,16 @@ impl UpdateClusterError {
 }
 impl fmt::Display for UpdateClusterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateClusterError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateClusterError::Ec2RequestFailed(ref cause) => cause,
-            UpdateClusterError::InvalidInputCombination(ref cause) => cause,
-            UpdateClusterError::InvalidJobState(ref cause) => cause,
-            UpdateClusterError::InvalidResource(ref cause) => cause,
-            UpdateClusterError::KMSRequestFailed(ref cause) => cause,
+            UpdateClusterError::Ec2RequestFailed(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::InvalidInputCombination(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::InvalidResource(ref cause) => write!(f, "{}", cause),
+            UpdateClusterError::KMSRequestFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateClusterError {}
 /// Errors returned by UpdateJob
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobError {
@@ -1699,21 +1627,17 @@ impl UpdateJobError {
 }
 impl fmt::Display for UpdateJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateJobError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateJobError::ClusterLimitExceeded(ref cause) => cause,
-            UpdateJobError::Ec2RequestFailed(ref cause) => cause,
-            UpdateJobError::InvalidInputCombination(ref cause) => cause,
-            UpdateJobError::InvalidJobState(ref cause) => cause,
-            UpdateJobError::InvalidResource(ref cause) => cause,
-            UpdateJobError::KMSRequestFailed(ref cause) => cause,
+            UpdateJobError::ClusterLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::Ec2RequestFailed(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidInputCombination(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidJobState(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::InvalidResource(ref cause) => write!(f, "{}", cause),
+            UpdateJobError::KMSRequestFailed(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateJobError {}
 /// Trait representing the capabilities of the Amazon Snowball API. Amazon Snowball clients implement this trait.
 pub trait Snowball {
     /// <p>Cancels a cluster job. You can only cancel a cluster job while it's in the <code>AwaitingQuorum</code> status. You'll have at least an hour after creating a cluster job to cancel it.</p>

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -2291,19 +2291,15 @@ impl AddPermissionError {
 }
 impl fmt::Display for AddPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            AddPermissionError::AuthorizationError(ref cause) => cause,
-            AddPermissionError::InternalError(ref cause) => cause,
-            AddPermissionError::InvalidParameter(ref cause) => cause,
-            AddPermissionError::NotFound(ref cause) => cause,
+            AddPermissionError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::InternalError(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AddPermissionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddPermissionError {}
 /// Errors returned by CheckIfPhoneNumberIsOptedOut
 #[derive(Debug, PartialEq)]
 pub enum CheckIfPhoneNumberIsOptedOutError {
@@ -2368,19 +2364,19 @@ impl CheckIfPhoneNumberIsOptedOutError {
 }
 impl fmt::Display for CheckIfPhoneNumberIsOptedOutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CheckIfPhoneNumberIsOptedOutError {
-    fn description(&self) -> &str {
         match *self {
-            CheckIfPhoneNumberIsOptedOutError::AuthorizationError(ref cause) => cause,
-            CheckIfPhoneNumberIsOptedOutError::InternalError(ref cause) => cause,
-            CheckIfPhoneNumberIsOptedOutError::InvalidParameter(ref cause) => cause,
-            CheckIfPhoneNumberIsOptedOutError::Throttled(ref cause) => cause,
+            CheckIfPhoneNumberIsOptedOutError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CheckIfPhoneNumberIsOptedOutError::InternalError(ref cause) => write!(f, "{}", cause),
+            CheckIfPhoneNumberIsOptedOutError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CheckIfPhoneNumberIsOptedOutError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CheckIfPhoneNumberIsOptedOutError {}
 /// Errors returned by ConfirmSubscription
 #[derive(Debug, PartialEq)]
 pub enum ConfirmSubscriptionError {
@@ -2457,21 +2453,21 @@ impl ConfirmSubscriptionError {
 }
 impl fmt::Display for ConfirmSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ConfirmSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            ConfirmSubscriptionError::AuthorizationError(ref cause) => cause,
-            ConfirmSubscriptionError::FilterPolicyLimitExceeded(ref cause) => cause,
-            ConfirmSubscriptionError::InternalError(ref cause) => cause,
-            ConfirmSubscriptionError::InvalidParameter(ref cause) => cause,
-            ConfirmSubscriptionError::NotFound(ref cause) => cause,
-            ConfirmSubscriptionError::SubscriptionLimitExceeded(ref cause) => cause,
+            ConfirmSubscriptionError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ConfirmSubscriptionError::FilterPolicyLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ConfirmSubscriptionError::InternalError(ref cause) => write!(f, "{}", cause),
+            ConfirmSubscriptionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ConfirmSubscriptionError::NotFound(ref cause) => write!(f, "{}", cause),
+            ConfirmSubscriptionError::SubscriptionLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ConfirmSubscriptionError {}
 /// Errors returned by CreatePlatformApplication
 #[derive(Debug, PartialEq)]
 pub enum CreatePlatformApplicationError {
@@ -2525,18 +2521,14 @@ impl CreatePlatformApplicationError {
 }
 impl fmt::Display for CreatePlatformApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePlatformApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePlatformApplicationError::AuthorizationError(ref cause) => cause,
-            CreatePlatformApplicationError::InternalError(ref cause) => cause,
-            CreatePlatformApplicationError::InvalidParameter(ref cause) => cause,
+            CreatePlatformApplicationError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            CreatePlatformApplicationError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreatePlatformApplicationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePlatformApplicationError {}
 /// Errors returned by CreatePlatformEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreatePlatformEndpointError {
@@ -2595,19 +2587,15 @@ impl CreatePlatformEndpointError {
 }
 impl fmt::Display for CreatePlatformEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePlatformEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePlatformEndpointError::AuthorizationError(ref cause) => cause,
-            CreatePlatformEndpointError::InternalError(ref cause) => cause,
-            CreatePlatformEndpointError::InvalidParameter(ref cause) => cause,
-            CreatePlatformEndpointError::NotFound(ref cause) => cause,
+            CreatePlatformEndpointError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            CreatePlatformEndpointError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreatePlatformEndpointError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreatePlatformEndpointError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePlatformEndpointError {}
 /// Errors returned by CreateTopic
 #[derive(Debug, PartialEq)]
 pub enum CreateTopicError {
@@ -2701,24 +2689,20 @@ impl CreateTopicError {
 }
 impl fmt::Display for CreateTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTopicError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTopicError::AuthorizationError(ref cause) => cause,
-            CreateTopicError::ConcurrentAccess(ref cause) => cause,
-            CreateTopicError::InternalError(ref cause) => cause,
-            CreateTopicError::InvalidParameter(ref cause) => cause,
-            CreateTopicError::InvalidSecurity(ref cause) => cause,
-            CreateTopicError::StaleTag(ref cause) => cause,
-            CreateTopicError::TagLimitExceeded(ref cause) => cause,
-            CreateTopicError::TagPolicy(ref cause) => cause,
-            CreateTopicError::TopicLimitExceeded(ref cause) => cause,
+            CreateTopicError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::ConcurrentAccess(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::InternalError(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::InvalidSecurity(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::StaleTag(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::TagLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::TagPolicy(ref cause) => write!(f, "{}", cause),
+            CreateTopicError::TopicLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTopicError {}
 /// Errors returned by DeleteEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteEndpointError {
@@ -2770,18 +2754,14 @@ impl DeleteEndpointError {
 }
 impl fmt::Display for DeleteEndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteEndpointError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteEndpointError::AuthorizationError(ref cause) => cause,
-            DeleteEndpointError::InternalError(ref cause) => cause,
-            DeleteEndpointError::InvalidParameter(ref cause) => cause,
+            DeleteEndpointError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DeleteEndpointError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteEndpointError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteEndpointError {}
 /// Errors returned by DeletePlatformApplication
 #[derive(Debug, PartialEq)]
 pub enum DeletePlatformApplicationError {
@@ -2835,18 +2815,14 @@ impl DeletePlatformApplicationError {
 }
 impl fmt::Display for DeletePlatformApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePlatformApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePlatformApplicationError::AuthorizationError(ref cause) => cause,
-            DeletePlatformApplicationError::InternalError(ref cause) => cause,
-            DeletePlatformApplicationError::InvalidParameter(ref cause) => cause,
+            DeletePlatformApplicationError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DeletePlatformApplicationError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeletePlatformApplicationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePlatformApplicationError {}
 /// Errors returned by DeleteTopic
 #[derive(Debug, PartialEq)]
 pub enum DeleteTopicError {
@@ -2926,22 +2902,18 @@ impl DeleteTopicError {
 }
 impl fmt::Display for DeleteTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTopicError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTopicError::AuthorizationError(ref cause) => cause,
-            DeleteTopicError::ConcurrentAccess(ref cause) => cause,
-            DeleteTopicError::InternalError(ref cause) => cause,
-            DeleteTopicError::InvalidParameter(ref cause) => cause,
-            DeleteTopicError::NotFound(ref cause) => cause,
-            DeleteTopicError::StaleTag(ref cause) => cause,
-            DeleteTopicError::TagPolicy(ref cause) => cause,
+            DeleteTopicError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            DeleteTopicError::ConcurrentAccess(ref cause) => write!(f, "{}", cause),
+            DeleteTopicError::InternalError(ref cause) => write!(f, "{}", cause),
+            DeleteTopicError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteTopicError::NotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTopicError::StaleTag(ref cause) => write!(f, "{}", cause),
+            DeleteTopicError::TagPolicy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTopicError {}
 /// Errors returned by GetEndpointAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetEndpointAttributesError {
@@ -3000,19 +2972,15 @@ impl GetEndpointAttributesError {
 }
 impl fmt::Display for GetEndpointAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEndpointAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetEndpointAttributesError::AuthorizationError(ref cause) => cause,
-            GetEndpointAttributesError::InternalError(ref cause) => cause,
-            GetEndpointAttributesError::InvalidParameter(ref cause) => cause,
-            GetEndpointAttributesError::NotFound(ref cause) => cause,
+            GetEndpointAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            GetEndpointAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetEndpointAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetEndpointAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEndpointAttributesError {}
 /// Errors returned by GetPlatformApplicationAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetPlatformApplicationAttributesError {
@@ -3079,19 +3047,21 @@ impl GetPlatformApplicationAttributesError {
 }
 impl fmt::Display for GetPlatformApplicationAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPlatformApplicationAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetPlatformApplicationAttributesError::AuthorizationError(ref cause) => cause,
-            GetPlatformApplicationAttributesError::InternalError(ref cause) => cause,
-            GetPlatformApplicationAttributesError::InvalidParameter(ref cause) => cause,
-            GetPlatformApplicationAttributesError::NotFound(ref cause) => cause,
+            GetPlatformApplicationAttributesError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPlatformApplicationAttributesError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPlatformApplicationAttributesError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetPlatformApplicationAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPlatformApplicationAttributesError {}
 /// Errors returned by GetSMSAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetSMSAttributesError {
@@ -3150,19 +3120,15 @@ impl GetSMSAttributesError {
 }
 impl fmt::Display for GetSMSAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSMSAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetSMSAttributesError::AuthorizationError(ref cause) => cause,
-            GetSMSAttributesError::InternalError(ref cause) => cause,
-            GetSMSAttributesError::InvalidParameter(ref cause) => cause,
-            GetSMSAttributesError::Throttled(ref cause) => cause,
+            GetSMSAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            GetSMSAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetSMSAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetSMSAttributesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSMSAttributesError {}
 /// Errors returned by GetSubscriptionAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetSubscriptionAttributesError {
@@ -3223,19 +3189,15 @@ impl GetSubscriptionAttributesError {
 }
 impl fmt::Display for GetSubscriptionAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSubscriptionAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetSubscriptionAttributesError::AuthorizationError(ref cause) => cause,
-            GetSubscriptionAttributesError::InternalError(ref cause) => cause,
-            GetSubscriptionAttributesError::InvalidParameter(ref cause) => cause,
-            GetSubscriptionAttributesError::NotFound(ref cause) => cause,
+            GetSubscriptionAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            GetSubscriptionAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetSubscriptionAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetSubscriptionAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSubscriptionAttributesError {}
 /// Errors returned by GetTopicAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetTopicAttributesError {
@@ -3301,20 +3263,16 @@ impl GetTopicAttributesError {
 }
 impl fmt::Display for GetTopicAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTopicAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetTopicAttributesError::AuthorizationError(ref cause) => cause,
-            GetTopicAttributesError::InternalError(ref cause) => cause,
-            GetTopicAttributesError::InvalidParameter(ref cause) => cause,
-            GetTopicAttributesError::InvalidSecurity(ref cause) => cause,
-            GetTopicAttributesError::NotFound(ref cause) => cause,
+            GetTopicAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            GetTopicAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            GetTopicAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetTopicAttributesError::InvalidSecurity(ref cause) => write!(f, "{}", cause),
+            GetTopicAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTopicAttributesError {}
 /// Errors returned by ListEndpointsByPlatformApplication
 #[derive(Debug, PartialEq)]
 pub enum ListEndpointsByPlatformApplicationError {
@@ -3381,19 +3339,21 @@ impl ListEndpointsByPlatformApplicationError {
 }
 impl fmt::Display for ListEndpointsByPlatformApplicationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListEndpointsByPlatformApplicationError {
-    fn description(&self) -> &str {
         match *self {
-            ListEndpointsByPlatformApplicationError::AuthorizationError(ref cause) => cause,
-            ListEndpointsByPlatformApplicationError::InternalError(ref cause) => cause,
-            ListEndpointsByPlatformApplicationError::InvalidParameter(ref cause) => cause,
-            ListEndpointsByPlatformApplicationError::NotFound(ref cause) => cause,
+            ListEndpointsByPlatformApplicationError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListEndpointsByPlatformApplicationError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListEndpointsByPlatformApplicationError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListEndpointsByPlatformApplicationError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListEndpointsByPlatformApplicationError {}
 /// Errors returned by ListPhoneNumbersOptedOut
 #[derive(Debug, PartialEq)]
 pub enum ListPhoneNumbersOptedOutError {
@@ -3452,19 +3412,15 @@ impl ListPhoneNumbersOptedOutError {
 }
 impl fmt::Display for ListPhoneNumbersOptedOutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPhoneNumbersOptedOutError {
-    fn description(&self) -> &str {
         match *self {
-            ListPhoneNumbersOptedOutError::AuthorizationError(ref cause) => cause,
-            ListPhoneNumbersOptedOutError::InternalError(ref cause) => cause,
-            ListPhoneNumbersOptedOutError::InvalidParameter(ref cause) => cause,
-            ListPhoneNumbersOptedOutError::Throttled(ref cause) => cause,
+            ListPhoneNumbersOptedOutError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersOptedOutError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersOptedOutError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListPhoneNumbersOptedOutError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPhoneNumbersOptedOutError {}
 /// Errors returned by ListPlatformApplications
 #[derive(Debug, PartialEq)]
 pub enum ListPlatformApplicationsError {
@@ -3516,18 +3472,14 @@ impl ListPlatformApplicationsError {
 }
 impl fmt::Display for ListPlatformApplicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListPlatformApplicationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListPlatformApplicationsError::AuthorizationError(ref cause) => cause,
-            ListPlatformApplicationsError::InternalError(ref cause) => cause,
-            ListPlatformApplicationsError::InvalidParameter(ref cause) => cause,
+            ListPlatformApplicationsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListPlatformApplicationsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListPlatformApplicationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListPlatformApplicationsError {}
 /// Errors returned by ListSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum ListSubscriptionsError {
@@ -3579,18 +3531,14 @@ impl ListSubscriptionsError {
 }
 impl fmt::Display for ListSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSubscriptionsError::AuthorizationError(ref cause) => cause,
-            ListSubscriptionsError::InternalError(ref cause) => cause,
-            ListSubscriptionsError::InvalidParameter(ref cause) => cause,
+            ListSubscriptionsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListSubscriptionsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListSubscriptionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSubscriptionsError {}
 /// Errors returned by ListSubscriptionsByTopic
 #[derive(Debug, PartialEq)]
 pub enum ListSubscriptionsByTopicError {
@@ -3649,19 +3597,15 @@ impl ListSubscriptionsByTopicError {
 }
 impl fmt::Display for ListSubscriptionsByTopicError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSubscriptionsByTopicError {
-    fn description(&self) -> &str {
         match *self {
-            ListSubscriptionsByTopicError::AuthorizationError(ref cause) => cause,
-            ListSubscriptionsByTopicError::InternalError(ref cause) => cause,
-            ListSubscriptionsByTopicError::InvalidParameter(ref cause) => cause,
-            ListSubscriptionsByTopicError::NotFound(ref cause) => cause,
+            ListSubscriptionsByTopicError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListSubscriptionsByTopicError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListSubscriptionsByTopicError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListSubscriptionsByTopicError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSubscriptionsByTopicError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3727,20 +3671,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::AuthorizationError(ref cause) => cause,
-            ListTagsForResourceError::ConcurrentAccess(ref cause) => cause,
-            ListTagsForResourceError::InvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
-            ListTagsForResourceError::TagPolicy(ref cause) => cause,
+            ListTagsForResourceError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ConcurrentAccess(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::TagPolicy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTopics
 #[derive(Debug, PartialEq)]
 pub enum ListTopicsError {
@@ -3792,18 +3732,14 @@ impl ListTopicsError {
 }
 impl fmt::Display for ListTopicsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTopicsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTopicsError::AuthorizationError(ref cause) => cause,
-            ListTopicsError::InternalError(ref cause) => cause,
-            ListTopicsError::InvalidParameter(ref cause) => cause,
+            ListTopicsError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            ListTopicsError::InternalError(ref cause) => write!(f, "{}", cause),
+            ListTopicsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTopicsError {}
 /// Errors returned by OptInPhoneNumber
 #[derive(Debug, PartialEq)]
 pub enum OptInPhoneNumberError {
@@ -3862,19 +3798,15 @@ impl OptInPhoneNumberError {
 }
 impl fmt::Display for OptInPhoneNumberError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for OptInPhoneNumberError {
-    fn description(&self) -> &str {
         match *self {
-            OptInPhoneNumberError::AuthorizationError(ref cause) => cause,
-            OptInPhoneNumberError::InternalError(ref cause) => cause,
-            OptInPhoneNumberError::InvalidParameter(ref cause) => cause,
-            OptInPhoneNumberError::Throttled(ref cause) => cause,
+            OptInPhoneNumberError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            OptInPhoneNumberError::InternalError(ref cause) => write!(f, "{}", cause),
+            OptInPhoneNumberError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            OptInPhoneNumberError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for OptInPhoneNumberError {}
 /// Errors returned by Publish
 #[derive(Debug, PartialEq)]
 pub enum PublishError {
@@ -4001,29 +3933,25 @@ impl PublishError {
 }
 impl fmt::Display for PublishError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PublishError {
-    fn description(&self) -> &str {
         match *self {
-            PublishError::AuthorizationError(ref cause) => cause,
-            PublishError::EndpointDisabled(ref cause) => cause,
-            PublishError::InternalError(ref cause) => cause,
-            PublishError::InvalidParameter(ref cause) => cause,
-            PublishError::InvalidParameterValue(ref cause) => cause,
-            PublishError::InvalidSecurity(ref cause) => cause,
-            PublishError::KMSAccessDenied(ref cause) => cause,
-            PublishError::KMSDisabled(ref cause) => cause,
-            PublishError::KMSInvalidState(ref cause) => cause,
-            PublishError::KMSNotFound(ref cause) => cause,
-            PublishError::KMSOptInRequired(ref cause) => cause,
-            PublishError::KMSThrottling(ref cause) => cause,
-            PublishError::NotFound(ref cause) => cause,
-            PublishError::PlatformApplicationDisabled(ref cause) => cause,
+            PublishError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            PublishError::EndpointDisabled(ref cause) => write!(f, "{}", cause),
+            PublishError::InternalError(ref cause) => write!(f, "{}", cause),
+            PublishError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PublishError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            PublishError::InvalidSecurity(ref cause) => write!(f, "{}", cause),
+            PublishError::KMSAccessDenied(ref cause) => write!(f, "{}", cause),
+            PublishError::KMSDisabled(ref cause) => write!(f, "{}", cause),
+            PublishError::KMSInvalidState(ref cause) => write!(f, "{}", cause),
+            PublishError::KMSNotFound(ref cause) => write!(f, "{}", cause),
+            PublishError::KMSOptInRequired(ref cause) => write!(f, "{}", cause),
+            PublishError::KMSThrottling(ref cause) => write!(f, "{}", cause),
+            PublishError::NotFound(ref cause) => write!(f, "{}", cause),
+            PublishError::PlatformApplicationDisabled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PublishError {}
 /// Errors returned by RemovePermission
 #[derive(Debug, PartialEq)]
 pub enum RemovePermissionError {
@@ -4082,19 +4010,15 @@ impl RemovePermissionError {
 }
 impl fmt::Display for RemovePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemovePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            RemovePermissionError::AuthorizationError(ref cause) => cause,
-            RemovePermissionError::InternalError(ref cause) => cause,
-            RemovePermissionError::InvalidParameter(ref cause) => cause,
-            RemovePermissionError::NotFound(ref cause) => cause,
+            RemovePermissionError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::InternalError(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RemovePermissionError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemovePermissionError {}
 /// Errors returned by SetEndpointAttributes
 #[derive(Debug, PartialEq)]
 pub enum SetEndpointAttributesError {
@@ -4153,19 +4077,15 @@ impl SetEndpointAttributesError {
 }
 impl fmt::Display for SetEndpointAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetEndpointAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            SetEndpointAttributesError::AuthorizationError(ref cause) => cause,
-            SetEndpointAttributesError::InternalError(ref cause) => cause,
-            SetEndpointAttributesError::InvalidParameter(ref cause) => cause,
-            SetEndpointAttributesError::NotFound(ref cause) => cause,
+            SetEndpointAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            SetEndpointAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetEndpointAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetEndpointAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetEndpointAttributesError {}
 /// Errors returned by SetPlatformApplicationAttributes
 #[derive(Debug, PartialEq)]
 pub enum SetPlatformApplicationAttributesError {
@@ -4232,19 +4152,21 @@ impl SetPlatformApplicationAttributesError {
 }
 impl fmt::Display for SetPlatformApplicationAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetPlatformApplicationAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            SetPlatformApplicationAttributesError::AuthorizationError(ref cause) => cause,
-            SetPlatformApplicationAttributesError::InternalError(ref cause) => cause,
-            SetPlatformApplicationAttributesError::InvalidParameter(ref cause) => cause,
-            SetPlatformApplicationAttributesError::NotFound(ref cause) => cause,
+            SetPlatformApplicationAttributesError::AuthorizationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetPlatformApplicationAttributesError::InternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetPlatformApplicationAttributesError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetPlatformApplicationAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetPlatformApplicationAttributesError {}
 /// Errors returned by SetSMSAttributes
 #[derive(Debug, PartialEq)]
 pub enum SetSMSAttributesError {
@@ -4303,19 +4225,15 @@ impl SetSMSAttributesError {
 }
 impl fmt::Display for SetSMSAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetSMSAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            SetSMSAttributesError::AuthorizationError(ref cause) => cause,
-            SetSMSAttributesError::InternalError(ref cause) => cause,
-            SetSMSAttributesError::InvalidParameter(ref cause) => cause,
-            SetSMSAttributesError::Throttled(ref cause) => cause,
+            SetSMSAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            SetSMSAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetSMSAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetSMSAttributesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetSMSAttributesError {}
 /// Errors returned by SetSubscriptionAttributes
 #[derive(Debug, PartialEq)]
 pub enum SetSubscriptionAttributesError {
@@ -4385,20 +4303,18 @@ impl SetSubscriptionAttributesError {
 }
 impl fmt::Display for SetSubscriptionAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetSubscriptionAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            SetSubscriptionAttributesError::AuthorizationError(ref cause) => cause,
-            SetSubscriptionAttributesError::FilterPolicyLimitExceeded(ref cause) => cause,
-            SetSubscriptionAttributesError::InternalError(ref cause) => cause,
-            SetSubscriptionAttributesError::InvalidParameter(ref cause) => cause,
-            SetSubscriptionAttributesError::NotFound(ref cause) => cause,
+            SetSubscriptionAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            SetSubscriptionAttributesError::FilterPolicyLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SetSubscriptionAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetSubscriptionAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetSubscriptionAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetSubscriptionAttributesError {}
 /// Errors returned by SetTopicAttributes
 #[derive(Debug, PartialEq)]
 pub enum SetTopicAttributesError {
@@ -4464,20 +4380,16 @@ impl SetTopicAttributesError {
 }
 impl fmt::Display for SetTopicAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetTopicAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            SetTopicAttributesError::AuthorizationError(ref cause) => cause,
-            SetTopicAttributesError::InternalError(ref cause) => cause,
-            SetTopicAttributesError::InvalidParameter(ref cause) => cause,
-            SetTopicAttributesError::InvalidSecurity(ref cause) => cause,
-            SetTopicAttributesError::NotFound(ref cause) => cause,
+            SetTopicAttributesError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            SetTopicAttributesError::InternalError(ref cause) => write!(f, "{}", cause),
+            SetTopicAttributesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SetTopicAttributesError::InvalidSecurity(ref cause) => write!(f, "{}", cause),
+            SetTopicAttributesError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetTopicAttributesError {}
 /// Errors returned by Subscribe
 #[derive(Debug, PartialEq)]
 pub enum SubscribeError {
@@ -4555,22 +4467,18 @@ impl SubscribeError {
 }
 impl fmt::Display for SubscribeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SubscribeError {
-    fn description(&self) -> &str {
         match *self {
-            SubscribeError::AuthorizationError(ref cause) => cause,
-            SubscribeError::FilterPolicyLimitExceeded(ref cause) => cause,
-            SubscribeError::InternalError(ref cause) => cause,
-            SubscribeError::InvalidParameter(ref cause) => cause,
-            SubscribeError::InvalidSecurity(ref cause) => cause,
-            SubscribeError::NotFound(ref cause) => cause,
-            SubscribeError::SubscriptionLimitExceeded(ref cause) => cause,
+            SubscribeError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            SubscribeError::FilterPolicyLimitExceeded(ref cause) => write!(f, "{}", cause),
+            SubscribeError::InternalError(ref cause) => write!(f, "{}", cause),
+            SubscribeError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            SubscribeError::InvalidSecurity(ref cause) => write!(f, "{}", cause),
+            SubscribeError::NotFound(ref cause) => write!(f, "{}", cause),
+            SubscribeError::SubscriptionLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SubscribeError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -4650,22 +4558,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::AuthorizationError(ref cause) => cause,
-            TagResourceError::ConcurrentAccess(ref cause) => cause,
-            TagResourceError::InvalidParameter(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::StaleTag(ref cause) => cause,
-            TagResourceError::TagLimitExceeded(ref cause) => cause,
-            TagResourceError::TagPolicy(ref cause) => cause,
+            TagResourceError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ConcurrentAccess(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::StaleTag(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TagPolicy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by Unsubscribe
 #[derive(Debug, PartialEq)]
 pub enum UnsubscribeError {
@@ -4731,20 +4635,16 @@ impl UnsubscribeError {
 }
 impl fmt::Display for UnsubscribeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UnsubscribeError {
-    fn description(&self) -> &str {
         match *self {
-            UnsubscribeError::AuthorizationError(ref cause) => cause,
-            UnsubscribeError::InternalError(ref cause) => cause,
-            UnsubscribeError::InvalidParameter(ref cause) => cause,
-            UnsubscribeError::InvalidSecurity(ref cause) => cause,
-            UnsubscribeError::NotFound(ref cause) => cause,
+            UnsubscribeError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            UnsubscribeError::InternalError(ref cause) => write!(f, "{}", cause),
+            UnsubscribeError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UnsubscribeError::InvalidSecurity(ref cause) => write!(f, "{}", cause),
+            UnsubscribeError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UnsubscribeError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -4824,22 +4724,18 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::AuthorizationError(ref cause) => cause,
-            UntagResourceError::ConcurrentAccess(ref cause) => cause,
-            UntagResourceError::InvalidParameter(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::StaleTag(ref cause) => cause,
-            UntagResourceError::TagLimitExceeded(ref cause) => cause,
-            UntagResourceError::TagPolicy(ref cause) => cause,
+            UntagResourceError::AuthorizationError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ConcurrentAccess(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::StaleTag(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TagLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::TagPolicy(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the Amazon SNS API. Amazon SNS clients implement this trait.
 pub trait Sns {
     /// <p>Adds a statement to a topic's access control policy, granting access for the specified AWS accounts to the specified actions.</p>

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -2061,16 +2061,12 @@ impl AddPermissionError {
 }
 impl fmt::Display for AddPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            AddPermissionError::OverLimit(ref cause) => cause,
+            AddPermissionError::OverLimit(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddPermissionError {}
 /// Errors returned by ChangeMessageVisibility
 #[derive(Debug, PartialEq)]
 pub enum ChangeMessageVisibilityError {
@@ -2117,17 +2113,15 @@ impl ChangeMessageVisibilityError {
 }
 impl fmt::Display for ChangeMessageVisibilityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ChangeMessageVisibilityError {
-    fn description(&self) -> &str {
         match *self {
-            ChangeMessageVisibilityError::MessageNotInflight(ref cause) => cause,
-            ChangeMessageVisibilityError::ReceiptHandleIsInvalid(ref cause) => cause,
+            ChangeMessageVisibilityError::MessageNotInflight(ref cause) => write!(f, "{}", cause),
+            ChangeMessageVisibilityError::ReceiptHandleIsInvalid(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ChangeMessageVisibilityError {}
 /// Errors returned by ChangeMessageVisibilityBatch
 #[derive(Debug, PartialEq)]
 pub enum ChangeMessageVisibilityBatchError {
@@ -2196,19 +2190,23 @@ impl ChangeMessageVisibilityBatchError {
 }
 impl fmt::Display for ChangeMessageVisibilityBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ChangeMessageVisibilityBatchError {
-    fn description(&self) -> &str {
         match *self {
-            ChangeMessageVisibilityBatchError::BatchEntryIdsNotDistinct(ref cause) => cause,
-            ChangeMessageVisibilityBatchError::EmptyBatchRequest(ref cause) => cause,
-            ChangeMessageVisibilityBatchError::InvalidBatchEntryId(ref cause) => cause,
-            ChangeMessageVisibilityBatchError::TooManyEntriesInBatchRequest(ref cause) => cause,
+            ChangeMessageVisibilityBatchError::BatchEntryIdsNotDistinct(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ChangeMessageVisibilityBatchError::EmptyBatchRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ChangeMessageVisibilityBatchError::InvalidBatchEntryId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ChangeMessageVisibilityBatchError::TooManyEntriesInBatchRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ChangeMessageVisibilityBatchError {}
 /// Errors returned by CreateQueue
 #[derive(Debug, PartialEq)]
 pub enum CreateQueueError {
@@ -2253,17 +2251,13 @@ impl CreateQueueError {
 }
 impl fmt::Display for CreateQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateQueueError {
-    fn description(&self) -> &str {
         match *self {
-            CreateQueueError::QueueDeletedRecently(ref cause) => cause,
-            CreateQueueError::QueueNameExists(ref cause) => cause,
+            CreateQueueError::QueueDeletedRecently(ref cause) => write!(f, "{}", cause),
+            CreateQueueError::QueueNameExists(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateQueueError {}
 /// Errors returned by DeleteMessage
 #[derive(Debug, PartialEq)]
 pub enum DeleteMessageError {
@@ -2308,17 +2302,13 @@ impl DeleteMessageError {
 }
 impl fmt::Display for DeleteMessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMessageError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMessageError::InvalidIdFormat(ref cause) => cause,
-            DeleteMessageError::ReceiptHandleIsInvalid(ref cause) => cause,
+            DeleteMessageError::InvalidIdFormat(ref cause) => write!(f, "{}", cause),
+            DeleteMessageError::ReceiptHandleIsInvalid(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMessageError {}
 /// Errors returned by DeleteMessageBatch
 #[derive(Debug, PartialEq)]
 pub enum DeleteMessageBatchError {
@@ -2379,19 +2369,17 @@ impl DeleteMessageBatchError {
 }
 impl fmt::Display for DeleteMessageBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMessageBatchError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMessageBatchError::BatchEntryIdsNotDistinct(ref cause) => cause,
-            DeleteMessageBatchError::EmptyBatchRequest(ref cause) => cause,
-            DeleteMessageBatchError::InvalidBatchEntryId(ref cause) => cause,
-            DeleteMessageBatchError::TooManyEntriesInBatchRequest(ref cause) => cause,
+            DeleteMessageBatchError::BatchEntryIdsNotDistinct(ref cause) => write!(f, "{}", cause),
+            DeleteMessageBatchError::EmptyBatchRequest(ref cause) => write!(f, "{}", cause),
+            DeleteMessageBatchError::InvalidBatchEntryId(ref cause) => write!(f, "{}", cause),
+            DeleteMessageBatchError::TooManyEntriesInBatchRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteMessageBatchError {}
 /// Errors returned by DeleteQueue
 #[derive(Debug, PartialEq)]
 pub enum DeleteQueueError {}
@@ -2421,14 +2409,10 @@ impl DeleteQueueError {
 }
 impl fmt::Display for DeleteQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteQueueError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for DeleteQueueError {}
 /// Errors returned by GetQueueAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetQueueAttributesError {
@@ -2466,16 +2450,12 @@ impl GetQueueAttributesError {
 }
 impl fmt::Display for GetQueueAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQueueAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            GetQueueAttributesError::InvalidAttributeName(ref cause) => cause,
+            GetQueueAttributesError::InvalidAttributeName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQueueAttributesError {}
 /// Errors returned by GetQueueUrl
 #[derive(Debug, PartialEq)]
 pub enum GetQueueUrlError {
@@ -2513,16 +2493,12 @@ impl GetQueueUrlError {
 }
 impl fmt::Display for GetQueueUrlError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetQueueUrlError {
-    fn description(&self) -> &str {
         match *self {
-            GetQueueUrlError::QueueDoesNotExist(ref cause) => cause,
+            GetQueueUrlError::QueueDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetQueueUrlError {}
 /// Errors returned by ListDeadLetterSourceQueues
 #[derive(Debug, PartialEq)]
 pub enum ListDeadLetterSourceQueuesError {
@@ -2564,16 +2540,12 @@ impl ListDeadLetterSourceQueuesError {
 }
 impl fmt::Display for ListDeadLetterSourceQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDeadLetterSourceQueuesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDeadLetterSourceQueuesError::QueueDoesNotExist(ref cause) => cause,
+            ListDeadLetterSourceQueuesError::QueueDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDeadLetterSourceQueuesError {}
 /// Errors returned by ListQueueTags
 #[derive(Debug, PartialEq)]
 pub enum ListQueueTagsError {}
@@ -2603,14 +2575,10 @@ impl ListQueueTagsError {
 }
 impl fmt::Display for ListQueueTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQueueTagsError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListQueueTagsError {}
 /// Errors returned by ListQueues
 #[derive(Debug, PartialEq)]
 pub enum ListQueuesError {}
@@ -2640,14 +2608,10 @@ impl ListQueuesError {
 }
 impl fmt::Display for ListQueuesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListQueuesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for ListQueuesError {}
 /// Errors returned by PurgeQueue
 #[derive(Debug, PartialEq)]
 pub enum PurgeQueueError {
@@ -2692,17 +2656,13 @@ impl PurgeQueueError {
 }
 impl fmt::Display for PurgeQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PurgeQueueError {
-    fn description(&self) -> &str {
         match *self {
-            PurgeQueueError::PurgeQueueInProgress(ref cause) => cause,
-            PurgeQueueError::QueueDoesNotExist(ref cause) => cause,
+            PurgeQueueError::PurgeQueueInProgress(ref cause) => write!(f, "{}", cause),
+            PurgeQueueError::QueueDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PurgeQueueError {}
 /// Errors returned by ReceiveMessage
 #[derive(Debug, PartialEq)]
 pub enum ReceiveMessageError {
@@ -2740,16 +2700,12 @@ impl ReceiveMessageError {
 }
 impl fmt::Display for ReceiveMessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ReceiveMessageError {
-    fn description(&self) -> &str {
         match *self {
-            ReceiveMessageError::OverLimit(ref cause) => cause,
+            ReceiveMessageError::OverLimit(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ReceiveMessageError {}
 /// Errors returned by RemovePermission
 #[derive(Debug, PartialEq)]
 pub enum RemovePermissionError {}
@@ -2779,14 +2735,10 @@ impl RemovePermissionError {
 }
 impl fmt::Display for RemovePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemovePermissionError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RemovePermissionError {}
 /// Errors returned by SendMessage
 #[derive(Debug, PartialEq)]
 pub enum SendMessageError {
@@ -2831,17 +2783,13 @@ impl SendMessageError {
 }
 impl fmt::Display for SendMessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendMessageError {
-    fn description(&self) -> &str {
         match *self {
-            SendMessageError::InvalidMessageContents(ref cause) => cause,
-            SendMessageError::UnsupportedOperation(ref cause) => cause,
+            SendMessageError::InvalidMessageContents(ref cause) => write!(f, "{}", cause),
+            SendMessageError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendMessageError {}
 /// Errors returned by SendMessageBatch
 #[derive(Debug, PartialEq)]
 pub enum SendMessageBatchError {
@@ -2916,21 +2864,19 @@ impl SendMessageBatchError {
 }
 impl fmt::Display for SendMessageBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendMessageBatchError {
-    fn description(&self) -> &str {
         match *self {
-            SendMessageBatchError::BatchEntryIdsNotDistinct(ref cause) => cause,
-            SendMessageBatchError::BatchRequestTooLong(ref cause) => cause,
-            SendMessageBatchError::EmptyBatchRequest(ref cause) => cause,
-            SendMessageBatchError::InvalidBatchEntryId(ref cause) => cause,
-            SendMessageBatchError::TooManyEntriesInBatchRequest(ref cause) => cause,
-            SendMessageBatchError::UnsupportedOperation(ref cause) => cause,
+            SendMessageBatchError::BatchEntryIdsNotDistinct(ref cause) => write!(f, "{}", cause),
+            SendMessageBatchError::BatchRequestTooLong(ref cause) => write!(f, "{}", cause),
+            SendMessageBatchError::EmptyBatchRequest(ref cause) => write!(f, "{}", cause),
+            SendMessageBatchError::InvalidBatchEntryId(ref cause) => write!(f, "{}", cause),
+            SendMessageBatchError::TooManyEntriesInBatchRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendMessageBatchError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendMessageBatchError {}
 /// Errors returned by SetQueueAttributes
 #[derive(Debug, PartialEq)]
 pub enum SetQueueAttributesError {
@@ -2968,16 +2914,12 @@ impl SetQueueAttributesError {
 }
 impl fmt::Display for SetQueueAttributesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetQueueAttributesError {
-    fn description(&self) -> &str {
         match *self {
-            SetQueueAttributesError::InvalidAttributeName(ref cause) => cause,
+            SetQueueAttributesError::InvalidAttributeName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetQueueAttributesError {}
 /// Errors returned by TagQueue
 #[derive(Debug, PartialEq)]
 pub enum TagQueueError {}
@@ -3007,14 +2949,10 @@ impl TagQueueError {
 }
 impl fmt::Display for TagQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagQueueError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for TagQueueError {}
 /// Errors returned by UntagQueue
 #[derive(Debug, PartialEq)]
 pub enum UntagQueueError {}
@@ -3044,14 +2982,10 @@ impl UntagQueueError {
 }
 impl fmt::Display for UntagQueueError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagQueueError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for UntagQueueError {}
 /// Trait representing the capabilities of the Amazon SQS API. Amazon SQS clients implement this trait.
 pub trait Sqs {
     /// <p><p>Adds a permission to a queue for a specific <a href="https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#P">principal</a>. This allows sharing access to the queue.</p> <p>When you create a queue, you have full control access rights for the queue. Only you, the owner of the queue, can grant or deny permissions to the queue. For more information about these permissions, see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-writing-an-sqs-policy.html#write-messages-to-shared-queue">Allow Developers to Write Messages to a Shared Queue</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> <note> <ul> <li> <p> <code>AddPermission</code> generates a policy for you. You can use <code> <a>SetQueueAttributes</a> </code> to upload your policy. For more information, see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-creating-custom-policies.html">Using Custom Policies with the Amazon SQS Access Policy Language</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> </li> <li> <p>An Amazon SQS policy can have a maximum of 7 actions.</p> </li> <li> <p>To remove the ability to change queue permissions, you must deny permission to the <code>AddPermission</code>, <code>RemovePermission</code>, and <code>SetQueueAttributes</code> actions in your IAM policy.</p> </li> </ul> </note> <p>Some actions take lists of parameters. These lists are specified using the <code>param.n</code> notation. Values of <code>n</code> are integers starting from 1. For example, a parameter list with two elements looks like this:</p> <p> <code>&amp;Attribute.1=first</code> </p> <p> <code>&amp;Attribute.2=second</code> </p> <note> <p>Cross-account permissions don&#39;t apply to this action. For more information, see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-customer-managed-policy-examples.html#grant-cross-account-permissions-to-role-and-user-name">Grant Cross-Account Permissions to a Role and a User Name</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> </note></p>

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -7835,20 +7835,16 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::InternalServerError(ref cause) => cause,
-            AddTagsToResourceError::InvalidResourceId(ref cause) => cause,
-            AddTagsToResourceError::InvalidResourceType(ref cause) => cause,
-            AddTagsToResourceError::TooManyTagsError(ref cause) => cause,
-            AddTagsToResourceError::TooManyUpdates(ref cause) => cause,
+            AddTagsToResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::InvalidResourceId(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::InvalidResourceType(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::TooManyTagsError(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by CancelCommand
 #[derive(Debug, PartialEq)]
 pub enum CancelCommandError {
@@ -7887,19 +7883,15 @@ impl CancelCommandError {
 }
 impl fmt::Display for CancelCommandError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelCommandError {
-    fn description(&self) -> &str {
         match *self {
-            CancelCommandError::DuplicateInstanceId(ref cause) => cause,
-            CancelCommandError::InternalServerError(ref cause) => cause,
-            CancelCommandError::InvalidCommandId(ref cause) => cause,
-            CancelCommandError::InvalidInstanceId(ref cause) => cause,
+            CancelCommandError::DuplicateInstanceId(ref cause) => write!(f, "{}", cause),
+            CancelCommandError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CancelCommandError::InvalidCommandId(ref cause) => write!(f, "{}", cause),
+            CancelCommandError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelCommandError {}
 /// Errors returned by CancelMaintenanceWindowExecution
 #[derive(Debug, PartialEq)]
 pub enum CancelMaintenanceWindowExecutionError {
@@ -7934,17 +7926,17 @@ impl CancelMaintenanceWindowExecutionError {
 }
 impl fmt::Display for CancelMaintenanceWindowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelMaintenanceWindowExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            CancelMaintenanceWindowExecutionError::DoesNotExist(ref cause) => cause,
-            CancelMaintenanceWindowExecutionError::InternalServerError(ref cause) => cause,
+            CancelMaintenanceWindowExecutionError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CancelMaintenanceWindowExecutionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CancelMaintenanceWindowExecutionError {}
 /// Errors returned by CreateActivation
 #[derive(Debug, PartialEq)]
 pub enum CreateActivationError {
@@ -7970,16 +7962,12 @@ impl CreateActivationError {
 }
 impl fmt::Display for CreateActivationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateActivationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateActivationError::InternalServerError(ref cause) => cause,
+            CreateActivationError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateActivationError {}
 /// Errors returned by CreateAssociation
 #[derive(Debug, PartialEq)]
 pub enum CreateAssociationError {
@@ -8065,26 +8053,22 @@ impl CreateAssociationError {
 }
 impl fmt::Display for CreateAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAssociationError::AssociationAlreadyExists(ref cause) => cause,
-            CreateAssociationError::AssociationLimitExceeded(ref cause) => cause,
-            CreateAssociationError::InternalServerError(ref cause) => cause,
-            CreateAssociationError::InvalidDocument(ref cause) => cause,
-            CreateAssociationError::InvalidDocumentVersion(ref cause) => cause,
-            CreateAssociationError::InvalidInstanceId(ref cause) => cause,
-            CreateAssociationError::InvalidOutputLocation(ref cause) => cause,
-            CreateAssociationError::InvalidParameters(ref cause) => cause,
-            CreateAssociationError::InvalidSchedule(ref cause) => cause,
-            CreateAssociationError::InvalidTarget(ref cause) => cause,
-            CreateAssociationError::UnsupportedPlatformType(ref cause) => cause,
+            CreateAssociationError::AssociationAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::AssociationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InvalidDocumentVersion(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InvalidOutputLocation(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InvalidSchedule(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            CreateAssociationError::UnsupportedPlatformType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAssociationError {}
 /// Errors returned by CreateAssociationBatch
 #[derive(Debug, PartialEq)]
 pub enum CreateAssociationBatchError {
@@ -8180,26 +8164,28 @@ impl CreateAssociationBatchError {
 }
 impl fmt::Display for CreateAssociationBatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAssociationBatchError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAssociationBatchError::AssociationLimitExceeded(ref cause) => cause,
-            CreateAssociationBatchError::DuplicateInstanceId(ref cause) => cause,
-            CreateAssociationBatchError::InternalServerError(ref cause) => cause,
-            CreateAssociationBatchError::InvalidDocument(ref cause) => cause,
-            CreateAssociationBatchError::InvalidDocumentVersion(ref cause) => cause,
-            CreateAssociationBatchError::InvalidInstanceId(ref cause) => cause,
-            CreateAssociationBatchError::InvalidOutputLocation(ref cause) => cause,
-            CreateAssociationBatchError::InvalidParameters(ref cause) => cause,
-            CreateAssociationBatchError::InvalidSchedule(ref cause) => cause,
-            CreateAssociationBatchError::InvalidTarget(ref cause) => cause,
-            CreateAssociationBatchError::UnsupportedPlatformType(ref cause) => cause,
+            CreateAssociationBatchError::AssociationLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAssociationBatchError::DuplicateInstanceId(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::InvalidDocumentVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateAssociationBatchError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::InvalidOutputLocation(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::InvalidSchedule(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            CreateAssociationBatchError::UnsupportedPlatformType(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateAssociationBatchError {}
 /// Errors returned by CreateDocument
 #[derive(Debug, PartialEq)]
 pub enum CreateDocumentError {
@@ -8258,21 +8244,17 @@ impl CreateDocumentError {
 }
 impl fmt::Display for CreateDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateDocumentError::DocumentAlreadyExists(ref cause) => cause,
-            CreateDocumentError::DocumentLimitExceeded(ref cause) => cause,
-            CreateDocumentError::InternalServerError(ref cause) => cause,
-            CreateDocumentError::InvalidDocumentContent(ref cause) => cause,
-            CreateDocumentError::InvalidDocumentSchemaVersion(ref cause) => cause,
-            CreateDocumentError::MaxDocumentSizeExceeded(ref cause) => cause,
+            CreateDocumentError::DocumentAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateDocumentError::DocumentLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateDocumentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateDocumentError::InvalidDocumentContent(ref cause) => write!(f, "{}", cause),
+            CreateDocumentError::InvalidDocumentSchemaVersion(ref cause) => write!(f, "{}", cause),
+            CreateDocumentError::MaxDocumentSizeExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateDocumentError {}
 /// Errors returned by CreateMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum CreateMaintenanceWindowError {
@@ -8312,18 +8294,18 @@ impl CreateMaintenanceWindowError {
 }
 impl fmt::Display for CreateMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            CreateMaintenanceWindowError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateMaintenanceWindowError::InternalServerError(ref cause) => cause,
-            CreateMaintenanceWindowError::ResourceLimitExceeded(ref cause) => cause,
+            CreateMaintenanceWindowError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateMaintenanceWindowError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateMaintenanceWindowError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateMaintenanceWindowError {}
 /// Errors returned by CreateOpsItem
 #[derive(Debug, PartialEq)]
 pub enum CreateOpsItemError {
@@ -8364,19 +8346,15 @@ impl CreateOpsItemError {
 }
 impl fmt::Display for CreateOpsItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateOpsItemError {
-    fn description(&self) -> &str {
         match *self {
-            CreateOpsItemError::InternalServerError(ref cause) => cause,
-            CreateOpsItemError::OpsItemAlreadyExists(ref cause) => cause,
-            CreateOpsItemError::OpsItemInvalidParameter(ref cause) => cause,
-            CreateOpsItemError::OpsItemLimitExceeded(ref cause) => cause,
+            CreateOpsItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateOpsItemError::OpsItemAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateOpsItemError::OpsItemInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateOpsItemError::OpsItemLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateOpsItemError {}
 /// Errors returned by CreatePatchBaseline
 #[derive(Debug, PartialEq)]
 pub enum CreatePatchBaselineError {
@@ -8416,18 +8394,16 @@ impl CreatePatchBaselineError {
 }
 impl fmt::Display for CreatePatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreatePatchBaselineError {
-    fn description(&self) -> &str {
         match *self {
-            CreatePatchBaselineError::IdempotentParameterMismatch(ref cause) => cause,
-            CreatePatchBaselineError::InternalServerError(ref cause) => cause,
-            CreatePatchBaselineError::ResourceLimitExceeded(ref cause) => cause,
+            CreatePatchBaselineError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreatePatchBaselineError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreatePatchBaselineError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreatePatchBaselineError {}
 /// Errors returned by CreateResourceDataSync
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceDataSyncError {
@@ -8474,19 +8450,21 @@ impl CreateResourceDataSyncError {
 }
 impl fmt::Display for CreateResourceDataSyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceDataSyncError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceDataSyncError::InternalServerError(ref cause) => cause,
-            CreateResourceDataSyncError::ResourceDataSyncAlreadyExists(ref cause) => cause,
-            CreateResourceDataSyncError::ResourceDataSyncCountExceeded(ref cause) => cause,
-            CreateResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => cause,
+            CreateResourceDataSyncError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateResourceDataSyncError::ResourceDataSyncAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateResourceDataSyncError::ResourceDataSyncCountExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateResourceDataSyncError {}
 /// Errors returned by DeleteActivation
 #[derive(Debug, PartialEq)]
 pub enum DeleteActivationError {
@@ -8529,19 +8507,15 @@ impl DeleteActivationError {
 }
 impl fmt::Display for DeleteActivationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteActivationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteActivationError::InternalServerError(ref cause) => cause,
-            DeleteActivationError::InvalidActivation(ref cause) => cause,
-            DeleteActivationError::InvalidActivationId(ref cause) => cause,
-            DeleteActivationError::TooManyUpdates(ref cause) => cause,
+            DeleteActivationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteActivationError::InvalidActivation(ref cause) => write!(f, "{}", cause),
+            DeleteActivationError::InvalidActivationId(ref cause) => write!(f, "{}", cause),
+            DeleteActivationError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteActivationError {}
 /// Errors returned by DeleteAssociation
 #[derive(Debug, PartialEq)]
 pub enum DeleteAssociationError {
@@ -8589,20 +8563,16 @@ impl DeleteAssociationError {
 }
 impl fmt::Display for DeleteAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAssociationError::AssociationDoesNotExist(ref cause) => cause,
-            DeleteAssociationError::InternalServerError(ref cause) => cause,
-            DeleteAssociationError::InvalidDocument(ref cause) => cause,
-            DeleteAssociationError::InvalidInstanceId(ref cause) => cause,
-            DeleteAssociationError::TooManyUpdates(ref cause) => cause,
+            DeleteAssociationError::AssociationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DeleteAssociationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteAssociationError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            DeleteAssociationError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            DeleteAssociationError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAssociationError {}
 /// Errors returned by DeleteDocument
 #[derive(Debug, PartialEq)]
 pub enum DeleteDocumentError {
@@ -8643,19 +8613,15 @@ impl DeleteDocumentError {
 }
 impl fmt::Display for DeleteDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDocumentError::AssociatedInstances(ref cause) => cause,
-            DeleteDocumentError::InternalServerError(ref cause) => cause,
-            DeleteDocumentError::InvalidDocument(ref cause) => cause,
-            DeleteDocumentError::InvalidDocumentOperation(ref cause) => cause,
+            DeleteDocumentError::AssociatedInstances(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::InvalidDocumentOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDocumentError {}
 /// Errors returned by DeleteInventory
 #[derive(Debug, PartialEq)]
 pub enum DeleteInventoryError {
@@ -8703,20 +8669,18 @@ impl DeleteInventoryError {
 }
 impl fmt::Display for DeleteInventoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteInventoryError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteInventoryError::InternalServerError(ref cause) => cause,
-            DeleteInventoryError::InvalidDeleteInventoryParameters(ref cause) => cause,
-            DeleteInventoryError::InvalidInventoryRequest(ref cause) => cause,
-            DeleteInventoryError::InvalidOption(ref cause) => cause,
-            DeleteInventoryError::InvalidTypeName(ref cause) => cause,
+            DeleteInventoryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteInventoryError::InvalidDeleteInventoryParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteInventoryError::InvalidInventoryRequest(ref cause) => write!(f, "{}", cause),
+            DeleteInventoryError::InvalidOption(ref cause) => write!(f, "{}", cause),
+            DeleteInventoryError::InvalidTypeName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteInventoryError {}
 /// Errors returned by DeleteMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum DeleteMaintenanceWindowError {
@@ -8742,16 +8706,12 @@ impl DeleteMaintenanceWindowError {
 }
 impl fmt::Display for DeleteMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMaintenanceWindowError::InternalServerError(ref cause) => cause,
+            DeleteMaintenanceWindowError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMaintenanceWindowError {}
 /// Errors returned by DeleteParameter
 #[derive(Debug, PartialEq)]
 pub enum DeleteParameterError {
@@ -8780,17 +8740,13 @@ impl DeleteParameterError {
 }
 impl fmt::Display for DeleteParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteParameterError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteParameterError::InternalServerError(ref cause) => cause,
-            DeleteParameterError::ParameterNotFound(ref cause) => cause,
+            DeleteParameterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteParameterError::ParameterNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteParameterError {}
 /// Errors returned by DeleteParameters
 #[derive(Debug, PartialEq)]
 pub enum DeleteParametersError {
@@ -8816,16 +8772,12 @@ impl DeleteParametersError {
 }
 impl fmt::Display for DeleteParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteParametersError::InternalServerError(ref cause) => cause,
+            DeleteParametersError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteParametersError {}
 /// Errors returned by DeletePatchBaseline
 #[derive(Debug, PartialEq)]
 pub enum DeletePatchBaselineError {
@@ -8856,17 +8808,13 @@ impl DeletePatchBaselineError {
 }
 impl fmt::Display for DeletePatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePatchBaselineError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePatchBaselineError::InternalServerError(ref cause) => cause,
-            DeletePatchBaselineError::ResourceInUse(ref cause) => cause,
+            DeletePatchBaselineError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeletePatchBaselineError::ResourceInUse(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePatchBaselineError {}
 /// Errors returned by DeleteResourceDataSync
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourceDataSyncError {
@@ -8906,18 +8854,18 @@ impl DeleteResourceDataSyncError {
 }
 impl fmt::Display for DeleteResourceDataSyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourceDataSyncError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourceDataSyncError::InternalServerError(ref cause) => cause,
-            DeleteResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => cause,
-            DeleteResourceDataSyncError::ResourceDataSyncNotFound(ref cause) => cause,
+            DeleteResourceDataSyncError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteResourceDataSyncError::ResourceDataSyncNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteResourceDataSyncError {}
 /// Errors returned by DeregisterManagedInstance
 #[derive(Debug, PartialEq)]
 pub enum DeregisterManagedInstanceError {
@@ -8950,17 +8898,15 @@ impl DeregisterManagedInstanceError {
 }
 impl fmt::Display for DeregisterManagedInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterManagedInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterManagedInstanceError::InternalServerError(ref cause) => cause,
-            DeregisterManagedInstanceError::InvalidInstanceId(ref cause) => cause,
+            DeregisterManagedInstanceError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterManagedInstanceError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterManagedInstanceError {}
 /// Errors returned by DeregisterPatchBaselineForPatchGroup
 #[derive(Debug, PartialEq)]
 pub enum DeregisterPatchBaselineForPatchGroupError {
@@ -8995,17 +8941,17 @@ impl DeregisterPatchBaselineForPatchGroupError {
 }
 impl fmt::Display for DeregisterPatchBaselineForPatchGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterPatchBaselineForPatchGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterPatchBaselineForPatchGroupError::InternalServerError(ref cause) => cause,
-            DeregisterPatchBaselineForPatchGroupError::InvalidResourceId(ref cause) => cause,
+            DeregisterPatchBaselineForPatchGroupError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterPatchBaselineForPatchGroupError::InvalidResourceId(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterPatchBaselineForPatchGroupError {}
 /// Errors returned by DeregisterTargetFromMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum DeregisterTargetFromMaintenanceWindowError {
@@ -9047,18 +8993,20 @@ impl DeregisterTargetFromMaintenanceWindowError {
 }
 impl fmt::Display for DeregisterTargetFromMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterTargetFromMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterTargetFromMaintenanceWindowError::DoesNotExist(ref cause) => cause,
-            DeregisterTargetFromMaintenanceWindowError::InternalServerError(ref cause) => cause,
-            DeregisterTargetFromMaintenanceWindowError::TargetInUse(ref cause) => cause,
+            DeregisterTargetFromMaintenanceWindowError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterTargetFromMaintenanceWindowError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterTargetFromMaintenanceWindowError::TargetInUse(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterTargetFromMaintenanceWindowError {}
 /// Errors returned by DeregisterTaskFromMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum DeregisterTaskFromMaintenanceWindowError {
@@ -9093,17 +9041,17 @@ impl DeregisterTaskFromMaintenanceWindowError {
 }
 impl fmt::Display for DeregisterTaskFromMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterTaskFromMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterTaskFromMaintenanceWindowError::DoesNotExist(ref cause) => cause,
-            DeregisterTaskFromMaintenanceWindowError::InternalServerError(ref cause) => cause,
+            DeregisterTaskFromMaintenanceWindowError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterTaskFromMaintenanceWindowError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterTaskFromMaintenanceWindowError {}
 /// Errors returned by DescribeActivations
 #[derive(Debug, PartialEq)]
 pub enum DescribeActivationsError {
@@ -9141,18 +9089,14 @@ impl DescribeActivationsError {
 }
 impl fmt::Display for DescribeActivationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeActivationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeActivationsError::InternalServerError(ref cause) => cause,
-            DescribeActivationsError::InvalidFilter(ref cause) => cause,
-            DescribeActivationsError::InvalidNextToken(ref cause) => cause,
+            DescribeActivationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeActivationsError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            DescribeActivationsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeActivationsError {}
 /// Errors returned by DescribeAssociation
 #[derive(Debug, PartialEq)]
 pub enum DescribeAssociationError {
@@ -9204,20 +9148,18 @@ impl DescribeAssociationError {
 }
 impl fmt::Display for DescribeAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAssociationError::AssociationDoesNotExist(ref cause) => cause,
-            DescribeAssociationError::InternalServerError(ref cause) => cause,
-            DescribeAssociationError::InvalidAssociationVersion(ref cause) => cause,
-            DescribeAssociationError::InvalidDocument(ref cause) => cause,
-            DescribeAssociationError::InvalidInstanceId(ref cause) => cause,
+            DescribeAssociationError::AssociationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeAssociationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeAssociationError::InvalidAssociationVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAssociationError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            DescribeAssociationError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAssociationError {}
 /// Errors returned by DescribeAssociationExecutionTargets
 #[derive(Debug, PartialEq)]
 pub enum DescribeAssociationExecutionTargetsError {
@@ -9268,21 +9210,23 @@ impl DescribeAssociationExecutionTargetsError {
 }
 impl fmt::Display for DescribeAssociationExecutionTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAssociationExecutionTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAssociationExecutionTargetsError::AssociationDoesNotExist(ref cause) => cause,
+            DescribeAssociationExecutionTargetsError::AssociationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeAssociationExecutionTargetsError::AssociationExecutionDoesNotExist(
                 ref cause,
-            ) => cause,
-            DescribeAssociationExecutionTargetsError::InternalServerError(ref cause) => cause,
-            DescribeAssociationExecutionTargetsError::InvalidNextToken(ref cause) => cause,
+            ) => write!(f, "{}", cause),
+            DescribeAssociationExecutionTargetsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAssociationExecutionTargetsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAssociationExecutionTargetsError {}
 /// Errors returned by DescribeAssociationExecutions
 #[derive(Debug, PartialEq)]
 pub enum DescribeAssociationExecutionsError {
@@ -9324,18 +9268,20 @@ impl DescribeAssociationExecutionsError {
 }
 impl fmt::Display for DescribeAssociationExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAssociationExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAssociationExecutionsError::AssociationDoesNotExist(ref cause) => cause,
-            DescribeAssociationExecutionsError::InternalServerError(ref cause) => cause,
-            DescribeAssociationExecutionsError::InvalidNextToken(ref cause) => cause,
+            DescribeAssociationExecutionsError::AssociationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAssociationExecutionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAssociationExecutionsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAssociationExecutionsError {}
 /// Errors returned by DescribeAutomationExecutions
 #[derive(Debug, PartialEq)]
 pub enum DescribeAutomationExecutionsError {
@@ -9384,19 +9330,23 @@ impl DescribeAutomationExecutionsError {
 }
 impl fmt::Display for DescribeAutomationExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAutomationExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAutomationExecutionsError::InternalServerError(ref cause) => cause,
-            DescribeAutomationExecutionsError::InvalidFilterKey(ref cause) => cause,
-            DescribeAutomationExecutionsError::InvalidFilterValue(ref cause) => cause,
-            DescribeAutomationExecutionsError::InvalidNextToken(ref cause) => cause,
+            DescribeAutomationExecutionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutomationExecutionsError::InvalidFilterKey(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutomationExecutionsError::InvalidFilterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutomationExecutionsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAutomationExecutionsError {}
 /// Errors returned by DescribeAutomationStepExecutions
 #[derive(Debug, PartialEq)]
 pub enum DescribeAutomationStepExecutionsError {
@@ -9452,20 +9402,26 @@ impl DescribeAutomationStepExecutionsError {
 }
 impl fmt::Display for DescribeAutomationStepExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAutomationStepExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAutomationStepExecutionsError::AutomationExecutionNotFound(ref cause) => cause,
-            DescribeAutomationStepExecutionsError::InternalServerError(ref cause) => cause,
-            DescribeAutomationStepExecutionsError::InvalidFilterKey(ref cause) => cause,
-            DescribeAutomationStepExecutionsError::InvalidFilterValue(ref cause) => cause,
-            DescribeAutomationStepExecutionsError::InvalidNextToken(ref cause) => cause,
+            DescribeAutomationStepExecutionsError::AutomationExecutionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutomationStepExecutionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutomationStepExecutionsError::InvalidFilterKey(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutomationStepExecutionsError::InvalidFilterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAutomationStepExecutionsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAutomationStepExecutionsError {}
 /// Errors returned by DescribeAvailablePatches
 #[derive(Debug, PartialEq)]
 pub enum DescribeAvailablePatchesError {
@@ -9491,16 +9447,12 @@ impl DescribeAvailablePatchesError {
 }
 impl fmt::Display for DescribeAvailablePatchesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAvailablePatchesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAvailablePatchesError::InternalServerError(ref cause) => cause,
+            DescribeAvailablePatchesError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAvailablePatchesError {}
 /// Errors returned by DescribeDocument
 #[derive(Debug, PartialEq)]
 pub enum DescribeDocumentError {
@@ -9538,18 +9490,14 @@ impl DescribeDocumentError {
 }
 impl fmt::Display for DescribeDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDocumentError::InternalServerError(ref cause) => cause,
-            DescribeDocumentError::InvalidDocument(ref cause) => cause,
-            DescribeDocumentError::InvalidDocumentVersion(ref cause) => cause,
+            DescribeDocumentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentError::InvalidDocumentVersion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDocumentError {}
 /// Errors returned by DescribeDocumentPermission
 #[derive(Debug, PartialEq)]
 pub enum DescribeDocumentPermissionError {
@@ -9591,18 +9539,18 @@ impl DescribeDocumentPermissionError {
 }
 impl fmt::Display for DescribeDocumentPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDocumentPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDocumentPermissionError::InternalServerError(ref cause) => cause,
-            DescribeDocumentPermissionError::InvalidDocument(ref cause) => cause,
-            DescribeDocumentPermissionError::InvalidPermissionType(ref cause) => cause,
+            DescribeDocumentPermissionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDocumentPermissionError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentPermissionError::InvalidPermissionType(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDocumentPermissionError {}
 /// Errors returned by DescribeEffectiveInstanceAssociations
 #[derive(Debug, PartialEq)]
 pub enum DescribeEffectiveInstanceAssociationsError {
@@ -9644,18 +9592,20 @@ impl DescribeEffectiveInstanceAssociationsError {
 }
 impl fmt::Display for DescribeEffectiveInstanceAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEffectiveInstanceAssociationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEffectiveInstanceAssociationsError::InternalServerError(ref cause) => cause,
-            DescribeEffectiveInstanceAssociationsError::InvalidInstanceId(ref cause) => cause,
-            DescribeEffectiveInstanceAssociationsError::InvalidNextToken(ref cause) => cause,
+            DescribeEffectiveInstanceAssociationsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEffectiveInstanceAssociationsError::InvalidInstanceId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEffectiveInstanceAssociationsError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeEffectiveInstanceAssociationsError {}
 /// Errors returned by DescribeEffectivePatchesForPatchBaseline
 #[derive(Debug, PartialEq)]
 pub enum DescribeEffectivePatchesForPatchBaselineError {
@@ -9706,21 +9656,23 @@ impl DescribeEffectivePatchesForPatchBaselineError {
 }
 impl fmt::Display for DescribeEffectivePatchesForPatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeEffectivePatchesForPatchBaselineError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeEffectivePatchesForPatchBaselineError::DoesNotExist(ref cause) => cause,
-            DescribeEffectivePatchesForPatchBaselineError::InternalServerError(ref cause) => cause,
-            DescribeEffectivePatchesForPatchBaselineError::InvalidResourceId(ref cause) => cause,
+            DescribeEffectivePatchesForPatchBaselineError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEffectivePatchesForPatchBaselineError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeEffectivePatchesForPatchBaselineError::InvalidResourceId(ref cause) => {
+                write!(f, "{}", cause)
+            }
             DescribeEffectivePatchesForPatchBaselineError::UnsupportedOperatingSystem(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeEffectivePatchesForPatchBaselineError {}
 /// Errors returned by DescribeInstanceAssociationsStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstanceAssociationsStatusError {
@@ -9762,18 +9714,20 @@ impl DescribeInstanceAssociationsStatusError {
 }
 impl fmt::Display for DescribeInstanceAssociationsStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstanceAssociationsStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstanceAssociationsStatusError::InternalServerError(ref cause) => cause,
-            DescribeInstanceAssociationsStatusError::InvalidInstanceId(ref cause) => cause,
-            DescribeInstanceAssociationsStatusError::InvalidNextToken(ref cause) => cause,
+            DescribeInstanceAssociationsStatusError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstanceAssociationsStatusError::InvalidInstanceId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstanceAssociationsStatusError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeInstanceAssociationsStatusError {}
 /// Errors returned by DescribeInstanceInformation
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstanceInformationError {
@@ -9831,22 +9785,22 @@ impl DescribeInstanceInformationError {
 }
 impl fmt::Display for DescribeInstanceInformationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstanceInformationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstanceInformationError::InternalServerError(ref cause) => cause,
-            DescribeInstanceInformationError::InvalidFilterKey(ref cause) => cause,
-            DescribeInstanceInformationError::InvalidInstanceId(ref cause) => cause,
-            DescribeInstanceInformationError::InvalidInstanceInformationFilterValue(ref cause) => {
-                cause
+            DescribeInstanceInformationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
             }
-            DescribeInstanceInformationError::InvalidNextToken(ref cause) => cause,
+            DescribeInstanceInformationError::InvalidFilterKey(ref cause) => write!(f, "{}", cause),
+            DescribeInstanceInformationError::InvalidInstanceId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstanceInformationError::InvalidInstanceInformationFilterValue(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstanceInformationError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInstanceInformationError {}
 /// Errors returned by DescribeInstancePatchStates
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstancePatchStatesError {
@@ -9881,17 +9835,15 @@ impl DescribeInstancePatchStatesError {
 }
 impl fmt::Display for DescribeInstancePatchStatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstancePatchStatesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstancePatchStatesError::InternalServerError(ref cause) => cause,
-            DescribeInstancePatchStatesError::InvalidNextToken(ref cause) => cause,
+            DescribeInstancePatchStatesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstancePatchStatesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInstancePatchStatesError {}
 /// Errors returned by DescribeInstancePatchStatesForPatchGroup
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstancePatchStatesForPatchGroupError {
@@ -9933,18 +9885,20 @@ impl DescribeInstancePatchStatesForPatchGroupError {
 }
 impl fmt::Display for DescribeInstancePatchStatesForPatchGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstancePatchStatesForPatchGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstancePatchStatesForPatchGroupError::InternalServerError(ref cause) => cause,
-            DescribeInstancePatchStatesForPatchGroupError::InvalidFilter(ref cause) => cause,
-            DescribeInstancePatchStatesForPatchGroupError::InvalidNextToken(ref cause) => cause,
+            DescribeInstancePatchStatesForPatchGroupError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstancePatchStatesForPatchGroupError::InvalidFilter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInstancePatchStatesForPatchGroupError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeInstancePatchStatesForPatchGroupError {}
 /// Errors returned by DescribeInstancePatches
 #[derive(Debug, PartialEq)]
 pub enum DescribeInstancePatchesError {
@@ -9991,19 +9945,15 @@ impl DescribeInstancePatchesError {
 }
 impl fmt::Display for DescribeInstancePatchesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInstancePatchesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInstancePatchesError::InternalServerError(ref cause) => cause,
-            DescribeInstancePatchesError::InvalidFilter(ref cause) => cause,
-            DescribeInstancePatchesError::InvalidInstanceId(ref cause) => cause,
-            DescribeInstancePatchesError::InvalidNextToken(ref cause) => cause,
+            DescribeInstancePatchesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeInstancePatchesError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            DescribeInstancePatchesError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            DescribeInstancePatchesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInstancePatchesError {}
 /// Errors returned by DescribeInventoryDeletions
 #[derive(Debug, PartialEq)]
 pub enum DescribeInventoryDeletionsError {
@@ -10045,18 +9995,16 @@ impl DescribeInventoryDeletionsError {
 }
 impl fmt::Display for DescribeInventoryDeletionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeInventoryDeletionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeInventoryDeletionsError::InternalServerError(ref cause) => cause,
-            DescribeInventoryDeletionsError::InvalidDeletionId(ref cause) => cause,
-            DescribeInventoryDeletionsError::InvalidNextToken(ref cause) => cause,
+            DescribeInventoryDeletionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeInventoryDeletionsError::InvalidDeletionId(ref cause) => write!(f, "{}", cause),
+            DescribeInventoryDeletionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeInventoryDeletionsError {}
 /// Errors returned by DescribeMaintenanceWindowExecutionTaskInvocations
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowExecutionTaskInvocationsError {
@@ -10095,21 +10043,17 @@ impl DescribeMaintenanceWindowExecutionTaskInvocationsError {
 }
 impl fmt::Display for DescribeMaintenanceWindowExecutionTaskInvocationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowExecutionTaskInvocationsError {
-    fn description(&self) -> &str {
         match *self {
             DescribeMaintenanceWindowExecutionTaskInvocationsError::DoesNotExist(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             DescribeMaintenanceWindowExecutionTaskInvocationsError::InternalServerError(
                 ref cause,
-            ) => cause,
+            ) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeMaintenanceWindowExecutionTaskInvocationsError {}
 /// Errors returned by DescribeMaintenanceWindowExecutionTasks
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowExecutionTasksError {
@@ -10144,17 +10088,17 @@ impl DescribeMaintenanceWindowExecutionTasksError {
 }
 impl fmt::Display for DescribeMaintenanceWindowExecutionTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowExecutionTasksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceWindowExecutionTasksError::DoesNotExist(ref cause) => cause,
-            DescribeMaintenanceWindowExecutionTasksError::InternalServerError(ref cause) => cause,
+            DescribeMaintenanceWindowExecutionTasksError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMaintenanceWindowExecutionTasksError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceWindowExecutionTasksError {}
 /// Errors returned by DescribeMaintenanceWindowExecutions
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowExecutionsError {
@@ -10182,16 +10126,14 @@ impl DescribeMaintenanceWindowExecutionsError {
 }
 impl fmt::Display for DescribeMaintenanceWindowExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceWindowExecutionsError::InternalServerError(ref cause) => cause,
+            DescribeMaintenanceWindowExecutionsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceWindowExecutionsError {}
 /// Errors returned by DescribeMaintenanceWindowSchedule
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowScheduleError {
@@ -10226,17 +10168,17 @@ impl DescribeMaintenanceWindowScheduleError {
 }
 impl fmt::Display for DescribeMaintenanceWindowScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceWindowScheduleError::DoesNotExist(ref cause) => cause,
-            DescribeMaintenanceWindowScheduleError::InternalServerError(ref cause) => cause,
+            DescribeMaintenanceWindowScheduleError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMaintenanceWindowScheduleError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceWindowScheduleError {}
 /// Errors returned by DescribeMaintenanceWindowTargets
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowTargetsError {
@@ -10271,17 +10213,17 @@ impl DescribeMaintenanceWindowTargetsError {
 }
 impl fmt::Display for DescribeMaintenanceWindowTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceWindowTargetsError::DoesNotExist(ref cause) => cause,
-            DescribeMaintenanceWindowTargetsError::InternalServerError(ref cause) => cause,
+            DescribeMaintenanceWindowTargetsError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMaintenanceWindowTargetsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceWindowTargetsError {}
 /// Errors returned by DescribeMaintenanceWindowTasks
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowTasksError {
@@ -10316,17 +10258,15 @@ impl DescribeMaintenanceWindowTasksError {
 }
 impl fmt::Display for DescribeMaintenanceWindowTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowTasksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceWindowTasksError::DoesNotExist(ref cause) => cause,
-            DescribeMaintenanceWindowTasksError::InternalServerError(ref cause) => cause,
+            DescribeMaintenanceWindowTasksError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeMaintenanceWindowTasksError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceWindowTasksError {}
 /// Errors returned by DescribeMaintenanceWindows
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowsError {
@@ -10354,16 +10294,14 @@ impl DescribeMaintenanceWindowsError {
 }
 impl fmt::Display for DescribeMaintenanceWindowsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceWindowsError::InternalServerError(ref cause) => cause,
+            DescribeMaintenanceWindowsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceWindowsError {}
 /// Errors returned by DescribeMaintenanceWindowsForTarget
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceWindowsForTargetError {
@@ -10391,16 +10329,14 @@ impl DescribeMaintenanceWindowsForTargetError {
 }
 impl fmt::Display for DescribeMaintenanceWindowsForTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceWindowsForTargetError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceWindowsForTargetError::InternalServerError(ref cause) => cause,
+            DescribeMaintenanceWindowsForTargetError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceWindowsForTargetError {}
 /// Errors returned by DescribeOpsItems
 #[derive(Debug, PartialEq)]
 pub enum DescribeOpsItemsError {
@@ -10426,16 +10362,12 @@ impl DescribeOpsItemsError {
 }
 impl fmt::Display for DescribeOpsItemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOpsItemsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOpsItemsError::InternalServerError(ref cause) => cause,
+            DescribeOpsItemsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeOpsItemsError {}
 /// Errors returned by DescribeParameters
 #[derive(Debug, PartialEq)]
 pub enum DescribeParametersError {
@@ -10485,20 +10417,16 @@ impl DescribeParametersError {
 }
 impl fmt::Display for DescribeParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeParametersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeParametersError::InternalServerError(ref cause) => cause,
-            DescribeParametersError::InvalidFilterKey(ref cause) => cause,
-            DescribeParametersError::InvalidFilterOption(ref cause) => cause,
-            DescribeParametersError::InvalidFilterValue(ref cause) => cause,
-            DescribeParametersError::InvalidNextToken(ref cause) => cause,
+            DescribeParametersError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeParametersError::InvalidFilterKey(ref cause) => write!(f, "{}", cause),
+            DescribeParametersError::InvalidFilterOption(ref cause) => write!(f, "{}", cause),
+            DescribeParametersError::InvalidFilterValue(ref cause) => write!(f, "{}", cause),
+            DescribeParametersError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeParametersError {}
 /// Errors returned by DescribePatchBaselines
 #[derive(Debug, PartialEq)]
 pub enum DescribePatchBaselinesError {
@@ -10524,16 +10452,12 @@ impl DescribePatchBaselinesError {
 }
 impl fmt::Display for DescribePatchBaselinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePatchBaselinesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePatchBaselinesError::InternalServerError(ref cause) => cause,
+            DescribePatchBaselinesError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePatchBaselinesError {}
 /// Errors returned by DescribePatchGroupState
 #[derive(Debug, PartialEq)]
 pub enum DescribePatchGroupStateError {
@@ -10566,17 +10490,13 @@ impl DescribePatchGroupStateError {
 }
 impl fmt::Display for DescribePatchGroupStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePatchGroupStateError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePatchGroupStateError::InternalServerError(ref cause) => cause,
-            DescribePatchGroupStateError::InvalidNextToken(ref cause) => cause,
+            DescribePatchGroupStateError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribePatchGroupStateError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePatchGroupStateError {}
 /// Errors returned by DescribePatchGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribePatchGroupsError {
@@ -10602,16 +10522,12 @@ impl DescribePatchGroupsError {
 }
 impl fmt::Display for DescribePatchGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePatchGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePatchGroupsError::InternalServerError(ref cause) => cause,
+            DescribePatchGroupsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePatchGroupsError {}
 /// Errors returned by DescribePatchProperties
 #[derive(Debug, PartialEq)]
 pub enum DescribePatchPropertiesError {
@@ -10637,16 +10553,12 @@ impl DescribePatchPropertiesError {
 }
 impl fmt::Display for DescribePatchPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribePatchPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribePatchPropertiesError::InternalServerError(ref cause) => cause,
+            DescribePatchPropertiesError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribePatchPropertiesError {}
 /// Errors returned by DescribeSessions
 #[derive(Debug, PartialEq)]
 pub enum DescribeSessionsError {
@@ -10682,18 +10594,14 @@ impl DescribeSessionsError {
 }
 impl fmt::Display for DescribeSessionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSessionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSessionsError::InternalServerError(ref cause) => cause,
-            DescribeSessionsError::InvalidFilterKey(ref cause) => cause,
-            DescribeSessionsError::InvalidNextToken(ref cause) => cause,
+            DescribeSessionsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeSessionsError::InvalidFilterKey(ref cause) => write!(f, "{}", cause),
+            DescribeSessionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSessionsError {}
 /// Errors returned by GetAutomationExecution
 #[derive(Debug, PartialEq)]
 pub enum GetAutomationExecutionError {
@@ -10726,17 +10634,15 @@ impl GetAutomationExecutionError {
 }
 impl fmt::Display for GetAutomationExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAutomationExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            GetAutomationExecutionError::AutomationExecutionNotFound(ref cause) => cause,
-            GetAutomationExecutionError::InternalServerError(ref cause) => cause,
+            GetAutomationExecutionError::AutomationExecutionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetAutomationExecutionError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetAutomationExecutionError {}
 /// Errors returned by GetCommandInvocation
 #[derive(Debug, PartialEq)]
 pub enum GetCommandInvocationError {
@@ -10790,20 +10696,16 @@ impl GetCommandInvocationError {
 }
 impl fmt::Display for GetCommandInvocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCommandInvocationError {
-    fn description(&self) -> &str {
         match *self {
-            GetCommandInvocationError::InternalServerError(ref cause) => cause,
-            GetCommandInvocationError::InvalidCommandId(ref cause) => cause,
-            GetCommandInvocationError::InvalidInstanceId(ref cause) => cause,
-            GetCommandInvocationError::InvalidPluginName(ref cause) => cause,
-            GetCommandInvocationError::InvocationDoesNotExist(ref cause) => cause,
+            GetCommandInvocationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetCommandInvocationError::InvalidCommandId(ref cause) => write!(f, "{}", cause),
+            GetCommandInvocationError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            GetCommandInvocationError::InvalidPluginName(ref cause) => write!(f, "{}", cause),
+            GetCommandInvocationError::InvocationDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCommandInvocationError {}
 /// Errors returned by GetConnectionStatus
 #[derive(Debug, PartialEq)]
 pub enum GetConnectionStatusError {
@@ -10829,16 +10731,12 @@ impl GetConnectionStatusError {
 }
 impl fmt::Display for GetConnectionStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetConnectionStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetConnectionStatusError::InternalServerError(ref cause) => cause,
+            GetConnectionStatusError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetConnectionStatusError {}
 /// Errors returned by GetDefaultPatchBaseline
 #[derive(Debug, PartialEq)]
 pub enum GetDefaultPatchBaselineError {
@@ -10864,16 +10762,12 @@ impl GetDefaultPatchBaselineError {
 }
 impl fmt::Display for GetDefaultPatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDefaultPatchBaselineError {
-    fn description(&self) -> &str {
         match *self {
-            GetDefaultPatchBaselineError::InternalServerError(ref cause) => cause,
+            GetDefaultPatchBaselineError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDefaultPatchBaselineError {}
 /// Errors returned by GetDeployablePatchSnapshotForInstance
 #[derive(Debug, PartialEq)]
 pub enum GetDeployablePatchSnapshotForInstanceError {
@@ -10919,22 +10813,20 @@ impl GetDeployablePatchSnapshotForInstanceError {
 }
 impl fmt::Display for GetDeployablePatchSnapshotForInstanceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDeployablePatchSnapshotForInstanceError {
-    fn description(&self) -> &str {
         match *self {
-            GetDeployablePatchSnapshotForInstanceError::InternalServerError(ref cause) => cause,
+            GetDeployablePatchSnapshotForInstanceError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetDeployablePatchSnapshotForInstanceError::UnsupportedFeatureRequired(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
             GetDeployablePatchSnapshotForInstanceError::UnsupportedOperatingSystem(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GetDeployablePatchSnapshotForInstanceError {}
 /// Errors returned by GetDocument
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentError {
@@ -10968,18 +10860,14 @@ impl GetDocumentError {
 }
 impl fmt::Display for GetDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentError::InternalServerError(ref cause) => cause,
-            GetDocumentError::InvalidDocument(ref cause) => cause,
-            GetDocumentError::InvalidDocumentVersion(ref cause) => cause,
+            GetDocumentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::InvalidDocumentVersion(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentError {}
 /// Errors returned by GetInventory
 #[derive(Debug, PartialEq)]
 pub enum GetInventoryError {
@@ -11033,22 +10921,18 @@ impl GetInventoryError {
 }
 impl fmt::Display for GetInventoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInventoryError {
-    fn description(&self) -> &str {
         match *self {
-            GetInventoryError::InternalServerError(ref cause) => cause,
-            GetInventoryError::InvalidAggregator(ref cause) => cause,
-            GetInventoryError::InvalidFilter(ref cause) => cause,
-            GetInventoryError::InvalidInventoryGroup(ref cause) => cause,
-            GetInventoryError::InvalidNextToken(ref cause) => cause,
-            GetInventoryError::InvalidResultAttribute(ref cause) => cause,
-            GetInventoryError::InvalidTypeName(ref cause) => cause,
+            GetInventoryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetInventoryError::InvalidAggregator(ref cause) => write!(f, "{}", cause),
+            GetInventoryError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            GetInventoryError::InvalidInventoryGroup(ref cause) => write!(f, "{}", cause),
+            GetInventoryError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetInventoryError::InvalidResultAttribute(ref cause) => write!(f, "{}", cause),
+            GetInventoryError::InvalidTypeName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInventoryError {}
 /// Errors returned by GetInventorySchema
 #[derive(Debug, PartialEq)]
 pub enum GetInventorySchemaError {
@@ -11084,18 +10968,14 @@ impl GetInventorySchemaError {
 }
 impl fmt::Display for GetInventorySchemaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetInventorySchemaError {
-    fn description(&self) -> &str {
         match *self {
-            GetInventorySchemaError::InternalServerError(ref cause) => cause,
-            GetInventorySchemaError::InvalidNextToken(ref cause) => cause,
-            GetInventorySchemaError::InvalidTypeName(ref cause) => cause,
+            GetInventorySchemaError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetInventorySchemaError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetInventorySchemaError::InvalidTypeName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetInventorySchemaError {}
 /// Errors returned by GetMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum GetMaintenanceWindowError {
@@ -11126,17 +11006,13 @@ impl GetMaintenanceWindowError {
 }
 impl fmt::Display for GetMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            GetMaintenanceWindowError::DoesNotExist(ref cause) => cause,
-            GetMaintenanceWindowError::InternalServerError(ref cause) => cause,
+            GetMaintenanceWindowError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMaintenanceWindowError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMaintenanceWindowError {}
 /// Errors returned by GetMaintenanceWindowExecution
 #[derive(Debug, PartialEq)]
 pub enum GetMaintenanceWindowExecutionError {
@@ -11171,17 +11047,15 @@ impl GetMaintenanceWindowExecutionError {
 }
 impl fmt::Display for GetMaintenanceWindowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMaintenanceWindowExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            GetMaintenanceWindowExecutionError::DoesNotExist(ref cause) => cause,
-            GetMaintenanceWindowExecutionError::InternalServerError(ref cause) => cause,
+            GetMaintenanceWindowExecutionError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMaintenanceWindowExecutionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetMaintenanceWindowExecutionError {}
 /// Errors returned by GetMaintenanceWindowExecutionTask
 #[derive(Debug, PartialEq)]
 pub enum GetMaintenanceWindowExecutionTaskError {
@@ -11216,17 +11090,17 @@ impl GetMaintenanceWindowExecutionTaskError {
 }
 impl fmt::Display for GetMaintenanceWindowExecutionTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMaintenanceWindowExecutionTaskError {
-    fn description(&self) -> &str {
         match *self {
-            GetMaintenanceWindowExecutionTaskError::DoesNotExist(ref cause) => cause,
-            GetMaintenanceWindowExecutionTaskError::InternalServerError(ref cause) => cause,
+            GetMaintenanceWindowExecutionTaskError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetMaintenanceWindowExecutionTaskError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetMaintenanceWindowExecutionTaskError {}
 /// Errors returned by GetMaintenanceWindowExecutionTaskInvocation
 #[derive(Debug, PartialEq)]
 pub enum GetMaintenanceWindowExecutionTaskInvocationError {
@@ -11263,19 +11137,17 @@ impl GetMaintenanceWindowExecutionTaskInvocationError {
 }
 impl fmt::Display for GetMaintenanceWindowExecutionTaskInvocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMaintenanceWindowExecutionTaskInvocationError {
-    fn description(&self) -> &str {
         match *self {
-            GetMaintenanceWindowExecutionTaskInvocationError::DoesNotExist(ref cause) => cause,
+            GetMaintenanceWindowExecutionTaskInvocationError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
             GetMaintenanceWindowExecutionTaskInvocationError::InternalServerError(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for GetMaintenanceWindowExecutionTaskInvocationError {}
 /// Errors returned by GetMaintenanceWindowTask
 #[derive(Debug, PartialEq)]
 pub enum GetMaintenanceWindowTaskError {
@@ -11308,17 +11180,13 @@ impl GetMaintenanceWindowTaskError {
 }
 impl fmt::Display for GetMaintenanceWindowTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMaintenanceWindowTaskError {
-    fn description(&self) -> &str {
         match *self {
-            GetMaintenanceWindowTaskError::DoesNotExist(ref cause) => cause,
-            GetMaintenanceWindowTaskError::InternalServerError(ref cause) => cause,
+            GetMaintenanceWindowTaskError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetMaintenanceWindowTaskError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMaintenanceWindowTaskError {}
 /// Errors returned by GetOpsItem
 #[derive(Debug, PartialEq)]
 pub enum GetOpsItemError {
@@ -11347,17 +11215,13 @@ impl GetOpsItemError {
 }
 impl fmt::Display for GetOpsItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOpsItemError {
-    fn description(&self) -> &str {
         match *self {
-            GetOpsItemError::InternalServerError(ref cause) => cause,
-            GetOpsItemError::OpsItemNotFound(ref cause) => cause,
+            GetOpsItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetOpsItemError::OpsItemNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOpsItemError {}
 /// Errors returned by GetOpsSummary
 #[derive(Debug, PartialEq)]
 pub enum GetOpsSummaryError {
@@ -11408,21 +11272,17 @@ impl GetOpsSummaryError {
 }
 impl fmt::Display for GetOpsSummaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetOpsSummaryError {
-    fn description(&self) -> &str {
         match *self {
-            GetOpsSummaryError::InternalServerError(ref cause) => cause,
-            GetOpsSummaryError::InvalidAggregator(ref cause) => cause,
-            GetOpsSummaryError::InvalidFilter(ref cause) => cause,
-            GetOpsSummaryError::InvalidNextToken(ref cause) => cause,
-            GetOpsSummaryError::InvalidTypeName(ref cause) => cause,
-            GetOpsSummaryError::ResourceDataSyncNotFound(ref cause) => cause,
+            GetOpsSummaryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetOpsSummaryError::InvalidAggregator(ref cause) => write!(f, "{}", cause),
+            GetOpsSummaryError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            GetOpsSummaryError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetOpsSummaryError::InvalidTypeName(ref cause) => write!(f, "{}", cause),
+            GetOpsSummaryError::ResourceDataSyncNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetOpsSummaryError {}
 /// Errors returned by GetParameter
 #[derive(Debug, PartialEq)]
 pub enum GetParameterError {
@@ -11463,19 +11323,15 @@ impl GetParameterError {
 }
 impl fmt::Display for GetParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetParameterError {
-    fn description(&self) -> &str {
         match *self {
-            GetParameterError::InternalServerError(ref cause) => cause,
-            GetParameterError::InvalidKeyId(ref cause) => cause,
-            GetParameterError::ParameterNotFound(ref cause) => cause,
-            GetParameterError::ParameterVersionNotFound(ref cause) => cause,
+            GetParameterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetParameterError::InvalidKeyId(ref cause) => write!(f, "{}", cause),
+            GetParameterError::ParameterNotFound(ref cause) => write!(f, "{}", cause),
+            GetParameterError::ParameterVersionNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetParameterError {}
 /// Errors returned by GetParameterHistory
 #[derive(Debug, PartialEq)]
 pub enum GetParameterHistoryError {
@@ -11520,19 +11376,15 @@ impl GetParameterHistoryError {
 }
 impl fmt::Display for GetParameterHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetParameterHistoryError {
-    fn description(&self) -> &str {
         match *self {
-            GetParameterHistoryError::InternalServerError(ref cause) => cause,
-            GetParameterHistoryError::InvalidKeyId(ref cause) => cause,
-            GetParameterHistoryError::InvalidNextToken(ref cause) => cause,
-            GetParameterHistoryError::ParameterNotFound(ref cause) => cause,
+            GetParameterHistoryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetParameterHistoryError::InvalidKeyId(ref cause) => write!(f, "{}", cause),
+            GetParameterHistoryError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            GetParameterHistoryError::ParameterNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetParameterHistoryError {}
 /// Errors returned by GetParameters
 #[derive(Debug, PartialEq)]
 pub enum GetParametersError {
@@ -11561,17 +11413,13 @@ impl GetParametersError {
 }
 impl fmt::Display for GetParametersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetParametersError {
-    fn description(&self) -> &str {
         match *self {
-            GetParametersError::InternalServerError(ref cause) => cause,
-            GetParametersError::InvalidKeyId(ref cause) => cause,
+            GetParametersError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetParametersError::InvalidKeyId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetParametersError {}
 /// Errors returned by GetParametersByPath
 #[derive(Debug, PartialEq)]
 pub enum GetParametersByPathError {
@@ -11630,21 +11478,17 @@ impl GetParametersByPathError {
 }
 impl fmt::Display for GetParametersByPathError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetParametersByPathError {
-    fn description(&self) -> &str {
         match *self {
-            GetParametersByPathError::InternalServerError(ref cause) => cause,
-            GetParametersByPathError::InvalidFilterKey(ref cause) => cause,
-            GetParametersByPathError::InvalidFilterOption(ref cause) => cause,
-            GetParametersByPathError::InvalidFilterValue(ref cause) => cause,
-            GetParametersByPathError::InvalidKeyId(ref cause) => cause,
-            GetParametersByPathError::InvalidNextToken(ref cause) => cause,
+            GetParametersByPathError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetParametersByPathError::InvalidFilterKey(ref cause) => write!(f, "{}", cause),
+            GetParametersByPathError::InvalidFilterOption(ref cause) => write!(f, "{}", cause),
+            GetParametersByPathError::InvalidFilterValue(ref cause) => write!(f, "{}", cause),
+            GetParametersByPathError::InvalidKeyId(ref cause) => write!(f, "{}", cause),
+            GetParametersByPathError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetParametersByPathError {}
 /// Errors returned by GetPatchBaseline
 #[derive(Debug, PartialEq)]
 pub enum GetPatchBaselineError {
@@ -11680,18 +11524,14 @@ impl GetPatchBaselineError {
 }
 impl fmt::Display for GetPatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPatchBaselineError {
-    fn description(&self) -> &str {
         match *self {
-            GetPatchBaselineError::DoesNotExist(ref cause) => cause,
-            GetPatchBaselineError::InternalServerError(ref cause) => cause,
-            GetPatchBaselineError::InvalidResourceId(ref cause) => cause,
+            GetPatchBaselineError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetPatchBaselineError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetPatchBaselineError::InvalidResourceId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPatchBaselineError {}
 /// Errors returned by GetPatchBaselineForPatchGroup
 #[derive(Debug, PartialEq)]
 pub enum GetPatchBaselineForPatchGroupError {
@@ -11719,16 +11559,14 @@ impl GetPatchBaselineForPatchGroupError {
 }
 impl fmt::Display for GetPatchBaselineForPatchGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPatchBaselineForPatchGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetPatchBaselineForPatchGroupError::InternalServerError(ref cause) => cause,
+            GetPatchBaselineForPatchGroupError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetPatchBaselineForPatchGroupError {}
 /// Errors returned by GetServiceSetting
 #[derive(Debug, PartialEq)]
 pub enum GetServiceSettingError {
@@ -11761,17 +11599,13 @@ impl GetServiceSettingError {
 }
 impl fmt::Display for GetServiceSettingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceSettingError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceSettingError::InternalServerError(ref cause) => cause,
-            GetServiceSettingError::ServiceSettingNotFound(ref cause) => cause,
+            GetServiceSettingError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetServiceSettingError::ServiceSettingNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServiceSettingError {}
 /// Errors returned by LabelParameterVersion
 #[derive(Debug, PartialEq)]
 pub enum LabelParameterVersionError {
@@ -11825,20 +11659,20 @@ impl LabelParameterVersionError {
 }
 impl fmt::Display for LabelParameterVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for LabelParameterVersionError {
-    fn description(&self) -> &str {
         match *self {
-            LabelParameterVersionError::InternalServerError(ref cause) => cause,
-            LabelParameterVersionError::ParameterNotFound(ref cause) => cause,
-            LabelParameterVersionError::ParameterVersionLabelLimitExceeded(ref cause) => cause,
-            LabelParameterVersionError::ParameterVersionNotFound(ref cause) => cause,
-            LabelParameterVersionError::TooManyUpdates(ref cause) => cause,
+            LabelParameterVersionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            LabelParameterVersionError::ParameterNotFound(ref cause) => write!(f, "{}", cause),
+            LabelParameterVersionError::ParameterVersionLabelLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            LabelParameterVersionError::ParameterVersionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            LabelParameterVersionError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for LabelParameterVersionError {}
 /// Errors returned by ListAssociationVersions
 #[derive(Debug, PartialEq)]
 pub enum ListAssociationVersionsError {
@@ -11878,18 +11712,16 @@ impl ListAssociationVersionsError {
 }
 impl fmt::Display for ListAssociationVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssociationVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssociationVersionsError::AssociationDoesNotExist(ref cause) => cause,
-            ListAssociationVersionsError::InternalServerError(ref cause) => cause,
-            ListAssociationVersionsError::InvalidNextToken(ref cause) => cause,
+            ListAssociationVersionsError::AssociationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAssociationVersionsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListAssociationVersionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAssociationVersionsError {}
 /// Errors returned by ListAssociations
 #[derive(Debug, PartialEq)]
 pub enum ListAssociationsError {
@@ -11920,17 +11752,13 @@ impl ListAssociationsError {
 }
 impl fmt::Display for ListAssociationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAssociationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListAssociationsError::InternalServerError(ref cause) => cause,
-            ListAssociationsError::InvalidNextToken(ref cause) => cause,
+            ListAssociationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListAssociationsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAssociationsError {}
 /// Errors returned by ListCommandInvocations
 #[derive(Debug, PartialEq)]
 pub enum ListCommandInvocationsError {
@@ -11984,20 +11812,16 @@ impl ListCommandInvocationsError {
 }
 impl fmt::Display for ListCommandInvocationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCommandInvocationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListCommandInvocationsError::InternalServerError(ref cause) => cause,
-            ListCommandInvocationsError::InvalidCommandId(ref cause) => cause,
-            ListCommandInvocationsError::InvalidFilterKey(ref cause) => cause,
-            ListCommandInvocationsError::InvalidInstanceId(ref cause) => cause,
-            ListCommandInvocationsError::InvalidNextToken(ref cause) => cause,
+            ListCommandInvocationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListCommandInvocationsError::InvalidCommandId(ref cause) => write!(f, "{}", cause),
+            ListCommandInvocationsError::InvalidFilterKey(ref cause) => write!(f, "{}", cause),
+            ListCommandInvocationsError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            ListCommandInvocationsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCommandInvocationsError {}
 /// Errors returned by ListCommands
 #[derive(Debug, PartialEq)]
 pub enum ListCommandsError {
@@ -12041,20 +11865,16 @@ impl ListCommandsError {
 }
 impl fmt::Display for ListCommandsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListCommandsError {
-    fn description(&self) -> &str {
         match *self {
-            ListCommandsError::InternalServerError(ref cause) => cause,
-            ListCommandsError::InvalidCommandId(ref cause) => cause,
-            ListCommandsError::InvalidFilterKey(ref cause) => cause,
-            ListCommandsError::InvalidInstanceId(ref cause) => cause,
-            ListCommandsError::InvalidNextToken(ref cause) => cause,
+            ListCommandsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListCommandsError::InvalidCommandId(ref cause) => write!(f, "{}", cause),
+            ListCommandsError::InvalidFilterKey(ref cause) => write!(f, "{}", cause),
+            ListCommandsError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            ListCommandsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListCommandsError {}
 /// Errors returned by ListComplianceItems
 #[derive(Debug, PartialEq)]
 pub enum ListComplianceItemsError {
@@ -12106,20 +11926,16 @@ impl ListComplianceItemsError {
 }
 impl fmt::Display for ListComplianceItemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListComplianceItemsError {
-    fn description(&self) -> &str {
         match *self {
-            ListComplianceItemsError::InternalServerError(ref cause) => cause,
-            ListComplianceItemsError::InvalidFilter(ref cause) => cause,
-            ListComplianceItemsError::InvalidNextToken(ref cause) => cause,
-            ListComplianceItemsError::InvalidResourceId(ref cause) => cause,
-            ListComplianceItemsError::InvalidResourceType(ref cause) => cause,
+            ListComplianceItemsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListComplianceItemsError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListComplianceItemsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListComplianceItemsError::InvalidResourceId(ref cause) => write!(f, "{}", cause),
+            ListComplianceItemsError::InvalidResourceType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListComplianceItemsError {}
 /// Errors returned by ListComplianceSummaries
 #[derive(Debug, PartialEq)]
 pub enum ListComplianceSummariesError {
@@ -12159,18 +11975,14 @@ impl ListComplianceSummariesError {
 }
 impl fmt::Display for ListComplianceSummariesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListComplianceSummariesError {
-    fn description(&self) -> &str {
         match *self {
-            ListComplianceSummariesError::InternalServerError(ref cause) => cause,
-            ListComplianceSummariesError::InvalidFilter(ref cause) => cause,
-            ListComplianceSummariesError::InvalidNextToken(ref cause) => cause,
+            ListComplianceSummariesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListComplianceSummariesError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListComplianceSummariesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListComplianceSummariesError {}
 /// Errors returned by ListDocumentVersions
 #[derive(Debug, PartialEq)]
 pub enum ListDocumentVersionsError {
@@ -12210,18 +12022,14 @@ impl ListDocumentVersionsError {
 }
 impl fmt::Display for ListDocumentVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDocumentVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDocumentVersionsError::InternalServerError(ref cause) => cause,
-            ListDocumentVersionsError::InvalidDocument(ref cause) => cause,
-            ListDocumentVersionsError::InvalidNextToken(ref cause) => cause,
+            ListDocumentVersionsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListDocumentVersionsError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            ListDocumentVersionsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDocumentVersionsError {}
 /// Errors returned by ListDocuments
 #[derive(Debug, PartialEq)]
 pub enum ListDocumentsError {
@@ -12255,18 +12063,14 @@ impl ListDocumentsError {
 }
 impl fmt::Display for ListDocumentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDocumentsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDocumentsError::InternalServerError(ref cause) => cause,
-            ListDocumentsError::InvalidFilterKey(ref cause) => cause,
-            ListDocumentsError::InvalidNextToken(ref cause) => cause,
+            ListDocumentsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListDocumentsError::InvalidFilterKey(ref cause) => write!(f, "{}", cause),
+            ListDocumentsError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDocumentsError {}
 /// Errors returned by ListInventoryEntries
 #[derive(Debug, PartialEq)]
 pub enum ListInventoryEntriesError {
@@ -12318,20 +12122,16 @@ impl ListInventoryEntriesError {
 }
 impl fmt::Display for ListInventoryEntriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListInventoryEntriesError {
-    fn description(&self) -> &str {
         match *self {
-            ListInventoryEntriesError::InternalServerError(ref cause) => cause,
-            ListInventoryEntriesError::InvalidFilter(ref cause) => cause,
-            ListInventoryEntriesError::InvalidInstanceId(ref cause) => cause,
-            ListInventoryEntriesError::InvalidNextToken(ref cause) => cause,
-            ListInventoryEntriesError::InvalidTypeName(ref cause) => cause,
+            ListInventoryEntriesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListInventoryEntriesError::InvalidFilter(ref cause) => write!(f, "{}", cause),
+            ListInventoryEntriesError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            ListInventoryEntriesError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListInventoryEntriesError::InvalidTypeName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListInventoryEntriesError {}
 /// Errors returned by ListResourceComplianceSummaries
 #[derive(Debug, PartialEq)]
 pub enum ListResourceComplianceSummariesError {
@@ -12373,18 +12173,20 @@ impl ListResourceComplianceSummariesError {
 }
 impl fmt::Display for ListResourceComplianceSummariesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceComplianceSummariesError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceComplianceSummariesError::InternalServerError(ref cause) => cause,
-            ListResourceComplianceSummariesError::InvalidFilter(ref cause) => cause,
-            ListResourceComplianceSummariesError::InvalidNextToken(ref cause) => cause,
+            ListResourceComplianceSummariesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListResourceComplianceSummariesError::InvalidFilter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListResourceComplianceSummariesError::InvalidNextToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListResourceComplianceSummariesError {}
 /// Errors returned by ListResourceDataSync
 #[derive(Debug, PartialEq)]
 pub enum ListResourceDataSyncError {
@@ -12424,18 +12226,16 @@ impl ListResourceDataSyncError {
 }
 impl fmt::Display for ListResourceDataSyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceDataSyncError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceDataSyncError::InternalServerError(ref cause) => cause,
-            ListResourceDataSyncError::InvalidNextToken(ref cause) => cause,
-            ListResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => cause,
+            ListResourceDataSyncError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListResourceDataSyncError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListResourceDataSyncError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -12475,18 +12275,14 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
-            ListTagsForResourceError::InvalidResourceId(ref cause) => cause,
-            ListTagsForResourceError::InvalidResourceType(ref cause) => cause,
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidResourceId(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidResourceType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ModifyDocumentPermission
 #[derive(Debug, PartialEq)]
 pub enum ModifyDocumentPermissionError {
@@ -12540,20 +12336,22 @@ impl ModifyDocumentPermissionError {
 }
 impl fmt::Display for ModifyDocumentPermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyDocumentPermissionError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyDocumentPermissionError::DocumentLimitExceeded(ref cause) => cause,
-            ModifyDocumentPermissionError::DocumentPermissionLimit(ref cause) => cause,
-            ModifyDocumentPermissionError::InternalServerError(ref cause) => cause,
-            ModifyDocumentPermissionError::InvalidDocument(ref cause) => cause,
-            ModifyDocumentPermissionError::InvalidPermissionType(ref cause) => cause,
+            ModifyDocumentPermissionError::DocumentLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDocumentPermissionError::DocumentPermissionLimit(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyDocumentPermissionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ModifyDocumentPermissionError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            ModifyDocumentPermissionError::InvalidPermissionType(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyDocumentPermissionError {}
 /// Errors returned by PutComplianceItems
 #[derive(Debug, PartialEq)]
 pub enum PutComplianceItemsError {
@@ -12621,22 +12419,20 @@ impl PutComplianceItemsError {
 }
 impl fmt::Display for PutComplianceItemsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutComplianceItemsError {
-    fn description(&self) -> &str {
         match *self {
-            PutComplianceItemsError::ComplianceTypeCountLimitExceeded(ref cause) => cause,
-            PutComplianceItemsError::InternalServerError(ref cause) => cause,
-            PutComplianceItemsError::InvalidItemContent(ref cause) => cause,
-            PutComplianceItemsError::InvalidResourceId(ref cause) => cause,
-            PutComplianceItemsError::InvalidResourceType(ref cause) => cause,
-            PutComplianceItemsError::ItemSizeLimitExceeded(ref cause) => cause,
-            PutComplianceItemsError::TotalSizeLimitExceeded(ref cause) => cause,
+            PutComplianceItemsError::ComplianceTypeCountLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutComplianceItemsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            PutComplianceItemsError::InvalidItemContent(ref cause) => write!(f, "{}", cause),
+            PutComplianceItemsError::InvalidResourceId(ref cause) => write!(f, "{}", cause),
+            PutComplianceItemsError::InvalidResourceType(ref cause) => write!(f, "{}", cause),
+            PutComplianceItemsError::ItemSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutComplianceItemsError::TotalSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutComplianceItemsError {}
 /// Errors returned by PutInventory
 #[derive(Debug, PartialEq)]
 pub enum PutInventoryError {
@@ -12725,27 +12521,25 @@ impl PutInventoryError {
 }
 impl fmt::Display for PutInventoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutInventoryError {
-    fn description(&self) -> &str {
         match *self {
-            PutInventoryError::CustomSchemaCountLimitExceeded(ref cause) => cause,
-            PutInventoryError::InternalServerError(ref cause) => cause,
-            PutInventoryError::InvalidInstanceId(ref cause) => cause,
-            PutInventoryError::InvalidInventoryItemContext(ref cause) => cause,
-            PutInventoryError::InvalidItemContent(ref cause) => cause,
-            PutInventoryError::InvalidTypeName(ref cause) => cause,
-            PutInventoryError::ItemContentMismatch(ref cause) => cause,
-            PutInventoryError::ItemSizeLimitExceeded(ref cause) => cause,
-            PutInventoryError::SubTypeCountLimitExceeded(ref cause) => cause,
-            PutInventoryError::TotalSizeLimitExceeded(ref cause) => cause,
-            PutInventoryError::UnsupportedInventoryItemContext(ref cause) => cause,
-            PutInventoryError::UnsupportedInventorySchemaVersion(ref cause) => cause,
+            PutInventoryError::CustomSchemaCountLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::InvalidInventoryItemContext(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::InvalidItemContent(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::InvalidTypeName(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::ItemContentMismatch(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::ItemSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::SubTypeCountLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::TotalSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::UnsupportedInventoryItemContext(ref cause) => write!(f, "{}", cause),
+            PutInventoryError::UnsupportedInventorySchemaVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for PutInventoryError {}
 /// Errors returned by PutParameter
 #[derive(Debug, PartialEq)]
 pub enum PutParameterError {
@@ -12847,30 +12641,28 @@ impl PutParameterError {
 }
 impl fmt::Display for PutParameterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutParameterError {
-    fn description(&self) -> &str {
         match *self {
-            PutParameterError::HierarchyLevelLimitExceeded(ref cause) => cause,
-            PutParameterError::HierarchyTypeMismatch(ref cause) => cause,
-            PutParameterError::IncompatiblePolicy(ref cause) => cause,
-            PutParameterError::InternalServerError(ref cause) => cause,
-            PutParameterError::InvalidAllowedPattern(ref cause) => cause,
-            PutParameterError::InvalidKeyId(ref cause) => cause,
-            PutParameterError::InvalidPolicyAttribute(ref cause) => cause,
-            PutParameterError::InvalidPolicyType(ref cause) => cause,
-            PutParameterError::ParameterAlreadyExists(ref cause) => cause,
-            PutParameterError::ParameterLimitExceeded(ref cause) => cause,
-            PutParameterError::ParameterMaxVersionLimitExceeded(ref cause) => cause,
-            PutParameterError::ParameterPatternMismatch(ref cause) => cause,
-            PutParameterError::PoliciesLimitExceeded(ref cause) => cause,
-            PutParameterError::TooManyUpdates(ref cause) => cause,
-            PutParameterError::UnsupportedParameterType(ref cause) => cause,
+            PutParameterError::HierarchyLevelLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutParameterError::HierarchyTypeMismatch(ref cause) => write!(f, "{}", cause),
+            PutParameterError::IncompatiblePolicy(ref cause) => write!(f, "{}", cause),
+            PutParameterError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            PutParameterError::InvalidAllowedPattern(ref cause) => write!(f, "{}", cause),
+            PutParameterError::InvalidKeyId(ref cause) => write!(f, "{}", cause),
+            PutParameterError::InvalidPolicyAttribute(ref cause) => write!(f, "{}", cause),
+            PutParameterError::InvalidPolicyType(ref cause) => write!(f, "{}", cause),
+            PutParameterError::ParameterAlreadyExists(ref cause) => write!(f, "{}", cause),
+            PutParameterError::ParameterLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutParameterError::ParameterMaxVersionLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutParameterError::ParameterPatternMismatch(ref cause) => write!(f, "{}", cause),
+            PutParameterError::PoliciesLimitExceeded(ref cause) => write!(f, "{}", cause),
+            PutParameterError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
+            PutParameterError::UnsupportedParameterType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutParameterError {}
 /// Errors returned by RegisterDefaultPatchBaseline
 #[derive(Debug, PartialEq)]
 pub enum RegisterDefaultPatchBaselineError {
@@ -12912,18 +12704,18 @@ impl RegisterDefaultPatchBaselineError {
 }
 impl fmt::Display for RegisterDefaultPatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterDefaultPatchBaselineError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterDefaultPatchBaselineError::DoesNotExist(ref cause) => cause,
-            RegisterDefaultPatchBaselineError::InternalServerError(ref cause) => cause,
-            RegisterDefaultPatchBaselineError::InvalidResourceId(ref cause) => cause,
+            RegisterDefaultPatchBaselineError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            RegisterDefaultPatchBaselineError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterDefaultPatchBaselineError::InvalidResourceId(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterDefaultPatchBaselineError {}
 /// Errors returned by RegisterPatchBaselineForPatchGroup
 #[derive(Debug, PartialEq)]
 pub enum RegisterPatchBaselineForPatchGroupError {
@@ -12979,20 +12771,26 @@ impl RegisterPatchBaselineForPatchGroupError {
 }
 impl fmt::Display for RegisterPatchBaselineForPatchGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterPatchBaselineForPatchGroupError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterPatchBaselineForPatchGroupError::AlreadyExists(ref cause) => cause,
-            RegisterPatchBaselineForPatchGroupError::DoesNotExist(ref cause) => cause,
-            RegisterPatchBaselineForPatchGroupError::InternalServerError(ref cause) => cause,
-            RegisterPatchBaselineForPatchGroupError::InvalidResourceId(ref cause) => cause,
-            RegisterPatchBaselineForPatchGroupError::ResourceLimitExceeded(ref cause) => cause,
+            RegisterPatchBaselineForPatchGroupError::AlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterPatchBaselineForPatchGroupError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterPatchBaselineForPatchGroupError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterPatchBaselineForPatchGroupError::InvalidResourceId(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterPatchBaselineForPatchGroupError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterPatchBaselineForPatchGroupError {}
 /// Errors returned by RegisterTargetWithMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum RegisterTargetWithMaintenanceWindowError {
@@ -13043,21 +12841,23 @@ impl RegisterTargetWithMaintenanceWindowError {
 }
 impl fmt::Display for RegisterTargetWithMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterTargetWithMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterTargetWithMaintenanceWindowError::DoesNotExist(ref cause) => cause,
-            RegisterTargetWithMaintenanceWindowError::IdempotentParameterMismatch(ref cause) => {
-                cause
+            RegisterTargetWithMaintenanceWindowError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
             }
-            RegisterTargetWithMaintenanceWindowError::InternalServerError(ref cause) => cause,
-            RegisterTargetWithMaintenanceWindowError::ResourceLimitExceeded(ref cause) => cause,
+            RegisterTargetWithMaintenanceWindowError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterTargetWithMaintenanceWindowError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterTargetWithMaintenanceWindowError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterTargetWithMaintenanceWindowError {}
 /// Errors returned by RegisterTaskWithMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum RegisterTaskWithMaintenanceWindowError {
@@ -13115,20 +12915,26 @@ impl RegisterTaskWithMaintenanceWindowError {
 }
 impl fmt::Display for RegisterTaskWithMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterTaskWithMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterTaskWithMaintenanceWindowError::DoesNotExist(ref cause) => cause,
-            RegisterTaskWithMaintenanceWindowError::FeatureNotAvailable(ref cause) => cause,
-            RegisterTaskWithMaintenanceWindowError::IdempotentParameterMismatch(ref cause) => cause,
-            RegisterTaskWithMaintenanceWindowError::InternalServerError(ref cause) => cause,
-            RegisterTaskWithMaintenanceWindowError::ResourceLimitExceeded(ref cause) => cause,
+            RegisterTaskWithMaintenanceWindowError::DoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterTaskWithMaintenanceWindowError::FeatureNotAvailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterTaskWithMaintenanceWindowError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterTaskWithMaintenanceWindowError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterTaskWithMaintenanceWindowError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterTaskWithMaintenanceWindowError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -13175,19 +12981,15 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::InternalServerError(ref cause) => cause,
-            RemoveTagsFromResourceError::InvalidResourceId(ref cause) => cause,
-            RemoveTagsFromResourceError::InvalidResourceType(ref cause) => cause,
-            RemoveTagsFromResourceError::TooManyUpdates(ref cause) => cause,
+            RemoveTagsFromResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::InvalidResourceId(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::InvalidResourceType(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by ResetServiceSetting
 #[derive(Debug, PartialEq)]
 pub enum ResetServiceSettingError {
@@ -13225,18 +13027,14 @@ impl ResetServiceSettingError {
 }
 impl fmt::Display for ResetServiceSettingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetServiceSettingError {
-    fn description(&self) -> &str {
         match *self {
-            ResetServiceSettingError::InternalServerError(ref cause) => cause,
-            ResetServiceSettingError::ServiceSettingNotFound(ref cause) => cause,
-            ResetServiceSettingError::TooManyUpdates(ref cause) => cause,
+            ResetServiceSettingError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ResetServiceSettingError::ServiceSettingNotFound(ref cause) => write!(f, "{}", cause),
+            ResetServiceSettingError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetServiceSettingError {}
 /// Errors returned by ResumeSession
 #[derive(Debug, PartialEq)]
 pub enum ResumeSessionError {
@@ -13265,17 +13063,13 @@ impl ResumeSessionError {
 }
 impl fmt::Display for ResumeSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResumeSessionError {
-    fn description(&self) -> &str {
         match *self {
-            ResumeSessionError::DoesNotExist(ref cause) => cause,
-            ResumeSessionError::InternalServerError(ref cause) => cause,
+            ResumeSessionError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            ResumeSessionError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResumeSessionError {}
 /// Errors returned by SendAutomationSignal
 #[derive(Debug, PartialEq)]
 pub enum SendAutomationSignalError {
@@ -13322,19 +13116,17 @@ impl SendAutomationSignalError {
 }
 impl fmt::Display for SendAutomationSignalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendAutomationSignalError {
-    fn description(&self) -> &str {
         match *self {
-            SendAutomationSignalError::AutomationExecutionNotFound(ref cause) => cause,
-            SendAutomationSignalError::AutomationStepNotFound(ref cause) => cause,
-            SendAutomationSignalError::InternalServerError(ref cause) => cause,
-            SendAutomationSignalError::InvalidAutomationSignal(ref cause) => cause,
+            SendAutomationSignalError::AutomationExecutionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SendAutomationSignalError::AutomationStepNotFound(ref cause) => write!(f, "{}", cause),
+            SendAutomationSignalError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SendAutomationSignalError::InvalidAutomationSignal(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendAutomationSignalError {}
 /// Errors returned by SendCommand
 #[derive(Debug, PartialEq)]
 pub enum SendCommandError {
@@ -13410,26 +13202,22 @@ impl SendCommandError {
 }
 impl fmt::Display for SendCommandError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendCommandError {
-    fn description(&self) -> &str {
         match *self {
-            SendCommandError::DuplicateInstanceId(ref cause) => cause,
-            SendCommandError::InternalServerError(ref cause) => cause,
-            SendCommandError::InvalidDocument(ref cause) => cause,
-            SendCommandError::InvalidDocumentVersion(ref cause) => cause,
-            SendCommandError::InvalidInstanceId(ref cause) => cause,
-            SendCommandError::InvalidNotificationConfig(ref cause) => cause,
-            SendCommandError::InvalidOutputFolder(ref cause) => cause,
-            SendCommandError::InvalidParameters(ref cause) => cause,
-            SendCommandError::InvalidRole(ref cause) => cause,
-            SendCommandError::MaxDocumentSizeExceeded(ref cause) => cause,
-            SendCommandError::UnsupportedPlatformType(ref cause) => cause,
+            SendCommandError::DuplicateInstanceId(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidDocumentVersion(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidNotificationConfig(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidOutputFolder(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            SendCommandError::InvalidRole(ref cause) => write!(f, "{}", cause),
+            SendCommandError::MaxDocumentSizeExceeded(ref cause) => write!(f, "{}", cause),
+            SendCommandError::UnsupportedPlatformType(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendCommandError {}
 /// Errors returned by StartAssociationsOnce
 #[derive(Debug, PartialEq)]
 pub enum StartAssociationsOnceError {
@@ -13462,17 +13250,15 @@ impl StartAssociationsOnceError {
 }
 impl fmt::Display for StartAssociationsOnceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartAssociationsOnceError {
-    fn description(&self) -> &str {
         match *self {
-            StartAssociationsOnceError::AssociationDoesNotExist(ref cause) => cause,
-            StartAssociationsOnceError::InvalidAssociation(ref cause) => cause,
+            StartAssociationsOnceError::AssociationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAssociationsOnceError::InvalidAssociation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartAssociationsOnceError {}
 /// Errors returned by StartAutomationExecution
 #[derive(Debug, PartialEq)]
 pub enum StartAutomationExecutionError {
@@ -13542,22 +13328,28 @@ impl StartAutomationExecutionError {
 }
 impl fmt::Display for StartAutomationExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartAutomationExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StartAutomationExecutionError::AutomationDefinitionNotFound(ref cause) => cause,
-            StartAutomationExecutionError::AutomationDefinitionVersionNotFound(ref cause) => cause,
-            StartAutomationExecutionError::AutomationExecutionLimitExceeded(ref cause) => cause,
-            StartAutomationExecutionError::IdempotentParameterMismatch(ref cause) => cause,
-            StartAutomationExecutionError::InternalServerError(ref cause) => cause,
-            StartAutomationExecutionError::InvalidAutomationExecutionParameters(ref cause) => cause,
-            StartAutomationExecutionError::InvalidTarget(ref cause) => cause,
+            StartAutomationExecutionError::AutomationDefinitionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAutomationExecutionError::AutomationDefinitionVersionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAutomationExecutionError::AutomationExecutionLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAutomationExecutionError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAutomationExecutionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartAutomationExecutionError::InvalidAutomationExecutionParameters(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAutomationExecutionError::InvalidTarget(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartAutomationExecutionError {}
 /// Errors returned by StartSession
 #[derive(Debug, PartialEq)]
 pub enum StartSessionError {
@@ -13591,18 +13383,14 @@ impl StartSessionError {
 }
 impl fmt::Display for StartSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartSessionError {
-    fn description(&self) -> &str {
         match *self {
-            StartSessionError::InternalServerError(ref cause) => cause,
-            StartSessionError::InvalidDocument(ref cause) => cause,
-            StartSessionError::TargetNotConnected(ref cause) => cause,
+            StartSessionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartSessionError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            StartSessionError::TargetNotConnected(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartSessionError {}
 /// Errors returned by StopAutomationExecution
 #[derive(Debug, PartialEq)]
 pub enum StopAutomationExecutionError {
@@ -13642,18 +13430,18 @@ impl StopAutomationExecutionError {
 }
 impl fmt::Display for StopAutomationExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopAutomationExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StopAutomationExecutionError::AutomationExecutionNotFound(ref cause) => cause,
-            StopAutomationExecutionError::InternalServerError(ref cause) => cause,
-            StopAutomationExecutionError::InvalidAutomationStatusUpdate(ref cause) => cause,
+            StopAutomationExecutionError::AutomationExecutionNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StopAutomationExecutionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StopAutomationExecutionError::InvalidAutomationStatusUpdate(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StopAutomationExecutionError {}
 /// Errors returned by TerminateSession
 #[derive(Debug, PartialEq)]
 pub enum TerminateSessionError {
@@ -13684,17 +13472,13 @@ impl TerminateSessionError {
 }
 impl fmt::Display for TerminateSessionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateSessionError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateSessionError::DoesNotExist(ref cause) => cause,
-            TerminateSessionError::InternalServerError(ref cause) => cause,
+            TerminateSessionError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            TerminateSessionError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TerminateSessionError {}
 /// Errors returned by UpdateAssociation
 #[derive(Debug, PartialEq)]
 pub enum UpdateAssociationError {
@@ -13785,27 +13569,25 @@ impl UpdateAssociationError {
 }
 impl fmt::Display for UpdateAssociationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAssociationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAssociationError::AssociationDoesNotExist(ref cause) => cause,
-            UpdateAssociationError::AssociationVersionLimitExceeded(ref cause) => cause,
-            UpdateAssociationError::InternalServerError(ref cause) => cause,
-            UpdateAssociationError::InvalidAssociationVersion(ref cause) => cause,
-            UpdateAssociationError::InvalidDocument(ref cause) => cause,
-            UpdateAssociationError::InvalidDocumentVersion(ref cause) => cause,
-            UpdateAssociationError::InvalidOutputLocation(ref cause) => cause,
-            UpdateAssociationError::InvalidParameters(ref cause) => cause,
-            UpdateAssociationError::InvalidSchedule(ref cause) => cause,
-            UpdateAssociationError::InvalidTarget(ref cause) => cause,
-            UpdateAssociationError::InvalidUpdate(ref cause) => cause,
-            UpdateAssociationError::TooManyUpdates(ref cause) => cause,
+            UpdateAssociationError::AssociationDoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::AssociationVersionLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAssociationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidAssociationVersion(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidDocumentVersion(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidOutputLocation(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidParameters(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidSchedule(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidTarget(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::InvalidUpdate(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAssociationError {}
 /// Errors returned by UpdateAssociationStatus
 #[derive(Debug, PartialEq)]
 pub enum UpdateAssociationStatusError {
@@ -13866,21 +13648,19 @@ impl UpdateAssociationStatusError {
 }
 impl fmt::Display for UpdateAssociationStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAssociationStatusError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAssociationStatusError::AssociationDoesNotExist(ref cause) => cause,
-            UpdateAssociationStatusError::InternalServerError(ref cause) => cause,
-            UpdateAssociationStatusError::InvalidDocument(ref cause) => cause,
-            UpdateAssociationStatusError::InvalidInstanceId(ref cause) => cause,
-            UpdateAssociationStatusError::StatusUnchanged(ref cause) => cause,
-            UpdateAssociationStatusError::TooManyUpdates(ref cause) => cause,
+            UpdateAssociationStatusError::AssociationDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAssociationStatusError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationStatusError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationStatusError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationStatusError::StatusUnchanged(ref cause) => write!(f, "{}", cause),
+            UpdateAssociationStatusError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAssociationStatusError {}
 /// Errors returned by UpdateDocument
 #[derive(Debug, PartialEq)]
 pub enum UpdateDocumentError {
@@ -13965,25 +13745,21 @@ impl UpdateDocumentError {
 }
 impl fmt::Display for UpdateDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDocumentError::DocumentVersionLimitExceeded(ref cause) => cause,
-            UpdateDocumentError::DuplicateDocumentContent(ref cause) => cause,
-            UpdateDocumentError::DuplicateDocumentVersionName(ref cause) => cause,
-            UpdateDocumentError::InternalServerError(ref cause) => cause,
-            UpdateDocumentError::InvalidDocument(ref cause) => cause,
-            UpdateDocumentError::InvalidDocumentContent(ref cause) => cause,
-            UpdateDocumentError::InvalidDocumentOperation(ref cause) => cause,
-            UpdateDocumentError::InvalidDocumentSchemaVersion(ref cause) => cause,
-            UpdateDocumentError::InvalidDocumentVersion(ref cause) => cause,
-            UpdateDocumentError::MaxDocumentSizeExceeded(ref cause) => cause,
+            UpdateDocumentError::DocumentVersionLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::DuplicateDocumentContent(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::DuplicateDocumentVersionName(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::InvalidDocumentContent(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::InvalidDocumentOperation(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::InvalidDocumentSchemaVersion(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::InvalidDocumentVersion(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::MaxDocumentSizeExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDocumentError {}
 /// Errors returned by UpdateDocumentDefaultVersion
 #[derive(Debug, PartialEq)]
 pub enum UpdateDocumentDefaultVersionError {
@@ -14032,19 +13808,21 @@ impl UpdateDocumentDefaultVersionError {
 }
 impl fmt::Display for UpdateDocumentDefaultVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDocumentDefaultVersionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDocumentDefaultVersionError::InternalServerError(ref cause) => cause,
-            UpdateDocumentDefaultVersionError::InvalidDocument(ref cause) => cause,
-            UpdateDocumentDefaultVersionError::InvalidDocumentSchemaVersion(ref cause) => cause,
-            UpdateDocumentDefaultVersionError::InvalidDocumentVersion(ref cause) => cause,
+            UpdateDocumentDefaultVersionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDocumentDefaultVersionError::InvalidDocument(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentDefaultVersionError::InvalidDocumentSchemaVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDocumentDefaultVersionError::InvalidDocumentVersion(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateDocumentDefaultVersionError {}
 /// Errors returned by UpdateMaintenanceWindow
 #[derive(Debug, PartialEq)]
 pub enum UpdateMaintenanceWindowError {
@@ -14077,17 +13855,13 @@ impl UpdateMaintenanceWindowError {
 }
 impl fmt::Display for UpdateMaintenanceWindowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMaintenanceWindowError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMaintenanceWindowError::DoesNotExist(ref cause) => cause,
-            UpdateMaintenanceWindowError::InternalServerError(ref cause) => cause,
+            UpdateMaintenanceWindowError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateMaintenanceWindowError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMaintenanceWindowError {}
 /// Errors returned by UpdateMaintenanceWindowTarget
 #[derive(Debug, PartialEq)]
 pub enum UpdateMaintenanceWindowTargetError {
@@ -14122,17 +13896,15 @@ impl UpdateMaintenanceWindowTargetError {
 }
 impl fmt::Display for UpdateMaintenanceWindowTargetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMaintenanceWindowTargetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMaintenanceWindowTargetError::DoesNotExist(ref cause) => cause,
-            UpdateMaintenanceWindowTargetError::InternalServerError(ref cause) => cause,
+            UpdateMaintenanceWindowTargetError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateMaintenanceWindowTargetError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateMaintenanceWindowTargetError {}
 /// Errors returned by UpdateMaintenanceWindowTask
 #[derive(Debug, PartialEq)]
 pub enum UpdateMaintenanceWindowTaskError {
@@ -14167,17 +13939,15 @@ impl UpdateMaintenanceWindowTaskError {
 }
 impl fmt::Display for UpdateMaintenanceWindowTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMaintenanceWindowTaskError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMaintenanceWindowTaskError::DoesNotExist(ref cause) => cause,
-            UpdateMaintenanceWindowTaskError::InternalServerError(ref cause) => cause,
+            UpdateMaintenanceWindowTaskError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdateMaintenanceWindowTaskError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateMaintenanceWindowTaskError {}
 /// Errors returned by UpdateManagedInstanceRole
 #[derive(Debug, PartialEq)]
 pub enum UpdateManagedInstanceRoleError {
@@ -14210,17 +13980,15 @@ impl UpdateManagedInstanceRoleError {
 }
 impl fmt::Display for UpdateManagedInstanceRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateManagedInstanceRoleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateManagedInstanceRoleError::InternalServerError(ref cause) => cause,
-            UpdateManagedInstanceRoleError::InvalidInstanceId(ref cause) => cause,
+            UpdateManagedInstanceRoleError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateManagedInstanceRoleError::InvalidInstanceId(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateManagedInstanceRoleError {}
 /// Errors returned by UpdateOpsItem
 #[derive(Debug, PartialEq)]
 pub enum UpdateOpsItemError {
@@ -14266,20 +14034,16 @@ impl UpdateOpsItemError {
 }
 impl fmt::Display for UpdateOpsItemError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateOpsItemError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateOpsItemError::InternalServerError(ref cause) => cause,
-            UpdateOpsItemError::OpsItemAlreadyExists(ref cause) => cause,
-            UpdateOpsItemError::OpsItemInvalidParameter(ref cause) => cause,
-            UpdateOpsItemError::OpsItemLimitExceeded(ref cause) => cause,
-            UpdateOpsItemError::OpsItemNotFound(ref cause) => cause,
+            UpdateOpsItemError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateOpsItemError::OpsItemAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateOpsItemError::OpsItemInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateOpsItemError::OpsItemLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateOpsItemError::OpsItemNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateOpsItemError {}
 /// Errors returned by UpdatePatchBaseline
 #[derive(Debug, PartialEq)]
 pub enum UpdatePatchBaselineError {
@@ -14310,17 +14074,13 @@ impl UpdatePatchBaselineError {
 }
 impl fmt::Display for UpdatePatchBaselineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePatchBaselineError {
-    fn description(&self) -> &str {
         match *self {
-            UpdatePatchBaselineError::DoesNotExist(ref cause) => cause,
-            UpdatePatchBaselineError::InternalServerError(ref cause) => cause,
+            UpdatePatchBaselineError::DoesNotExist(ref cause) => write!(f, "{}", cause),
+            UpdatePatchBaselineError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdatePatchBaselineError {}
 /// Errors returned by UpdateResourceDataSync
 #[derive(Debug, PartialEq)]
 pub enum UpdateResourceDataSyncError {
@@ -14367,19 +14127,21 @@ impl UpdateResourceDataSyncError {
 }
 impl fmt::Display for UpdateResourceDataSyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateResourceDataSyncError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateResourceDataSyncError::InternalServerError(ref cause) => cause,
-            UpdateResourceDataSyncError::ResourceDataSyncConflict(ref cause) => cause,
-            UpdateResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => cause,
-            UpdateResourceDataSyncError::ResourceDataSyncNotFound(ref cause) => cause,
+            UpdateResourceDataSyncError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateResourceDataSyncError::ResourceDataSyncConflict(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateResourceDataSyncError::ResourceDataSyncInvalidConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateResourceDataSyncError::ResourceDataSyncNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateResourceDataSyncError {}
 /// Errors returned by UpdateServiceSetting
 #[derive(Debug, PartialEq)]
 pub enum UpdateServiceSettingError {
@@ -14417,18 +14179,14 @@ impl UpdateServiceSettingError {
 }
 impl fmt::Display for UpdateServiceSettingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServiceSettingError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServiceSettingError::InternalServerError(ref cause) => cause,
-            UpdateServiceSettingError::ServiceSettingNotFound(ref cause) => cause,
-            UpdateServiceSettingError::TooManyUpdates(ref cause) => cause,
+            UpdateServiceSettingError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateServiceSettingError::ServiceSettingNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateServiceSettingError::TooManyUpdates(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServiceSettingError {}
 /// Trait representing the capabilities of the Amazon SSM API. Amazon SSM clients implement this trait.
 pub trait Ssm {
     /// <p>Adds or overwrites one or more tags for the specified resource. Tags are metadata that you can assign to your documents, managed instances, maintenance windows, Parameter Store parameters, and patch baselines. Tags enable you to categorize your resources in different ways, for example, by purpose, owner, or environment. Each tag consists of a key and an optional value, both of which you define. For example, you could define a set of tags for your account's managed instances that helps you track each instance's owner and stack level. For example: Key=Owner and Value=DbAdmin, SysAdmin, or Dev. Or Key=Stack and Value=Production, Pre-Production, or Test.</p> <p>Each resource can have a maximum of 50 tags. </p> <p>We recommend that you devise a set of tag keys that meets your needs for each resource type. Using a consistent set of tag keys makes it easier for you to manage your resources. You can search and filter the resources based on the tags you add. Tags don't have any semantic meaning to Amazon EC2 and are interpreted strictly as a string of characters. </p> <p>For more information about tags, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html">Tagging Your Amazon EC2 Resources</a> in the <i>Amazon EC2 User Guide</i>.</p>

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -1226,18 +1226,14 @@ impl CreateActivityError {
 }
 impl fmt::Display for CreateActivityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateActivityError {
-    fn description(&self) -> &str {
         match *self {
-            CreateActivityError::ActivityLimitExceeded(ref cause) => cause,
-            CreateActivityError::InvalidName(ref cause) => cause,
-            CreateActivityError::TooManyTags(ref cause) => cause,
+            CreateActivityError::ActivityLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateActivityError::InvalidName(ref cause) => write!(f, "{}", cause),
+            CreateActivityError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateActivityError {}
 /// Errors returned by CreateStateMachine
 #[derive(Debug, PartialEq)]
 pub enum CreateStateMachineError {
@@ -1313,24 +1309,24 @@ impl CreateStateMachineError {
 }
 impl fmt::Display for CreateStateMachineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStateMachineError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStateMachineError::InvalidArn(ref cause) => cause,
-            CreateStateMachineError::InvalidDefinition(ref cause) => cause,
-            CreateStateMachineError::InvalidLoggingConfiguration(ref cause) => cause,
-            CreateStateMachineError::InvalidName(ref cause) => cause,
-            CreateStateMachineError::StateMachineAlreadyExists(ref cause) => cause,
-            CreateStateMachineError::StateMachineDeleting(ref cause) => cause,
-            CreateStateMachineError::StateMachineLimitExceeded(ref cause) => cause,
-            CreateStateMachineError::StateMachineTypeNotSupported(ref cause) => cause,
-            CreateStateMachineError::TooManyTags(ref cause) => cause,
+            CreateStateMachineError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            CreateStateMachineError::InvalidDefinition(ref cause) => write!(f, "{}", cause),
+            CreateStateMachineError::InvalidLoggingConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStateMachineError::InvalidName(ref cause) => write!(f, "{}", cause),
+            CreateStateMachineError::StateMachineAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateStateMachineError::StateMachineDeleting(ref cause) => write!(f, "{}", cause),
+            CreateStateMachineError::StateMachineLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateStateMachineError::StateMachineTypeNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateStateMachineError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateStateMachineError {}
 /// Errors returned by DeleteActivity
 #[derive(Debug, PartialEq)]
 pub enum DeleteActivityError {
@@ -1354,16 +1350,12 @@ impl DeleteActivityError {
 }
 impl fmt::Display for DeleteActivityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteActivityError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteActivityError::InvalidArn(ref cause) => cause,
+            DeleteActivityError::InvalidArn(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteActivityError {}
 /// Errors returned by DeleteStateMachine
 #[derive(Debug, PartialEq)]
 pub enum DeleteStateMachineError {
@@ -1387,16 +1379,12 @@ impl DeleteStateMachineError {
 }
 impl fmt::Display for DeleteStateMachineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteStateMachineError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteStateMachineError::InvalidArn(ref cause) => cause,
+            DeleteStateMachineError::InvalidArn(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteStateMachineError {}
 /// Errors returned by DescribeActivity
 #[derive(Debug, PartialEq)]
 pub enum DescribeActivityError {
@@ -1427,17 +1415,13 @@ impl DescribeActivityError {
 }
 impl fmt::Display for DescribeActivityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeActivityError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeActivityError::ActivityDoesNotExist(ref cause) => cause,
-            DescribeActivityError::InvalidArn(ref cause) => cause,
+            DescribeActivityError::ActivityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeActivityError::InvalidArn(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeActivityError {}
 /// Errors returned by DescribeExecution
 #[derive(Debug, PartialEq)]
 pub enum DescribeExecutionError {
@@ -1468,17 +1452,13 @@ impl DescribeExecutionError {
 }
 impl fmt::Display for DescribeExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeExecutionError::ExecutionDoesNotExist(ref cause) => cause,
-            DescribeExecutionError::InvalidArn(ref cause) => cause,
+            DescribeExecutionError::ExecutionDoesNotExist(ref cause) => write!(f, "{}", cause),
+            DescribeExecutionError::InvalidArn(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeExecutionError {}
 /// Errors returned by DescribeStateMachine
 #[derive(Debug, PartialEq)]
 pub enum DescribeStateMachineError {
@@ -1509,17 +1489,15 @@ impl DescribeStateMachineError {
 }
 impl fmt::Display for DescribeStateMachineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStateMachineError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStateMachineError::InvalidArn(ref cause) => cause,
-            DescribeStateMachineError::StateMachineDoesNotExist(ref cause) => cause,
+            DescribeStateMachineError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            DescribeStateMachineError::StateMachineDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeStateMachineError {}
 /// Errors returned by DescribeStateMachineForExecution
 #[derive(Debug, PartialEq)]
 pub enum DescribeStateMachineForExecutionError {
@@ -1554,17 +1532,15 @@ impl DescribeStateMachineForExecutionError {
 }
 impl fmt::Display for DescribeStateMachineForExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStateMachineForExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStateMachineForExecutionError::ExecutionDoesNotExist(ref cause) => cause,
-            DescribeStateMachineForExecutionError::InvalidArn(ref cause) => cause,
+            DescribeStateMachineForExecutionError::ExecutionDoesNotExist(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeStateMachineForExecutionError::InvalidArn(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeStateMachineForExecutionError {}
 /// Errors returned by GetActivityTask
 #[derive(Debug, PartialEq)]
 pub enum GetActivityTaskError {
@@ -1602,18 +1578,14 @@ impl GetActivityTaskError {
 }
 impl fmt::Display for GetActivityTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetActivityTaskError {
-    fn description(&self) -> &str {
         match *self {
-            GetActivityTaskError::ActivityDoesNotExist(ref cause) => cause,
-            GetActivityTaskError::ActivityWorkerLimitExceeded(ref cause) => cause,
-            GetActivityTaskError::InvalidArn(ref cause) => cause,
+            GetActivityTaskError::ActivityDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetActivityTaskError::ActivityWorkerLimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetActivityTaskError::InvalidArn(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetActivityTaskError {}
 /// Errors returned by GetExecutionHistory
 #[derive(Debug, PartialEq)]
 pub enum GetExecutionHistoryError {
@@ -1649,18 +1621,14 @@ impl GetExecutionHistoryError {
 }
 impl fmt::Display for GetExecutionHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetExecutionHistoryError {
-    fn description(&self) -> &str {
         match *self {
-            GetExecutionHistoryError::ExecutionDoesNotExist(ref cause) => cause,
-            GetExecutionHistoryError::InvalidArn(ref cause) => cause,
-            GetExecutionHistoryError::InvalidToken(ref cause) => cause,
+            GetExecutionHistoryError::ExecutionDoesNotExist(ref cause) => write!(f, "{}", cause),
+            GetExecutionHistoryError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            GetExecutionHistoryError::InvalidToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetExecutionHistoryError {}
 /// Errors returned by ListActivities
 #[derive(Debug, PartialEq)]
 pub enum ListActivitiesError {
@@ -1684,16 +1652,12 @@ impl ListActivitiesError {
 }
 impl fmt::Display for ListActivitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListActivitiesError {
-    fn description(&self) -> &str {
         match *self {
-            ListActivitiesError::InvalidToken(ref cause) => cause,
+            ListActivitiesError::InvalidToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListActivitiesError {}
 /// Errors returned by ListExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListExecutionsError {
@@ -1736,19 +1700,15 @@ impl ListExecutionsError {
 }
 impl fmt::Display for ListExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListExecutionsError::InvalidArn(ref cause) => cause,
-            ListExecutionsError::InvalidToken(ref cause) => cause,
-            ListExecutionsError::StateMachineDoesNotExist(ref cause) => cause,
-            ListExecutionsError::StateMachineTypeNotSupported(ref cause) => cause,
+            ListExecutionsError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListExecutionsError::InvalidToken(ref cause) => write!(f, "{}", cause),
+            ListExecutionsError::StateMachineDoesNotExist(ref cause) => write!(f, "{}", cause),
+            ListExecutionsError::StateMachineTypeNotSupported(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListExecutionsError {}
 /// Errors returned by ListStateMachines
 #[derive(Debug, PartialEq)]
 pub enum ListStateMachinesError {
@@ -1772,16 +1732,12 @@ impl ListStateMachinesError {
 }
 impl fmt::Display for ListStateMachinesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListStateMachinesError {
-    fn description(&self) -> &str {
         match *self {
-            ListStateMachinesError::InvalidToken(ref cause) => cause,
+            ListStateMachinesError::InvalidToken(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListStateMachinesError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1812,17 +1768,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InvalidArn(ref cause) => cause,
-            ListTagsForResourceError::ResourceNotFound(ref cause) => cause,
+            ListTagsForResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by SendTaskFailure
 #[derive(Debug, PartialEq)]
 pub enum SendTaskFailureError {
@@ -1856,18 +1808,14 @@ impl SendTaskFailureError {
 }
 impl fmt::Display for SendTaskFailureError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendTaskFailureError {
-    fn description(&self) -> &str {
         match *self {
-            SendTaskFailureError::InvalidToken(ref cause) => cause,
-            SendTaskFailureError::TaskDoesNotExist(ref cause) => cause,
-            SendTaskFailureError::TaskTimedOut(ref cause) => cause,
+            SendTaskFailureError::InvalidToken(ref cause) => write!(f, "{}", cause),
+            SendTaskFailureError::TaskDoesNotExist(ref cause) => write!(f, "{}", cause),
+            SendTaskFailureError::TaskTimedOut(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendTaskFailureError {}
 /// Errors returned by SendTaskHeartbeat
 #[derive(Debug, PartialEq)]
 pub enum SendTaskHeartbeatError {
@@ -1901,18 +1849,14 @@ impl SendTaskHeartbeatError {
 }
 impl fmt::Display for SendTaskHeartbeatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendTaskHeartbeatError {
-    fn description(&self) -> &str {
         match *self {
-            SendTaskHeartbeatError::InvalidToken(ref cause) => cause,
-            SendTaskHeartbeatError::TaskDoesNotExist(ref cause) => cause,
-            SendTaskHeartbeatError::TaskTimedOut(ref cause) => cause,
+            SendTaskHeartbeatError::InvalidToken(ref cause) => write!(f, "{}", cause),
+            SendTaskHeartbeatError::TaskDoesNotExist(ref cause) => write!(f, "{}", cause),
+            SendTaskHeartbeatError::TaskTimedOut(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendTaskHeartbeatError {}
 /// Errors returned by SendTaskSuccess
 #[derive(Debug, PartialEq)]
 pub enum SendTaskSuccessError {
@@ -1951,19 +1895,15 @@ impl SendTaskSuccessError {
 }
 impl fmt::Display for SendTaskSuccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SendTaskSuccessError {
-    fn description(&self) -> &str {
         match *self {
-            SendTaskSuccessError::InvalidOutput(ref cause) => cause,
-            SendTaskSuccessError::InvalidToken(ref cause) => cause,
-            SendTaskSuccessError::TaskDoesNotExist(ref cause) => cause,
-            SendTaskSuccessError::TaskTimedOut(ref cause) => cause,
+            SendTaskSuccessError::InvalidOutput(ref cause) => write!(f, "{}", cause),
+            SendTaskSuccessError::InvalidToken(ref cause) => write!(f, "{}", cause),
+            SendTaskSuccessError::TaskDoesNotExist(ref cause) => write!(f, "{}", cause),
+            SendTaskSuccessError::TaskTimedOut(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SendTaskSuccessError {}
 /// Errors returned by StartExecution
 #[derive(Debug, PartialEq)]
 pub enum StartExecutionError {
@@ -2025,22 +1965,18 @@ impl StartExecutionError {
 }
 impl fmt::Display for StartExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StartExecutionError::ExecutionAlreadyExists(ref cause) => cause,
-            StartExecutionError::ExecutionLimitExceeded(ref cause) => cause,
-            StartExecutionError::InvalidArn(ref cause) => cause,
-            StartExecutionError::InvalidExecutionInput(ref cause) => cause,
-            StartExecutionError::InvalidName(ref cause) => cause,
-            StartExecutionError::StateMachineDeleting(ref cause) => cause,
-            StartExecutionError::StateMachineDoesNotExist(ref cause) => cause,
+            StartExecutionError::ExecutionAlreadyExists(ref cause) => write!(f, "{}", cause),
+            StartExecutionError::ExecutionLimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartExecutionError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            StartExecutionError::InvalidExecutionInput(ref cause) => write!(f, "{}", cause),
+            StartExecutionError::InvalidName(ref cause) => write!(f, "{}", cause),
+            StartExecutionError::StateMachineDeleting(ref cause) => write!(f, "{}", cause),
+            StartExecutionError::StateMachineDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartExecutionError {}
 /// Errors returned by StopExecution
 #[derive(Debug, PartialEq)]
 pub enum StopExecutionError {
@@ -2069,17 +2005,13 @@ impl StopExecutionError {
 }
 impl fmt::Display for StopExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StopExecutionError::ExecutionDoesNotExist(ref cause) => cause,
-            StopExecutionError::InvalidArn(ref cause) => cause,
+            StopExecutionError::ExecutionDoesNotExist(ref cause) => write!(f, "{}", cause),
+            StopExecutionError::InvalidArn(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopExecutionError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -2111,18 +2043,14 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InvalidArn(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::TooManyTags(ref cause) => cause,
+            TagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTags(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -2151,17 +2079,13 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InvalidArn(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
+            UntagResourceError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateStateMachine
 #[derive(Debug, PartialEq)]
 pub enum UpdateStateMachineError {
@@ -2220,21 +2144,19 @@ impl UpdateStateMachineError {
 }
 impl fmt::Display for UpdateStateMachineError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateStateMachineError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateStateMachineError::InvalidArn(ref cause) => cause,
-            UpdateStateMachineError::InvalidDefinition(ref cause) => cause,
-            UpdateStateMachineError::InvalidLoggingConfiguration(ref cause) => cause,
-            UpdateStateMachineError::MissingRequiredParameter(ref cause) => cause,
-            UpdateStateMachineError::StateMachineDeleting(ref cause) => cause,
-            UpdateStateMachineError::StateMachineDoesNotExist(ref cause) => cause,
+            UpdateStateMachineError::InvalidArn(ref cause) => write!(f, "{}", cause),
+            UpdateStateMachineError::InvalidDefinition(ref cause) => write!(f, "{}", cause),
+            UpdateStateMachineError::InvalidLoggingConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateStateMachineError::MissingRequiredParameter(ref cause) => write!(f, "{}", cause),
+            UpdateStateMachineError::StateMachineDeleting(ref cause) => write!(f, "{}", cause),
+            UpdateStateMachineError::StateMachineDoesNotExist(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateStateMachineError {}
 /// Trait representing the capabilities of the AWS SFN API. AWS SFN clients implement this trait.
 pub trait StepFunctions {
     /// <p><p>Creates an activity. An activity is a task that you write in any programming language and host on any machine that has access to AWS Step Functions. Activities must poll Step Functions using the <code>GetActivityTask</code> API action and respond using <code>SendTask*</code> API actions. This function lets Step Functions know the existence of your activity and returns an identifier for use in a state machine and when polling from the activity.</p> <note> <p>This operation is eventually consistent. The results are best effort and may not reflect very recent updates and changes.</p> </note> <note> <p> <code>CreateActivity</code> is an idempotent API. Subsequent requests won’t create a duplicate resource if it was already created. <code>CreateActivity</code>&#39;s idempotency check is based on the activity <code>name</code>. If a following request has different <code>tags</code> values, Step Functions will ignore these differences and treat it as an idempotent request of the previous. In this case, <code>tags</code> will not be updated, even if they are different.</p> </note></p>

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -2879,17 +2879,13 @@ impl ActivateGatewayError {
 }
 impl fmt::Display for ActivateGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ActivateGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            ActivateGatewayError::InternalServerError(ref cause) => cause,
-            ActivateGatewayError::InvalidGatewayRequest(ref cause) => cause,
+            ActivateGatewayError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ActivateGatewayError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ActivateGatewayError {}
 /// Errors returned by AddCache
 #[derive(Debug, PartialEq)]
 pub enum AddCacheError {
@@ -2918,17 +2914,13 @@ impl AddCacheError {
 }
 impl fmt::Display for AddCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddCacheError {
-    fn description(&self) -> &str {
         match *self {
-            AddCacheError::InternalServerError(ref cause) => cause,
-            AddCacheError::InvalidGatewayRequest(ref cause) => cause,
+            AddCacheError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AddCacheError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddCacheError {}
 /// Errors returned by AddTagsToResource
 #[derive(Debug, PartialEq)]
 pub enum AddTagsToResourceError {
@@ -2961,17 +2953,13 @@ impl AddTagsToResourceError {
 }
 impl fmt::Display for AddTagsToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddTagsToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AddTagsToResourceError::InternalServerError(ref cause) => cause,
-            AddTagsToResourceError::InvalidGatewayRequest(ref cause) => cause,
+            AddTagsToResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AddTagsToResourceError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddTagsToResourceError {}
 /// Errors returned by AddUploadBuffer
 #[derive(Debug, PartialEq)]
 pub enum AddUploadBufferError {
@@ -3002,17 +2990,13 @@ impl AddUploadBufferError {
 }
 impl fmt::Display for AddUploadBufferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddUploadBufferError {
-    fn description(&self) -> &str {
         match *self {
-            AddUploadBufferError::InternalServerError(ref cause) => cause,
-            AddUploadBufferError::InvalidGatewayRequest(ref cause) => cause,
+            AddUploadBufferError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AddUploadBufferError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddUploadBufferError {}
 /// Errors returned by AddWorkingStorage
 #[derive(Debug, PartialEq)]
 pub enum AddWorkingStorageError {
@@ -3045,17 +3029,13 @@ impl AddWorkingStorageError {
 }
 impl fmt::Display for AddWorkingStorageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddWorkingStorageError {
-    fn description(&self) -> &str {
         match *self {
-            AddWorkingStorageError::InternalServerError(ref cause) => cause,
-            AddWorkingStorageError::InvalidGatewayRequest(ref cause) => cause,
+            AddWorkingStorageError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AddWorkingStorageError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddWorkingStorageError {}
 /// Errors returned by AssignTapePool
 #[derive(Debug, PartialEq)]
 pub enum AssignTapePoolError {
@@ -3086,17 +3066,13 @@ impl AssignTapePoolError {
 }
 impl fmt::Display for AssignTapePoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssignTapePoolError {
-    fn description(&self) -> &str {
         match *self {
-            AssignTapePoolError::InternalServerError(ref cause) => cause,
-            AssignTapePoolError::InvalidGatewayRequest(ref cause) => cause,
+            AssignTapePoolError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AssignTapePoolError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssignTapePoolError {}
 /// Errors returned by AttachVolume
 #[derive(Debug, PartialEq)]
 pub enum AttachVolumeError {
@@ -3125,17 +3101,13 @@ impl AttachVolumeError {
 }
 impl fmt::Display for AttachVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AttachVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            AttachVolumeError::InternalServerError(ref cause) => cause,
-            AttachVolumeError::InvalidGatewayRequest(ref cause) => cause,
+            AttachVolumeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AttachVolumeError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AttachVolumeError {}
 /// Errors returned by CancelArchival
 #[derive(Debug, PartialEq)]
 pub enum CancelArchivalError {
@@ -3166,17 +3138,13 @@ impl CancelArchivalError {
 }
 impl fmt::Display for CancelArchivalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelArchivalError {
-    fn description(&self) -> &str {
         match *self {
-            CancelArchivalError::InternalServerError(ref cause) => cause,
-            CancelArchivalError::InvalidGatewayRequest(ref cause) => cause,
+            CancelArchivalError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CancelArchivalError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelArchivalError {}
 /// Errors returned by CancelRetrieval
 #[derive(Debug, PartialEq)]
 pub enum CancelRetrievalError {
@@ -3207,17 +3175,13 @@ impl CancelRetrievalError {
 }
 impl fmt::Display for CancelRetrievalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CancelRetrievalError {
-    fn description(&self) -> &str {
         match *self {
-            CancelRetrievalError::InternalServerError(ref cause) => cause,
-            CancelRetrievalError::InvalidGatewayRequest(ref cause) => cause,
+            CancelRetrievalError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CancelRetrievalError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CancelRetrievalError {}
 /// Errors returned by CreateCachediSCSIVolume
 #[derive(Debug, PartialEq)]
 pub enum CreateCachediSCSIVolumeError {
@@ -3250,17 +3214,15 @@ impl CreateCachediSCSIVolumeError {
 }
 impl fmt::Display for CreateCachediSCSIVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCachediSCSIVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCachediSCSIVolumeError::InternalServerError(ref cause) => cause,
-            CreateCachediSCSIVolumeError::InvalidGatewayRequest(ref cause) => cause,
+            CreateCachediSCSIVolumeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateCachediSCSIVolumeError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCachediSCSIVolumeError {}
 /// Errors returned by CreateNFSFileShare
 #[derive(Debug, PartialEq)]
 pub enum CreateNFSFileShareError {
@@ -3293,17 +3255,13 @@ impl CreateNFSFileShareError {
 }
 impl fmt::Display for CreateNFSFileShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNFSFileShareError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNFSFileShareError::InternalServerError(ref cause) => cause,
-            CreateNFSFileShareError::InvalidGatewayRequest(ref cause) => cause,
+            CreateNFSFileShareError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateNFSFileShareError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateNFSFileShareError {}
 /// Errors returned by CreateSMBFileShare
 #[derive(Debug, PartialEq)]
 pub enum CreateSMBFileShareError {
@@ -3336,17 +3294,13 @@ impl CreateSMBFileShareError {
 }
 impl fmt::Display for CreateSMBFileShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSMBFileShareError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSMBFileShareError::InternalServerError(ref cause) => cause,
-            CreateSMBFileShareError::InvalidGatewayRequest(ref cause) => cause,
+            CreateSMBFileShareError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateSMBFileShareError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSMBFileShareError {}
 /// Errors returned by CreateSnapshot
 #[derive(Debug, PartialEq)]
 pub enum CreateSnapshotError {
@@ -3384,18 +3338,14 @@ impl CreateSnapshotError {
 }
 impl fmt::Display for CreateSnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSnapshotError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSnapshotError::InternalServerError(ref cause) => cause,
-            CreateSnapshotError::InvalidGatewayRequest(ref cause) => cause,
-            CreateSnapshotError::ServiceUnavailableError(ref cause) => cause,
+            CreateSnapshotError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
+            CreateSnapshotError::ServiceUnavailableError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSnapshotError {}
 /// Errors returned by CreateSnapshotFromVolumeRecoveryPoint
 #[derive(Debug, PartialEq)]
 pub enum CreateSnapshotFromVolumeRecoveryPointError {
@@ -3439,18 +3389,20 @@ impl CreateSnapshotFromVolumeRecoveryPointError {
 }
 impl fmt::Display for CreateSnapshotFromVolumeRecoveryPointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSnapshotFromVolumeRecoveryPointError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSnapshotFromVolumeRecoveryPointError::InternalServerError(ref cause) => cause,
-            CreateSnapshotFromVolumeRecoveryPointError::InvalidGatewayRequest(ref cause) => cause,
-            CreateSnapshotFromVolumeRecoveryPointError::ServiceUnavailableError(ref cause) => cause,
+            CreateSnapshotFromVolumeRecoveryPointError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotFromVolumeRecoveryPointError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSnapshotFromVolumeRecoveryPointError::ServiceUnavailableError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateSnapshotFromVolumeRecoveryPointError {}
 /// Errors returned by CreateStorediSCSIVolume
 #[derive(Debug, PartialEq)]
 pub enum CreateStorediSCSIVolumeError {
@@ -3483,17 +3435,15 @@ impl CreateStorediSCSIVolumeError {
 }
 impl fmt::Display for CreateStorediSCSIVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateStorediSCSIVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateStorediSCSIVolumeError::InternalServerError(ref cause) => cause,
-            CreateStorediSCSIVolumeError::InvalidGatewayRequest(ref cause) => cause,
+            CreateStorediSCSIVolumeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateStorediSCSIVolumeError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateStorediSCSIVolumeError {}
 /// Errors returned by CreateTapeWithBarcode
 #[derive(Debug, PartialEq)]
 pub enum CreateTapeWithBarcodeError {
@@ -3526,17 +3476,13 @@ impl CreateTapeWithBarcodeError {
 }
 impl fmt::Display for CreateTapeWithBarcodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTapeWithBarcodeError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTapeWithBarcodeError::InternalServerError(ref cause) => cause,
-            CreateTapeWithBarcodeError::InvalidGatewayRequest(ref cause) => cause,
+            CreateTapeWithBarcodeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateTapeWithBarcodeError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTapeWithBarcodeError {}
 /// Errors returned by CreateTapes
 #[derive(Debug, PartialEq)]
 pub enum CreateTapesError {
@@ -3565,17 +3511,13 @@ impl CreateTapesError {
 }
 impl fmt::Display for CreateTapesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTapesError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTapesError::InternalServerError(ref cause) => cause,
-            CreateTapesError::InvalidGatewayRequest(ref cause) => cause,
+            CreateTapesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateTapesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTapesError {}
 /// Errors returned by DeleteBandwidthRateLimit
 #[derive(Debug, PartialEq)]
 pub enum DeleteBandwidthRateLimitError {
@@ -3608,17 +3550,15 @@ impl DeleteBandwidthRateLimitError {
 }
 impl fmt::Display for DeleteBandwidthRateLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteBandwidthRateLimitError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteBandwidthRateLimitError::InternalServerError(ref cause) => cause,
-            DeleteBandwidthRateLimitError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteBandwidthRateLimitError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteBandwidthRateLimitError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteBandwidthRateLimitError {}
 /// Errors returned by DeleteChapCredentials
 #[derive(Debug, PartialEq)]
 pub enum DeleteChapCredentialsError {
@@ -3651,17 +3591,13 @@ impl DeleteChapCredentialsError {
 }
 impl fmt::Display for DeleteChapCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteChapCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteChapCredentialsError::InternalServerError(ref cause) => cause,
-            DeleteChapCredentialsError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteChapCredentialsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteChapCredentialsError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteChapCredentialsError {}
 /// Errors returned by DeleteFileShare
 #[derive(Debug, PartialEq)]
 pub enum DeleteFileShareError {
@@ -3692,17 +3628,13 @@ impl DeleteFileShareError {
 }
 impl fmt::Display for DeleteFileShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFileShareError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFileShareError::InternalServerError(ref cause) => cause,
-            DeleteFileShareError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteFileShareError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteFileShareError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFileShareError {}
 /// Errors returned by DeleteGateway
 #[derive(Debug, PartialEq)]
 pub enum DeleteGatewayError {
@@ -3731,17 +3663,13 @@ impl DeleteGatewayError {
 }
 impl fmt::Display for DeleteGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGatewayError::InternalServerError(ref cause) => cause,
-            DeleteGatewayError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteGatewayError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteGatewayError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGatewayError {}
 /// Errors returned by DeleteSnapshotSchedule
 #[derive(Debug, PartialEq)]
 pub enum DeleteSnapshotScheduleError {
@@ -3774,17 +3702,13 @@ impl DeleteSnapshotScheduleError {
 }
 impl fmt::Display for DeleteSnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSnapshotScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSnapshotScheduleError::InternalServerError(ref cause) => cause,
-            DeleteSnapshotScheduleError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteSnapshotScheduleError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteSnapshotScheduleError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSnapshotScheduleError {}
 /// Errors returned by DeleteTape
 #[derive(Debug, PartialEq)]
 pub enum DeleteTapeError {
@@ -3813,17 +3737,13 @@ impl DeleteTapeError {
 }
 impl fmt::Display for DeleteTapeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTapeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTapeError::InternalServerError(ref cause) => cause,
-            DeleteTapeError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteTapeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteTapeError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTapeError {}
 /// Errors returned by DeleteTapeArchive
 #[derive(Debug, PartialEq)]
 pub enum DeleteTapeArchiveError {
@@ -3856,17 +3776,13 @@ impl DeleteTapeArchiveError {
 }
 impl fmt::Display for DeleteTapeArchiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTapeArchiveError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTapeArchiveError::InternalServerError(ref cause) => cause,
-            DeleteTapeArchiveError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteTapeArchiveError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteTapeArchiveError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTapeArchiveError {}
 /// Errors returned by DeleteVolume
 #[derive(Debug, PartialEq)]
 pub enum DeleteVolumeError {
@@ -3895,17 +3811,13 @@ impl DeleteVolumeError {
 }
 impl fmt::Display for DeleteVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVolumeError::InternalServerError(ref cause) => cause,
-            DeleteVolumeError::InvalidGatewayRequest(ref cause) => cause,
+            DeleteVolumeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteVolumeError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVolumeError {}
 /// Errors returned by DescribeAvailabilityMonitorTest
 #[derive(Debug, PartialEq)]
 pub enum DescribeAvailabilityMonitorTestError {
@@ -3940,17 +3852,17 @@ impl DescribeAvailabilityMonitorTestError {
 }
 impl fmt::Display for DescribeAvailabilityMonitorTestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAvailabilityMonitorTestError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAvailabilityMonitorTestError::InternalServerError(ref cause) => cause,
-            DescribeAvailabilityMonitorTestError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeAvailabilityMonitorTestError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAvailabilityMonitorTestError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAvailabilityMonitorTestError {}
 /// Errors returned by DescribeBandwidthRateLimit
 #[derive(Debug, PartialEq)]
 pub enum DescribeBandwidthRateLimitError {
@@ -3985,17 +3897,17 @@ impl DescribeBandwidthRateLimitError {
 }
 impl fmt::Display for DescribeBandwidthRateLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeBandwidthRateLimitError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeBandwidthRateLimitError::InternalServerError(ref cause) => cause,
-            DescribeBandwidthRateLimitError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeBandwidthRateLimitError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeBandwidthRateLimitError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeBandwidthRateLimitError {}
 /// Errors returned by DescribeCache
 #[derive(Debug, PartialEq)]
 pub enum DescribeCacheError {
@@ -4024,17 +3936,13 @@ impl DescribeCacheError {
 }
 impl fmt::Display for DescribeCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCacheError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCacheError::InternalServerError(ref cause) => cause,
-            DescribeCacheError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeCacheError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeCacheError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCacheError {}
 /// Errors returned by DescribeCachediSCSIVolumes
 #[derive(Debug, PartialEq)]
 pub enum DescribeCachediSCSIVolumesError {
@@ -4069,17 +3977,17 @@ impl DescribeCachediSCSIVolumesError {
 }
 impl fmt::Display for DescribeCachediSCSIVolumesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCachediSCSIVolumesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCachediSCSIVolumesError::InternalServerError(ref cause) => cause,
-            DescribeCachediSCSIVolumesError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeCachediSCSIVolumesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCachediSCSIVolumesError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCachediSCSIVolumesError {}
 /// Errors returned by DescribeChapCredentials
 #[derive(Debug, PartialEq)]
 pub enum DescribeChapCredentialsError {
@@ -4112,17 +4020,15 @@ impl DescribeChapCredentialsError {
 }
 impl fmt::Display for DescribeChapCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeChapCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeChapCredentialsError::InternalServerError(ref cause) => cause,
-            DescribeChapCredentialsError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeChapCredentialsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeChapCredentialsError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeChapCredentialsError {}
 /// Errors returned by DescribeGatewayInformation
 #[derive(Debug, PartialEq)]
 pub enum DescribeGatewayInformationError {
@@ -4157,17 +4063,17 @@ impl DescribeGatewayInformationError {
 }
 impl fmt::Display for DescribeGatewayInformationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGatewayInformationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGatewayInformationError::InternalServerError(ref cause) => cause,
-            DescribeGatewayInformationError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeGatewayInformationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeGatewayInformationError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeGatewayInformationError {}
 /// Errors returned by DescribeMaintenanceStartTime
 #[derive(Debug, PartialEq)]
 pub enum DescribeMaintenanceStartTimeError {
@@ -4202,17 +4108,17 @@ impl DescribeMaintenanceStartTimeError {
 }
 impl fmt::Display for DescribeMaintenanceStartTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeMaintenanceStartTimeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeMaintenanceStartTimeError::InternalServerError(ref cause) => cause,
-            DescribeMaintenanceStartTimeError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeMaintenanceStartTimeError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeMaintenanceStartTimeError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeMaintenanceStartTimeError {}
 /// Errors returned by DescribeNFSFileShares
 #[derive(Debug, PartialEq)]
 pub enum DescribeNFSFileSharesError {
@@ -4245,17 +4151,13 @@ impl DescribeNFSFileSharesError {
 }
 impl fmt::Display for DescribeNFSFileSharesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNFSFileSharesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeNFSFileSharesError::InternalServerError(ref cause) => cause,
-            DescribeNFSFileSharesError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeNFSFileSharesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeNFSFileSharesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeNFSFileSharesError {}
 /// Errors returned by DescribeSMBFileShares
 #[derive(Debug, PartialEq)]
 pub enum DescribeSMBFileSharesError {
@@ -4288,17 +4190,13 @@ impl DescribeSMBFileSharesError {
 }
 impl fmt::Display for DescribeSMBFileSharesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSMBFileSharesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSMBFileSharesError::InternalServerError(ref cause) => cause,
-            DescribeSMBFileSharesError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeSMBFileSharesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeSMBFileSharesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSMBFileSharesError {}
 /// Errors returned by DescribeSMBSettings
 #[derive(Debug, PartialEq)]
 pub enum DescribeSMBSettingsError {
@@ -4331,17 +4229,13 @@ impl DescribeSMBSettingsError {
 }
 impl fmt::Display for DescribeSMBSettingsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSMBSettingsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSMBSettingsError::InternalServerError(ref cause) => cause,
-            DescribeSMBSettingsError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeSMBSettingsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeSMBSettingsError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSMBSettingsError {}
 /// Errors returned by DescribeSnapshotSchedule
 #[derive(Debug, PartialEq)]
 pub enum DescribeSnapshotScheduleError {
@@ -4374,17 +4268,15 @@ impl DescribeSnapshotScheduleError {
 }
 impl fmt::Display for DescribeSnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSnapshotScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSnapshotScheduleError::InternalServerError(ref cause) => cause,
-            DescribeSnapshotScheduleError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeSnapshotScheduleError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeSnapshotScheduleError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeSnapshotScheduleError {}
 /// Errors returned by DescribeStorediSCSIVolumes
 #[derive(Debug, PartialEq)]
 pub enum DescribeStorediSCSIVolumesError {
@@ -4419,17 +4311,17 @@ impl DescribeStorediSCSIVolumesError {
 }
 impl fmt::Display for DescribeStorediSCSIVolumesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeStorediSCSIVolumesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeStorediSCSIVolumesError::InternalServerError(ref cause) => cause,
-            DescribeStorediSCSIVolumesError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeStorediSCSIVolumesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeStorediSCSIVolumesError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeStorediSCSIVolumesError {}
 /// Errors returned by DescribeTapeArchives
 #[derive(Debug, PartialEq)]
 pub enum DescribeTapeArchivesError {
@@ -4462,17 +4354,13 @@ impl DescribeTapeArchivesError {
 }
 impl fmt::Display for DescribeTapeArchivesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTapeArchivesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTapeArchivesError::InternalServerError(ref cause) => cause,
-            DescribeTapeArchivesError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeTapeArchivesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeTapeArchivesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTapeArchivesError {}
 /// Errors returned by DescribeTapeRecoveryPoints
 #[derive(Debug, PartialEq)]
 pub enum DescribeTapeRecoveryPointsError {
@@ -4507,17 +4395,17 @@ impl DescribeTapeRecoveryPointsError {
 }
 impl fmt::Display for DescribeTapeRecoveryPointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTapeRecoveryPointsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTapeRecoveryPointsError::InternalServerError(ref cause) => cause,
-            DescribeTapeRecoveryPointsError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeTapeRecoveryPointsError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeTapeRecoveryPointsError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTapeRecoveryPointsError {}
 /// Errors returned by DescribeTapes
 #[derive(Debug, PartialEq)]
 pub enum DescribeTapesError {
@@ -4546,17 +4434,13 @@ impl DescribeTapesError {
 }
 impl fmt::Display for DescribeTapesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTapesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTapesError::InternalServerError(ref cause) => cause,
-            DescribeTapesError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeTapesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeTapesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTapesError {}
 /// Errors returned by DescribeUploadBuffer
 #[derive(Debug, PartialEq)]
 pub enum DescribeUploadBufferError {
@@ -4589,17 +4473,13 @@ impl DescribeUploadBufferError {
 }
 impl fmt::Display for DescribeUploadBufferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUploadBufferError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUploadBufferError::InternalServerError(ref cause) => cause,
-            DescribeUploadBufferError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeUploadBufferError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeUploadBufferError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUploadBufferError {}
 /// Errors returned by DescribeVTLDevices
 #[derive(Debug, PartialEq)]
 pub enum DescribeVTLDevicesError {
@@ -4632,17 +4512,13 @@ impl DescribeVTLDevicesError {
 }
 impl fmt::Display for DescribeVTLDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeVTLDevicesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeVTLDevicesError::InternalServerError(ref cause) => cause,
-            DescribeVTLDevicesError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeVTLDevicesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeVTLDevicesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeVTLDevicesError {}
 /// Errors returned by DescribeWorkingStorage
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkingStorageError {
@@ -4675,17 +4551,13 @@ impl DescribeWorkingStorageError {
 }
 impl fmt::Display for DescribeWorkingStorageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkingStorageError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkingStorageError::InternalServerError(ref cause) => cause,
-            DescribeWorkingStorageError::InvalidGatewayRequest(ref cause) => cause,
+            DescribeWorkingStorageError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeWorkingStorageError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeWorkingStorageError {}
 /// Errors returned by DetachVolume
 #[derive(Debug, PartialEq)]
 pub enum DetachVolumeError {
@@ -4714,17 +4586,13 @@ impl DetachVolumeError {
 }
 impl fmt::Display for DetachVolumeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetachVolumeError {
-    fn description(&self) -> &str {
         match *self {
-            DetachVolumeError::InternalServerError(ref cause) => cause,
-            DetachVolumeError::InvalidGatewayRequest(ref cause) => cause,
+            DetachVolumeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DetachVolumeError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetachVolumeError {}
 /// Errors returned by DisableGateway
 #[derive(Debug, PartialEq)]
 pub enum DisableGatewayError {
@@ -4755,17 +4623,13 @@ impl DisableGatewayError {
 }
 impl fmt::Display for DisableGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisableGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            DisableGatewayError::InternalServerError(ref cause) => cause,
-            DisableGatewayError::InvalidGatewayRequest(ref cause) => cause,
+            DisableGatewayError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DisableGatewayError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisableGatewayError {}
 /// Errors returned by JoinDomain
 #[derive(Debug, PartialEq)]
 pub enum JoinDomainError {
@@ -4794,17 +4658,13 @@ impl JoinDomainError {
 }
 impl fmt::Display for JoinDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for JoinDomainError {
-    fn description(&self) -> &str {
         match *self {
-            JoinDomainError::InternalServerError(ref cause) => cause,
-            JoinDomainError::InvalidGatewayRequest(ref cause) => cause,
+            JoinDomainError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            JoinDomainError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for JoinDomainError {}
 /// Errors returned by ListFileShares
 #[derive(Debug, PartialEq)]
 pub enum ListFileSharesError {
@@ -4835,17 +4695,13 @@ impl ListFileSharesError {
 }
 impl fmt::Display for ListFileSharesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFileSharesError {
-    fn description(&self) -> &str {
         match *self {
-            ListFileSharesError::InternalServerError(ref cause) => cause,
-            ListFileSharesError::InvalidGatewayRequest(ref cause) => cause,
+            ListFileSharesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListFileSharesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFileSharesError {}
 /// Errors returned by ListGateways
 #[derive(Debug, PartialEq)]
 pub enum ListGatewaysError {
@@ -4874,17 +4730,13 @@ impl ListGatewaysError {
 }
 impl fmt::Display for ListGatewaysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGatewaysError {
-    fn description(&self) -> &str {
         match *self {
-            ListGatewaysError::InternalServerError(ref cause) => cause,
-            ListGatewaysError::InvalidGatewayRequest(ref cause) => cause,
+            ListGatewaysError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListGatewaysError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGatewaysError {}
 /// Errors returned by ListLocalDisks
 #[derive(Debug, PartialEq)]
 pub enum ListLocalDisksError {
@@ -4915,17 +4767,13 @@ impl ListLocalDisksError {
 }
 impl fmt::Display for ListLocalDisksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLocalDisksError {
-    fn description(&self) -> &str {
         match *self {
-            ListLocalDisksError::InternalServerError(ref cause) => cause,
-            ListLocalDisksError::InvalidGatewayRequest(ref cause) => cause,
+            ListLocalDisksError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListLocalDisksError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLocalDisksError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -4958,17 +4806,13 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalServerError(ref cause) => cause,
-            ListTagsForResourceError::InvalidGatewayRequest(ref cause) => cause,
+            ListTagsForResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListTapes
 #[derive(Debug, PartialEq)]
 pub enum ListTapesError {
@@ -4997,17 +4841,13 @@ impl ListTapesError {
 }
 impl fmt::Display for ListTapesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTapesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTapesError::InternalServerError(ref cause) => cause,
-            ListTapesError::InvalidGatewayRequest(ref cause) => cause,
+            ListTapesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListTapesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTapesError {}
 /// Errors returned by ListVolumeInitiators
 #[derive(Debug, PartialEq)]
 pub enum ListVolumeInitiatorsError {
@@ -5040,17 +4880,13 @@ impl ListVolumeInitiatorsError {
 }
 impl fmt::Display for ListVolumeInitiatorsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVolumeInitiatorsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVolumeInitiatorsError::InternalServerError(ref cause) => cause,
-            ListVolumeInitiatorsError::InvalidGatewayRequest(ref cause) => cause,
+            ListVolumeInitiatorsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListVolumeInitiatorsError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVolumeInitiatorsError {}
 /// Errors returned by ListVolumeRecoveryPoints
 #[derive(Debug, PartialEq)]
 pub enum ListVolumeRecoveryPointsError {
@@ -5083,17 +4919,15 @@ impl ListVolumeRecoveryPointsError {
 }
 impl fmt::Display for ListVolumeRecoveryPointsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVolumeRecoveryPointsError {
-    fn description(&self) -> &str {
         match *self {
-            ListVolumeRecoveryPointsError::InternalServerError(ref cause) => cause,
-            ListVolumeRecoveryPointsError::InvalidGatewayRequest(ref cause) => cause,
+            ListVolumeRecoveryPointsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListVolumeRecoveryPointsError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListVolumeRecoveryPointsError {}
 /// Errors returned by ListVolumes
 #[derive(Debug, PartialEq)]
 pub enum ListVolumesError {
@@ -5122,17 +4956,13 @@ impl ListVolumesError {
 }
 impl fmt::Display for ListVolumesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVolumesError {
-    fn description(&self) -> &str {
         match *self {
-            ListVolumesError::InternalServerError(ref cause) => cause,
-            ListVolumesError::InvalidGatewayRequest(ref cause) => cause,
+            ListVolumesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListVolumesError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVolumesError {}
 /// Errors returned by NotifyWhenUploaded
 #[derive(Debug, PartialEq)]
 pub enum NotifyWhenUploadedError {
@@ -5165,17 +4995,13 @@ impl NotifyWhenUploadedError {
 }
 impl fmt::Display for NotifyWhenUploadedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for NotifyWhenUploadedError {
-    fn description(&self) -> &str {
         match *self {
-            NotifyWhenUploadedError::InternalServerError(ref cause) => cause,
-            NotifyWhenUploadedError::InvalidGatewayRequest(ref cause) => cause,
+            NotifyWhenUploadedError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            NotifyWhenUploadedError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for NotifyWhenUploadedError {}
 /// Errors returned by RefreshCache
 #[derive(Debug, PartialEq)]
 pub enum RefreshCacheError {
@@ -5204,17 +5030,13 @@ impl RefreshCacheError {
 }
 impl fmt::Display for RefreshCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RefreshCacheError {
-    fn description(&self) -> &str {
         match *self {
-            RefreshCacheError::InternalServerError(ref cause) => cause,
-            RefreshCacheError::InvalidGatewayRequest(ref cause) => cause,
+            RefreshCacheError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RefreshCacheError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RefreshCacheError {}
 /// Errors returned by RemoveTagsFromResource
 #[derive(Debug, PartialEq)]
 pub enum RemoveTagsFromResourceError {
@@ -5247,17 +5069,13 @@ impl RemoveTagsFromResourceError {
 }
 impl fmt::Display for RemoveTagsFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveTagsFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveTagsFromResourceError::InternalServerError(ref cause) => cause,
-            RemoveTagsFromResourceError::InvalidGatewayRequest(ref cause) => cause,
+            RemoveTagsFromResourceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RemoveTagsFromResourceError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RemoveTagsFromResourceError {}
 /// Errors returned by ResetCache
 #[derive(Debug, PartialEq)]
 pub enum ResetCacheError {
@@ -5286,17 +5104,13 @@ impl ResetCacheError {
 }
 impl fmt::Display for ResetCacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetCacheError {
-    fn description(&self) -> &str {
         match *self {
-            ResetCacheError::InternalServerError(ref cause) => cause,
-            ResetCacheError::InvalidGatewayRequest(ref cause) => cause,
+            ResetCacheError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ResetCacheError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetCacheError {}
 /// Errors returned by RetrieveTapeArchive
 #[derive(Debug, PartialEq)]
 pub enum RetrieveTapeArchiveError {
@@ -5329,17 +5143,13 @@ impl RetrieveTapeArchiveError {
 }
 impl fmt::Display for RetrieveTapeArchiveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RetrieveTapeArchiveError {
-    fn description(&self) -> &str {
         match *self {
-            RetrieveTapeArchiveError::InternalServerError(ref cause) => cause,
-            RetrieveTapeArchiveError::InvalidGatewayRequest(ref cause) => cause,
+            RetrieveTapeArchiveError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RetrieveTapeArchiveError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RetrieveTapeArchiveError {}
 /// Errors returned by RetrieveTapeRecoveryPoint
 #[derive(Debug, PartialEq)]
 pub enum RetrieveTapeRecoveryPointError {
@@ -5372,17 +5182,17 @@ impl RetrieveTapeRecoveryPointError {
 }
 impl fmt::Display for RetrieveTapeRecoveryPointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RetrieveTapeRecoveryPointError {
-    fn description(&self) -> &str {
         match *self {
-            RetrieveTapeRecoveryPointError::InternalServerError(ref cause) => cause,
-            RetrieveTapeRecoveryPointError::InvalidGatewayRequest(ref cause) => cause,
+            RetrieveTapeRecoveryPointError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RetrieveTapeRecoveryPointError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RetrieveTapeRecoveryPointError {}
 /// Errors returned by SetLocalConsolePassword
 #[derive(Debug, PartialEq)]
 pub enum SetLocalConsolePasswordError {
@@ -5415,17 +5225,15 @@ impl SetLocalConsolePasswordError {
 }
 impl fmt::Display for SetLocalConsolePasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetLocalConsolePasswordError {
-    fn description(&self) -> &str {
         match *self {
-            SetLocalConsolePasswordError::InternalServerError(ref cause) => cause,
-            SetLocalConsolePasswordError::InvalidGatewayRequest(ref cause) => cause,
+            SetLocalConsolePasswordError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SetLocalConsolePasswordError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for SetLocalConsolePasswordError {}
 /// Errors returned by SetSMBGuestPassword
 #[derive(Debug, PartialEq)]
 pub enum SetSMBGuestPasswordError {
@@ -5458,17 +5266,13 @@ impl SetSMBGuestPasswordError {
 }
 impl fmt::Display for SetSMBGuestPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SetSMBGuestPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            SetSMBGuestPasswordError::InternalServerError(ref cause) => cause,
-            SetSMBGuestPasswordError::InvalidGatewayRequest(ref cause) => cause,
+            SetSMBGuestPasswordError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SetSMBGuestPasswordError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SetSMBGuestPasswordError {}
 /// Errors returned by ShutdownGateway
 #[derive(Debug, PartialEq)]
 pub enum ShutdownGatewayError {
@@ -5499,17 +5303,13 @@ impl ShutdownGatewayError {
 }
 impl fmt::Display for ShutdownGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ShutdownGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            ShutdownGatewayError::InternalServerError(ref cause) => cause,
-            ShutdownGatewayError::InvalidGatewayRequest(ref cause) => cause,
+            ShutdownGatewayError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ShutdownGatewayError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ShutdownGatewayError {}
 /// Errors returned by StartAvailabilityMonitorTest
 #[derive(Debug, PartialEq)]
 pub enum StartAvailabilityMonitorTestError {
@@ -5544,17 +5344,17 @@ impl StartAvailabilityMonitorTestError {
 }
 impl fmt::Display for StartAvailabilityMonitorTestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartAvailabilityMonitorTestError {
-    fn description(&self) -> &str {
         match *self {
-            StartAvailabilityMonitorTestError::InternalServerError(ref cause) => cause,
-            StartAvailabilityMonitorTestError::InvalidGatewayRequest(ref cause) => cause,
+            StartAvailabilityMonitorTestError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartAvailabilityMonitorTestError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartAvailabilityMonitorTestError {}
 /// Errors returned by StartGateway
 #[derive(Debug, PartialEq)]
 pub enum StartGatewayError {
@@ -5583,17 +5383,13 @@ impl StartGatewayError {
 }
 impl fmt::Display for StartGatewayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartGatewayError {
-    fn description(&self) -> &str {
         match *self {
-            StartGatewayError::InternalServerError(ref cause) => cause,
-            StartGatewayError::InvalidGatewayRequest(ref cause) => cause,
+            StartGatewayError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartGatewayError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartGatewayError {}
 /// Errors returned by UpdateBandwidthRateLimit
 #[derive(Debug, PartialEq)]
 pub enum UpdateBandwidthRateLimitError {
@@ -5626,17 +5422,15 @@ impl UpdateBandwidthRateLimitError {
 }
 impl fmt::Display for UpdateBandwidthRateLimitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateBandwidthRateLimitError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateBandwidthRateLimitError::InternalServerError(ref cause) => cause,
-            UpdateBandwidthRateLimitError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateBandwidthRateLimitError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateBandwidthRateLimitError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateBandwidthRateLimitError {}
 /// Errors returned by UpdateChapCredentials
 #[derive(Debug, PartialEq)]
 pub enum UpdateChapCredentialsError {
@@ -5669,17 +5463,13 @@ impl UpdateChapCredentialsError {
 }
 impl fmt::Display for UpdateChapCredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateChapCredentialsError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateChapCredentialsError::InternalServerError(ref cause) => cause,
-            UpdateChapCredentialsError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateChapCredentialsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateChapCredentialsError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateChapCredentialsError {}
 /// Errors returned by UpdateGatewayInformation
 #[derive(Debug, PartialEq)]
 pub enum UpdateGatewayInformationError {
@@ -5712,17 +5502,15 @@ impl UpdateGatewayInformationError {
 }
 impl fmt::Display for UpdateGatewayInformationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGatewayInformationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGatewayInformationError::InternalServerError(ref cause) => cause,
-            UpdateGatewayInformationError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateGatewayInformationError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateGatewayInformationError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateGatewayInformationError {}
 /// Errors returned by UpdateGatewaySoftwareNow
 #[derive(Debug, PartialEq)]
 pub enum UpdateGatewaySoftwareNowError {
@@ -5755,17 +5543,15 @@ impl UpdateGatewaySoftwareNowError {
 }
 impl fmt::Display for UpdateGatewaySoftwareNowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGatewaySoftwareNowError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGatewaySoftwareNowError::InternalServerError(ref cause) => cause,
-            UpdateGatewaySoftwareNowError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateGatewaySoftwareNowError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateGatewaySoftwareNowError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateGatewaySoftwareNowError {}
 /// Errors returned by UpdateMaintenanceStartTime
 #[derive(Debug, PartialEq)]
 pub enum UpdateMaintenanceStartTimeError {
@@ -5800,17 +5586,17 @@ impl UpdateMaintenanceStartTimeError {
 }
 impl fmt::Display for UpdateMaintenanceStartTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMaintenanceStartTimeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMaintenanceStartTimeError::InternalServerError(ref cause) => cause,
-            UpdateMaintenanceStartTimeError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateMaintenanceStartTimeError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateMaintenanceStartTimeError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateMaintenanceStartTimeError {}
 /// Errors returned by UpdateNFSFileShare
 #[derive(Debug, PartialEq)]
 pub enum UpdateNFSFileShareError {
@@ -5843,17 +5629,13 @@ impl UpdateNFSFileShareError {
 }
 impl fmt::Display for UpdateNFSFileShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateNFSFileShareError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateNFSFileShareError::InternalServerError(ref cause) => cause,
-            UpdateNFSFileShareError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateNFSFileShareError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateNFSFileShareError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateNFSFileShareError {}
 /// Errors returned by UpdateSMBFileShare
 #[derive(Debug, PartialEq)]
 pub enum UpdateSMBFileShareError {
@@ -5886,17 +5668,13 @@ impl UpdateSMBFileShareError {
 }
 impl fmt::Display for UpdateSMBFileShareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSMBFileShareError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSMBFileShareError::InternalServerError(ref cause) => cause,
-            UpdateSMBFileShareError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateSMBFileShareError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateSMBFileShareError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSMBFileShareError {}
 /// Errors returned by UpdateSMBSecurityStrategy
 #[derive(Debug, PartialEq)]
 pub enum UpdateSMBSecurityStrategyError {
@@ -5929,17 +5707,17 @@ impl UpdateSMBSecurityStrategyError {
 }
 impl fmt::Display for UpdateSMBSecurityStrategyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSMBSecurityStrategyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSMBSecurityStrategyError::InternalServerError(ref cause) => cause,
-            UpdateSMBSecurityStrategyError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateSMBSecurityStrategyError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSMBSecurityStrategyError::InvalidGatewayRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateSMBSecurityStrategyError {}
 /// Errors returned by UpdateSnapshotSchedule
 #[derive(Debug, PartialEq)]
 pub enum UpdateSnapshotScheduleError {
@@ -5972,17 +5750,13 @@ impl UpdateSnapshotScheduleError {
 }
 impl fmt::Display for UpdateSnapshotScheduleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSnapshotScheduleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSnapshotScheduleError::InternalServerError(ref cause) => cause,
-            UpdateSnapshotScheduleError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateSnapshotScheduleError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateSnapshotScheduleError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSnapshotScheduleError {}
 /// Errors returned by UpdateVTLDeviceType
 #[derive(Debug, PartialEq)]
 pub enum UpdateVTLDeviceTypeError {
@@ -6015,17 +5789,13 @@ impl UpdateVTLDeviceTypeError {
 }
 impl fmt::Display for UpdateVTLDeviceTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVTLDeviceTypeError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVTLDeviceTypeError::InternalServerError(ref cause) => cause,
-            UpdateVTLDeviceTypeError::InvalidGatewayRequest(ref cause) => cause,
+            UpdateVTLDeviceTypeError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateVTLDeviceTypeError::InvalidGatewayRequest(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVTLDeviceTypeError {}
 /// Trait representing the capabilities of the AWS Storage Gateway API. AWS Storage Gateway clients implement this trait.
 pub trait StorageGateway {
     /// <p><p>Activates the gateway you previously deployed on your host. In the activation process, you specify information such as the AWS Region that you want to use for storing snapshots or tapes, the time zone for scheduled snapshots the gateway snapshot schedule window, an activation key, and a name for your gateway. The activation process also associates your gateway with your account; for more information, see <a>UpdateGatewayInformation</a>.</p> <note> <p>You must turn on the gateway VM before you can activate your gateway.</p> </note></p>

--- a/rusoto/services/sts/src/custom/web_identity.rs
+++ b/rusoto/services/sts/src/custom/web_identity.rs
@@ -137,7 +137,7 @@ impl Future for WebIdentityProviderFuture {
             LoadBearerToken(_, Err(e), _) => Err(e.clone()),
             LoadBearerToken(_, _, Err(e)) => Err(e.clone()),
             LoadBearerToken(Ok(token), Ok(role), Ok(session)) => match HttpClient::new() {
-                Err(e) => Err(CredentialsError::new(e.description().to_string())),
+                Err(e) => Err(CredentialsError::new(e.to_string())),
                 Ok(c) => {
                     let client = Client::new_not_signing(c);
                     let sts = StsClient::new_with_client(client, Region::default());

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -1118,18 +1118,14 @@ impl AssumeRoleError {
 }
 impl fmt::Display for AssumeRoleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssumeRoleError {
-    fn description(&self) -> &str {
         match *self {
-            AssumeRoleError::MalformedPolicyDocument(ref cause) => cause,
-            AssumeRoleError::PackedPolicyTooLarge(ref cause) => cause,
-            AssumeRoleError::RegionDisabled(ref cause) => cause,
+            AssumeRoleError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            AssumeRoleError::PackedPolicyTooLarge(ref cause) => write!(f, "{}", cause),
+            AssumeRoleError::RegionDisabled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssumeRoleError {}
 /// Errors returned by AssumeRoleWithSAML
 #[derive(Debug, PartialEq)]
 pub enum AssumeRoleWithSAMLError {
@@ -1202,21 +1198,17 @@ impl AssumeRoleWithSAMLError {
 }
 impl fmt::Display for AssumeRoleWithSAMLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssumeRoleWithSAMLError {
-    fn description(&self) -> &str {
         match *self {
-            AssumeRoleWithSAMLError::ExpiredToken(ref cause) => cause,
-            AssumeRoleWithSAMLError::IDPRejectedClaim(ref cause) => cause,
-            AssumeRoleWithSAMLError::InvalidIdentityToken(ref cause) => cause,
-            AssumeRoleWithSAMLError::MalformedPolicyDocument(ref cause) => cause,
-            AssumeRoleWithSAMLError::PackedPolicyTooLarge(ref cause) => cause,
-            AssumeRoleWithSAMLError::RegionDisabled(ref cause) => cause,
+            AssumeRoleWithSAMLError::ExpiredToken(ref cause) => write!(f, "{}", cause),
+            AssumeRoleWithSAMLError::IDPRejectedClaim(ref cause) => write!(f, "{}", cause),
+            AssumeRoleWithSAMLError::InvalidIdentityToken(ref cause) => write!(f, "{}", cause),
+            AssumeRoleWithSAMLError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            AssumeRoleWithSAMLError::PackedPolicyTooLarge(ref cause) => write!(f, "{}", cause),
+            AssumeRoleWithSAMLError::RegionDisabled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssumeRoleWithSAMLError {}
 /// Errors returned by AssumeRoleWithWebIdentity
 #[derive(Debug, PartialEq)]
 pub enum AssumeRoleWithWebIdentityError {
@@ -1304,22 +1296,26 @@ impl AssumeRoleWithWebIdentityError {
 }
 impl fmt::Display for AssumeRoleWithWebIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssumeRoleWithWebIdentityError {
-    fn description(&self) -> &str {
         match *self {
-            AssumeRoleWithWebIdentityError::ExpiredToken(ref cause) => cause,
-            AssumeRoleWithWebIdentityError::IDPCommunicationError(ref cause) => cause,
-            AssumeRoleWithWebIdentityError::IDPRejectedClaim(ref cause) => cause,
-            AssumeRoleWithWebIdentityError::InvalidIdentityToken(ref cause) => cause,
-            AssumeRoleWithWebIdentityError::MalformedPolicyDocument(ref cause) => cause,
-            AssumeRoleWithWebIdentityError::PackedPolicyTooLarge(ref cause) => cause,
-            AssumeRoleWithWebIdentityError::RegionDisabled(ref cause) => cause,
+            AssumeRoleWithWebIdentityError::ExpiredToken(ref cause) => write!(f, "{}", cause),
+            AssumeRoleWithWebIdentityError::IDPCommunicationError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssumeRoleWithWebIdentityError::IDPRejectedClaim(ref cause) => write!(f, "{}", cause),
+            AssumeRoleWithWebIdentityError::InvalidIdentityToken(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssumeRoleWithWebIdentityError::MalformedPolicyDocument(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssumeRoleWithWebIdentityError::PackedPolicyTooLarge(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssumeRoleWithWebIdentityError::RegionDisabled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssumeRoleWithWebIdentityError {}
 /// Errors returned by DecodeAuthorizationMessage
 #[derive(Debug, PartialEq)]
 pub enum DecodeAuthorizationMessageError {
@@ -1361,16 +1357,14 @@ impl DecodeAuthorizationMessageError {
 }
 impl fmt::Display for DecodeAuthorizationMessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DecodeAuthorizationMessageError {
-    fn description(&self) -> &str {
         match *self {
-            DecodeAuthorizationMessageError::InvalidAuthorizationMessage(ref cause) => cause,
+            DecodeAuthorizationMessageError::InvalidAuthorizationMessage(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DecodeAuthorizationMessageError {}
 /// Errors returned by GetAccessKeyInfo
 #[derive(Debug, PartialEq)]
 pub enum GetAccessKeyInfoError {}
@@ -1400,14 +1394,10 @@ impl GetAccessKeyInfoError {
 }
 impl fmt::Display for GetAccessKeyInfoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetAccessKeyInfoError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetAccessKeyInfoError {}
 /// Errors returned by GetCallerIdentity
 #[derive(Debug, PartialEq)]
 pub enum GetCallerIdentityError {}
@@ -1437,14 +1427,10 @@ impl GetCallerIdentityError {
 }
 impl fmt::Display for GetCallerIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCallerIdentityError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for GetCallerIdentityError {}
 /// Errors returned by GetFederationToken
 #[derive(Debug, PartialEq)]
 pub enum GetFederationTokenError {
@@ -1496,18 +1482,14 @@ impl GetFederationTokenError {
 }
 impl fmt::Display for GetFederationTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFederationTokenError {
-    fn description(&self) -> &str {
         match *self {
-            GetFederationTokenError::MalformedPolicyDocument(ref cause) => cause,
-            GetFederationTokenError::PackedPolicyTooLarge(ref cause) => cause,
-            GetFederationTokenError::RegionDisabled(ref cause) => cause,
+            GetFederationTokenError::MalformedPolicyDocument(ref cause) => write!(f, "{}", cause),
+            GetFederationTokenError::PackedPolicyTooLarge(ref cause) => write!(f, "{}", cause),
+            GetFederationTokenError::RegionDisabled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFederationTokenError {}
 /// Errors returned by GetSessionToken
 #[derive(Debug, PartialEq)]
 pub enum GetSessionTokenError {
@@ -1545,16 +1527,12 @@ impl GetSessionTokenError {
 }
 impl fmt::Display for GetSessionTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSessionTokenError {
-    fn description(&self) -> &str {
         match *self {
-            GetSessionTokenError::RegionDisabled(ref cause) => cause,
+            GetSessionTokenError::RegionDisabled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSessionTokenError {}
 /// Trait representing the capabilities of the AWS STS API. AWS STS clients implement this trait.
 pub trait Sts {
     /// <p>Returns a set of temporary security credentials that you can use to access AWS resources that you might not normally have access to. These temporary credentials consist of an access key ID, a secret access key, and a security token. Typically, you use <code>AssumeRole</code> within your account or for cross-account access. For a comparison of <code>AssumeRole</code> with other API operations that produce temporary credentials, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html">Requesting Temporary Security Credentials</a> and <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#stsapi_comparison">Comparing the AWS STS API operations</a> in the <i>IAM User Guide</i>.</p> <important> <p>You cannot use AWS account root user credentials to call <code>AssumeRole</code>. You must use credentials for an IAM user or an IAM role to call <code>AssumeRole</code>.</p> </important> <p>For cross-account access, imagine that you own multiple accounts and need to access resources in each account. You could create long-term credentials in each account to access those resources. However, managing all those credentials and remembering which one can access which account can be time consuming. Instead, you can create one set of long-term credentials in one account. Then use temporary security credentials to access all the other accounts by assuming roles in those accounts. For more information about roles, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html">IAM Roles</a> in the <i>IAM User Guide</i>. </p> <p> <b>Session Duration</b> </p> <p>By default, the temporary security credentials created by <code>AssumeRole</code> last for one hour. However, you can use the optional <code>DurationSeconds</code> parameter to specify the duration of your session. You can provide a value from 900 seconds (15 minutes) up to the maximum session duration setting for the role. This setting can have a value from 1 hour to 12 hours. To learn how to view the maximum value for your role, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session">View the Maximum Session Duration Setting for a Role</a> in the <i>IAM User Guide</i>. The maximum session duration limit applies when you use the <code>AssumeRole*</code> API operations or the <code>assume-role*</code> CLI commands. However the limit does not apply when you use those operations to create a console URL. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html">Using IAM Roles</a> in the <i>IAM User Guide</i>.</p> <p> <b>Permissions</b> </p> <p>The temporary security credentials created by <code>AssumeRole</code> can be used to make API calls to any AWS service with the following exception: You cannot call the AWS STS <code>GetFederationToken</code> or <code>GetSessionToken</code> API operations.</p> <p>(Optional) You can pass inline or managed <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session">session policies</a> to this operation. You can pass a single JSON policy document to use as an inline session policy. You can also specify up to 10 managed policies to use as managed session policies. The plain text that you use for both inline and managed session policies can't exceed 2,048 characters. Passing policies to this operation returns new temporary credentials. The resulting session's permissions are the intersection of the role's identity-based policy and the session policies. You can use the role's temporary credentials in subsequent AWS API calls to access resources in the account that owns the role. You cannot use session policies to grant more permissions than those allowed by the identity-based policy of the role that is being assumed. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session">Session Policies</a> in the <i>IAM User Guide</i>.</p> <p>To assume a role from a different account, your AWS account must be trusted by the role. The trust relationship is defined in the role's trust policy when the role is created. That trust policy states which accounts are allowed to delegate that access to users in the account. </p> <p>A user who wants to access a role in a different account must also have permissions that are delegated from the user account administrator. The administrator must attach a policy that allows the user to call <code>AssumeRole</code> for the ARN of the role in the other account. If the user is in the same account as the role, then you can do either of the following:</p> <ul> <li> <p>Attach a policy to the user (identical to the previous user in a different account).</p> </li> <li> <p>Add the user as a principal directly in the role's trust policy.</p> </li> </ul> <p>In this case, the trust policy acts as an IAM resource-based policy. Users in the same account as the role do not need explicit permission to assume the role. For more information about trust policies and resource-based policies, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html">IAM Policies</a> in the <i>IAM User Guide</i>.</p> <p> <b>Tags</b> </p> <p>(Optional) You can pass tag key-value pairs to your session. These tags are called session tags. For more information about session tags, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html">Passing Session Tags in STS</a> in the <i>IAM User Guide</i>.</p> <p>An administrator must grant you the permissions necessary to pass session tags. The administrator can also create granular permissions to allow you to pass only specific session tags. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html">Tutorial: Using Tags for Attribute-Based Access Control</a> in the <i>IAM User Guide</i>.</p> <p>You can set the session tags as transitive. Transitive tags persist during role chaining. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining">Chaining Roles with Session Tags</a> in the <i>IAM User Guide</i>.</p> <p> <b>Using MFA with AssumeRole</b> </p> <p>(Optional) You can include multi-factor authentication (MFA) information when you call <code>AssumeRole</code>. This is useful for cross-account scenarios to ensure that the user that assumes the role has been authenticated with an AWS MFA device. In that scenario, the trust policy of the role being assumed includes a condition that tests for MFA authentication. If the caller does not include valid MFA information, the request to assume the role is denied. The condition in a trust policy that tests for MFA authentication might look like the following example.</p> <p> <code>"Condition": {"Bool": {"aws:MultiFactorAuthPresent": true}}</code> </p> <p>For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/MFAProtectedAPI.html">Configuring MFA-Protected API Access</a> in the <i>IAM User Guide</i> guide.</p> <p>To use MFA with <code>AssumeRole</code>, you pass values for the <code>SerialNumber</code> and <code>TokenCode</code> parameters. The <code>SerialNumber</code> value identifies the user's hardware or virtual MFA device. The <code>TokenCode</code> is the time-based one-time password (TOTP) that the MFA device produces. </p>

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -757,20 +757,18 @@ impl AddAttachmentsToSetError {
 }
 impl fmt::Display for AddAttachmentsToSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddAttachmentsToSetError {
-    fn description(&self) -> &str {
         match *self {
-            AddAttachmentsToSetError::AttachmentLimitExceeded(ref cause) => cause,
-            AddAttachmentsToSetError::AttachmentSetExpired(ref cause) => cause,
-            AddAttachmentsToSetError::AttachmentSetIdNotFound(ref cause) => cause,
-            AddAttachmentsToSetError::AttachmentSetSizeLimitExceeded(ref cause) => cause,
-            AddAttachmentsToSetError::InternalServerError(ref cause) => cause,
+            AddAttachmentsToSetError::AttachmentLimitExceeded(ref cause) => write!(f, "{}", cause),
+            AddAttachmentsToSetError::AttachmentSetExpired(ref cause) => write!(f, "{}", cause),
+            AddAttachmentsToSetError::AttachmentSetIdNotFound(ref cause) => write!(f, "{}", cause),
+            AddAttachmentsToSetError::AttachmentSetSizeLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddAttachmentsToSetError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddAttachmentsToSetError {}
 /// Errors returned by AddCommunicationToCase
 #[derive(Debug, PartialEq)]
 pub enum AddCommunicationToCaseError {
@@ -817,19 +815,17 @@ impl AddCommunicationToCaseError {
 }
 impl fmt::Display for AddCommunicationToCaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddCommunicationToCaseError {
-    fn description(&self) -> &str {
         match *self {
-            AddCommunicationToCaseError::AttachmentSetExpired(ref cause) => cause,
-            AddCommunicationToCaseError::AttachmentSetIdNotFound(ref cause) => cause,
-            AddCommunicationToCaseError::CaseIdNotFound(ref cause) => cause,
-            AddCommunicationToCaseError::InternalServerError(ref cause) => cause,
+            AddCommunicationToCaseError::AttachmentSetExpired(ref cause) => write!(f, "{}", cause),
+            AddCommunicationToCaseError::AttachmentSetIdNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AddCommunicationToCaseError::CaseIdNotFound(ref cause) => write!(f, "{}", cause),
+            AddCommunicationToCaseError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AddCommunicationToCaseError {}
 /// Errors returned by CreateCase
 #[derive(Debug, PartialEq)]
 pub enum CreateCaseError {
@@ -870,19 +866,15 @@ impl CreateCaseError {
 }
 impl fmt::Display for CreateCaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCaseError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCaseError::AttachmentSetExpired(ref cause) => cause,
-            CreateCaseError::AttachmentSetIdNotFound(ref cause) => cause,
-            CreateCaseError::CaseCreationLimitExceeded(ref cause) => cause,
-            CreateCaseError::InternalServerError(ref cause) => cause,
+            CreateCaseError::AttachmentSetExpired(ref cause) => write!(f, "{}", cause),
+            CreateCaseError::AttachmentSetIdNotFound(ref cause) => write!(f, "{}", cause),
+            CreateCaseError::CaseCreationLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateCaseError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCaseError {}
 /// Errors returned by DescribeAttachment
 #[derive(Debug, PartialEq)]
 pub enum DescribeAttachmentError {
@@ -922,18 +914,16 @@ impl DescribeAttachmentError {
 }
 impl fmt::Display for DescribeAttachmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAttachmentError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAttachmentError::AttachmentIdNotFound(ref cause) => cause,
-            DescribeAttachmentError::DescribeAttachmentLimitExceeded(ref cause) => cause,
-            DescribeAttachmentError::InternalServerError(ref cause) => cause,
+            DescribeAttachmentError::AttachmentIdNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeAttachmentError::DescribeAttachmentLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAttachmentError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAttachmentError {}
 /// Errors returned by DescribeCases
 #[derive(Debug, PartialEq)]
 pub enum DescribeCasesError {
@@ -962,17 +952,13 @@ impl DescribeCasesError {
 }
 impl fmt::Display for DescribeCasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCasesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCasesError::CaseIdNotFound(ref cause) => cause,
-            DescribeCasesError::InternalServerError(ref cause) => cause,
+            DescribeCasesError::CaseIdNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeCasesError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCasesError {}
 /// Errors returned by DescribeCommunications
 #[derive(Debug, PartialEq)]
 pub enum DescribeCommunicationsError {
@@ -1005,17 +991,13 @@ impl DescribeCommunicationsError {
 }
 impl fmt::Display for DescribeCommunicationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCommunicationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCommunicationsError::CaseIdNotFound(ref cause) => cause,
-            DescribeCommunicationsError::InternalServerError(ref cause) => cause,
+            DescribeCommunicationsError::CaseIdNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeCommunicationsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCommunicationsError {}
 /// Errors returned by DescribeServices
 #[derive(Debug, PartialEq)]
 pub enum DescribeServicesError {
@@ -1041,16 +1023,12 @@ impl DescribeServicesError {
 }
 impl fmt::Display for DescribeServicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServicesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServicesError::InternalServerError(ref cause) => cause,
+            DescribeServicesError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeServicesError {}
 /// Errors returned by DescribeSeverityLevels
 #[derive(Debug, PartialEq)]
 pub enum DescribeSeverityLevelsError {
@@ -1076,16 +1054,12 @@ impl DescribeSeverityLevelsError {
 }
 impl fmt::Display for DescribeSeverityLevelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeSeverityLevelsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeSeverityLevelsError::InternalServerError(ref cause) => cause,
+            DescribeSeverityLevelsError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeSeverityLevelsError {}
 /// Errors returned by DescribeTrustedAdvisorCheckRefreshStatuses
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrustedAdvisorCheckRefreshStatusesError {
@@ -1115,18 +1089,14 @@ impl DescribeTrustedAdvisorCheckRefreshStatusesError {
 }
 impl fmt::Display for DescribeTrustedAdvisorCheckRefreshStatusesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrustedAdvisorCheckRefreshStatusesError {
-    fn description(&self) -> &str {
         match *self {
             DescribeTrustedAdvisorCheckRefreshStatusesError::InternalServerError(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
         }
     }
 }
+impl Error for DescribeTrustedAdvisorCheckRefreshStatusesError {}
 /// Errors returned by DescribeTrustedAdvisorCheckResult
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrustedAdvisorCheckResultError {
@@ -1154,16 +1124,14 @@ impl DescribeTrustedAdvisorCheckResultError {
 }
 impl fmt::Display for DescribeTrustedAdvisorCheckResultError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrustedAdvisorCheckResultError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrustedAdvisorCheckResultError::InternalServerError(ref cause) => cause,
+            DescribeTrustedAdvisorCheckResultError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTrustedAdvisorCheckResultError {}
 /// Errors returned by DescribeTrustedAdvisorCheckSummaries
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrustedAdvisorCheckSummariesError {
@@ -1191,16 +1159,14 @@ impl DescribeTrustedAdvisorCheckSummariesError {
 }
 impl fmt::Display for DescribeTrustedAdvisorCheckSummariesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrustedAdvisorCheckSummariesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrustedAdvisorCheckSummariesError::InternalServerError(ref cause) => cause,
+            DescribeTrustedAdvisorCheckSummariesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTrustedAdvisorCheckSummariesError {}
 /// Errors returned by DescribeTrustedAdvisorChecks
 #[derive(Debug, PartialEq)]
 pub enum DescribeTrustedAdvisorChecksError {
@@ -1228,16 +1194,14 @@ impl DescribeTrustedAdvisorChecksError {
 }
 impl fmt::Display for DescribeTrustedAdvisorChecksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTrustedAdvisorChecksError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTrustedAdvisorChecksError::InternalServerError(ref cause) => cause,
+            DescribeTrustedAdvisorChecksError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeTrustedAdvisorChecksError {}
 /// Errors returned by RefreshTrustedAdvisorCheck
 #[derive(Debug, PartialEq)]
 pub enum RefreshTrustedAdvisorCheckError {
@@ -1265,16 +1229,14 @@ impl RefreshTrustedAdvisorCheckError {
 }
 impl fmt::Display for RefreshTrustedAdvisorCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RefreshTrustedAdvisorCheckError {
-    fn description(&self) -> &str {
         match *self {
-            RefreshTrustedAdvisorCheckError::InternalServerError(ref cause) => cause,
+            RefreshTrustedAdvisorCheckError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RefreshTrustedAdvisorCheckError {}
 /// Errors returned by ResolveCase
 #[derive(Debug, PartialEq)]
 pub enum ResolveCaseError {
@@ -1303,17 +1265,13 @@ impl ResolveCaseError {
 }
 impl fmt::Display for ResolveCaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResolveCaseError {
-    fn description(&self) -> &str {
         match *self {
-            ResolveCaseError::CaseIdNotFound(ref cause) => cause,
-            ResolveCaseError::InternalServerError(ref cause) => cause,
+            ResolveCaseError::CaseIdNotFound(ref cause) => write!(f, "{}", cause),
+            ResolveCaseError::InternalServerError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResolveCaseError {}
 /// Trait representing the capabilities of the AWS Support API. AWS Support clients implement this trait.
 pub trait AWSSupport {
     /// <p>Adds one or more attachments to an attachment set. If an <code>attachmentSetId</code> is not specified, a new attachment set is created, and the ID of the set is returned in the response. If an <code>attachmentSetId</code> is specified, the attachments are added to the specified set, if it exists.</p> <p>An attachment set is a temporary container for attachments that are to be added to a case or case communication. The set is available for one hour after it is created; the <code>expiryTime</code> returned in the response indicates when the set expires. The maximum number of attachments in a set is 3, and the maximum size of any attachment in the set is 5 MB.</p>

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -2931,17 +2931,17 @@ impl CountClosedWorkflowExecutionsError {
 }
 impl fmt::Display for CountClosedWorkflowExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CountClosedWorkflowExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            CountClosedWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => cause,
-            CountClosedWorkflowExecutionsError::UnknownResourceFault(ref cause) => cause,
+            CountClosedWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CountClosedWorkflowExecutionsError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CountClosedWorkflowExecutionsError {}
 /// Errors returned by CountOpenWorkflowExecutions
 #[derive(Debug, PartialEq)]
 pub enum CountOpenWorkflowExecutionsError {
@@ -2976,17 +2976,17 @@ impl CountOpenWorkflowExecutionsError {
 }
 impl fmt::Display for CountOpenWorkflowExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CountOpenWorkflowExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            CountOpenWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => cause,
-            CountOpenWorkflowExecutionsError::UnknownResourceFault(ref cause) => cause,
+            CountOpenWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CountOpenWorkflowExecutionsError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CountOpenWorkflowExecutionsError {}
 /// Errors returned by CountPendingActivityTasks
 #[derive(Debug, PartialEq)]
 pub enum CountPendingActivityTasksError {
@@ -3019,17 +3019,17 @@ impl CountPendingActivityTasksError {
 }
 impl fmt::Display for CountPendingActivityTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CountPendingActivityTasksError {
-    fn description(&self) -> &str {
         match *self {
-            CountPendingActivityTasksError::OperationNotPermittedFault(ref cause) => cause,
-            CountPendingActivityTasksError::UnknownResourceFault(ref cause) => cause,
+            CountPendingActivityTasksError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CountPendingActivityTasksError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CountPendingActivityTasksError {}
 /// Errors returned by CountPendingDecisionTasks
 #[derive(Debug, PartialEq)]
 pub enum CountPendingDecisionTasksError {
@@ -3062,17 +3062,17 @@ impl CountPendingDecisionTasksError {
 }
 impl fmt::Display for CountPendingDecisionTasksError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CountPendingDecisionTasksError {
-    fn description(&self) -> &str {
         match *self {
-            CountPendingDecisionTasksError::OperationNotPermittedFault(ref cause) => cause,
-            CountPendingDecisionTasksError::UnknownResourceFault(ref cause) => cause,
+            CountPendingDecisionTasksError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CountPendingDecisionTasksError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CountPendingDecisionTasksError {}
 /// Errors returned by DeprecateActivityType
 #[derive(Debug, PartialEq)]
 pub enum DeprecateActivityTypeError {
@@ -3112,18 +3112,16 @@ impl DeprecateActivityTypeError {
 }
 impl fmt::Display for DeprecateActivityTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeprecateActivityTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeprecateActivityTypeError::OperationNotPermittedFault(ref cause) => cause,
-            DeprecateActivityTypeError::TypeDeprecatedFault(ref cause) => cause,
-            DeprecateActivityTypeError::UnknownResourceFault(ref cause) => cause,
+            DeprecateActivityTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeprecateActivityTypeError::TypeDeprecatedFault(ref cause) => write!(f, "{}", cause),
+            DeprecateActivityTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeprecateActivityTypeError {}
 /// Errors returned by DeprecateDomain
 #[derive(Debug, PartialEq)]
 pub enum DeprecateDomainError {
@@ -3163,18 +3161,14 @@ impl DeprecateDomainError {
 }
 impl fmt::Display for DeprecateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeprecateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DeprecateDomainError::DomainDeprecatedFault(ref cause) => cause,
-            DeprecateDomainError::OperationNotPermittedFault(ref cause) => cause,
-            DeprecateDomainError::UnknownResourceFault(ref cause) => cause,
+            DeprecateDomainError::DomainDeprecatedFault(ref cause) => write!(f, "{}", cause),
+            DeprecateDomainError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            DeprecateDomainError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeprecateDomainError {}
 /// Errors returned by DeprecateWorkflowType
 #[derive(Debug, PartialEq)]
 pub enum DeprecateWorkflowTypeError {
@@ -3214,18 +3208,16 @@ impl DeprecateWorkflowTypeError {
 }
 impl fmt::Display for DeprecateWorkflowTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeprecateWorkflowTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DeprecateWorkflowTypeError::OperationNotPermittedFault(ref cause) => cause,
-            DeprecateWorkflowTypeError::TypeDeprecatedFault(ref cause) => cause,
-            DeprecateWorkflowTypeError::UnknownResourceFault(ref cause) => cause,
+            DeprecateWorkflowTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeprecateWorkflowTypeError::TypeDeprecatedFault(ref cause) => write!(f, "{}", cause),
+            DeprecateWorkflowTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeprecateWorkflowTypeError {}
 /// Errors returned by DescribeActivityType
 #[derive(Debug, PartialEq)]
 pub enum DescribeActivityTypeError {
@@ -3258,17 +3250,15 @@ impl DescribeActivityTypeError {
 }
 impl fmt::Display for DescribeActivityTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeActivityTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeActivityTypeError::OperationNotPermittedFault(ref cause) => cause,
-            DescribeActivityTypeError::UnknownResourceFault(ref cause) => cause,
+            DescribeActivityTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeActivityTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeActivityTypeError {}
 /// Errors returned by DescribeDomain
 #[derive(Debug, PartialEq)]
 pub enum DescribeDomainError {
@@ -3299,17 +3289,13 @@ impl DescribeDomainError {
 }
 impl fmt::Display for DescribeDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDomainError::OperationNotPermittedFault(ref cause) => cause,
-            DescribeDomainError::UnknownResourceFault(ref cause) => cause,
+            DescribeDomainError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            DescribeDomainError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDomainError {}
 /// Errors returned by DescribeWorkflowExecution
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkflowExecutionError {
@@ -3342,17 +3328,17 @@ impl DescribeWorkflowExecutionError {
 }
 impl fmt::Display for DescribeWorkflowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkflowExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkflowExecutionError::OperationNotPermittedFault(ref cause) => cause,
-            DescribeWorkflowExecutionError::UnknownResourceFault(ref cause) => cause,
+            DescribeWorkflowExecutionError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeWorkflowExecutionError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeWorkflowExecutionError {}
 /// Errors returned by DescribeWorkflowType
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkflowTypeError {
@@ -3385,17 +3371,15 @@ impl DescribeWorkflowTypeError {
 }
 impl fmt::Display for DescribeWorkflowTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkflowTypeError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkflowTypeError::OperationNotPermittedFault(ref cause) => cause,
-            DescribeWorkflowTypeError::UnknownResourceFault(ref cause) => cause,
+            DescribeWorkflowTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeWorkflowTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeWorkflowTypeError {}
 /// Errors returned by GetWorkflowExecutionHistory
 #[derive(Debug, PartialEq)]
 pub enum GetWorkflowExecutionHistoryError {
@@ -3430,17 +3414,17 @@ impl GetWorkflowExecutionHistoryError {
 }
 impl fmt::Display for GetWorkflowExecutionHistoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWorkflowExecutionHistoryError {
-    fn description(&self) -> &str {
         match *self {
-            GetWorkflowExecutionHistoryError::OperationNotPermittedFault(ref cause) => cause,
-            GetWorkflowExecutionHistoryError::UnknownResourceFault(ref cause) => cause,
+            GetWorkflowExecutionHistoryError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetWorkflowExecutionHistoryError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetWorkflowExecutionHistoryError {}
 /// Errors returned by ListActivityTypes
 #[derive(Debug, PartialEq)]
 pub enum ListActivityTypesError {
@@ -3473,17 +3457,13 @@ impl ListActivityTypesError {
 }
 impl fmt::Display for ListActivityTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListActivityTypesError {
-    fn description(&self) -> &str {
         match *self {
-            ListActivityTypesError::OperationNotPermittedFault(ref cause) => cause,
-            ListActivityTypesError::UnknownResourceFault(ref cause) => cause,
+            ListActivityTypesError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            ListActivityTypesError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListActivityTypesError {}
 /// Errors returned by ListClosedWorkflowExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListClosedWorkflowExecutionsError {
@@ -3518,17 +3498,17 @@ impl ListClosedWorkflowExecutionsError {
 }
 impl fmt::Display for ListClosedWorkflowExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListClosedWorkflowExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListClosedWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => cause,
-            ListClosedWorkflowExecutionsError::UnknownResourceFault(ref cause) => cause,
+            ListClosedWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListClosedWorkflowExecutionsError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListClosedWorkflowExecutionsError {}
 /// Errors returned by ListDomains
 #[derive(Debug, PartialEq)]
 pub enum ListDomainsError {
@@ -3554,16 +3534,12 @@ impl ListDomainsError {
 }
 impl fmt::Display for ListDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDomainsError::OperationNotPermittedFault(ref cause) => cause,
+            ListDomainsError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDomainsError {}
 /// Errors returned by ListOpenWorkflowExecutions
 #[derive(Debug, PartialEq)]
 pub enum ListOpenWorkflowExecutionsError {
@@ -3598,17 +3574,17 @@ impl ListOpenWorkflowExecutionsError {
 }
 impl fmt::Display for ListOpenWorkflowExecutionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOpenWorkflowExecutionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOpenWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => cause,
-            ListOpenWorkflowExecutionsError::UnknownResourceFault(ref cause) => cause,
+            ListOpenWorkflowExecutionsError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListOpenWorkflowExecutionsError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListOpenWorkflowExecutionsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -3648,18 +3624,16 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::LimitExceededFault(ref cause) => cause,
-            ListTagsForResourceError::OperationNotPermittedFault(ref cause) => cause,
-            ListTagsForResourceError::UnknownResourceFault(ref cause) => cause,
+            ListTagsForResourceError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListTagsForResourceError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListWorkflowTypes
 #[derive(Debug, PartialEq)]
 pub enum ListWorkflowTypesError {
@@ -3692,17 +3666,13 @@ impl ListWorkflowTypesError {
 }
 impl fmt::Display for ListWorkflowTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWorkflowTypesError {
-    fn description(&self) -> &str {
         match *self {
-            ListWorkflowTypesError::OperationNotPermittedFault(ref cause) => cause,
-            ListWorkflowTypesError::UnknownResourceFault(ref cause) => cause,
+            ListWorkflowTypesError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            ListWorkflowTypesError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWorkflowTypesError {}
 /// Errors returned by PollForActivityTask
 #[derive(Debug, PartialEq)]
 pub enum PollForActivityTaskError {
@@ -3742,18 +3712,16 @@ impl PollForActivityTaskError {
 }
 impl fmt::Display for PollForActivityTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PollForActivityTaskError {
-    fn description(&self) -> &str {
         match *self {
-            PollForActivityTaskError::LimitExceededFault(ref cause) => cause,
-            PollForActivityTaskError::OperationNotPermittedFault(ref cause) => cause,
-            PollForActivityTaskError::UnknownResourceFault(ref cause) => cause,
+            PollForActivityTaskError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            PollForActivityTaskError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PollForActivityTaskError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PollForActivityTaskError {}
 /// Errors returned by PollForDecisionTask
 #[derive(Debug, PartialEq)]
 pub enum PollForDecisionTaskError {
@@ -3793,18 +3761,16 @@ impl PollForDecisionTaskError {
 }
 impl fmt::Display for PollForDecisionTaskError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PollForDecisionTaskError {
-    fn description(&self) -> &str {
         match *self {
-            PollForDecisionTaskError::LimitExceededFault(ref cause) => cause,
-            PollForDecisionTaskError::OperationNotPermittedFault(ref cause) => cause,
-            PollForDecisionTaskError::UnknownResourceFault(ref cause) => cause,
+            PollForDecisionTaskError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            PollForDecisionTaskError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PollForDecisionTaskError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PollForDecisionTaskError {}
 /// Errors returned by RecordActivityTaskHeartbeat
 #[derive(Debug, PartialEq)]
 pub enum RecordActivityTaskHeartbeatError {
@@ -3839,17 +3805,17 @@ impl RecordActivityTaskHeartbeatError {
 }
 impl fmt::Display for RecordActivityTaskHeartbeatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RecordActivityTaskHeartbeatError {
-    fn description(&self) -> &str {
         match *self {
-            RecordActivityTaskHeartbeatError::OperationNotPermittedFault(ref cause) => cause,
-            RecordActivityTaskHeartbeatError::UnknownResourceFault(ref cause) => cause,
+            RecordActivityTaskHeartbeatError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RecordActivityTaskHeartbeatError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RecordActivityTaskHeartbeatError {}
 /// Errors returned by RegisterActivityType
 #[derive(Debug, PartialEq)]
 pub enum RegisterActivityTypeError {
@@ -3896,19 +3862,17 @@ impl RegisterActivityTypeError {
 }
 impl fmt::Display for RegisterActivityTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterActivityTypeError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterActivityTypeError::LimitExceededFault(ref cause) => cause,
-            RegisterActivityTypeError::OperationNotPermittedFault(ref cause) => cause,
-            RegisterActivityTypeError::TypeAlreadyExistsFault(ref cause) => cause,
-            RegisterActivityTypeError::UnknownResourceFault(ref cause) => cause,
+            RegisterActivityTypeError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            RegisterActivityTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterActivityTypeError::TypeAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            RegisterActivityTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterActivityTypeError {}
 /// Errors returned by RegisterDomain
 #[derive(Debug, PartialEq)]
 pub enum RegisterDomainError {
@@ -3951,19 +3915,15 @@ impl RegisterDomainError {
 }
 impl fmt::Display for RegisterDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterDomainError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterDomainError::DomainAlreadyExistsFault(ref cause) => cause,
-            RegisterDomainError::LimitExceededFault(ref cause) => cause,
-            RegisterDomainError::OperationNotPermittedFault(ref cause) => cause,
-            RegisterDomainError::TooManyTagsFault(ref cause) => cause,
+            RegisterDomainError::DomainAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            RegisterDomainError::TooManyTagsFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterDomainError {}
 /// Errors returned by RegisterWorkflowType
 #[derive(Debug, PartialEq)]
 pub enum RegisterWorkflowTypeError {
@@ -4010,19 +3970,17 @@ impl RegisterWorkflowTypeError {
 }
 impl fmt::Display for RegisterWorkflowTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterWorkflowTypeError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterWorkflowTypeError::LimitExceededFault(ref cause) => cause,
-            RegisterWorkflowTypeError::OperationNotPermittedFault(ref cause) => cause,
-            RegisterWorkflowTypeError::TypeAlreadyExistsFault(ref cause) => cause,
-            RegisterWorkflowTypeError::UnknownResourceFault(ref cause) => cause,
+            RegisterWorkflowTypeError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            RegisterWorkflowTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterWorkflowTypeError::TypeAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            RegisterWorkflowTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterWorkflowTypeError {}
 /// Errors returned by RequestCancelWorkflowExecution
 #[derive(Debug, PartialEq)]
 pub enum RequestCancelWorkflowExecutionError {
@@ -4057,17 +4015,17 @@ impl RequestCancelWorkflowExecutionError {
 }
 impl fmt::Display for RequestCancelWorkflowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RequestCancelWorkflowExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            RequestCancelWorkflowExecutionError::OperationNotPermittedFault(ref cause) => cause,
-            RequestCancelWorkflowExecutionError::UnknownResourceFault(ref cause) => cause,
+            RequestCancelWorkflowExecutionError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RequestCancelWorkflowExecutionError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RequestCancelWorkflowExecutionError {}
 /// Errors returned by RespondActivityTaskCanceled
 #[derive(Debug, PartialEq)]
 pub enum RespondActivityTaskCanceledError {
@@ -4102,17 +4060,17 @@ impl RespondActivityTaskCanceledError {
 }
 impl fmt::Display for RespondActivityTaskCanceledError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RespondActivityTaskCanceledError {
-    fn description(&self) -> &str {
         match *self {
-            RespondActivityTaskCanceledError::OperationNotPermittedFault(ref cause) => cause,
-            RespondActivityTaskCanceledError::UnknownResourceFault(ref cause) => cause,
+            RespondActivityTaskCanceledError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondActivityTaskCanceledError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RespondActivityTaskCanceledError {}
 /// Errors returned by RespondActivityTaskCompleted
 #[derive(Debug, PartialEq)]
 pub enum RespondActivityTaskCompletedError {
@@ -4147,17 +4105,17 @@ impl RespondActivityTaskCompletedError {
 }
 impl fmt::Display for RespondActivityTaskCompletedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RespondActivityTaskCompletedError {
-    fn description(&self) -> &str {
         match *self {
-            RespondActivityTaskCompletedError::OperationNotPermittedFault(ref cause) => cause,
-            RespondActivityTaskCompletedError::UnknownResourceFault(ref cause) => cause,
+            RespondActivityTaskCompletedError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondActivityTaskCompletedError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RespondActivityTaskCompletedError {}
 /// Errors returned by RespondActivityTaskFailed
 #[derive(Debug, PartialEq)]
 pub enum RespondActivityTaskFailedError {
@@ -4190,17 +4148,17 @@ impl RespondActivityTaskFailedError {
 }
 impl fmt::Display for RespondActivityTaskFailedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RespondActivityTaskFailedError {
-    fn description(&self) -> &str {
         match *self {
-            RespondActivityTaskFailedError::OperationNotPermittedFault(ref cause) => cause,
-            RespondActivityTaskFailedError::UnknownResourceFault(ref cause) => cause,
+            RespondActivityTaskFailedError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondActivityTaskFailedError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RespondActivityTaskFailedError {}
 /// Errors returned by RespondDecisionTaskCompleted
 #[derive(Debug, PartialEq)]
 pub enum RespondDecisionTaskCompletedError {
@@ -4235,17 +4193,17 @@ impl RespondDecisionTaskCompletedError {
 }
 impl fmt::Display for RespondDecisionTaskCompletedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RespondDecisionTaskCompletedError {
-    fn description(&self) -> &str {
         match *self {
-            RespondDecisionTaskCompletedError::OperationNotPermittedFault(ref cause) => cause,
-            RespondDecisionTaskCompletedError::UnknownResourceFault(ref cause) => cause,
+            RespondDecisionTaskCompletedError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RespondDecisionTaskCompletedError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RespondDecisionTaskCompletedError {}
 /// Errors returned by SignalWorkflowExecution
 #[derive(Debug, PartialEq)]
 pub enum SignalWorkflowExecutionError {
@@ -4278,17 +4236,15 @@ impl SignalWorkflowExecutionError {
 }
 impl fmt::Display for SignalWorkflowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SignalWorkflowExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            SignalWorkflowExecutionError::OperationNotPermittedFault(ref cause) => cause,
-            SignalWorkflowExecutionError::UnknownResourceFault(ref cause) => cause,
+            SignalWorkflowExecutionError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            SignalWorkflowExecutionError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SignalWorkflowExecutionError {}
 /// Errors returned by StartWorkflowExecution
 #[derive(Debug, PartialEq)]
 pub enum StartWorkflowExecutionError {
@@ -4349,21 +4305,21 @@ impl StartWorkflowExecutionError {
 }
 impl fmt::Display for StartWorkflowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartWorkflowExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            StartWorkflowExecutionError::DefaultUndefinedFault(ref cause) => cause,
-            StartWorkflowExecutionError::LimitExceededFault(ref cause) => cause,
-            StartWorkflowExecutionError::OperationNotPermittedFault(ref cause) => cause,
-            StartWorkflowExecutionError::TypeDeprecatedFault(ref cause) => cause,
-            StartWorkflowExecutionError::UnknownResourceFault(ref cause) => cause,
-            StartWorkflowExecutionError::WorkflowExecutionAlreadyStartedFault(ref cause) => cause,
+            StartWorkflowExecutionError::DefaultUndefinedFault(ref cause) => write!(f, "{}", cause),
+            StartWorkflowExecutionError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            StartWorkflowExecutionError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartWorkflowExecutionError::TypeDeprecatedFault(ref cause) => write!(f, "{}", cause),
+            StartWorkflowExecutionError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
+            StartWorkflowExecutionError::WorkflowExecutionAlreadyStartedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartWorkflowExecutionError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -4404,19 +4360,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::LimitExceededFault(ref cause) => cause,
-            TagResourceError::OperationNotPermittedFault(ref cause) => cause,
-            TagResourceError::TooManyTagsFault(ref cause) => cause,
-            TagResourceError::UnknownResourceFault(ref cause) => cause,
+            TagResourceError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::TooManyTagsFault(ref cause) => write!(f, "{}", cause),
+            TagResourceError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TerminateWorkflowExecution
 #[derive(Debug, PartialEq)]
 pub enum TerminateWorkflowExecutionError {
@@ -4451,17 +4403,17 @@ impl TerminateWorkflowExecutionError {
 }
 impl fmt::Display for TerminateWorkflowExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateWorkflowExecutionError {
-    fn description(&self) -> &str {
         match *self {
-            TerminateWorkflowExecutionError::OperationNotPermittedFault(ref cause) => cause,
-            TerminateWorkflowExecutionError::UnknownResourceFault(ref cause) => cause,
+            TerminateWorkflowExecutionError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            TerminateWorkflowExecutionError::UnknownResourceFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for TerminateWorkflowExecutionError {}
 /// Errors returned by UndeprecateActivityType
 #[derive(Debug, PartialEq)]
 pub enum UndeprecateActivityTypeError {
@@ -4501,18 +4453,18 @@ impl UndeprecateActivityTypeError {
 }
 impl fmt::Display for UndeprecateActivityTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UndeprecateActivityTypeError {
-    fn description(&self) -> &str {
         match *self {
-            UndeprecateActivityTypeError::OperationNotPermittedFault(ref cause) => cause,
-            UndeprecateActivityTypeError::TypeAlreadyExistsFault(ref cause) => cause,
-            UndeprecateActivityTypeError::UnknownResourceFault(ref cause) => cause,
+            UndeprecateActivityTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UndeprecateActivityTypeError::TypeAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UndeprecateActivityTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UndeprecateActivityTypeError {}
 /// Errors returned by UndeprecateDomain
 #[derive(Debug, PartialEq)]
 pub enum UndeprecateDomainError {
@@ -4552,18 +4504,14 @@ impl UndeprecateDomainError {
 }
 impl fmt::Display for UndeprecateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UndeprecateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            UndeprecateDomainError::DomainAlreadyExistsFault(ref cause) => cause,
-            UndeprecateDomainError::OperationNotPermittedFault(ref cause) => cause,
-            UndeprecateDomainError::UnknownResourceFault(ref cause) => cause,
+            UndeprecateDomainError::DomainAlreadyExistsFault(ref cause) => write!(f, "{}", cause),
+            UndeprecateDomainError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            UndeprecateDomainError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UndeprecateDomainError {}
 /// Errors returned by UndeprecateWorkflowType
 #[derive(Debug, PartialEq)]
 pub enum UndeprecateWorkflowTypeError {
@@ -4603,18 +4551,18 @@ impl UndeprecateWorkflowTypeError {
 }
 impl fmt::Display for UndeprecateWorkflowTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UndeprecateWorkflowTypeError {
-    fn description(&self) -> &str {
         match *self {
-            UndeprecateWorkflowTypeError::OperationNotPermittedFault(ref cause) => cause,
-            UndeprecateWorkflowTypeError::TypeAlreadyExistsFault(ref cause) => cause,
-            UndeprecateWorkflowTypeError::UnknownResourceFault(ref cause) => cause,
+            UndeprecateWorkflowTypeError::OperationNotPermittedFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UndeprecateWorkflowTypeError::TypeAlreadyExistsFault(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UndeprecateWorkflowTypeError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UndeprecateWorkflowTypeError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -4650,18 +4598,14 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::LimitExceededFault(ref cause) => cause,
-            UntagResourceError::OperationNotPermittedFault(ref cause) => cause,
-            UntagResourceError::UnknownResourceFault(ref cause) => cause,
+            UntagResourceError::LimitExceededFault(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::OperationNotPermittedFault(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::UnknownResourceFault(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Trait representing the capabilities of the Amazon SWF API. Amazon SWF clients implement this trait.
 pub trait Swf {
     /// <p>Returns the number of closed workflow executions within the given domain that meet the specified filtering criteria.</p> <note> <p>This operation is eventually consistent. The results are best effort and may not exactly reflect recent updates and changes.</p> </note> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this action's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys.</p> <ul> <li> <p> <code>tagFilter.tag</code>: String constraint. The key is <code>swf:tagFilter.tag</code>.</p> </li> <li> <p> <code>typeFilter.name</code>: String constraint. The key is <code>swf:typeFilter.name</code>.</p> </li> <li> <p> <code>typeFilter.version</code>: String constraint. The key is <code>swf:typeFilter.version</code>.</p> </li> </ul> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>

--- a/rusoto/services/textract/src/generated.rs
+++ b/rusoto/services/textract/src/generated.rs
@@ -552,25 +552,23 @@ impl AnalyzeDocumentError {
 }
 impl fmt::Display for AnalyzeDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AnalyzeDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            AnalyzeDocumentError::AccessDenied(ref cause) => cause,
-            AnalyzeDocumentError::BadDocument(ref cause) => cause,
-            AnalyzeDocumentError::DocumentTooLarge(ref cause) => cause,
-            AnalyzeDocumentError::HumanLoopQuotaExceeded(ref cause) => cause,
-            AnalyzeDocumentError::InternalServerError(ref cause) => cause,
-            AnalyzeDocumentError::InvalidParameter(ref cause) => cause,
-            AnalyzeDocumentError::InvalidS3Object(ref cause) => cause,
-            AnalyzeDocumentError::ProvisionedThroughputExceeded(ref cause) => cause,
-            AnalyzeDocumentError::Throttling(ref cause) => cause,
-            AnalyzeDocumentError::UnsupportedDocument(ref cause) => cause,
+            AnalyzeDocumentError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::BadDocument(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::DocumentTooLarge(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::HumanLoopQuotaExceeded(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AnalyzeDocumentError::Throttling(ref cause) => write!(f, "{}", cause),
+            AnalyzeDocumentError::UnsupportedDocument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AnalyzeDocumentError {}
 /// Errors returned by DetectDocumentText
 #[derive(Debug, PartialEq)]
 pub enum DetectDocumentTextError {
@@ -640,24 +638,22 @@ impl DetectDocumentTextError {
 }
 impl fmt::Display for DetectDocumentTextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DetectDocumentTextError {
-    fn description(&self) -> &str {
         match *self {
-            DetectDocumentTextError::AccessDenied(ref cause) => cause,
-            DetectDocumentTextError::BadDocument(ref cause) => cause,
-            DetectDocumentTextError::DocumentTooLarge(ref cause) => cause,
-            DetectDocumentTextError::InternalServerError(ref cause) => cause,
-            DetectDocumentTextError::InvalidParameter(ref cause) => cause,
-            DetectDocumentTextError::InvalidS3Object(ref cause) => cause,
-            DetectDocumentTextError::ProvisionedThroughputExceeded(ref cause) => cause,
-            DetectDocumentTextError::Throttling(ref cause) => cause,
-            DetectDocumentTextError::UnsupportedDocument(ref cause) => cause,
+            DetectDocumentTextError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DetectDocumentTextError::BadDocument(ref cause) => write!(f, "{}", cause),
+            DetectDocumentTextError::DocumentTooLarge(ref cause) => write!(f, "{}", cause),
+            DetectDocumentTextError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DetectDocumentTextError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DetectDocumentTextError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            DetectDocumentTextError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DetectDocumentTextError::Throttling(ref cause) => write!(f, "{}", cause),
+            DetectDocumentTextError::UnsupportedDocument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DetectDocumentTextError {}
 /// Errors returned by GetDocumentAnalysis
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentAnalysisError {
@@ -712,21 +708,19 @@ impl GetDocumentAnalysisError {
 }
 impl fmt::Display for GetDocumentAnalysisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentAnalysisError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentAnalysisError::AccessDenied(ref cause) => cause,
-            GetDocumentAnalysisError::InternalServerError(ref cause) => cause,
-            GetDocumentAnalysisError::InvalidJobId(ref cause) => cause,
-            GetDocumentAnalysisError::InvalidParameter(ref cause) => cause,
-            GetDocumentAnalysisError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetDocumentAnalysisError::Throttling(ref cause) => cause,
+            GetDocumentAnalysisError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDocumentAnalysisError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetDocumentAnalysisError::InvalidJobId(ref cause) => write!(f, "{}", cause),
+            GetDocumentAnalysisError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetDocumentAnalysisError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDocumentAnalysisError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentAnalysisError {}
 /// Errors returned by GetDocumentTextDetection
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentTextDetectionError {
@@ -785,21 +779,19 @@ impl GetDocumentTextDetectionError {
 }
 impl fmt::Display for GetDocumentTextDetectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentTextDetectionError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentTextDetectionError::AccessDenied(ref cause) => cause,
-            GetDocumentTextDetectionError::InternalServerError(ref cause) => cause,
-            GetDocumentTextDetectionError::InvalidJobId(ref cause) => cause,
-            GetDocumentTextDetectionError::InvalidParameter(ref cause) => cause,
-            GetDocumentTextDetectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            GetDocumentTextDetectionError::Throttling(ref cause) => cause,
+            GetDocumentTextDetectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            GetDocumentTextDetectionError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            GetDocumentTextDetectionError::InvalidJobId(ref cause) => write!(f, "{}", cause),
+            GetDocumentTextDetectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetDocumentTextDetectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetDocumentTextDetectionError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentTextDetectionError {}
 /// Errors returned by StartDocumentAnalysis
 #[derive(Debug, PartialEq)]
 pub enum StartDocumentAnalysisError {
@@ -887,26 +879,26 @@ impl StartDocumentAnalysisError {
 }
 impl fmt::Display for StartDocumentAnalysisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDocumentAnalysisError {
-    fn description(&self) -> &str {
         match *self {
-            StartDocumentAnalysisError::AccessDenied(ref cause) => cause,
-            StartDocumentAnalysisError::BadDocument(ref cause) => cause,
-            StartDocumentAnalysisError::DocumentTooLarge(ref cause) => cause,
-            StartDocumentAnalysisError::IdempotentParameterMismatch(ref cause) => cause,
-            StartDocumentAnalysisError::InternalServerError(ref cause) => cause,
-            StartDocumentAnalysisError::InvalidParameter(ref cause) => cause,
-            StartDocumentAnalysisError::InvalidS3Object(ref cause) => cause,
-            StartDocumentAnalysisError::LimitExceeded(ref cause) => cause,
-            StartDocumentAnalysisError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartDocumentAnalysisError::Throttling(ref cause) => cause,
-            StartDocumentAnalysisError::UnsupportedDocument(ref cause) => cause,
+            StartDocumentAnalysisError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::BadDocument(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::DocumentTooLarge(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentAnalysisError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentAnalysisError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartDocumentAnalysisError::UnsupportedDocument(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartDocumentAnalysisError {}
 /// Errors returned by StartDocumentTextDetection
 #[derive(Debug, PartialEq)]
 pub enum StartDocumentTextDetectionError {
@@ -1004,26 +996,30 @@ impl StartDocumentTextDetectionError {
 }
 impl fmt::Display for StartDocumentTextDetectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartDocumentTextDetectionError {
-    fn description(&self) -> &str {
         match *self {
-            StartDocumentTextDetectionError::AccessDenied(ref cause) => cause,
-            StartDocumentTextDetectionError::BadDocument(ref cause) => cause,
-            StartDocumentTextDetectionError::DocumentTooLarge(ref cause) => cause,
-            StartDocumentTextDetectionError::IdempotentParameterMismatch(ref cause) => cause,
-            StartDocumentTextDetectionError::InternalServerError(ref cause) => cause,
-            StartDocumentTextDetectionError::InvalidParameter(ref cause) => cause,
-            StartDocumentTextDetectionError::InvalidS3Object(ref cause) => cause,
-            StartDocumentTextDetectionError::LimitExceeded(ref cause) => cause,
-            StartDocumentTextDetectionError::ProvisionedThroughputExceeded(ref cause) => cause,
-            StartDocumentTextDetectionError::Throttling(ref cause) => cause,
-            StartDocumentTextDetectionError::UnsupportedDocument(ref cause) => cause,
+            StartDocumentTextDetectionError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            StartDocumentTextDetectionError::BadDocument(ref cause) => write!(f, "{}", cause),
+            StartDocumentTextDetectionError::DocumentTooLarge(ref cause) => write!(f, "{}", cause),
+            StartDocumentTextDetectionError::IdempotentParameterMismatch(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentTextDetectionError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentTextDetectionError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            StartDocumentTextDetectionError::InvalidS3Object(ref cause) => write!(f, "{}", cause),
+            StartDocumentTextDetectionError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            StartDocumentTextDetectionError::ProvisionedThroughputExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            StartDocumentTextDetectionError::Throttling(ref cause) => write!(f, "{}", cause),
+            StartDocumentTextDetectionError::UnsupportedDocument(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for StartDocumentTextDetectionError {}
 /// Trait representing the capabilities of the Amazon Textract API. Amazon Textract clients implement this trait.
 pub trait Textract {
     /// <p>Analyzes an input document for relationships between detected items. </p> <p>The types of information returned are as follows: </p> <ul> <li> <p>Form data (key-value pairs). The related information is returned in two <a>Block</a> objects, each of type <code>KEY_VALUE_SET</code>: a KEY <code>Block</code> object and a VALUE <code>Block</code> object. For example, <i>Name: Ana Silva Carolina</i> contains a key and value. <i>Name:</i> is the key. <i>Ana Silva Carolina</i> is the value.</p> </li> <li> <p>Table and table cell data. A TABLE <code>Block</code> object contains information about a detected table. A CELL <code>Block</code> object is returned for each cell in a table.</p> </li> <li> <p>Lines and words of text. A LINE <code>Block</code> object contains one or more WORD <code>Block</code> objects. All lines and words that are detected in the document are returned (including text that doesn't have a relationship with the value of <code>FeatureTypes</code>). </p> </li> </ul> <p>Selection elements such as check boxes and option buttons (radio buttons) can be detected in form data and in tables. A SELECTION_ELEMENT <code>Block</code> object contains information about a selection element, including the selection status.</p> <p>You can choose which type of analysis to perform by specifying the <code>FeatureTypes</code> list. </p> <p>The output is returned in a list of <code>Block</code> objects.</p> <p> <code>AnalyzeDocument</code> is a synchronous operation. To analyze documents asynchronously, use <a>StartDocumentAnalysis</a>.</p> <p>For more information, see <a href="https://docs.aws.amazon.com/textract/latest/dg/how-it-works-analyzing.html">Document Text Analysis</a>.</p>

--- a/rusoto/services/transcribe/src/generated.rs
+++ b/rusoto/services/transcribe/src/generated.rs
@@ -479,19 +479,15 @@ impl CreateVocabularyError {
 }
 impl fmt::Display for CreateVocabularyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateVocabularyError {
-    fn description(&self) -> &str {
         match *self {
-            CreateVocabularyError::BadRequest(ref cause) => cause,
-            CreateVocabularyError::Conflict(ref cause) => cause,
-            CreateVocabularyError::InternalFailure(ref cause) => cause,
-            CreateVocabularyError::LimitExceeded(ref cause) => cause,
+            CreateVocabularyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            CreateVocabularyError::Conflict(ref cause) => write!(f, "{}", cause),
+            CreateVocabularyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            CreateVocabularyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateVocabularyError {}
 /// Errors returned by DeleteTranscriptionJob
 #[derive(Debug, PartialEq)]
 pub enum DeleteTranscriptionJobError {
@@ -529,18 +525,14 @@ impl DeleteTranscriptionJobError {
 }
 impl fmt::Display for DeleteTranscriptionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTranscriptionJobError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTranscriptionJobError::BadRequest(ref cause) => cause,
-            DeleteTranscriptionJobError::InternalFailure(ref cause) => cause,
-            DeleteTranscriptionJobError::LimitExceeded(ref cause) => cause,
+            DeleteTranscriptionJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteTranscriptionJobError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteTranscriptionJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTranscriptionJobError {}
 /// Errors returned by DeleteVocabulary
 #[derive(Debug, PartialEq)]
 pub enum DeleteVocabularyError {
@@ -579,19 +571,15 @@ impl DeleteVocabularyError {
 }
 impl fmt::Display for DeleteVocabularyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteVocabularyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteVocabularyError::BadRequest(ref cause) => cause,
-            DeleteVocabularyError::InternalFailure(ref cause) => cause,
-            DeleteVocabularyError::LimitExceeded(ref cause) => cause,
-            DeleteVocabularyError::NotFound(ref cause) => cause,
+            DeleteVocabularyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            DeleteVocabularyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            DeleteVocabularyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            DeleteVocabularyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteVocabularyError {}
 /// Errors returned by GetTranscriptionJob
 #[derive(Debug, PartialEq)]
 pub enum GetTranscriptionJobError {
@@ -630,19 +618,15 @@ impl GetTranscriptionJobError {
 }
 impl fmt::Display for GetTranscriptionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTranscriptionJobError {
-    fn description(&self) -> &str {
         match *self {
-            GetTranscriptionJobError::BadRequest(ref cause) => cause,
-            GetTranscriptionJobError::InternalFailure(ref cause) => cause,
-            GetTranscriptionJobError::LimitExceeded(ref cause) => cause,
-            GetTranscriptionJobError::NotFound(ref cause) => cause,
+            GetTranscriptionJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetTranscriptionJobError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetTranscriptionJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetTranscriptionJobError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTranscriptionJobError {}
 /// Errors returned by GetVocabulary
 #[derive(Debug, PartialEq)]
 pub enum GetVocabularyError {
@@ -681,19 +665,15 @@ impl GetVocabularyError {
 }
 impl fmt::Display for GetVocabularyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetVocabularyError {
-    fn description(&self) -> &str {
         match *self {
-            GetVocabularyError::BadRequest(ref cause) => cause,
-            GetVocabularyError::InternalFailure(ref cause) => cause,
-            GetVocabularyError::LimitExceeded(ref cause) => cause,
-            GetVocabularyError::NotFound(ref cause) => cause,
+            GetVocabularyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            GetVocabularyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            GetVocabularyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            GetVocabularyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetVocabularyError {}
 /// Errors returned by ListTranscriptionJobs
 #[derive(Debug, PartialEq)]
 pub enum ListTranscriptionJobsError {
@@ -729,18 +709,14 @@ impl ListTranscriptionJobsError {
 }
 impl fmt::Display for ListTranscriptionJobsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTranscriptionJobsError {
-    fn description(&self) -> &str {
         match *self {
-            ListTranscriptionJobsError::BadRequest(ref cause) => cause,
-            ListTranscriptionJobsError::InternalFailure(ref cause) => cause,
-            ListTranscriptionJobsError::LimitExceeded(ref cause) => cause,
+            ListTranscriptionJobsError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListTranscriptionJobsError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListTranscriptionJobsError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTranscriptionJobsError {}
 /// Errors returned by ListVocabularies
 #[derive(Debug, PartialEq)]
 pub enum ListVocabulariesError {
@@ -774,18 +750,14 @@ impl ListVocabulariesError {
 }
 impl fmt::Display for ListVocabulariesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListVocabulariesError {
-    fn description(&self) -> &str {
         match *self {
-            ListVocabulariesError::BadRequest(ref cause) => cause,
-            ListVocabulariesError::InternalFailure(ref cause) => cause,
-            ListVocabulariesError::LimitExceeded(ref cause) => cause,
+            ListVocabulariesError::BadRequest(ref cause) => write!(f, "{}", cause),
+            ListVocabulariesError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            ListVocabulariesError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListVocabulariesError {}
 /// Errors returned by StartTranscriptionJob
 #[derive(Debug, PartialEq)]
 pub enum StartTranscriptionJobError {
@@ -826,19 +798,15 @@ impl StartTranscriptionJobError {
 }
 impl fmt::Display for StartTranscriptionJobError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartTranscriptionJobError {
-    fn description(&self) -> &str {
         match *self {
-            StartTranscriptionJobError::BadRequest(ref cause) => cause,
-            StartTranscriptionJobError::Conflict(ref cause) => cause,
-            StartTranscriptionJobError::InternalFailure(ref cause) => cause,
-            StartTranscriptionJobError::LimitExceeded(ref cause) => cause,
+            StartTranscriptionJobError::BadRequest(ref cause) => write!(f, "{}", cause),
+            StartTranscriptionJobError::Conflict(ref cause) => write!(f, "{}", cause),
+            StartTranscriptionJobError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            StartTranscriptionJobError::LimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartTranscriptionJobError {}
 /// Errors returned by UpdateVocabulary
 #[derive(Debug, PartialEq)]
 pub enum UpdateVocabularyError {
@@ -882,20 +850,16 @@ impl UpdateVocabularyError {
 }
 impl fmt::Display for UpdateVocabularyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateVocabularyError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateVocabularyError::BadRequest(ref cause) => cause,
-            UpdateVocabularyError::Conflict(ref cause) => cause,
-            UpdateVocabularyError::InternalFailure(ref cause) => cause,
-            UpdateVocabularyError::LimitExceeded(ref cause) => cause,
-            UpdateVocabularyError::NotFound(ref cause) => cause,
+            UpdateVocabularyError::BadRequest(ref cause) => write!(f, "{}", cause),
+            UpdateVocabularyError::Conflict(ref cause) => write!(f, "{}", cause),
+            UpdateVocabularyError::InternalFailure(ref cause) => write!(f, "{}", cause),
+            UpdateVocabularyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateVocabularyError::NotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateVocabularyError {}
 /// Trait representing the capabilities of the Amazon Transcribe Service API. Amazon Transcribe Service clients implement this trait.
 pub trait Transcribe {
     /// <p>Creates a new custom vocabulary that you can use to change the way Amazon Transcribe handles transcription of an audio file. </p>

--- a/rusoto/services/transfer/src/generated.rs
+++ b/rusoto/services/transfer/src/generated.rs
@@ -684,19 +684,15 @@ impl CreateServerError {
 }
 impl fmt::Display for CreateServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateServerError {
-    fn description(&self) -> &str {
         match *self {
-            CreateServerError::InternalServiceError(ref cause) => cause,
-            CreateServerError::InvalidRequest(ref cause) => cause,
-            CreateServerError::ResourceExists(ref cause) => cause,
-            CreateServerError::ServiceUnavailable(ref cause) => cause,
+            CreateServerError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            CreateServerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateServerError::ResourceExists(ref cause) => write!(f, "{}", cause),
+            CreateServerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateServerError {}
 /// Errors returned by CreateUser
 #[derive(Debug, PartialEq)]
 pub enum CreateUserError {
@@ -740,20 +736,16 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::InternalServiceError(ref cause) => cause,
-            CreateUserError::InvalidRequest(ref cause) => cause,
-            CreateUserError::ResourceExists(ref cause) => cause,
-            CreateUserError::ResourceNotFound(ref cause) => cause,
-            CreateUserError::ServiceUnavailable(ref cause) => cause,
+            CreateUserError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ResourceExists(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by DeleteServer
 #[derive(Debug, PartialEq)]
 pub enum DeleteServerError {
@@ -792,19 +784,15 @@ impl DeleteServerError {
 }
 impl fmt::Display for DeleteServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteServerError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteServerError::InternalServiceError(ref cause) => cause,
-            DeleteServerError::InvalidRequest(ref cause) => cause,
-            DeleteServerError::ResourceNotFound(ref cause) => cause,
-            DeleteServerError::ServiceUnavailable(ref cause) => cause,
+            DeleteServerError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DeleteServerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteServerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteServerError {}
 /// Errors returned by DeleteSshPublicKey
 #[derive(Debug, PartialEq)]
 pub enum DeleteSshPublicKeyError {
@@ -852,20 +840,16 @@ impl DeleteSshPublicKeyError {
 }
 impl fmt::Display for DeleteSshPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSshPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSshPublicKeyError::InternalServiceError(ref cause) => cause,
-            DeleteSshPublicKeyError::InvalidRequest(ref cause) => cause,
-            DeleteSshPublicKeyError::ResourceNotFound(ref cause) => cause,
-            DeleteSshPublicKeyError::ServiceUnavailable(ref cause) => cause,
-            DeleteSshPublicKeyError::Throttling(ref cause) => cause,
+            DeleteSshPublicKeyError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DeleteSshPublicKeyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteSshPublicKeyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteSshPublicKeyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteSshPublicKeyError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSshPublicKeyError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -904,19 +888,15 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::InternalServiceError(ref cause) => cause,
-            DeleteUserError::InvalidRequest(ref cause) => cause,
-            DeleteUserError::ResourceNotFound(ref cause) => cause,
-            DeleteUserError::ServiceUnavailable(ref cause) => cause,
+            DeleteUserError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DescribeServer
 #[derive(Debug, PartialEq)]
 pub enum DescribeServerError {
@@ -955,19 +935,15 @@ impl DescribeServerError {
 }
 impl fmt::Display for DescribeServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeServerError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeServerError::InternalServiceError(ref cause) => cause,
-            DescribeServerError::InvalidRequest(ref cause) => cause,
-            DescribeServerError::ResourceNotFound(ref cause) => cause,
-            DescribeServerError::ServiceUnavailable(ref cause) => cause,
+            DescribeServerError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DescribeServerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeServerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeServerError {}
 /// Errors returned by DescribeUser
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserError {
@@ -1006,19 +982,15 @@ impl DescribeUserError {
 }
 impl fmt::Display for DescribeUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserError::InternalServiceError(ref cause) => cause,
-            DescribeUserError::InvalidRequest(ref cause) => cause,
-            DescribeUserError::ResourceNotFound(ref cause) => cause,
-            DescribeUserError::ServiceUnavailable(ref cause) => cause,
+            DescribeUserError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserError {}
 /// Errors returned by ImportSshPublicKey
 #[derive(Debug, PartialEq)]
 pub enum ImportSshPublicKeyError {
@@ -1071,21 +1043,17 @@ impl ImportSshPublicKeyError {
 }
 impl fmt::Display for ImportSshPublicKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportSshPublicKeyError {
-    fn description(&self) -> &str {
         match *self {
-            ImportSshPublicKeyError::InternalServiceError(ref cause) => cause,
-            ImportSshPublicKeyError::InvalidRequest(ref cause) => cause,
-            ImportSshPublicKeyError::ResourceExists(ref cause) => cause,
-            ImportSshPublicKeyError::ResourceNotFound(ref cause) => cause,
-            ImportSshPublicKeyError::ServiceUnavailable(ref cause) => cause,
-            ImportSshPublicKeyError::Throttling(ref cause) => cause,
+            ImportSshPublicKeyError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ImportSshPublicKeyError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ImportSshPublicKeyError::ResourceExists(ref cause) => write!(f, "{}", cause),
+            ImportSshPublicKeyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ImportSshPublicKeyError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ImportSshPublicKeyError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportSshPublicKeyError {}
 /// Errors returned by ListServers
 #[derive(Debug, PartialEq)]
 pub enum ListServersError {
@@ -1124,19 +1092,15 @@ impl ListServersError {
 }
 impl fmt::Display for ListServersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListServersError {
-    fn description(&self) -> &str {
         match *self {
-            ListServersError::InternalServiceError(ref cause) => cause,
-            ListServersError::InvalidNextToken(ref cause) => cause,
-            ListServersError::InvalidRequest(ref cause) => cause,
-            ListServersError::ServiceUnavailable(ref cause) => cause,
+            ListServersError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ListServersError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListServersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListServersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListServersError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -1181,19 +1145,15 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::InternalServiceError(ref cause) => cause,
-            ListTagsForResourceError::InvalidNextToken(ref cause) => cause,
-            ListTagsForResourceError::InvalidRequest(ref cause) => cause,
-            ListTagsForResourceError::ServiceUnavailable(ref cause) => cause,
+            ListTagsForResourceError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListUsers
 #[derive(Debug, PartialEq)]
 pub enum ListUsersError {
@@ -1237,20 +1197,16 @@ impl ListUsersError {
 }
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersError::InternalServiceError(ref cause) => cause,
-            ListUsersError::InvalidNextToken(ref cause) => cause,
-            ListUsersError::InvalidRequest(ref cause) => cause,
-            ListUsersError::ResourceNotFound(ref cause) => cause,
-            ListUsersError::ServiceUnavailable(ref cause) => cause,
+            ListUsersError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            ListUsersError::InvalidNextToken(ref cause) => write!(f, "{}", cause),
+            ListUsersError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListUsersError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListUsersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersError {}
 /// Errors returned by StartServer
 #[derive(Debug, PartialEq)]
 pub enum StartServerError {
@@ -1294,20 +1250,16 @@ impl StartServerError {
 }
 impl fmt::Display for StartServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartServerError {
-    fn description(&self) -> &str {
         match *self {
-            StartServerError::InternalServiceError(ref cause) => cause,
-            StartServerError::InvalidRequest(ref cause) => cause,
-            StartServerError::ResourceNotFound(ref cause) => cause,
-            StartServerError::ServiceUnavailable(ref cause) => cause,
-            StartServerError::Throttling(ref cause) => cause,
+            StartServerError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            StartServerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StartServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StartServerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            StartServerError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StartServerError {}
 /// Errors returned by StopServer
 #[derive(Debug, PartialEq)]
 pub enum StopServerError {
@@ -1351,20 +1303,16 @@ impl StopServerError {
 }
 impl fmt::Display for StopServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopServerError {
-    fn description(&self) -> &str {
         match *self {
-            StopServerError::InternalServiceError(ref cause) => cause,
-            StopServerError::InvalidRequest(ref cause) => cause,
-            StopServerError::ResourceNotFound(ref cause) => cause,
-            StopServerError::ServiceUnavailable(ref cause) => cause,
-            StopServerError::Throttling(ref cause) => cause,
+            StopServerError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            StopServerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            StopServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            StopServerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            StopServerError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for StopServerError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -1403,19 +1351,15 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::InternalServiceError(ref cause) => cause,
-            TagResourceError::InvalidRequest(ref cause) => cause,
-            TagResourceError::ResourceNotFound(ref cause) => cause,
-            TagResourceError::ServiceUnavailable(ref cause) => cause,
+            TagResourceError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by TestIdentityProvider
 #[derive(Debug, PartialEq)]
 pub enum TestIdentityProviderError {
@@ -1460,19 +1404,15 @@ impl TestIdentityProviderError {
 }
 impl fmt::Display for TestIdentityProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TestIdentityProviderError {
-    fn description(&self) -> &str {
         match *self {
-            TestIdentityProviderError::InternalServiceError(ref cause) => cause,
-            TestIdentityProviderError::InvalidRequest(ref cause) => cause,
-            TestIdentityProviderError::ResourceNotFound(ref cause) => cause,
-            TestIdentityProviderError::ServiceUnavailable(ref cause) => cause,
+            TestIdentityProviderError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            TestIdentityProviderError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TestIdentityProviderError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TestIdentityProviderError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TestIdentityProviderError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -1511,19 +1451,15 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::InternalServiceError(ref cause) => cause,
-            UntagResourceError::InvalidRequest(ref cause) => cause,
-            UntagResourceError::ResourceNotFound(ref cause) => cause,
-            UntagResourceError::ServiceUnavailable(ref cause) => cause,
+            UntagResourceError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateServer
 #[derive(Debug, PartialEq)]
 pub enum UpdateServerError {
@@ -1572,21 +1508,17 @@ impl UpdateServerError {
 }
 impl fmt::Display for UpdateServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateServerError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateServerError::InternalServiceError(ref cause) => cause,
-            UpdateServerError::InvalidRequest(ref cause) => cause,
-            UpdateServerError::ResourceExists(ref cause) => cause,
-            UpdateServerError::ResourceNotFound(ref cause) => cause,
-            UpdateServerError::ServiceUnavailable(ref cause) => cause,
-            UpdateServerError::Throttling(ref cause) => cause,
+            UpdateServerError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            UpdateServerError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateServerError::ResourceExists(ref cause) => write!(f, "{}", cause),
+            UpdateServerError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateServerError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateServerError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateServerError {}
 /// Errors returned by UpdateUser
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserError {
@@ -1630,20 +1562,16 @@ impl UpdateUserError {
 }
 impl fmt::Display for UpdateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserError::InternalServiceError(ref cause) => cause,
-            UpdateUserError::InvalidRequest(ref cause) => cause,
-            UpdateUserError::ResourceNotFound(ref cause) => cause,
-            UpdateUserError::ServiceUnavailable(ref cause) => cause,
-            UpdateUserError::Throttling(ref cause) => cause,
+            UpdateUserError::InternalServiceError(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::Throttling(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserError {}
 /// Trait representing the capabilities of the AWS Transfer API. AWS Transfer clients implement this trait.
 pub trait Transfer {
     /// <p>Instantiates an autoscaling virtual server based on Secure File Transfer Protocol (SFTP) in AWS. When you make updates to your server or when you work with users, use the service-generated <code>ServerId</code> property that is assigned to the newly created server.</p>

--- a/rusoto/services/translate/src/generated.rs
+++ b/rusoto/services/translate/src/generated.rs
@@ -289,18 +289,14 @@ impl DeleteTerminologyError {
 }
 impl fmt::Display for DeleteTerminologyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTerminologyError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTerminologyError::InternalServer(ref cause) => cause,
-            DeleteTerminologyError::ResourceNotFound(ref cause) => cause,
-            DeleteTerminologyError::TooManyRequests(ref cause) => cause,
+            DeleteTerminologyError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DeleteTerminologyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteTerminologyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTerminologyError {}
 /// Errors returned by GetTerminology
 #[derive(Debug, PartialEq)]
 pub enum GetTerminologyError {
@@ -341,19 +337,15 @@ impl GetTerminologyError {
 }
 impl fmt::Display for GetTerminologyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTerminologyError {
-    fn description(&self) -> &str {
         match *self {
-            GetTerminologyError::InternalServer(ref cause) => cause,
-            GetTerminologyError::InvalidParameterValue(ref cause) => cause,
-            GetTerminologyError::ResourceNotFound(ref cause) => cause,
-            GetTerminologyError::TooManyRequests(ref cause) => cause,
+            GetTerminologyError::InternalServer(ref cause) => write!(f, "{}", cause),
+            GetTerminologyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            GetTerminologyError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            GetTerminologyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTerminologyError {}
 /// Errors returned by ImportTerminology
 #[derive(Debug, PartialEq)]
 pub enum ImportTerminologyError {
@@ -394,19 +386,15 @@ impl ImportTerminologyError {
 }
 impl fmt::Display for ImportTerminologyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportTerminologyError {
-    fn description(&self) -> &str {
         match *self {
-            ImportTerminologyError::InternalServer(ref cause) => cause,
-            ImportTerminologyError::InvalidParameterValue(ref cause) => cause,
-            ImportTerminologyError::LimitExceeded(ref cause) => cause,
-            ImportTerminologyError::TooManyRequests(ref cause) => cause,
+            ImportTerminologyError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ImportTerminologyError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ImportTerminologyError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            ImportTerminologyError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportTerminologyError {}
 /// Errors returned by ListTerminologies
 #[derive(Debug, PartialEq)]
 pub enum ListTerminologiesError {
@@ -442,18 +430,14 @@ impl ListTerminologiesError {
 }
 impl fmt::Display for ListTerminologiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTerminologiesError {
-    fn description(&self) -> &str {
         match *self {
-            ListTerminologiesError::InternalServer(ref cause) => cause,
-            ListTerminologiesError::InvalidParameterValue(ref cause) => cause,
-            ListTerminologiesError::TooManyRequests(ref cause) => cause,
+            ListTerminologiesError::InternalServer(ref cause) => write!(f, "{}", cause),
+            ListTerminologiesError::InvalidParameterValue(ref cause) => write!(f, "{}", cause),
+            ListTerminologiesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListTerminologiesError {}
 /// Errors returned by TranslateText
 #[derive(Debug, PartialEq)]
 pub enum TranslateTextError {
@@ -516,23 +500,19 @@ impl TranslateTextError {
 }
 impl fmt::Display for TranslateTextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TranslateTextError {
-    fn description(&self) -> &str {
         match *self {
-            TranslateTextError::DetectedLanguageLowConfidence(ref cause) => cause,
-            TranslateTextError::InternalServer(ref cause) => cause,
-            TranslateTextError::InvalidRequest(ref cause) => cause,
-            TranslateTextError::ResourceNotFound(ref cause) => cause,
-            TranslateTextError::ServiceUnavailable(ref cause) => cause,
-            TranslateTextError::TextSizeLimitExceeded(ref cause) => cause,
-            TranslateTextError::TooManyRequests(ref cause) => cause,
-            TranslateTextError::UnsupportedLanguagePair(ref cause) => cause,
+            TranslateTextError::DetectedLanguageLowConfidence(ref cause) => write!(f, "{}", cause),
+            TranslateTextError::InternalServer(ref cause) => write!(f, "{}", cause),
+            TranslateTextError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            TranslateTextError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            TranslateTextError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            TranslateTextError::TextSizeLimitExceeded(ref cause) => write!(f, "{}", cause),
+            TranslateTextError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            TranslateTextError::UnsupportedLanguagePair(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TranslateTextError {}
 /// Trait representing the capabilities of the Amazon Translate API. Amazon Translate clients implement this trait.
 pub trait Translate {
     /// <p>A synchronous action that deletes a custom terminology.</p>

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -2522,20 +2522,16 @@ impl AssociateWebACLError {
 }
 impl fmt::Display for AssociateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateWebACLError::WAFInternalError(ref cause) => cause,
-            AssociateWebACLError::WAFInvalidAccount(ref cause) => cause,
-            AssociateWebACLError::WAFInvalidParameter(ref cause) => cause,
-            AssociateWebACLError::WAFNonexistentItem(ref cause) => cause,
-            AssociateWebACLError::WAFUnavailableEntity(ref cause) => cause,
+            AssociateWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            AssociateWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            AssociateWebACLError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            AssociateWebACLError::WAFUnavailableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateWebACLError {}
 /// Errors returned by CreateByteMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateByteMatchSetError {
@@ -2592,21 +2588,17 @@ impl CreateByteMatchSetError {
 }
 impl fmt::Display for CreateByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateByteMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateByteMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateByteMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateByteMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateByteMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateByteMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateByteMatchSetError {}
 /// Errors returned by CreateGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateGeoMatchSetError {
@@ -2657,21 +2649,17 @@ impl CreateGeoMatchSetError {
 }
 impl fmt::Display for CreateGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGeoMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateGeoMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateGeoMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateGeoMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateGeoMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGeoMatchSetError {}
 /// Errors returned by CreateIPSet
 #[derive(Debug, PartialEq)]
 pub enum CreateIPSetError {
@@ -2720,21 +2708,17 @@ impl CreateIPSetError {
 }
 impl fmt::Display for CreateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIPSetError::WAFDisallowedName(ref cause) => cause,
-            CreateIPSetError::WAFInternalError(ref cause) => cause,
-            CreateIPSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateIPSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateIPSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateIPSetError::WAFStaleData(ref cause) => cause,
+            CreateIPSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIPSetError {}
 /// Errors returned by CreateRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum CreateRateBasedRuleError {
@@ -2802,23 +2786,21 @@ impl CreateRateBasedRuleError {
 }
 impl fmt::Display for CreateRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRateBasedRuleError::WAFBadRequest(ref cause) => cause,
-            CreateRateBasedRuleError::WAFDisallowedName(ref cause) => cause,
-            CreateRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            CreateRateBasedRuleError::WAFInvalidParameter(ref cause) => cause,
-            CreateRateBasedRuleError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRateBasedRuleError::WAFStaleData(ref cause) => cause,
-            CreateRateBasedRuleError::WAFTagOperation(ref cause) => cause,
-            CreateRateBasedRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateRateBasedRuleError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFTagOperationInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateRateBasedRuleError {}
 /// Errors returned by CreateRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateRegexMatchSetError {
@@ -2863,19 +2845,15 @@ impl CreateRegexMatchSetError {
 }
 impl fmt::Display for CreateRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRegexMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateRegexMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRegexMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateRegexMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRegexMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRegexMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRegexMatchSetError {}
 /// Errors returned by CreateRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum CreateRegexPatternSetError {
@@ -2920,19 +2898,15 @@ impl CreateRegexPatternSetError {
 }
 impl fmt::Display for CreateRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRegexPatternSetError::WAFDisallowedName(ref cause) => cause,
-            CreateRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            CreateRegexPatternSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRegexPatternSetError::WAFStaleData(ref cause) => cause,
+            CreateRegexPatternSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRegexPatternSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRegexPatternSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRegexPatternSetError {}
 /// Errors returned by CreateRule
 #[derive(Debug, PartialEq)]
 pub enum CreateRuleError {
@@ -2992,23 +2966,19 @@ impl CreateRuleError {
 }
 impl fmt::Display for CreateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRuleError::WAFBadRequest(ref cause) => cause,
-            CreateRuleError::WAFDisallowedName(ref cause) => cause,
-            CreateRuleError::WAFInternalError(ref cause) => cause,
-            CreateRuleError::WAFInvalidParameter(ref cause) => cause,
-            CreateRuleError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRuleError::WAFStaleData(ref cause) => cause,
-            CreateRuleError::WAFTagOperation(ref cause) => cause,
-            CreateRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateRuleError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRuleError {}
 /// Errors returned by CreateRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateRuleGroupError {
@@ -3063,22 +3033,18 @@ impl CreateRuleGroupError {
 }
 impl fmt::Display for CreateRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRuleGroupError::WAFBadRequest(ref cause) => cause,
-            CreateRuleGroupError::WAFDisallowedName(ref cause) => cause,
-            CreateRuleGroupError::WAFInternalError(ref cause) => cause,
-            CreateRuleGroupError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRuleGroupError::WAFStaleData(ref cause) => cause,
-            CreateRuleGroupError::WAFTagOperation(ref cause) => cause,
-            CreateRuleGroupError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateRuleGroupError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRuleGroupError {}
 /// Errors returned by CreateSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum CreateSizeConstraintSetError {
@@ -3139,21 +3105,17 @@ impl CreateSizeConstraintSetError {
 }
 impl fmt::Display for CreateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSizeConstraintSetError::WAFDisallowedName(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFStaleData(ref cause) => cause,
+            CreateSizeConstraintSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSizeConstraintSetError {}
 /// Errors returned by CreateSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateSqlInjectionMatchSetError {
@@ -3216,21 +3178,19 @@ impl CreateSqlInjectionMatchSetError {
 }
 impl fmt::Display for CreateSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSqlInjectionMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateSqlInjectionMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSqlInjectionMatchSetError {}
 /// Errors returned by CreateWebACL
 #[derive(Debug, PartialEq)]
 pub enum CreateWebACLError {
@@ -3295,24 +3255,20 @@ impl CreateWebACLError {
 }
 impl fmt::Display for CreateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWebACLError::WAFBadRequest(ref cause) => cause,
-            CreateWebACLError::WAFDisallowedName(ref cause) => cause,
-            CreateWebACLError::WAFInternalError(ref cause) => cause,
-            CreateWebACLError::WAFInvalidAccount(ref cause) => cause,
-            CreateWebACLError::WAFInvalidParameter(ref cause) => cause,
-            CreateWebACLError::WAFLimitsExceeded(ref cause) => cause,
-            CreateWebACLError::WAFStaleData(ref cause) => cause,
-            CreateWebACLError::WAFTagOperation(ref cause) => cause,
-            CreateWebACLError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateWebACLError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWebACLError {}
 /// Errors returned by CreateXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateXssMatchSetError {
@@ -3363,21 +3319,17 @@ impl CreateXssMatchSetError {
 }
 impl fmt::Display for CreateXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateXssMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateXssMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateXssMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateXssMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateXssMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateXssMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateXssMatchSetError {}
 /// Errors returned by DeleteByteMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteByteMatchSetError {
@@ -3434,21 +3386,17 @@ impl DeleteByteMatchSetError {
 }
 impl fmt::Display for DeleteByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteByteMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteByteMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteByteMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteByteMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteByteMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteByteMatchSetError {}
 /// Errors returned by DeleteGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteGeoMatchSetError {
@@ -3499,21 +3447,17 @@ impl DeleteGeoMatchSetError {
 }
 impl fmt::Display for DeleteGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGeoMatchSetError {}
 /// Errors returned by DeleteIPSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteIPSetError {
@@ -3562,21 +3506,17 @@ impl DeleteIPSetError {
 }
 impl fmt::Display for DeleteIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIPSetError::WAFInternalError(ref cause) => cause,
-            DeleteIPSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteIPSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteIPSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteIPSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteIPSetError::WAFStaleData(ref cause) => cause,
+            DeleteIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIPSetError {}
 /// Errors returned by DeleteLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoggingConfigurationError {
@@ -3618,18 +3558,16 @@ impl DeleteLoggingConfigurationError {
 }
 impl fmt::Display for DeleteLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoggingConfigurationError::WAFInternalError(ref cause) => cause,
-            DeleteLoggingConfigurationError::WAFNonexistentItem(ref cause) => cause,
-            DeleteLoggingConfigurationError::WAFStaleData(ref cause) => cause,
+            DeleteLoggingConfigurationError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteLoggingConfigurationError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLoggingConfigurationError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLoggingConfigurationError {}
 /// Errors returned by DeletePermissionPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeletePermissionPolicyError {
@@ -3667,18 +3605,14 @@ impl DeletePermissionPolicyError {
 }
 impl fmt::Display for DeletePermissionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePermissionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePermissionPolicyError::WAFInternalError(ref cause) => cause,
-            DeletePermissionPolicyError::WAFNonexistentItem(ref cause) => cause,
-            DeletePermissionPolicyError::WAFStaleData(ref cause) => cause,
+            DeletePermissionPolicyError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeletePermissionPolicyError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeletePermissionPolicyError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePermissionPolicyError {}
 /// Errors returned by DeleteRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteRateBasedRuleError {
@@ -3749,23 +3683,21 @@ impl DeleteRateBasedRuleError {
 }
 impl fmt::Display for DeleteRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFReferencedItem(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFStaleData(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFTagOperation(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFTagOperationInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRateBasedRuleError {}
 /// Errors returned by DeleteRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteRegexMatchSetError {
@@ -3824,21 +3756,17 @@ impl DeleteRegexMatchSetError {
 }
 impl fmt::Display for DeleteRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRegexMatchSetError {}
 /// Errors returned by DeleteRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteRegexPatternSetError {
@@ -3897,21 +3825,17 @@ impl DeleteRegexPatternSetError {
 }
 impl fmt::Display for DeleteRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFStaleData(ref cause) => cause,
+            DeleteRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRegexPatternSetError {}
 /// Errors returned by DeleteRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteRuleError {
@@ -3972,23 +3896,19 @@ impl DeleteRuleError {
 }
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRuleError::WAFInternalError(ref cause) => cause,
-            DeleteRuleError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRuleError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRuleError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRuleError::WAFReferencedItem(ref cause) => cause,
-            DeleteRuleError::WAFStaleData(ref cause) => cause,
-            DeleteRuleError::WAFTagOperation(ref cause) => cause,
-            DeleteRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRuleError {}
 /// Errors returned by DeleteRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteRuleGroupError {
@@ -4049,23 +3969,19 @@ impl DeleteRuleGroupError {
 }
 impl fmt::Display for DeleteRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRuleGroupError::WAFInternalError(ref cause) => cause,
-            DeleteRuleGroupError::WAFInvalidOperation(ref cause) => cause,
-            DeleteRuleGroupError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRuleGroupError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRuleGroupError::WAFReferencedItem(ref cause) => cause,
-            DeleteRuleGroupError::WAFStaleData(ref cause) => cause,
-            DeleteRuleGroupError::WAFTagOperation(ref cause) => cause,
-            DeleteRuleGroupError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRuleGroupError {}
 /// Errors returned by DeleteSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteSizeConstraintSetError {
@@ -4126,21 +4042,17 @@ impl DeleteSizeConstraintSetError {
 }
 impl fmt::Display for DeleteSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFStaleData(ref cause) => cause,
+            DeleteSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSizeConstraintSetError {}
 /// Errors returned by DeleteSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteSqlInjectionMatchSetError {
@@ -4203,21 +4115,19 @@ impl DeleteSqlInjectionMatchSetError {
 }
 impl fmt::Display for DeleteSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteSqlInjectionMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSqlInjectionMatchSetError {}
 /// Errors returned by DeleteWebACL
 #[derive(Debug, PartialEq)]
 pub enum DeleteWebACLError {
@@ -4278,23 +4188,19 @@ impl DeleteWebACLError {
 }
 impl fmt::Display for DeleteWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWebACLError::WAFInternalError(ref cause) => cause,
-            DeleteWebACLError::WAFInvalidAccount(ref cause) => cause,
-            DeleteWebACLError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteWebACLError::WAFNonexistentItem(ref cause) => cause,
-            DeleteWebACLError::WAFReferencedItem(ref cause) => cause,
-            DeleteWebACLError::WAFStaleData(ref cause) => cause,
-            DeleteWebACLError::WAFTagOperation(ref cause) => cause,
-            DeleteWebACLError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWebACLError {}
 /// Errors returned by DeleteXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteXssMatchSetError {
@@ -4345,21 +4251,17 @@ impl DeleteXssMatchSetError {
 }
 impl fmt::Display for DeleteXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteXssMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteXssMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteXssMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteXssMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteXssMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteXssMatchSetError {}
 /// Errors returned by DisassociateWebACL
 #[derive(Debug, PartialEq)]
 pub enum DisassociateWebACLError {
@@ -4404,19 +4306,15 @@ impl DisassociateWebACLError {
 }
 impl fmt::Display for DisassociateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateWebACLError::WAFInternalError(ref cause) => cause,
-            DisassociateWebACLError::WAFInvalidAccount(ref cause) => cause,
-            DisassociateWebACLError::WAFInvalidParameter(ref cause) => cause,
-            DisassociateWebACLError::WAFNonexistentItem(ref cause) => cause,
+            DisassociateWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DisassociateWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DisassociateWebACLError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            DisassociateWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateWebACLError {}
 /// Errors returned by GetByteMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetByteMatchSetError {
@@ -4450,18 +4348,14 @@ impl GetByteMatchSetError {
 }
 impl fmt::Display for GetByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetByteMatchSetError::WAFInternalError(ref cause) => cause,
-            GetByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetByteMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetByteMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetByteMatchSetError {}
 /// Errors returned by GetChangeToken
 #[derive(Debug, PartialEq)]
 pub enum GetChangeTokenError {
@@ -4485,16 +4379,12 @@ impl GetChangeTokenError {
 }
 impl fmt::Display for GetChangeTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetChangeTokenError {
-    fn description(&self) -> &str {
         match *self {
-            GetChangeTokenError::WAFInternalError(ref cause) => cause,
+            GetChangeTokenError::WAFInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetChangeTokenError {}
 /// Errors returned by GetChangeTokenStatus
 #[derive(Debug, PartialEq)]
 pub enum GetChangeTokenStatusError {
@@ -4527,17 +4417,13 @@ impl GetChangeTokenStatusError {
 }
 impl fmt::Display for GetChangeTokenStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetChangeTokenStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetChangeTokenStatusError::WAFInternalError(ref cause) => cause,
-            GetChangeTokenStatusError::WAFNonexistentItem(ref cause) => cause,
+            GetChangeTokenStatusError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetChangeTokenStatusError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetChangeTokenStatusError {}
 /// Errors returned by GetGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetGeoMatchSetError {
@@ -4571,18 +4457,14 @@ impl GetGeoMatchSetError {
 }
 impl fmt::Display for GetGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            GetGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetGeoMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetGeoMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGeoMatchSetError {}
 /// Errors returned by GetIPSet
 #[derive(Debug, PartialEq)]
 pub enum GetIPSetError {
@@ -4616,18 +4498,14 @@ impl GetIPSetError {
 }
 impl fmt::Display for GetIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetIPSetError::WAFInternalError(ref cause) => cause,
-            GetIPSetError::WAFInvalidAccount(ref cause) => cause,
-            GetIPSetError::WAFNonexistentItem(ref cause) => cause,
+            GetIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetIPSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIPSetError {}
 /// Errors returned by GetLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetLoggingConfigurationError {
@@ -4660,17 +4538,13 @@ impl GetLoggingConfigurationError {
 }
 impl fmt::Display for GetLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoggingConfigurationError::WAFInternalError(ref cause) => cause,
-            GetLoggingConfigurationError::WAFNonexistentItem(ref cause) => cause,
+            GetLoggingConfigurationError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetLoggingConfigurationError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoggingConfigurationError {}
 /// Errors returned by GetPermissionPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetPermissionPolicyError {
@@ -4703,17 +4577,13 @@ impl GetPermissionPolicyError {
 }
 impl fmt::Display for GetPermissionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPermissionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPermissionPolicyError::WAFInternalError(ref cause) => cause,
-            GetPermissionPolicyError::WAFNonexistentItem(ref cause) => cause,
+            GetPermissionPolicyError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetPermissionPolicyError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPermissionPolicyError {}
 /// Errors returned by GetRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum GetRateBasedRuleError {
@@ -4747,18 +4617,14 @@ impl GetRateBasedRuleError {
 }
 impl fmt::Display for GetRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            GetRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            GetRateBasedRuleError::WAFInvalidAccount(ref cause) => cause,
-            GetRateBasedRuleError::WAFNonexistentItem(ref cause) => cause,
+            GetRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRateBasedRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRateBasedRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRateBasedRuleError {}
 /// Errors returned by GetRateBasedRuleManagedKeys
 #[derive(Debug, PartialEq)]
 pub enum GetRateBasedRuleManagedKeysError {
@@ -4807,19 +4673,21 @@ impl GetRateBasedRuleManagedKeysError {
 }
 impl fmt::Display for GetRateBasedRuleManagedKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRateBasedRuleManagedKeysError {
-    fn description(&self) -> &str {
         match *self {
-            GetRateBasedRuleManagedKeysError::WAFInternalError(ref cause) => cause,
-            GetRateBasedRuleManagedKeysError::WAFInvalidAccount(ref cause) => cause,
-            GetRateBasedRuleManagedKeysError::WAFInvalidParameter(ref cause) => cause,
-            GetRateBasedRuleManagedKeysError::WAFNonexistentItem(ref cause) => cause,
+            GetRateBasedRuleManagedKeysError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRateBasedRuleManagedKeysError::WAFInvalidAccount(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRateBasedRuleManagedKeysError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRateBasedRuleManagedKeysError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRateBasedRuleManagedKeysError {}
 /// Errors returned by GetRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetRegexMatchSetError {
@@ -4853,18 +4721,14 @@ impl GetRegexMatchSetError {
 }
 impl fmt::Display for GetRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            GetRegexMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetRegexMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRegexMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRegexMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRegexMatchSetError {}
 /// Errors returned by GetRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum GetRegexPatternSetError {
@@ -4902,18 +4766,14 @@ impl GetRegexPatternSetError {
 }
 impl fmt::Display for GetRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            GetRegexPatternSetError::WAFInvalidAccount(ref cause) => cause,
-            GetRegexPatternSetError::WAFNonexistentItem(ref cause) => cause,
+            GetRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRegexPatternSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRegexPatternSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRegexPatternSetError {}
 /// Errors returned by GetRule
 #[derive(Debug, PartialEq)]
 pub enum GetRuleError {
@@ -4947,18 +4807,14 @@ impl GetRuleError {
 }
 impl fmt::Display for GetRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRuleError {
-    fn description(&self) -> &str {
         match *self {
-            GetRuleError::WAFInternalError(ref cause) => cause,
-            GetRuleError::WAFInvalidAccount(ref cause) => cause,
-            GetRuleError::WAFNonexistentItem(ref cause) => cause,
+            GetRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRuleError {}
 /// Errors returned by GetRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum GetRuleGroupError {
@@ -4987,17 +4843,13 @@ impl GetRuleGroupError {
 }
 impl fmt::Display for GetRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetRuleGroupError::WAFInternalError(ref cause) => cause,
-            GetRuleGroupError::WAFNonexistentItem(ref cause) => cause,
+            GetRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRuleGroupError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRuleGroupError {}
 /// Errors returned by GetSampledRequests
 #[derive(Debug, PartialEq)]
 pub enum GetSampledRequestsError {
@@ -5028,17 +4880,13 @@ impl GetSampledRequestsError {
 }
 impl fmt::Display for GetSampledRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSampledRequestsError {
-    fn description(&self) -> &str {
         match *self {
-            GetSampledRequestsError::WAFInternalError(ref cause) => cause,
-            GetSampledRequestsError::WAFNonexistentItem(ref cause) => cause,
+            GetSampledRequestsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetSampledRequestsError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSampledRequestsError {}
 /// Errors returned by GetSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum GetSizeConstraintSetError {
@@ -5078,18 +4926,14 @@ impl GetSizeConstraintSetError {
 }
 impl fmt::Display for GetSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            GetSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            GetSizeConstraintSetError::WAFNonexistentItem(ref cause) => cause,
+            GetSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetSizeConstraintSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSizeConstraintSetError {}
 /// Errors returned by GetSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetSqlInjectionMatchSetError {
@@ -5129,18 +4973,14 @@ impl GetSqlInjectionMatchSetError {
 }
 impl fmt::Display for GetSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            GetSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSqlInjectionMatchSetError {}
 /// Errors returned by GetWebACL
 #[derive(Debug, PartialEq)]
 pub enum GetWebACLError {
@@ -5174,18 +5014,14 @@ impl GetWebACLError {
 }
 impl fmt::Display for GetWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            GetWebACLError::WAFInternalError(ref cause) => cause,
-            GetWebACLError::WAFInvalidAccount(ref cause) => cause,
-            GetWebACLError::WAFNonexistentItem(ref cause) => cause,
+            GetWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWebACLError {}
 /// Errors returned by GetWebACLForResource
 #[derive(Debug, PartialEq)]
 pub enum GetWebACLForResourceError {
@@ -5239,20 +5075,16 @@ impl GetWebACLForResourceError {
 }
 impl fmt::Display for GetWebACLForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWebACLForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            GetWebACLForResourceError::WAFInternalError(ref cause) => cause,
-            GetWebACLForResourceError::WAFInvalidAccount(ref cause) => cause,
-            GetWebACLForResourceError::WAFInvalidParameter(ref cause) => cause,
-            GetWebACLForResourceError::WAFNonexistentItem(ref cause) => cause,
-            GetWebACLForResourceError::WAFUnavailableEntity(ref cause) => cause,
+            GetWebACLForResourceError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetWebACLForResourceError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetWebACLForResourceError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            GetWebACLForResourceError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            GetWebACLForResourceError::WAFUnavailableEntity(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWebACLForResourceError {}
 /// Errors returned by GetXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetXssMatchSetError {
@@ -5286,18 +5118,14 @@ impl GetXssMatchSetError {
 }
 impl fmt::Display for GetXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetXssMatchSetError::WAFInternalError(ref cause) => cause,
-            GetXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetXssMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetXssMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetXssMatchSetError {}
 /// Errors returned by ListActivatedRulesInRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum ListActivatedRulesInRuleGroupError {
@@ -5339,18 +5167,20 @@ impl ListActivatedRulesInRuleGroupError {
 }
 impl fmt::Display for ListActivatedRulesInRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListActivatedRulesInRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ListActivatedRulesInRuleGroupError::WAFInternalError(ref cause) => cause,
-            ListActivatedRulesInRuleGroupError::WAFInvalidParameter(ref cause) => cause,
-            ListActivatedRulesInRuleGroupError::WAFNonexistentItem(ref cause) => cause,
+            ListActivatedRulesInRuleGroupError::WAFInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListActivatedRulesInRuleGroupError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListActivatedRulesInRuleGroupError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListActivatedRulesInRuleGroupError {}
 /// Errors returned by ListByteMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListByteMatchSetsError {
@@ -5379,17 +5209,13 @@ impl ListByteMatchSetsError {
 }
 impl fmt::Display for ListByteMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListByteMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListByteMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListByteMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListByteMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListByteMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListByteMatchSetsError {}
 /// Errors returned by ListGeoMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListGeoMatchSetsError {
@@ -5418,17 +5244,13 @@ impl ListGeoMatchSetsError {
 }
 impl fmt::Display for ListGeoMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGeoMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGeoMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListGeoMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListGeoMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListGeoMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGeoMatchSetsError {}
 /// Errors returned by ListIPSets
 #[derive(Debug, PartialEq)]
 pub enum ListIPSetsError {
@@ -5457,17 +5279,13 @@ impl ListIPSetsError {
 }
 impl fmt::Display for ListIPSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIPSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListIPSetsError::WAFInternalError(ref cause) => cause,
-            ListIPSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListIPSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListIPSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIPSetsError {}
 /// Errors returned by ListLoggingConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListLoggingConfigurationsError {
@@ -5507,18 +5325,16 @@ impl ListLoggingConfigurationsError {
 }
 impl fmt::Display for ListLoggingConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLoggingConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLoggingConfigurationsError::WAFInternalError(ref cause) => cause,
-            ListLoggingConfigurationsError::WAFInvalidParameter(ref cause) => cause,
-            ListLoggingConfigurationsError::WAFNonexistentItem(ref cause) => cause,
+            ListLoggingConfigurationsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListLoggingConfigurationsError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLoggingConfigurationsError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLoggingConfigurationsError {}
 /// Errors returned by ListRateBasedRules
 #[derive(Debug, PartialEq)]
 pub enum ListRateBasedRulesError {
@@ -5549,17 +5365,13 @@ impl ListRateBasedRulesError {
 }
 impl fmt::Display for ListRateBasedRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRateBasedRulesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRateBasedRulesError::WAFInternalError(ref cause) => cause,
-            ListRateBasedRulesError::WAFInvalidAccount(ref cause) => cause,
+            ListRateBasedRulesError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRateBasedRulesError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRateBasedRulesError {}
 /// Errors returned by ListRegexMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListRegexMatchSetsError {
@@ -5590,17 +5402,13 @@ impl ListRegexMatchSetsError {
 }
 impl fmt::Display for ListRegexMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRegexMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRegexMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListRegexMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListRegexMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRegexMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRegexMatchSetsError {}
 /// Errors returned by ListRegexPatternSets
 #[derive(Debug, PartialEq)]
 pub enum ListRegexPatternSetsError {
@@ -5633,17 +5441,13 @@ impl ListRegexPatternSetsError {
 }
 impl fmt::Display for ListRegexPatternSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRegexPatternSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRegexPatternSetsError::WAFInternalError(ref cause) => cause,
-            ListRegexPatternSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListRegexPatternSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRegexPatternSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRegexPatternSetsError {}
 /// Errors returned by ListResourcesForWebACL
 #[derive(Debug, PartialEq)]
 pub enum ListResourcesForWebACLError {
@@ -5690,19 +5494,15 @@ impl ListResourcesForWebACLError {
 }
 impl fmt::Display for ListResourcesForWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourcesForWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourcesForWebACLError::WAFInternalError(ref cause) => cause,
-            ListResourcesForWebACLError::WAFInvalidAccount(ref cause) => cause,
-            ListResourcesForWebACLError::WAFInvalidParameter(ref cause) => cause,
-            ListResourcesForWebACLError::WAFNonexistentItem(ref cause) => cause,
+            ListResourcesForWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListResourcesForWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            ListResourcesForWebACLError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListResourcesForWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourcesForWebACLError {}
 /// Errors returned by ListRuleGroups
 #[derive(Debug, PartialEq)]
 pub enum ListRuleGroupsError {
@@ -5726,16 +5526,12 @@ impl ListRuleGroupsError {
 }
 impl fmt::Display for ListRuleGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRuleGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRuleGroupsError::WAFInternalError(ref cause) => cause,
+            ListRuleGroupsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRuleGroupsError {}
 /// Errors returned by ListRules
 #[derive(Debug, PartialEq)]
 pub enum ListRulesError {
@@ -5764,17 +5560,13 @@ impl ListRulesError {
 }
 impl fmt::Display for ListRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRulesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRulesError::WAFInternalError(ref cause) => cause,
-            ListRulesError::WAFInvalidAccount(ref cause) => cause,
+            ListRulesError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRulesError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRulesError {}
 /// Errors returned by ListSizeConstraintSets
 #[derive(Debug, PartialEq)]
 pub enum ListSizeConstraintSetsError {
@@ -5807,17 +5599,13 @@ impl ListSizeConstraintSetsError {
 }
 impl fmt::Display for ListSizeConstraintSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSizeConstraintSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSizeConstraintSetsError::WAFInternalError(ref cause) => cause,
-            ListSizeConstraintSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListSizeConstraintSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListSizeConstraintSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSizeConstraintSetsError {}
 /// Errors returned by ListSqlInjectionMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListSqlInjectionMatchSetsError {
@@ -5850,17 +5638,13 @@ impl ListSqlInjectionMatchSetsError {
 }
 impl fmt::Display for ListSqlInjectionMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSqlInjectionMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSqlInjectionMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListSqlInjectionMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListSqlInjectionMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListSqlInjectionMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSqlInjectionMatchSetsError {}
 /// Errors returned by ListSubscribedRuleGroups
 #[derive(Debug, PartialEq)]
 pub enum ListSubscribedRuleGroupsError {
@@ -5893,17 +5677,13 @@ impl ListSubscribedRuleGroupsError {
 }
 impl fmt::Display for ListSubscribedRuleGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSubscribedRuleGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSubscribedRuleGroupsError::WAFInternalError(ref cause) => cause,
-            ListSubscribedRuleGroupsError::WAFNonexistentItem(ref cause) => cause,
+            ListSubscribedRuleGroupsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListSubscribedRuleGroupsError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSubscribedRuleGroupsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -5959,21 +5739,19 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::WAFBadRequest(ref cause) => cause,
-            ListTagsForResourceError::WAFInternalError(ref cause) => cause,
-            ListTagsForResourceError::WAFInvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::WAFNonexistentItem(ref cause) => cause,
-            ListTagsForResourceError::WAFTagOperation(ref cause) => cause,
-            ListTagsForResourceError::WAFTagOperationInternalError(ref cause) => cause,
+            ListTagsForResourceError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFTagOperationInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListWebACLs
 #[derive(Debug, PartialEq)]
 pub enum ListWebACLsError {
@@ -6002,17 +5780,13 @@ impl ListWebACLsError {
 }
 impl fmt::Display for ListWebACLsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWebACLsError {
-    fn description(&self) -> &str {
         match *self {
-            ListWebACLsError::WAFInternalError(ref cause) => cause,
-            ListWebACLsError::WAFInvalidAccount(ref cause) => cause,
+            ListWebACLsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListWebACLsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWebACLsError {}
 /// Errors returned by ListXssMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListXssMatchSetsError {
@@ -6041,17 +5815,13 @@ impl ListXssMatchSetsError {
 }
 impl fmt::Display for ListXssMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListXssMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListXssMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListXssMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListXssMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListXssMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListXssMatchSetsError {}
 /// Errors returned by PutLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutLoggingConfigurationError {
@@ -6098,19 +5868,17 @@ impl PutLoggingConfigurationError {
 }
 impl fmt::Display for PutLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutLoggingConfigurationError::WAFInternalError(ref cause) => cause,
-            PutLoggingConfigurationError::WAFNonexistentItem(ref cause) => cause,
-            PutLoggingConfigurationError::WAFServiceLinkedRoleError(ref cause) => cause,
-            PutLoggingConfigurationError::WAFStaleData(ref cause) => cause,
+            PutLoggingConfigurationError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            PutLoggingConfigurationError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            PutLoggingConfigurationError::WAFServiceLinkedRoleError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutLoggingConfigurationError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLoggingConfigurationError {}
 /// Errors returned by PutPermissionPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutPermissionPolicyError {
@@ -6155,19 +5923,17 @@ impl PutPermissionPolicyError {
 }
 impl fmt::Display for PutPermissionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPermissionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutPermissionPolicyError::WAFInternalError(ref cause) => cause,
-            PutPermissionPolicyError::WAFInvalidPermissionPolicy(ref cause) => cause,
-            PutPermissionPolicyError::WAFNonexistentItem(ref cause) => cause,
-            PutPermissionPolicyError::WAFStaleData(ref cause) => cause,
+            PutPermissionPolicyError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            PutPermissionPolicyError::WAFInvalidPermissionPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutPermissionPolicyError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            PutPermissionPolicyError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutPermissionPolicyError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -6222,22 +5988,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::WAFBadRequest(ref cause) => cause,
-            TagResourceError::WAFInternalError(ref cause) => cause,
-            TagResourceError::WAFInvalidParameter(ref cause) => cause,
-            TagResourceError::WAFLimitsExceeded(ref cause) => cause,
-            TagResourceError::WAFNonexistentItem(ref cause) => cause,
-            TagResourceError::WAFTagOperation(ref cause) => cause,
-            TagResourceError::WAFTagOperationInternalError(ref cause) => cause,
+            TagResourceError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -6287,21 +6049,17 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::WAFBadRequest(ref cause) => cause,
-            UntagResourceError::WAFInternalError(ref cause) => cause,
-            UntagResourceError::WAFInvalidParameter(ref cause) => cause,
-            UntagResourceError::WAFNonexistentItem(ref cause) => cause,
-            UntagResourceError::WAFTagOperation(ref cause) => cause,
-            UntagResourceError::WAFTagOperationInternalError(ref cause) => cause,
+            UntagResourceError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateByteMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateByteMatchSetError {
@@ -6372,23 +6130,19 @@ impl UpdateByteMatchSetError {
 }
 impl fmt::Display for UpdateByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateByteMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateByteMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateByteMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateByteMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateByteMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateByteMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateByteMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateByteMatchSetError {}
 /// Errors returned by UpdateGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateGeoMatchSetError {
@@ -6460,24 +6214,20 @@ impl UpdateGeoMatchSetError {
 }
 impl fmt::Display for UpdateGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFReferencedItem(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGeoMatchSetError {}
 /// Errors returned by UpdateIPSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateIPSetError {
@@ -6541,24 +6291,20 @@ impl UpdateIPSetError {
 }
 impl fmt::Display for UpdateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIPSetError::WAFInternalError(ref cause) => cause,
-            UpdateIPSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateIPSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateIPSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateIPSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateIPSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateIPSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateIPSetError::WAFReferencedItem(ref cause) => cause,
-            UpdateIPSetError::WAFStaleData(ref cause) => cause,
+            UpdateIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIPSetError {}
 /// Errors returned by UpdateRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum UpdateRateBasedRuleError {
@@ -6638,24 +6384,20 @@ impl UpdateRateBasedRuleError {
 }
 impl fmt::Display for UpdateRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFInvalidParameter(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFReferencedItem(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFStaleData(ref cause) => cause,
+            UpdateRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRateBasedRuleError {}
 /// Errors returned by UpdateRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateRegexMatchSetError {
@@ -6728,23 +6470,19 @@ impl UpdateRegexMatchSetError {
 }
 impl fmt::Display for UpdateRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRegexMatchSetError::WAFDisallowedName(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateRegexMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRegexMatchSetError {}
 /// Errors returned by UpdateRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateRegexPatternSetError {
@@ -6817,23 +6555,21 @@ impl UpdateRegexPatternSetError {
 }
 impl fmt::Display for UpdateRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFInvalidRegexPattern(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFStaleData(ref cause) => cause,
+            UpdateRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFInvalidRegexPattern(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFNonexistentContainer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRegexPatternSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRegexPatternSetError {}
 /// Errors returned by UpdateRule
 #[derive(Debug, PartialEq)]
 pub enum UpdateRuleError {
@@ -6897,24 +6633,20 @@ impl UpdateRuleError {
 }
 impl fmt::Display for UpdateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRuleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRuleError::WAFInternalError(ref cause) => cause,
-            UpdateRuleError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRuleError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRuleError::WAFInvalidParameter(ref cause) => cause,
-            UpdateRuleError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRuleError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRuleError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRuleError::WAFReferencedItem(ref cause) => cause,
-            UpdateRuleError::WAFStaleData(ref cause) => cause,
+            UpdateRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRuleError {}
 /// Errors returned by UpdateRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateRuleGroupError {
@@ -6970,22 +6702,18 @@ impl UpdateRuleGroupError {
 }
 impl fmt::Display for UpdateRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRuleGroupError::WAFInternalError(ref cause) => cause,
-            UpdateRuleGroupError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRuleGroupError::WAFInvalidParameter(ref cause) => cause,
-            UpdateRuleGroupError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRuleGroupError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRuleGroupError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRuleGroupError::WAFStaleData(ref cause) => cause,
+            UpdateRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRuleGroupError {}
 /// Errors returned by UpdateSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateSizeConstraintSetError {
@@ -7067,24 +6795,22 @@ impl UpdateSizeConstraintSetError {
 }
 impl fmt::Display for UpdateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFReferencedItem(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFStaleData(ref cause) => cause,
+            UpdateSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFNonexistentContainer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSizeConstraintSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSizeConstraintSetError {}
 /// Errors returned by UpdateSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateSqlInjectionMatchSetError {
@@ -7161,23 +6887,27 @@ impl UpdateSqlInjectionMatchSetError {
 }
 impl fmt::Display for UpdateSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateSqlInjectionMatchSetError::WAFInvalidOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSqlInjectionMatchSetError::WAFNonexistentContainer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSqlInjectionMatchSetError {}
 /// Errors returned by UpdateWebACL
 #[derive(Debug, PartialEq)]
 pub enum UpdateWebACLError {
@@ -7250,25 +6980,21 @@ impl UpdateWebACLError {
 }
 impl fmt::Display for UpdateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateWebACLError::WAFInternalError(ref cause) => cause,
-            UpdateWebACLError::WAFInvalidAccount(ref cause) => cause,
-            UpdateWebACLError::WAFInvalidOperation(ref cause) => cause,
-            UpdateWebACLError::WAFInvalidParameter(ref cause) => cause,
-            UpdateWebACLError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateWebACLError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateWebACLError::WAFNonexistentItem(ref cause) => cause,
-            UpdateWebACLError::WAFReferencedItem(ref cause) => cause,
-            UpdateWebACLError::WAFStaleData(ref cause) => cause,
-            UpdateWebACLError::WAFSubscriptionNotFound(ref cause) => cause,
+            UpdateWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFSubscriptionNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateWebACLError {}
 /// Errors returned by UpdateXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateXssMatchSetError {
@@ -7335,23 +7061,19 @@ impl UpdateXssMatchSetError {
 }
 impl fmt::Display for UpdateXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateXssMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateXssMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateXssMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateXssMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateXssMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateXssMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateXssMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateXssMatchSetError {}
 /// Trait representing the capabilities of the WAF Regional API. WAF Regional clients implement this trait.
 pub trait WAFRegional {
     /// <p>Associates a web ACL with a resource, either an application load balancer or Amazon API Gateway stage.</p>

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -2472,21 +2472,17 @@ impl CreateByteMatchSetError {
 }
 impl fmt::Display for CreateByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateByteMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateByteMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateByteMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateByteMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateByteMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateByteMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateByteMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateByteMatchSetError {}
 /// Errors returned by CreateGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateGeoMatchSetError {
@@ -2537,21 +2533,17 @@ impl CreateGeoMatchSetError {
 }
 impl fmt::Display for CreateGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGeoMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateGeoMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateGeoMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateGeoMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateGeoMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateGeoMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGeoMatchSetError {}
 /// Errors returned by CreateIPSet
 #[derive(Debug, PartialEq)]
 pub enum CreateIPSetError {
@@ -2600,21 +2592,17 @@ impl CreateIPSetError {
 }
 impl fmt::Display for CreateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIPSetError::WAFDisallowedName(ref cause) => cause,
-            CreateIPSetError::WAFInternalError(ref cause) => cause,
-            CreateIPSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateIPSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateIPSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateIPSetError::WAFStaleData(ref cause) => cause,
+            CreateIPSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateIPSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIPSetError {}
 /// Errors returned by CreateRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum CreateRateBasedRuleError {
@@ -2682,23 +2670,21 @@ impl CreateRateBasedRuleError {
 }
 impl fmt::Display for CreateRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRateBasedRuleError::WAFBadRequest(ref cause) => cause,
-            CreateRateBasedRuleError::WAFDisallowedName(ref cause) => cause,
-            CreateRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            CreateRateBasedRuleError::WAFInvalidParameter(ref cause) => cause,
-            CreateRateBasedRuleError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRateBasedRuleError::WAFStaleData(ref cause) => cause,
-            CreateRateBasedRuleError::WAFTagOperation(ref cause) => cause,
-            CreateRateBasedRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateRateBasedRuleError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateRateBasedRuleError::WAFTagOperationInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateRateBasedRuleError {}
 /// Errors returned by CreateRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateRegexMatchSetError {
@@ -2743,19 +2729,15 @@ impl CreateRegexMatchSetError {
 }
 impl fmt::Display for CreateRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRegexMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateRegexMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRegexMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateRegexMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRegexMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRegexMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRegexMatchSetError {}
 /// Errors returned by CreateRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum CreateRegexPatternSetError {
@@ -2800,19 +2782,15 @@ impl CreateRegexPatternSetError {
 }
 impl fmt::Display for CreateRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRegexPatternSetError::WAFDisallowedName(ref cause) => cause,
-            CreateRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            CreateRegexPatternSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRegexPatternSetError::WAFStaleData(ref cause) => cause,
+            CreateRegexPatternSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRegexPatternSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRegexPatternSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRegexPatternSetError {}
 /// Errors returned by CreateRule
 #[derive(Debug, PartialEq)]
 pub enum CreateRuleError {
@@ -2872,23 +2850,19 @@ impl CreateRuleError {
 }
 impl fmt::Display for CreateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRuleError::WAFBadRequest(ref cause) => cause,
-            CreateRuleError::WAFDisallowedName(ref cause) => cause,
-            CreateRuleError::WAFInternalError(ref cause) => cause,
-            CreateRuleError::WAFInvalidParameter(ref cause) => cause,
-            CreateRuleError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRuleError::WAFStaleData(ref cause) => cause,
-            CreateRuleError::WAFTagOperation(ref cause) => cause,
-            CreateRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateRuleError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateRuleError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRuleError {}
 /// Errors returned by CreateRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateRuleGroupError {
@@ -2943,22 +2917,18 @@ impl CreateRuleGroupError {
 }
 impl fmt::Display for CreateRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateRuleGroupError::WAFBadRequest(ref cause) => cause,
-            CreateRuleGroupError::WAFDisallowedName(ref cause) => cause,
-            CreateRuleGroupError::WAFInternalError(ref cause) => cause,
-            CreateRuleGroupError::WAFLimitsExceeded(ref cause) => cause,
-            CreateRuleGroupError::WAFStaleData(ref cause) => cause,
-            CreateRuleGroupError::WAFTagOperation(ref cause) => cause,
-            CreateRuleGroupError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateRuleGroupError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateRuleGroupError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateRuleGroupError {}
 /// Errors returned by CreateSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum CreateSizeConstraintSetError {
@@ -3019,21 +2989,17 @@ impl CreateSizeConstraintSetError {
 }
 impl fmt::Display for CreateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSizeConstraintSetError::WAFDisallowedName(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateSizeConstraintSetError::WAFStaleData(ref cause) => cause,
+            CreateSizeConstraintSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSizeConstraintSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSizeConstraintSetError {}
 /// Errors returned by CreateSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateSqlInjectionMatchSetError {
@@ -3096,21 +3062,19 @@ impl CreateSqlInjectionMatchSetError {
 }
 impl fmt::Display for CreateSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSqlInjectionMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateSqlInjectionMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateSqlInjectionMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSqlInjectionMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSqlInjectionMatchSetError {}
 /// Errors returned by CreateWebACL
 #[derive(Debug, PartialEq)]
 pub enum CreateWebACLError {
@@ -3175,24 +3139,20 @@ impl CreateWebACLError {
 }
 impl fmt::Display for CreateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWebACLError::WAFBadRequest(ref cause) => cause,
-            CreateWebACLError::WAFDisallowedName(ref cause) => cause,
-            CreateWebACLError::WAFInternalError(ref cause) => cause,
-            CreateWebACLError::WAFInvalidAccount(ref cause) => cause,
-            CreateWebACLError::WAFInvalidParameter(ref cause) => cause,
-            CreateWebACLError::WAFLimitsExceeded(ref cause) => cause,
-            CreateWebACLError::WAFStaleData(ref cause) => cause,
-            CreateWebACLError::WAFTagOperation(ref cause) => cause,
-            CreateWebACLError::WAFTagOperationInternalError(ref cause) => cause,
+            CreateWebACLError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            CreateWebACLError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWebACLError {}
 /// Errors returned by CreateXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum CreateXssMatchSetError {
@@ -3243,21 +3203,17 @@ impl CreateXssMatchSetError {
 }
 impl fmt::Display for CreateXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateXssMatchSetError::WAFDisallowedName(ref cause) => cause,
-            CreateXssMatchSetError::WAFInternalError(ref cause) => cause,
-            CreateXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            CreateXssMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            CreateXssMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            CreateXssMatchSetError::WAFStaleData(ref cause) => cause,
+            CreateXssMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            CreateXssMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateXssMatchSetError {}
 /// Errors returned by DeleteByteMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteByteMatchSetError {
@@ -3314,21 +3270,17 @@ impl DeleteByteMatchSetError {
 }
 impl fmt::Display for DeleteByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteByteMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteByteMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteByteMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteByteMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteByteMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteByteMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteByteMatchSetError {}
 /// Errors returned by DeleteGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteGeoMatchSetError {
@@ -3379,21 +3331,17 @@ impl DeleteGeoMatchSetError {
 }
 impl fmt::Display for DeleteGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteGeoMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteGeoMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGeoMatchSetError {}
 /// Errors returned by DeleteIPSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteIPSetError {
@@ -3442,21 +3390,17 @@ impl DeleteIPSetError {
 }
 impl fmt::Display for DeleteIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIPSetError::WAFInternalError(ref cause) => cause,
-            DeleteIPSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteIPSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteIPSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteIPSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteIPSetError::WAFStaleData(ref cause) => cause,
+            DeleteIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteIPSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIPSetError {}
 /// Errors returned by DeleteLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DeleteLoggingConfigurationError {
@@ -3498,18 +3442,16 @@ impl DeleteLoggingConfigurationError {
 }
 impl fmt::Display for DeleteLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLoggingConfigurationError::WAFInternalError(ref cause) => cause,
-            DeleteLoggingConfigurationError::WAFNonexistentItem(ref cause) => cause,
-            DeleteLoggingConfigurationError::WAFStaleData(ref cause) => cause,
+            DeleteLoggingConfigurationError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteLoggingConfigurationError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteLoggingConfigurationError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLoggingConfigurationError {}
 /// Errors returned by DeletePermissionPolicy
 #[derive(Debug, PartialEq)]
 pub enum DeletePermissionPolicyError {
@@ -3547,18 +3489,14 @@ impl DeletePermissionPolicyError {
 }
 impl fmt::Display for DeletePermissionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeletePermissionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            DeletePermissionPolicyError::WAFInternalError(ref cause) => cause,
-            DeletePermissionPolicyError::WAFNonexistentItem(ref cause) => cause,
-            DeletePermissionPolicyError::WAFStaleData(ref cause) => cause,
+            DeletePermissionPolicyError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeletePermissionPolicyError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeletePermissionPolicyError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeletePermissionPolicyError {}
 /// Errors returned by DeleteRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteRateBasedRuleError {
@@ -3629,23 +3567,21 @@ impl DeleteRateBasedRuleError {
 }
 impl fmt::Display for DeleteRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFReferencedItem(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFStaleData(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFTagOperation(ref cause) => cause,
-            DeleteRateBasedRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRateBasedRuleError::WAFTagOperationInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteRateBasedRuleError {}
 /// Errors returned by DeleteRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteRegexMatchSetError {
@@ -3704,21 +3640,17 @@ impl DeleteRegexMatchSetError {
 }
 impl fmt::Display for DeleteRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteRegexMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRegexMatchSetError {}
 /// Errors returned by DeleteRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteRegexPatternSetError {
@@ -3777,21 +3709,17 @@ impl DeleteRegexPatternSetError {
 }
 impl fmt::Display for DeleteRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteRegexPatternSetError::WAFStaleData(ref cause) => cause,
+            DeleteRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRegexPatternSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRegexPatternSetError {}
 /// Errors returned by DeleteRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteRuleError {
@@ -3852,23 +3780,19 @@ impl DeleteRuleError {
 }
 impl fmt::Display for DeleteRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRuleError::WAFInternalError(ref cause) => cause,
-            DeleteRuleError::WAFInvalidAccount(ref cause) => cause,
-            DeleteRuleError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRuleError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRuleError::WAFReferencedItem(ref cause) => cause,
-            DeleteRuleError::WAFStaleData(ref cause) => cause,
-            DeleteRuleError::WAFTagOperation(ref cause) => cause,
-            DeleteRuleError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRuleError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRuleError {}
 /// Errors returned by DeleteRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteRuleGroupError {
@@ -3929,23 +3853,19 @@ impl DeleteRuleGroupError {
 }
 impl fmt::Display for DeleteRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteRuleGroupError::WAFInternalError(ref cause) => cause,
-            DeleteRuleGroupError::WAFInvalidOperation(ref cause) => cause,
-            DeleteRuleGroupError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteRuleGroupError::WAFNonexistentItem(ref cause) => cause,
-            DeleteRuleGroupError::WAFReferencedItem(ref cause) => cause,
-            DeleteRuleGroupError::WAFStaleData(ref cause) => cause,
-            DeleteRuleGroupError::WAFTagOperation(ref cause) => cause,
-            DeleteRuleGroupError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteRuleGroupError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteRuleGroupError {}
 /// Errors returned by DeleteSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteSizeConstraintSetError {
@@ -4006,21 +3926,17 @@ impl DeleteSizeConstraintSetError {
 }
 impl fmt::Display for DeleteSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteSizeConstraintSetError::WAFStaleData(ref cause) => cause,
+            DeleteSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteSizeConstraintSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSizeConstraintSetError {}
 /// Errors returned by DeleteSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteSqlInjectionMatchSetError {
@@ -4083,21 +3999,19 @@ impl DeleteSqlInjectionMatchSetError {
 }
 impl fmt::Display for DeleteSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteSqlInjectionMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteSqlInjectionMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteSqlInjectionMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSqlInjectionMatchSetError {}
 /// Errors returned by DeleteWebACL
 #[derive(Debug, PartialEq)]
 pub enum DeleteWebACLError {
@@ -4158,23 +4072,19 @@ impl DeleteWebACLError {
 }
 impl fmt::Display for DeleteWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWebACLError::WAFInternalError(ref cause) => cause,
-            DeleteWebACLError::WAFInvalidAccount(ref cause) => cause,
-            DeleteWebACLError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteWebACLError::WAFNonexistentItem(ref cause) => cause,
-            DeleteWebACLError::WAFReferencedItem(ref cause) => cause,
-            DeleteWebACLError::WAFStaleData(ref cause) => cause,
-            DeleteWebACLError::WAFTagOperation(ref cause) => cause,
-            DeleteWebACLError::WAFTagOperationInternalError(ref cause) => cause,
+            DeleteWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            DeleteWebACLError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWebACLError {}
 /// Errors returned by DeleteXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum DeleteXssMatchSetError {
@@ -4225,21 +4135,17 @@ impl DeleteXssMatchSetError {
 }
 impl fmt::Display for DeleteXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteXssMatchSetError::WAFInternalError(ref cause) => cause,
-            DeleteXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            DeleteXssMatchSetError::WAFNonEmptyEntity(ref cause) => cause,
-            DeleteXssMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            DeleteXssMatchSetError::WAFReferencedItem(ref cause) => cause,
-            DeleteXssMatchSetError::WAFStaleData(ref cause) => cause,
+            DeleteXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFNonEmptyEntity(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            DeleteXssMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteXssMatchSetError {}
 /// Errors returned by GetByteMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetByteMatchSetError {
@@ -4273,18 +4179,14 @@ impl GetByteMatchSetError {
 }
 impl fmt::Display for GetByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetByteMatchSetError::WAFInternalError(ref cause) => cause,
-            GetByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetByteMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetByteMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetByteMatchSetError {}
 /// Errors returned by GetChangeToken
 #[derive(Debug, PartialEq)]
 pub enum GetChangeTokenError {
@@ -4308,16 +4210,12 @@ impl GetChangeTokenError {
 }
 impl fmt::Display for GetChangeTokenError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetChangeTokenError {
-    fn description(&self) -> &str {
         match *self {
-            GetChangeTokenError::WAFInternalError(ref cause) => cause,
+            GetChangeTokenError::WAFInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetChangeTokenError {}
 /// Errors returned by GetChangeTokenStatus
 #[derive(Debug, PartialEq)]
 pub enum GetChangeTokenStatusError {
@@ -4350,17 +4248,13 @@ impl GetChangeTokenStatusError {
 }
 impl fmt::Display for GetChangeTokenStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetChangeTokenStatusError {
-    fn description(&self) -> &str {
         match *self {
-            GetChangeTokenStatusError::WAFInternalError(ref cause) => cause,
-            GetChangeTokenStatusError::WAFNonexistentItem(ref cause) => cause,
+            GetChangeTokenStatusError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetChangeTokenStatusError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetChangeTokenStatusError {}
 /// Errors returned by GetGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetGeoMatchSetError {
@@ -4394,18 +4288,14 @@ impl GetGeoMatchSetError {
 }
 impl fmt::Display for GetGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            GetGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetGeoMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetGeoMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGeoMatchSetError {}
 /// Errors returned by GetIPSet
 #[derive(Debug, PartialEq)]
 pub enum GetIPSetError {
@@ -4439,18 +4329,14 @@ impl GetIPSetError {
 }
 impl fmt::Display for GetIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetIPSetError::WAFInternalError(ref cause) => cause,
-            GetIPSetError::WAFInvalidAccount(ref cause) => cause,
-            GetIPSetError::WAFNonexistentItem(ref cause) => cause,
+            GetIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetIPSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetIPSetError {}
 /// Errors returned by GetLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum GetLoggingConfigurationError {
@@ -4483,17 +4369,13 @@ impl GetLoggingConfigurationError {
 }
 impl fmt::Display for GetLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            GetLoggingConfigurationError::WAFInternalError(ref cause) => cause,
-            GetLoggingConfigurationError::WAFNonexistentItem(ref cause) => cause,
+            GetLoggingConfigurationError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetLoggingConfigurationError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetLoggingConfigurationError {}
 /// Errors returned by GetPermissionPolicy
 #[derive(Debug, PartialEq)]
 pub enum GetPermissionPolicyError {
@@ -4526,17 +4408,13 @@ impl GetPermissionPolicyError {
 }
 impl fmt::Display for GetPermissionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetPermissionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            GetPermissionPolicyError::WAFInternalError(ref cause) => cause,
-            GetPermissionPolicyError::WAFNonexistentItem(ref cause) => cause,
+            GetPermissionPolicyError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetPermissionPolicyError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetPermissionPolicyError {}
 /// Errors returned by GetRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum GetRateBasedRuleError {
@@ -4570,18 +4448,14 @@ impl GetRateBasedRuleError {
 }
 impl fmt::Display for GetRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            GetRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            GetRateBasedRuleError::WAFInvalidAccount(ref cause) => cause,
-            GetRateBasedRuleError::WAFNonexistentItem(ref cause) => cause,
+            GetRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRateBasedRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRateBasedRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRateBasedRuleError {}
 /// Errors returned by GetRateBasedRuleManagedKeys
 #[derive(Debug, PartialEq)]
 pub enum GetRateBasedRuleManagedKeysError {
@@ -4630,19 +4504,21 @@ impl GetRateBasedRuleManagedKeysError {
 }
 impl fmt::Display for GetRateBasedRuleManagedKeysError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRateBasedRuleManagedKeysError {
-    fn description(&self) -> &str {
         match *self {
-            GetRateBasedRuleManagedKeysError::WAFInternalError(ref cause) => cause,
-            GetRateBasedRuleManagedKeysError::WAFInvalidAccount(ref cause) => cause,
-            GetRateBasedRuleManagedKeysError::WAFInvalidParameter(ref cause) => cause,
-            GetRateBasedRuleManagedKeysError::WAFNonexistentItem(ref cause) => cause,
+            GetRateBasedRuleManagedKeysError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRateBasedRuleManagedKeysError::WAFInvalidAccount(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRateBasedRuleManagedKeysError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetRateBasedRuleManagedKeysError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetRateBasedRuleManagedKeysError {}
 /// Errors returned by GetRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetRegexMatchSetError {
@@ -4676,18 +4552,14 @@ impl GetRegexMatchSetError {
 }
 impl fmt::Display for GetRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            GetRegexMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetRegexMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRegexMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRegexMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRegexMatchSetError {}
 /// Errors returned by GetRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum GetRegexPatternSetError {
@@ -4725,18 +4597,14 @@ impl GetRegexPatternSetError {
 }
 impl fmt::Display for GetRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            GetRegexPatternSetError::WAFInvalidAccount(ref cause) => cause,
-            GetRegexPatternSetError::WAFNonexistentItem(ref cause) => cause,
+            GetRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRegexPatternSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRegexPatternSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRegexPatternSetError {}
 /// Errors returned by GetRule
 #[derive(Debug, PartialEq)]
 pub enum GetRuleError {
@@ -4770,18 +4638,14 @@ impl GetRuleError {
 }
 impl fmt::Display for GetRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRuleError {
-    fn description(&self) -> &str {
         match *self {
-            GetRuleError::WAFInternalError(ref cause) => cause,
-            GetRuleError::WAFInvalidAccount(ref cause) => cause,
-            GetRuleError::WAFNonexistentItem(ref cause) => cause,
+            GetRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRuleError {}
 /// Errors returned by GetRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum GetRuleGroupError {
@@ -4810,17 +4674,13 @@ impl GetRuleGroupError {
 }
 impl fmt::Display for GetRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetRuleGroupError::WAFInternalError(ref cause) => cause,
-            GetRuleGroupError::WAFNonexistentItem(ref cause) => cause,
+            GetRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetRuleGroupError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetRuleGroupError {}
 /// Errors returned by GetSampledRequests
 #[derive(Debug, PartialEq)]
 pub enum GetSampledRequestsError {
@@ -4851,17 +4711,13 @@ impl GetSampledRequestsError {
 }
 impl fmt::Display for GetSampledRequestsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSampledRequestsError {
-    fn description(&self) -> &str {
         match *self {
-            GetSampledRequestsError::WAFInternalError(ref cause) => cause,
-            GetSampledRequestsError::WAFNonexistentItem(ref cause) => cause,
+            GetSampledRequestsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetSampledRequestsError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSampledRequestsError {}
 /// Errors returned by GetSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum GetSizeConstraintSetError {
@@ -4901,18 +4757,14 @@ impl GetSizeConstraintSetError {
 }
 impl fmt::Display for GetSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            GetSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            GetSizeConstraintSetError::WAFNonexistentItem(ref cause) => cause,
+            GetSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetSizeConstraintSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSizeConstraintSetError {}
 /// Errors returned by GetSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetSqlInjectionMatchSetError {
@@ -4952,18 +4804,14 @@ impl GetSqlInjectionMatchSetError {
 }
 impl fmt::Display for GetSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            GetSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSqlInjectionMatchSetError {}
 /// Errors returned by GetWebACL
 #[derive(Debug, PartialEq)]
 pub enum GetWebACLError {
@@ -4997,18 +4845,14 @@ impl GetWebACLError {
 }
 impl fmt::Display for GetWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            GetWebACLError::WAFInternalError(ref cause) => cause,
-            GetWebACLError::WAFInvalidAccount(ref cause) => cause,
-            GetWebACLError::WAFNonexistentItem(ref cause) => cause,
+            GetWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetWebACLError {}
 /// Errors returned by GetXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum GetXssMatchSetError {
@@ -5042,18 +4886,14 @@ impl GetXssMatchSetError {
 }
 impl fmt::Display for GetXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            GetXssMatchSetError::WAFInternalError(ref cause) => cause,
-            GetXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            GetXssMatchSetError::WAFNonexistentItem(ref cause) => cause,
+            GetXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            GetXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            GetXssMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetXssMatchSetError {}
 /// Errors returned by ListActivatedRulesInRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum ListActivatedRulesInRuleGroupError {
@@ -5095,18 +4935,20 @@ impl ListActivatedRulesInRuleGroupError {
 }
 impl fmt::Display for ListActivatedRulesInRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListActivatedRulesInRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            ListActivatedRulesInRuleGroupError::WAFInternalError(ref cause) => cause,
-            ListActivatedRulesInRuleGroupError::WAFInvalidParameter(ref cause) => cause,
-            ListActivatedRulesInRuleGroupError::WAFNonexistentItem(ref cause) => cause,
+            ListActivatedRulesInRuleGroupError::WAFInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListActivatedRulesInRuleGroupError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListActivatedRulesInRuleGroupError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListActivatedRulesInRuleGroupError {}
 /// Errors returned by ListByteMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListByteMatchSetsError {
@@ -5135,17 +4977,13 @@ impl ListByteMatchSetsError {
 }
 impl fmt::Display for ListByteMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListByteMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListByteMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListByteMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListByteMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListByteMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListByteMatchSetsError {}
 /// Errors returned by ListGeoMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListGeoMatchSetsError {
@@ -5174,17 +5012,13 @@ impl ListGeoMatchSetsError {
 }
 impl fmt::Display for ListGeoMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGeoMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGeoMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListGeoMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListGeoMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListGeoMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGeoMatchSetsError {}
 /// Errors returned by ListIPSets
 #[derive(Debug, PartialEq)]
 pub enum ListIPSetsError {
@@ -5213,17 +5047,13 @@ impl ListIPSetsError {
 }
 impl fmt::Display for ListIPSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListIPSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListIPSetsError::WAFInternalError(ref cause) => cause,
-            ListIPSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListIPSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListIPSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListIPSetsError {}
 /// Errors returned by ListLoggingConfigurations
 #[derive(Debug, PartialEq)]
 pub enum ListLoggingConfigurationsError {
@@ -5263,18 +5093,16 @@ impl ListLoggingConfigurationsError {
 }
 impl fmt::Display for ListLoggingConfigurationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListLoggingConfigurationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListLoggingConfigurationsError::WAFInternalError(ref cause) => cause,
-            ListLoggingConfigurationsError::WAFInvalidParameter(ref cause) => cause,
-            ListLoggingConfigurationsError::WAFNonexistentItem(ref cause) => cause,
+            ListLoggingConfigurationsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListLoggingConfigurationsError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListLoggingConfigurationsError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListLoggingConfigurationsError {}
 /// Errors returned by ListRateBasedRules
 #[derive(Debug, PartialEq)]
 pub enum ListRateBasedRulesError {
@@ -5305,17 +5133,13 @@ impl ListRateBasedRulesError {
 }
 impl fmt::Display for ListRateBasedRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRateBasedRulesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRateBasedRulesError::WAFInternalError(ref cause) => cause,
-            ListRateBasedRulesError::WAFInvalidAccount(ref cause) => cause,
+            ListRateBasedRulesError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRateBasedRulesError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRateBasedRulesError {}
 /// Errors returned by ListRegexMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListRegexMatchSetsError {
@@ -5346,17 +5170,13 @@ impl ListRegexMatchSetsError {
 }
 impl fmt::Display for ListRegexMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRegexMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRegexMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListRegexMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListRegexMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRegexMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRegexMatchSetsError {}
 /// Errors returned by ListRegexPatternSets
 #[derive(Debug, PartialEq)]
 pub enum ListRegexPatternSetsError {
@@ -5389,17 +5209,13 @@ impl ListRegexPatternSetsError {
 }
 impl fmt::Display for ListRegexPatternSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRegexPatternSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRegexPatternSetsError::WAFInternalError(ref cause) => cause,
-            ListRegexPatternSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListRegexPatternSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRegexPatternSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRegexPatternSetsError {}
 /// Errors returned by ListRuleGroups
 #[derive(Debug, PartialEq)]
 pub enum ListRuleGroupsError {
@@ -5423,16 +5239,12 @@ impl ListRuleGroupsError {
 }
 impl fmt::Display for ListRuleGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRuleGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListRuleGroupsError::WAFInternalError(ref cause) => cause,
+            ListRuleGroupsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRuleGroupsError {}
 /// Errors returned by ListRules
 #[derive(Debug, PartialEq)]
 pub enum ListRulesError {
@@ -5461,17 +5273,13 @@ impl ListRulesError {
 }
 impl fmt::Display for ListRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListRulesError {
-    fn description(&self) -> &str {
         match *self {
-            ListRulesError::WAFInternalError(ref cause) => cause,
-            ListRulesError::WAFInvalidAccount(ref cause) => cause,
+            ListRulesError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListRulesError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListRulesError {}
 /// Errors returned by ListSizeConstraintSets
 #[derive(Debug, PartialEq)]
 pub enum ListSizeConstraintSetsError {
@@ -5504,17 +5312,13 @@ impl ListSizeConstraintSetsError {
 }
 impl fmt::Display for ListSizeConstraintSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSizeConstraintSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSizeConstraintSetsError::WAFInternalError(ref cause) => cause,
-            ListSizeConstraintSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListSizeConstraintSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListSizeConstraintSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSizeConstraintSetsError {}
 /// Errors returned by ListSqlInjectionMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListSqlInjectionMatchSetsError {
@@ -5547,17 +5351,13 @@ impl ListSqlInjectionMatchSetsError {
 }
 impl fmt::Display for ListSqlInjectionMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSqlInjectionMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSqlInjectionMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListSqlInjectionMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListSqlInjectionMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListSqlInjectionMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSqlInjectionMatchSetsError {}
 /// Errors returned by ListSubscribedRuleGroups
 #[derive(Debug, PartialEq)]
 pub enum ListSubscribedRuleGroupsError {
@@ -5590,17 +5390,13 @@ impl ListSubscribedRuleGroupsError {
 }
 impl fmt::Display for ListSubscribedRuleGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListSubscribedRuleGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListSubscribedRuleGroupsError::WAFInternalError(ref cause) => cause,
-            ListSubscribedRuleGroupsError::WAFNonexistentItem(ref cause) => cause,
+            ListSubscribedRuleGroupsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListSubscribedRuleGroupsError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListSubscribedRuleGroupsError {}
 /// Errors returned by ListTagsForResource
 #[derive(Debug, PartialEq)]
 pub enum ListTagsForResourceError {
@@ -5656,21 +5452,19 @@ impl ListTagsForResourceError {
 }
 impl fmt::Display for ListTagsForResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListTagsForResourceError {
-    fn description(&self) -> &str {
         match *self {
-            ListTagsForResourceError::WAFBadRequest(ref cause) => cause,
-            ListTagsForResourceError::WAFInternalError(ref cause) => cause,
-            ListTagsForResourceError::WAFInvalidParameter(ref cause) => cause,
-            ListTagsForResourceError::WAFNonexistentItem(ref cause) => cause,
-            ListTagsForResourceError::WAFTagOperation(ref cause) => cause,
-            ListTagsForResourceError::WAFTagOperationInternalError(ref cause) => cause,
+            ListTagsForResourceError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            ListTagsForResourceError::WAFTagOperationInternalError(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListTagsForResourceError {}
 /// Errors returned by ListWebACLs
 #[derive(Debug, PartialEq)]
 pub enum ListWebACLsError {
@@ -5699,17 +5493,13 @@ impl ListWebACLsError {
 }
 impl fmt::Display for ListWebACLsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWebACLsError {
-    fn description(&self) -> &str {
         match *self {
-            ListWebACLsError::WAFInternalError(ref cause) => cause,
-            ListWebACLsError::WAFInvalidAccount(ref cause) => cause,
+            ListWebACLsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListWebACLsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListWebACLsError {}
 /// Errors returned by ListXssMatchSets
 #[derive(Debug, PartialEq)]
 pub enum ListXssMatchSetsError {
@@ -5738,17 +5528,13 @@ impl ListXssMatchSetsError {
 }
 impl fmt::Display for ListXssMatchSetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListXssMatchSetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListXssMatchSetsError::WAFInternalError(ref cause) => cause,
-            ListXssMatchSetsError::WAFInvalidAccount(ref cause) => cause,
+            ListXssMatchSetsError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            ListXssMatchSetsError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListXssMatchSetsError {}
 /// Errors returned by PutLoggingConfiguration
 #[derive(Debug, PartialEq)]
 pub enum PutLoggingConfigurationError {
@@ -5795,19 +5581,17 @@ impl PutLoggingConfigurationError {
 }
 impl fmt::Display for PutLoggingConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutLoggingConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            PutLoggingConfigurationError::WAFInternalError(ref cause) => cause,
-            PutLoggingConfigurationError::WAFNonexistentItem(ref cause) => cause,
-            PutLoggingConfigurationError::WAFServiceLinkedRoleError(ref cause) => cause,
-            PutLoggingConfigurationError::WAFStaleData(ref cause) => cause,
+            PutLoggingConfigurationError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            PutLoggingConfigurationError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            PutLoggingConfigurationError::WAFServiceLinkedRoleError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutLoggingConfigurationError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutLoggingConfigurationError {}
 /// Errors returned by PutPermissionPolicy
 #[derive(Debug, PartialEq)]
 pub enum PutPermissionPolicyError {
@@ -5852,19 +5636,17 @@ impl PutPermissionPolicyError {
 }
 impl fmt::Display for PutPermissionPolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutPermissionPolicyError {
-    fn description(&self) -> &str {
         match *self {
-            PutPermissionPolicyError::WAFInternalError(ref cause) => cause,
-            PutPermissionPolicyError::WAFInvalidPermissionPolicy(ref cause) => cause,
-            PutPermissionPolicyError::WAFNonexistentItem(ref cause) => cause,
-            PutPermissionPolicyError::WAFStaleData(ref cause) => cause,
+            PutPermissionPolicyError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            PutPermissionPolicyError::WAFInvalidPermissionPolicy(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            PutPermissionPolicyError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            PutPermissionPolicyError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutPermissionPolicyError {}
 /// Errors returned by TagResource
 #[derive(Debug, PartialEq)]
 pub enum TagResourceError {
@@ -5919,22 +5701,18 @@ impl TagResourceError {
 }
 impl fmt::Display for TagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            TagResourceError::WAFBadRequest(ref cause) => cause,
-            TagResourceError::WAFInternalError(ref cause) => cause,
-            TagResourceError::WAFInvalidParameter(ref cause) => cause,
-            TagResourceError::WAFLimitsExceeded(ref cause) => cause,
-            TagResourceError::WAFNonexistentItem(ref cause) => cause,
-            TagResourceError::WAFTagOperation(ref cause) => cause,
-            TagResourceError::WAFTagOperationInternalError(ref cause) => cause,
+            TagResourceError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            TagResourceError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for TagResourceError {}
 /// Errors returned by UntagResource
 #[derive(Debug, PartialEq)]
 pub enum UntagResourceError {
@@ -5984,21 +5762,17 @@ impl UntagResourceError {
 }
 impl fmt::Display for UntagResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UntagResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UntagResourceError::WAFBadRequest(ref cause) => cause,
-            UntagResourceError::WAFInternalError(ref cause) => cause,
-            UntagResourceError::WAFInvalidParameter(ref cause) => cause,
-            UntagResourceError::WAFNonexistentItem(ref cause) => cause,
-            UntagResourceError::WAFTagOperation(ref cause) => cause,
-            UntagResourceError::WAFTagOperationInternalError(ref cause) => cause,
+            UntagResourceError::WAFBadRequest(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFTagOperation(ref cause) => write!(f, "{}", cause),
+            UntagResourceError::WAFTagOperationInternalError(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UntagResourceError {}
 /// Errors returned by UpdateByteMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateByteMatchSetError {
@@ -6069,23 +5843,19 @@ impl UpdateByteMatchSetError {
 }
 impl fmt::Display for UpdateByteMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateByteMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateByteMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateByteMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateByteMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateByteMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateByteMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateByteMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateByteMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateByteMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateByteMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateByteMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateByteMatchSetError {}
 /// Errors returned by UpdateGeoMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateGeoMatchSetError {
@@ -6157,24 +5927,20 @@ impl UpdateGeoMatchSetError {
 }
 impl fmt::Display for UpdateGeoMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGeoMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGeoMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFReferencedItem(ref cause) => cause,
-            UpdateGeoMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateGeoMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateGeoMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGeoMatchSetError {}
 /// Errors returned by UpdateIPSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateIPSetError {
@@ -6238,24 +6004,20 @@ impl UpdateIPSetError {
 }
 impl fmt::Display for UpdateIPSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIPSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIPSetError::WAFInternalError(ref cause) => cause,
-            UpdateIPSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateIPSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateIPSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateIPSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateIPSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateIPSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateIPSetError::WAFReferencedItem(ref cause) => cause,
-            UpdateIPSetError::WAFStaleData(ref cause) => cause,
+            UpdateIPSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateIPSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateIPSetError {}
 /// Errors returned by UpdateRateBasedRule
 #[derive(Debug, PartialEq)]
 pub enum UpdateRateBasedRuleError {
@@ -6335,24 +6097,20 @@ impl UpdateRateBasedRuleError {
 }
 impl fmt::Display for UpdateRateBasedRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRateBasedRuleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRateBasedRuleError::WAFInternalError(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFInvalidParameter(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFReferencedItem(ref cause) => cause,
-            UpdateRateBasedRuleError::WAFStaleData(ref cause) => cause,
+            UpdateRateBasedRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateRateBasedRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRateBasedRuleError {}
 /// Errors returned by UpdateRegexMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateRegexMatchSetError {
@@ -6425,23 +6183,19 @@ impl UpdateRegexMatchSetError {
 }
 impl fmt::Display for UpdateRegexMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRegexMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRegexMatchSetError::WAFDisallowedName(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRegexMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateRegexMatchSetError::WAFDisallowedName(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRegexMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRegexMatchSetError {}
 /// Errors returned by UpdateRegexPatternSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateRegexPatternSetError {
@@ -6514,23 +6268,21 @@ impl UpdateRegexPatternSetError {
 }
 impl fmt::Display for UpdateRegexPatternSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRegexPatternSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRegexPatternSetError::WAFInternalError(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFInvalidRegexPattern(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRegexPatternSetError::WAFStaleData(ref cause) => cause,
+            UpdateRegexPatternSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFInvalidRegexPattern(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFNonexistentContainer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateRegexPatternSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRegexPatternSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRegexPatternSetError {}
 /// Errors returned by UpdateRule
 #[derive(Debug, PartialEq)]
 pub enum UpdateRuleError {
@@ -6594,24 +6346,20 @@ impl UpdateRuleError {
 }
 impl fmt::Display for UpdateRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRuleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRuleError::WAFInternalError(ref cause) => cause,
-            UpdateRuleError::WAFInvalidAccount(ref cause) => cause,
-            UpdateRuleError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRuleError::WAFInvalidParameter(ref cause) => cause,
-            UpdateRuleError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRuleError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRuleError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRuleError::WAFReferencedItem(ref cause) => cause,
-            UpdateRuleError::WAFStaleData(ref cause) => cause,
+            UpdateRuleError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateRuleError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRuleError {}
 /// Errors returned by UpdateRuleGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateRuleGroupError {
@@ -6667,22 +6415,18 @@ impl UpdateRuleGroupError {
 }
 impl fmt::Display for UpdateRuleGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRuleGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRuleGroupError::WAFInternalError(ref cause) => cause,
-            UpdateRuleGroupError::WAFInvalidOperation(ref cause) => cause,
-            UpdateRuleGroupError::WAFInvalidParameter(ref cause) => cause,
-            UpdateRuleGroupError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateRuleGroupError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateRuleGroupError::WAFNonexistentItem(ref cause) => cause,
-            UpdateRuleGroupError::WAFStaleData(ref cause) => cause,
+            UpdateRuleGroupError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateRuleGroupError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRuleGroupError {}
 /// Errors returned by UpdateSizeConstraintSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateSizeConstraintSetError {
@@ -6764,24 +6508,22 @@ impl UpdateSizeConstraintSetError {
 }
 impl fmt::Display for UpdateSizeConstraintSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSizeConstraintSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSizeConstraintSetError::WAFInternalError(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFReferencedItem(ref cause) => cause,
-            UpdateSizeConstraintSetError::WAFStaleData(ref cause) => cause,
+            UpdateSizeConstraintSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFNonexistentContainer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSizeConstraintSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateSizeConstraintSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSizeConstraintSetError {}
 /// Errors returned by UpdateSqlInjectionMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateSqlInjectionMatchSetError {
@@ -6858,23 +6600,27 @@ impl UpdateSqlInjectionMatchSetError {
 }
 impl fmt::Display for UpdateSqlInjectionMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSqlInjectionMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSqlInjectionMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateSqlInjectionMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateSqlInjectionMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateSqlInjectionMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateSqlInjectionMatchSetError::WAFInvalidOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFInvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateSqlInjectionMatchSetError::WAFNonexistentContainer(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFNonexistentItem(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateSqlInjectionMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSqlInjectionMatchSetError {}
 /// Errors returned by UpdateWebACL
 #[derive(Debug, PartialEq)]
 pub enum UpdateWebACLError {
@@ -6947,25 +6693,21 @@ impl UpdateWebACLError {
 }
 impl fmt::Display for UpdateWebACLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateWebACLError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateWebACLError::WAFInternalError(ref cause) => cause,
-            UpdateWebACLError::WAFInvalidAccount(ref cause) => cause,
-            UpdateWebACLError::WAFInvalidOperation(ref cause) => cause,
-            UpdateWebACLError::WAFInvalidParameter(ref cause) => cause,
-            UpdateWebACLError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateWebACLError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateWebACLError::WAFNonexistentItem(ref cause) => cause,
-            UpdateWebACLError::WAFReferencedItem(ref cause) => cause,
-            UpdateWebACLError::WAFStaleData(ref cause) => cause,
-            UpdateWebACLError::WAFSubscriptionNotFound(ref cause) => cause,
+            UpdateWebACLError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFReferencedItem(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFStaleData(ref cause) => write!(f, "{}", cause),
+            UpdateWebACLError::WAFSubscriptionNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateWebACLError {}
 /// Errors returned by UpdateXssMatchSet
 #[derive(Debug, PartialEq)]
 pub enum UpdateXssMatchSetError {
@@ -7032,23 +6774,19 @@ impl UpdateXssMatchSetError {
 }
 impl fmt::Display for UpdateXssMatchSetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateXssMatchSetError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateXssMatchSetError::WAFInternalError(ref cause) => cause,
-            UpdateXssMatchSetError::WAFInvalidAccount(ref cause) => cause,
-            UpdateXssMatchSetError::WAFInvalidOperation(ref cause) => cause,
-            UpdateXssMatchSetError::WAFInvalidParameter(ref cause) => cause,
-            UpdateXssMatchSetError::WAFLimitsExceeded(ref cause) => cause,
-            UpdateXssMatchSetError::WAFNonexistentContainer(ref cause) => cause,
-            UpdateXssMatchSetError::WAFNonexistentItem(ref cause) => cause,
-            UpdateXssMatchSetError::WAFStaleData(ref cause) => cause,
+            UpdateXssMatchSetError::WAFInternalError(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFInvalidAccount(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFInvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFInvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFLimitsExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFNonexistentContainer(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFNonexistentItem(ref cause) => write!(f, "{}", cause),
+            UpdateXssMatchSetError::WAFStaleData(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateXssMatchSetError {}
 /// Trait representing the capabilities of the WAF API. WAF clients implement this trait.
 pub trait Waf {
     /// <p>Creates a <code>ByteMatchSet</code>. You then use <a>UpdateByteMatchSet</a> to identify the part of a web request that you want AWS WAF to inspect, such as the values of the <code>User-Agent</code> header or the query string. For example, you can create a <code>ByteMatchSet</code> that matches any requests with <code>User-Agent</code> headers that contain the string <code>BadBot</code>. You can then configure AWS WAF to reject those requests.</p> <p>To create and configure a <code>ByteMatchSet</code>, perform the following steps:</p> <ol> <li> <p>Use <a>GetChangeToken</a> to get the change token that you provide in the <code>ChangeToken</code> parameter of a <code>CreateByteMatchSet</code> request.</p> </li> <li> <p>Submit a <code>CreateByteMatchSet</code> request.</p> </li> <li> <p>Use <code>GetChangeToken</code> to get the change token that you provide in the <code>ChangeToken</code> parameter of an <code>UpdateByteMatchSet</code> request.</p> </li> <li> <p>Submit an <a>UpdateByteMatchSet</a> request to specify the part of the request that you want AWS WAF to inspect (for example, the header or the URI) and the value that you want AWS WAF to watch for.</p> </li> </ol> <p>For more information about how to use the AWS WAF API to allow or block HTTP requests, see the <a href="https://docs.aws.amazon.com/waf/latest/developerguide/">AWS WAF Developer Guide</a>.</p>

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -1806,21 +1806,23 @@ impl AbortDocumentVersionUploadError {
 }
 impl fmt::Display for AbortDocumentVersionUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AbortDocumentVersionUploadError {
-    fn description(&self) -> &str {
         match *self {
-            AbortDocumentVersionUploadError::EntityNotExists(ref cause) => cause,
-            AbortDocumentVersionUploadError::FailedDependency(ref cause) => cause,
-            AbortDocumentVersionUploadError::ProhibitedState(ref cause) => cause,
-            AbortDocumentVersionUploadError::ServiceUnavailable(ref cause) => cause,
-            AbortDocumentVersionUploadError::UnauthorizedOperation(ref cause) => cause,
-            AbortDocumentVersionUploadError::UnauthorizedResourceAccess(ref cause) => cause,
+            AbortDocumentVersionUploadError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            AbortDocumentVersionUploadError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            AbortDocumentVersionUploadError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            AbortDocumentVersionUploadError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AbortDocumentVersionUploadError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AbortDocumentVersionUploadError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AbortDocumentVersionUploadError {}
 /// Errors returned by ActivateUser
 #[derive(Debug, PartialEq)]
 pub enum ActivateUserError {
@@ -1866,20 +1868,16 @@ impl ActivateUserError {
 }
 impl fmt::Display for ActivateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ActivateUserError {
-    fn description(&self) -> &str {
         match *self {
-            ActivateUserError::EntityNotExists(ref cause) => cause,
-            ActivateUserError::FailedDependency(ref cause) => cause,
-            ActivateUserError::ServiceUnavailable(ref cause) => cause,
-            ActivateUserError::UnauthorizedOperation(ref cause) => cause,
-            ActivateUserError::UnauthorizedResourceAccess(ref cause) => cause,
+            ActivateUserError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            ActivateUserError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            ActivateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            ActivateUserError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            ActivateUserError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ActivateUserError {}
 /// Errors returned by AddResourcePermissions
 #[derive(Debug, PartialEq)]
 pub enum AddResourcePermissionsError {
@@ -1926,19 +1924,17 @@ impl AddResourcePermissionsError {
 }
 impl fmt::Display for AddResourcePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AddResourcePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            AddResourcePermissionsError::FailedDependency(ref cause) => cause,
-            AddResourcePermissionsError::ServiceUnavailable(ref cause) => cause,
-            AddResourcePermissionsError::UnauthorizedOperation(ref cause) => cause,
-            AddResourcePermissionsError::UnauthorizedResourceAccess(ref cause) => cause,
+            AddResourcePermissionsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            AddResourcePermissionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            AddResourcePermissionsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            AddResourcePermissionsError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AddResourcePermissionsError {}
 /// Errors returned by CreateComment
 #[derive(Debug, PartialEq)]
 pub enum CreateCommentError {
@@ -2003,23 +1999,19 @@ impl CreateCommentError {
 }
 impl fmt::Display for CreateCommentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCommentError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCommentError::DocumentLockedForComments(ref cause) => cause,
-            CreateCommentError::EntityNotExists(ref cause) => cause,
-            CreateCommentError::FailedDependency(ref cause) => cause,
-            CreateCommentError::InvalidCommentOperation(ref cause) => cause,
-            CreateCommentError::ProhibitedState(ref cause) => cause,
-            CreateCommentError::ServiceUnavailable(ref cause) => cause,
-            CreateCommentError::UnauthorizedOperation(ref cause) => cause,
-            CreateCommentError::UnauthorizedResourceAccess(ref cause) => cause,
+            CreateCommentError::DocumentLockedForComments(ref cause) => write!(f, "{}", cause),
+            CreateCommentError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            CreateCommentError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            CreateCommentError::InvalidCommentOperation(ref cause) => write!(f, "{}", cause),
+            CreateCommentError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            CreateCommentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateCommentError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            CreateCommentError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateCommentError {}
 /// Errors returned by CreateCustomMetadata
 #[derive(Debug, PartialEq)]
 pub enum CreateCustomMetadataError {
@@ -2087,22 +2079,22 @@ impl CreateCustomMetadataError {
 }
 impl fmt::Display for CreateCustomMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateCustomMetadataError {
-    fn description(&self) -> &str {
         match *self {
-            CreateCustomMetadataError::CustomMetadataLimitExceeded(ref cause) => cause,
-            CreateCustomMetadataError::EntityNotExists(ref cause) => cause,
-            CreateCustomMetadataError::FailedDependency(ref cause) => cause,
-            CreateCustomMetadataError::ProhibitedState(ref cause) => cause,
-            CreateCustomMetadataError::ServiceUnavailable(ref cause) => cause,
-            CreateCustomMetadataError::UnauthorizedOperation(ref cause) => cause,
-            CreateCustomMetadataError::UnauthorizedResourceAccess(ref cause) => cause,
+            CreateCustomMetadataError::CustomMetadataLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateCustomMetadataError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            CreateCustomMetadataError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            CreateCustomMetadataError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            CreateCustomMetadataError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateCustomMetadataError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            CreateCustomMetadataError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateCustomMetadataError {}
 /// Errors returned by CreateFolder
 #[derive(Debug, PartialEq)]
 pub enum CreateFolderError {
@@ -2168,24 +2160,20 @@ impl CreateFolderError {
 }
 impl fmt::Display for CreateFolderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFolderError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFolderError::ConflictingOperation(ref cause) => cause,
-            CreateFolderError::EntityAlreadyExists(ref cause) => cause,
-            CreateFolderError::EntityNotExists(ref cause) => cause,
-            CreateFolderError::FailedDependency(ref cause) => cause,
-            CreateFolderError::LimitExceeded(ref cause) => cause,
-            CreateFolderError::ProhibitedState(ref cause) => cause,
-            CreateFolderError::ServiceUnavailable(ref cause) => cause,
-            CreateFolderError::UnauthorizedOperation(ref cause) => cause,
-            CreateFolderError::UnauthorizedResourceAccess(ref cause) => cause,
+            CreateFolderError::ConflictingOperation(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            CreateFolderError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFolderError {}
 /// Errors returned by CreateLabels
 #[derive(Debug, PartialEq)]
 pub enum CreateLabelsError {
@@ -2236,21 +2224,17 @@ impl CreateLabelsError {
 }
 impl fmt::Display for CreateLabelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateLabelsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateLabelsError::EntityNotExists(ref cause) => cause,
-            CreateLabelsError::FailedDependency(ref cause) => cause,
-            CreateLabelsError::ServiceUnavailable(ref cause) => cause,
-            CreateLabelsError::TooManyLabels(ref cause) => cause,
-            CreateLabelsError::UnauthorizedOperation(ref cause) => cause,
-            CreateLabelsError::UnauthorizedResourceAccess(ref cause) => cause,
+            CreateLabelsError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            CreateLabelsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            CreateLabelsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateLabelsError::TooManyLabels(ref cause) => write!(f, "{}", cause),
+            CreateLabelsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            CreateLabelsError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateLabelsError {}
 /// Errors returned by CreateNotificationSubscription
 #[derive(Debug, PartialEq)]
 pub enum CreateNotificationSubscriptionError {
@@ -2292,18 +2276,20 @@ impl CreateNotificationSubscriptionError {
 }
 impl fmt::Display for CreateNotificationSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateNotificationSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            CreateNotificationSubscriptionError::ServiceUnavailable(ref cause) => cause,
-            CreateNotificationSubscriptionError::TooManySubscriptions(ref cause) => cause,
-            CreateNotificationSubscriptionError::UnauthorizedResourceAccess(ref cause) => cause,
+            CreateNotificationSubscriptionError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateNotificationSubscriptionError::TooManySubscriptions(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateNotificationSubscriptionError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for CreateNotificationSubscriptionError {}
 /// Errors returned by CreateUser
 #[derive(Debug, PartialEq)]
 pub enum CreateUserError {
@@ -2349,20 +2335,16 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::EntityAlreadyExists(ref cause) => cause,
-            CreateUserError::FailedDependency(ref cause) => cause,
-            CreateUserError::ServiceUnavailable(ref cause) => cause,
-            CreateUserError::UnauthorizedOperation(ref cause) => cause,
-            CreateUserError::UnauthorizedResourceAccess(ref cause) => cause,
+            CreateUserError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateUserError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateUserError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            CreateUserError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by DeactivateUser
 #[derive(Debug, PartialEq)]
 pub enum DeactivateUserError {
@@ -2410,20 +2392,16 @@ impl DeactivateUserError {
 }
 impl fmt::Display for DeactivateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeactivateUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeactivateUserError::EntityNotExists(ref cause) => cause,
-            DeactivateUserError::FailedDependency(ref cause) => cause,
-            DeactivateUserError::ServiceUnavailable(ref cause) => cause,
-            DeactivateUserError::UnauthorizedOperation(ref cause) => cause,
-            DeactivateUserError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeactivateUserError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeactivateUserError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeactivateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeactivateUserError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeactivateUserError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeactivateUserError {}
 /// Errors returned by DeleteComment
 #[derive(Debug, PartialEq)]
 pub enum DeleteCommentError {
@@ -2481,22 +2459,18 @@ impl DeleteCommentError {
 }
 impl fmt::Display for DeleteCommentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCommentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCommentError::DocumentLockedForComments(ref cause) => cause,
-            DeleteCommentError::EntityNotExists(ref cause) => cause,
-            DeleteCommentError::FailedDependency(ref cause) => cause,
-            DeleteCommentError::ProhibitedState(ref cause) => cause,
-            DeleteCommentError::ServiceUnavailable(ref cause) => cause,
-            DeleteCommentError::UnauthorizedOperation(ref cause) => cause,
-            DeleteCommentError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteCommentError::DocumentLockedForComments(ref cause) => write!(f, "{}", cause),
+            DeleteCommentError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeleteCommentError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeleteCommentError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DeleteCommentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteCommentError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeleteCommentError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteCommentError {}
 /// Errors returned by DeleteCustomMetadata
 #[derive(Debug, PartialEq)]
 pub enum DeleteCustomMetadataError {
@@ -2557,21 +2531,19 @@ impl DeleteCustomMetadataError {
 }
 impl fmt::Display for DeleteCustomMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteCustomMetadataError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteCustomMetadataError::EntityNotExists(ref cause) => cause,
-            DeleteCustomMetadataError::FailedDependency(ref cause) => cause,
-            DeleteCustomMetadataError::ProhibitedState(ref cause) => cause,
-            DeleteCustomMetadataError::ServiceUnavailable(ref cause) => cause,
-            DeleteCustomMetadataError::UnauthorizedOperation(ref cause) => cause,
-            DeleteCustomMetadataError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteCustomMetadataError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeleteCustomMetadataError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeleteCustomMetadataError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DeleteCustomMetadataError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteCustomMetadataError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeleteCustomMetadataError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteCustomMetadataError {}
 /// Errors returned by DeleteDocument
 #[derive(Debug, PartialEq)]
 pub enum DeleteDocumentError {
@@ -2636,23 +2608,19 @@ impl DeleteDocumentError {
 }
 impl fmt::Display for DeleteDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteDocumentError::ConcurrentModification(ref cause) => cause,
-            DeleteDocumentError::ConflictingOperation(ref cause) => cause,
-            DeleteDocumentError::EntityNotExists(ref cause) => cause,
-            DeleteDocumentError::FailedDependency(ref cause) => cause,
-            DeleteDocumentError::ProhibitedState(ref cause) => cause,
-            DeleteDocumentError::ServiceUnavailable(ref cause) => cause,
-            DeleteDocumentError::UnauthorizedOperation(ref cause) => cause,
-            DeleteDocumentError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteDocumentError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::ConflictingOperation(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeleteDocumentError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteDocumentError {}
 /// Errors returned by DeleteFolder
 #[derive(Debug, PartialEq)]
 pub enum DeleteFolderError {
@@ -2713,23 +2681,19 @@ impl DeleteFolderError {
 }
 impl fmt::Display for DeleteFolderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFolderError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFolderError::ConcurrentModification(ref cause) => cause,
-            DeleteFolderError::ConflictingOperation(ref cause) => cause,
-            DeleteFolderError::EntityNotExists(ref cause) => cause,
-            DeleteFolderError::FailedDependency(ref cause) => cause,
-            DeleteFolderError::ProhibitedState(ref cause) => cause,
-            DeleteFolderError::ServiceUnavailable(ref cause) => cause,
-            DeleteFolderError::UnauthorizedOperation(ref cause) => cause,
-            DeleteFolderError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteFolderError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            DeleteFolderError::ConflictingOperation(ref cause) => write!(f, "{}", cause),
+            DeleteFolderError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeleteFolderError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeleteFolderError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DeleteFolderError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteFolderError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeleteFolderError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFolderError {}
 /// Errors returned by DeleteFolderContents
 #[derive(Debug, PartialEq)]
 pub enum DeleteFolderContentsError {
@@ -2797,22 +2761,20 @@ impl DeleteFolderContentsError {
 }
 impl fmt::Display for DeleteFolderContentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFolderContentsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFolderContentsError::ConflictingOperation(ref cause) => cause,
-            DeleteFolderContentsError::EntityNotExists(ref cause) => cause,
-            DeleteFolderContentsError::FailedDependency(ref cause) => cause,
-            DeleteFolderContentsError::ProhibitedState(ref cause) => cause,
-            DeleteFolderContentsError::ServiceUnavailable(ref cause) => cause,
-            DeleteFolderContentsError::UnauthorizedOperation(ref cause) => cause,
-            DeleteFolderContentsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteFolderContentsError::ConflictingOperation(ref cause) => write!(f, "{}", cause),
+            DeleteFolderContentsError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeleteFolderContentsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeleteFolderContentsError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DeleteFolderContentsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteFolderContentsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeleteFolderContentsError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteFolderContentsError {}
 /// Errors returned by DeleteLabels
 #[derive(Debug, PartialEq)]
 pub enum DeleteLabelsError {
@@ -2858,20 +2820,16 @@ impl DeleteLabelsError {
 }
 impl fmt::Display for DeleteLabelsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteLabelsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteLabelsError::EntityNotExists(ref cause) => cause,
-            DeleteLabelsError::FailedDependency(ref cause) => cause,
-            DeleteLabelsError::ServiceUnavailable(ref cause) => cause,
-            DeleteLabelsError::UnauthorizedOperation(ref cause) => cause,
-            DeleteLabelsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteLabelsError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeleteLabelsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeleteLabelsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteLabelsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeleteLabelsError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteLabelsError {}
 /// Errors returned by DeleteNotificationSubscription
 #[derive(Debug, PartialEq)]
 pub enum DeleteNotificationSubscriptionError {
@@ -2920,19 +2878,23 @@ impl DeleteNotificationSubscriptionError {
 }
 impl fmt::Display for DeleteNotificationSubscriptionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteNotificationSubscriptionError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteNotificationSubscriptionError::EntityNotExists(ref cause) => cause,
-            DeleteNotificationSubscriptionError::ProhibitedState(ref cause) => cause,
-            DeleteNotificationSubscriptionError::ServiceUnavailable(ref cause) => cause,
-            DeleteNotificationSubscriptionError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteNotificationSubscriptionError::EntityNotExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteNotificationSubscriptionError::ProhibitedState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteNotificationSubscriptionError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteNotificationSubscriptionError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeleteNotificationSubscriptionError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -2978,20 +2940,16 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::EntityNotExists(ref cause) => cause,
-            DeleteUserError::FailedDependency(ref cause) => cause,
-            DeleteUserError::ServiceUnavailable(ref cause) => cause,
-            DeleteUserError::UnauthorizedOperation(ref cause) => cause,
-            DeleteUserError::UnauthorizedResourceAccess(ref cause) => cause,
+            DeleteUserError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DescribeActivities
 #[derive(Debug, PartialEq)]
 pub enum DescribeActivitiesError {
@@ -3041,20 +2999,18 @@ impl DescribeActivitiesError {
 }
 impl fmt::Display for DescribeActivitiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeActivitiesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeActivitiesError::FailedDependency(ref cause) => cause,
-            DescribeActivitiesError::InvalidArgument(ref cause) => cause,
-            DescribeActivitiesError::ServiceUnavailable(ref cause) => cause,
-            DescribeActivitiesError::UnauthorizedOperation(ref cause) => cause,
-            DescribeActivitiesError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeActivitiesError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeActivitiesError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeActivitiesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeActivitiesError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DescribeActivitiesError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeActivitiesError {}
 /// Errors returned by DescribeComments
 #[derive(Debug, PartialEq)]
 pub enum DescribeCommentsError {
@@ -3107,21 +3063,17 @@ impl DescribeCommentsError {
 }
 impl fmt::Display for DescribeCommentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCommentsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCommentsError::EntityNotExists(ref cause) => cause,
-            DescribeCommentsError::FailedDependency(ref cause) => cause,
-            DescribeCommentsError::ProhibitedState(ref cause) => cause,
-            DescribeCommentsError::ServiceUnavailable(ref cause) => cause,
-            DescribeCommentsError::UnauthorizedOperation(ref cause) => cause,
-            DescribeCommentsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeCommentsError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DescribeCommentsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeCommentsError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DescribeCommentsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeCommentsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DescribeCommentsError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeCommentsError {}
 /// Errors returned by DescribeDocumentVersions
 #[derive(Debug, PartialEq)]
 pub enum DescribeDocumentVersionsError {
@@ -3189,22 +3141,22 @@ impl DescribeDocumentVersionsError {
 }
 impl fmt::Display for DescribeDocumentVersionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDocumentVersionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDocumentVersionsError::EntityNotExists(ref cause) => cause,
-            DescribeDocumentVersionsError::FailedDependency(ref cause) => cause,
-            DescribeDocumentVersionsError::InvalidArgument(ref cause) => cause,
-            DescribeDocumentVersionsError::ProhibitedState(ref cause) => cause,
-            DescribeDocumentVersionsError::ServiceUnavailable(ref cause) => cause,
-            DescribeDocumentVersionsError::UnauthorizedOperation(ref cause) => cause,
-            DescribeDocumentVersionsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeDocumentVersionsError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentVersionsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentVersionsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentVersionsError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentVersionsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeDocumentVersionsError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDocumentVersionsError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDocumentVersionsError {}
 /// Errors returned by DescribeFolderContents
 #[derive(Debug, PartialEq)]
 pub enum DescribeFolderContentsError {
@@ -3265,21 +3217,19 @@ impl DescribeFolderContentsError {
 }
 impl fmt::Display for DescribeFolderContentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFolderContentsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFolderContentsError::EntityNotExists(ref cause) => cause,
-            DescribeFolderContentsError::FailedDependency(ref cause) => cause,
-            DescribeFolderContentsError::InvalidArgument(ref cause) => cause,
-            DescribeFolderContentsError::ProhibitedState(ref cause) => cause,
-            DescribeFolderContentsError::ServiceUnavailable(ref cause) => cause,
-            DescribeFolderContentsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeFolderContentsError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DescribeFolderContentsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeFolderContentsError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeFolderContentsError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            DescribeFolderContentsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeFolderContentsError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeFolderContentsError {}
 /// Errors returned by DescribeGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeGroupsError {
@@ -3322,19 +3272,15 @@ impl DescribeGroupsError {
 }
 impl fmt::Display for DescribeGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGroupsError::FailedDependency(ref cause) => cause,
-            DescribeGroupsError::ServiceUnavailable(ref cause) => cause,
-            DescribeGroupsError::UnauthorizedOperation(ref cause) => cause,
-            DescribeGroupsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeGroupsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeGroupsError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeGroupsError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DescribeGroupsError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeGroupsError {}
 /// Errors returned by DescribeNotificationSubscriptions
 #[derive(Debug, PartialEq)]
 pub enum DescribeNotificationSubscriptionsError {
@@ -3376,18 +3322,20 @@ impl DescribeNotificationSubscriptionsError {
 }
 impl fmt::Display for DescribeNotificationSubscriptionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeNotificationSubscriptionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeNotificationSubscriptionsError::EntityNotExists(ref cause) => cause,
-            DescribeNotificationSubscriptionsError::ServiceUnavailable(ref cause) => cause,
-            DescribeNotificationSubscriptionsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeNotificationSubscriptionsError::EntityNotExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNotificationSubscriptionsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeNotificationSubscriptionsError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeNotificationSubscriptionsError {}
 /// Errors returned by DescribeResourcePermissions
 #[derive(Debug, PartialEq)]
 pub enum DescribeResourcePermissionsError {
@@ -3436,19 +3384,21 @@ impl DescribeResourcePermissionsError {
 }
 impl fmt::Display for DescribeResourcePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeResourcePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeResourcePermissionsError::FailedDependency(ref cause) => cause,
-            DescribeResourcePermissionsError::ServiceUnavailable(ref cause) => cause,
-            DescribeResourcePermissionsError::UnauthorizedOperation(ref cause) => cause,
-            DescribeResourcePermissionsError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeResourcePermissionsError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeResourcePermissionsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeResourcePermissionsError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeResourcePermissionsError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeResourcePermissionsError {}
 /// Errors returned by DescribeRootFolders
 #[derive(Debug, PartialEq)]
 pub enum DescribeRootFoldersError {
@@ -3500,20 +3450,18 @@ impl DescribeRootFoldersError {
 }
 impl fmt::Display for DescribeRootFoldersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeRootFoldersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeRootFoldersError::FailedDependency(ref cause) => cause,
-            DescribeRootFoldersError::InvalidArgument(ref cause) => cause,
-            DescribeRootFoldersError::ServiceUnavailable(ref cause) => cause,
-            DescribeRootFoldersError::UnauthorizedOperation(ref cause) => cause,
-            DescribeRootFoldersError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeRootFoldersError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeRootFoldersError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeRootFoldersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeRootFoldersError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DescribeRootFoldersError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeRootFoldersError {}
 /// Errors returned by DescribeUsers
 #[derive(Debug, PartialEq)]
 pub enum DescribeUsersError {
@@ -3571,22 +3519,18 @@ impl DescribeUsersError {
 }
 impl fmt::Display for DescribeUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUsersError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUsersError::EntityNotExists(ref cause) => cause,
-            DescribeUsersError::FailedDependency(ref cause) => cause,
-            DescribeUsersError::InvalidArgument(ref cause) => cause,
-            DescribeUsersError::RequestedEntityTooLarge(ref cause) => cause,
-            DescribeUsersError::ServiceUnavailable(ref cause) => cause,
-            DescribeUsersError::UnauthorizedOperation(ref cause) => cause,
-            DescribeUsersError::UnauthorizedResourceAccess(ref cause) => cause,
+            DescribeUsersError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            DescribeUsersError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            DescribeUsersError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            DescribeUsersError::RequestedEntityTooLarge(ref cause) => write!(f, "{}", cause),
+            DescribeUsersError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            DescribeUsersError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            DescribeUsersError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUsersError {}
 /// Errors returned by GetCurrentUser
 #[derive(Debug, PartialEq)]
 pub enum GetCurrentUserError {
@@ -3634,20 +3578,16 @@ impl GetCurrentUserError {
 }
 impl fmt::Display for GetCurrentUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetCurrentUserError {
-    fn description(&self) -> &str {
         match *self {
-            GetCurrentUserError::EntityNotExists(ref cause) => cause,
-            GetCurrentUserError::FailedDependency(ref cause) => cause,
-            GetCurrentUserError::ServiceUnavailable(ref cause) => cause,
-            GetCurrentUserError::UnauthorizedOperation(ref cause) => cause,
-            GetCurrentUserError::UnauthorizedResourceAccess(ref cause) => cause,
+            GetCurrentUserError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            GetCurrentUserError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            GetCurrentUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetCurrentUserError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            GetCurrentUserError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetCurrentUserError {}
 /// Errors returned by GetDocument
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentError {
@@ -3703,22 +3643,18 @@ impl GetDocumentError {
 }
 impl fmt::Display for GetDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentError::EntityNotExists(ref cause) => cause,
-            GetDocumentError::FailedDependency(ref cause) => cause,
-            GetDocumentError::InvalidArgument(ref cause) => cause,
-            GetDocumentError::InvalidPassword(ref cause) => cause,
-            GetDocumentError::ServiceUnavailable(ref cause) => cause,
-            GetDocumentError::UnauthorizedOperation(ref cause) => cause,
-            GetDocumentError::UnauthorizedResourceAccess(ref cause) => cause,
+            GetDocumentError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            GetDocumentError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentError {}
 /// Errors returned by GetDocumentPath
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentPathError {
@@ -3766,20 +3702,16 @@ impl GetDocumentPathError {
 }
 impl fmt::Display for GetDocumentPathError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentPathError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentPathError::EntityNotExists(ref cause) => cause,
-            GetDocumentPathError::FailedDependency(ref cause) => cause,
-            GetDocumentPathError::ServiceUnavailable(ref cause) => cause,
-            GetDocumentPathError::UnauthorizedOperation(ref cause) => cause,
-            GetDocumentPathError::UnauthorizedResourceAccess(ref cause) => cause,
+            GetDocumentPathError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            GetDocumentPathError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            GetDocumentPathError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDocumentPathError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            GetDocumentPathError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetDocumentPathError {}
 /// Errors returned by GetDocumentVersion
 #[derive(Debug, PartialEq)]
 pub enum GetDocumentVersionError {
@@ -3839,22 +3771,20 @@ impl GetDocumentVersionError {
 }
 impl fmt::Display for GetDocumentVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetDocumentVersionError {
-    fn description(&self) -> &str {
         match *self {
-            GetDocumentVersionError::EntityNotExists(ref cause) => cause,
-            GetDocumentVersionError::FailedDependency(ref cause) => cause,
-            GetDocumentVersionError::InvalidPassword(ref cause) => cause,
-            GetDocumentVersionError::ProhibitedState(ref cause) => cause,
-            GetDocumentVersionError::ServiceUnavailable(ref cause) => cause,
-            GetDocumentVersionError::UnauthorizedOperation(ref cause) => cause,
-            GetDocumentVersionError::UnauthorizedResourceAccess(ref cause) => cause,
+            GetDocumentVersionError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            GetDocumentVersionError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            GetDocumentVersionError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            GetDocumentVersionError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            GetDocumentVersionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetDocumentVersionError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            GetDocumentVersionError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for GetDocumentVersionError {}
 /// Errors returned by GetFolder
 #[derive(Debug, PartialEq)]
 pub enum GetFolderError {
@@ -3910,22 +3840,18 @@ impl GetFolderError {
 }
 impl fmt::Display for GetFolderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFolderError {
-    fn description(&self) -> &str {
         match *self {
-            GetFolderError::EntityNotExists(ref cause) => cause,
-            GetFolderError::FailedDependency(ref cause) => cause,
-            GetFolderError::InvalidArgument(ref cause) => cause,
-            GetFolderError::ProhibitedState(ref cause) => cause,
-            GetFolderError::ServiceUnavailable(ref cause) => cause,
-            GetFolderError::UnauthorizedOperation(ref cause) => cause,
-            GetFolderError::UnauthorizedResourceAccess(ref cause) => cause,
+            GetFolderError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            GetFolderError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            GetFolderError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetFolderError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            GetFolderError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetFolderError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            GetFolderError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFolderError {}
 /// Errors returned by GetFolderPath
 #[derive(Debug, PartialEq)]
 pub enum GetFolderPathError {
@@ -3971,20 +3897,16 @@ impl GetFolderPathError {
 }
 impl fmt::Display for GetFolderPathError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetFolderPathError {
-    fn description(&self) -> &str {
         match *self {
-            GetFolderPathError::EntityNotExists(ref cause) => cause,
-            GetFolderPathError::FailedDependency(ref cause) => cause,
-            GetFolderPathError::ServiceUnavailable(ref cause) => cause,
-            GetFolderPathError::UnauthorizedOperation(ref cause) => cause,
-            GetFolderPathError::UnauthorizedResourceAccess(ref cause) => cause,
+            GetFolderPathError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            GetFolderPathError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            GetFolderPathError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetFolderPathError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            GetFolderPathError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetFolderPathError {}
 /// Errors returned by GetResources
 #[derive(Debug, PartialEq)]
 pub enum GetResourcesError {
@@ -4030,20 +3952,16 @@ impl GetResourcesError {
 }
 impl fmt::Display for GetResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            GetResourcesError::FailedDependency(ref cause) => cause,
-            GetResourcesError::InvalidArgument(ref cause) => cause,
-            GetResourcesError::ServiceUnavailable(ref cause) => cause,
-            GetResourcesError::UnauthorizedOperation(ref cause) => cause,
-            GetResourcesError::UnauthorizedResourceAccess(ref cause) => cause,
+            GetResourcesError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            GetResourcesError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetResourcesError {}
 /// Errors returned by InitiateDocumentVersionUpload
 #[derive(Debug, PartialEq)]
 pub enum InitiateDocumentVersionUploadError {
@@ -4141,26 +4059,44 @@ impl InitiateDocumentVersionUploadError {
 }
 impl fmt::Display for InitiateDocumentVersionUploadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for InitiateDocumentVersionUploadError {
-    fn description(&self) -> &str {
         match *self {
-            InitiateDocumentVersionUploadError::DraftUploadOutOfSync(ref cause) => cause,
-            InitiateDocumentVersionUploadError::EntityAlreadyExists(ref cause) => cause,
-            InitiateDocumentVersionUploadError::EntityNotExists(ref cause) => cause,
-            InitiateDocumentVersionUploadError::FailedDependency(ref cause) => cause,
-            InitiateDocumentVersionUploadError::ProhibitedState(ref cause) => cause,
-            InitiateDocumentVersionUploadError::ResourceAlreadyCheckedOut(ref cause) => cause,
-            InitiateDocumentVersionUploadError::ServiceUnavailable(ref cause) => cause,
-            InitiateDocumentVersionUploadError::StorageLimitExceeded(ref cause) => cause,
-            InitiateDocumentVersionUploadError::StorageLimitWillExceed(ref cause) => cause,
-            InitiateDocumentVersionUploadError::UnauthorizedOperation(ref cause) => cause,
-            InitiateDocumentVersionUploadError::UnauthorizedResourceAccess(ref cause) => cause,
+            InitiateDocumentVersionUploadError::DraftUploadOutOfSync(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::EntityAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::EntityNotExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::FailedDependency(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::ProhibitedState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::ResourceAlreadyCheckedOut(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::StorageLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::StorageLimitWillExceed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            InitiateDocumentVersionUploadError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for InitiateDocumentVersionUploadError {}
 /// Errors returned by RemoveAllResourcePermissions
 #[derive(Debug, PartialEq)]
 pub enum RemoveAllResourcePermissionsError {
@@ -4209,19 +4145,23 @@ impl RemoveAllResourcePermissionsError {
 }
 impl fmt::Display for RemoveAllResourcePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveAllResourcePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveAllResourcePermissionsError::FailedDependency(ref cause) => cause,
-            RemoveAllResourcePermissionsError::ServiceUnavailable(ref cause) => cause,
-            RemoveAllResourcePermissionsError::UnauthorizedOperation(ref cause) => cause,
-            RemoveAllResourcePermissionsError::UnauthorizedResourceAccess(ref cause) => cause,
+            RemoveAllResourcePermissionsError::FailedDependency(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAllResourcePermissionsError::ServiceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAllResourcePermissionsError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveAllResourcePermissionsError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveAllResourcePermissionsError {}
 /// Errors returned by RemoveResourcePermission
 #[derive(Debug, PartialEq)]
 pub enum RemoveResourcePermissionError {
@@ -4268,19 +4208,19 @@ impl RemoveResourcePermissionError {
 }
 impl fmt::Display for RemoveResourcePermissionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RemoveResourcePermissionError {
-    fn description(&self) -> &str {
         match *self {
-            RemoveResourcePermissionError::FailedDependency(ref cause) => cause,
-            RemoveResourcePermissionError::ServiceUnavailable(ref cause) => cause,
-            RemoveResourcePermissionError::UnauthorizedOperation(ref cause) => cause,
-            RemoveResourcePermissionError::UnauthorizedResourceAccess(ref cause) => cause,
+            RemoveResourcePermissionError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            RemoveResourcePermissionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            RemoveResourcePermissionError::UnauthorizedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RemoveResourcePermissionError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RemoveResourcePermissionError {}
 /// Errors returned by UpdateDocument
 #[derive(Debug, PartialEq)]
 pub enum UpdateDocumentError {
@@ -4355,25 +4295,21 @@ impl UpdateDocumentError {
 }
 impl fmt::Display for UpdateDocumentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDocumentError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDocumentError::ConcurrentModification(ref cause) => cause,
-            UpdateDocumentError::ConflictingOperation(ref cause) => cause,
-            UpdateDocumentError::EntityAlreadyExists(ref cause) => cause,
-            UpdateDocumentError::EntityNotExists(ref cause) => cause,
-            UpdateDocumentError::FailedDependency(ref cause) => cause,
-            UpdateDocumentError::LimitExceeded(ref cause) => cause,
-            UpdateDocumentError::ProhibitedState(ref cause) => cause,
-            UpdateDocumentError::ServiceUnavailable(ref cause) => cause,
-            UpdateDocumentError::UnauthorizedOperation(ref cause) => cause,
-            UpdateDocumentError::UnauthorizedResourceAccess(ref cause) => cause,
+            UpdateDocumentError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::ConflictingOperation(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDocumentError {}
 /// Errors returned by UpdateDocumentVersion
 #[derive(Debug, PartialEq)]
 pub enum UpdateDocumentVersionError {
@@ -4448,23 +4384,21 @@ impl UpdateDocumentVersionError {
 }
 impl fmt::Display for UpdateDocumentVersionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDocumentVersionError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDocumentVersionError::ConcurrentModification(ref cause) => cause,
-            UpdateDocumentVersionError::EntityNotExists(ref cause) => cause,
-            UpdateDocumentVersionError::FailedDependency(ref cause) => cause,
-            UpdateDocumentVersionError::InvalidOperation(ref cause) => cause,
-            UpdateDocumentVersionError::ProhibitedState(ref cause) => cause,
-            UpdateDocumentVersionError::ServiceUnavailable(ref cause) => cause,
-            UpdateDocumentVersionError::UnauthorizedOperation(ref cause) => cause,
-            UpdateDocumentVersionError::UnauthorizedResourceAccess(ref cause) => cause,
+            UpdateDocumentVersionError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentVersionError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentVersionError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentVersionError::InvalidOperation(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentVersionError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentVersionError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentVersionError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            UpdateDocumentVersionError::UnauthorizedResourceAccess(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateDocumentVersionError {}
 /// Errors returned by UpdateFolder
 #[derive(Debug, PartialEq)]
 pub enum UpdateFolderError {
@@ -4535,25 +4469,21 @@ impl UpdateFolderError {
 }
 impl fmt::Display for UpdateFolderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFolderError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFolderError::ConcurrentModification(ref cause) => cause,
-            UpdateFolderError::ConflictingOperation(ref cause) => cause,
-            UpdateFolderError::EntityAlreadyExists(ref cause) => cause,
-            UpdateFolderError::EntityNotExists(ref cause) => cause,
-            UpdateFolderError::FailedDependency(ref cause) => cause,
-            UpdateFolderError::LimitExceeded(ref cause) => cause,
-            UpdateFolderError::ProhibitedState(ref cause) => cause,
-            UpdateFolderError::ServiceUnavailable(ref cause) => cause,
-            UpdateFolderError::UnauthorizedOperation(ref cause) => cause,
-            UpdateFolderError::UnauthorizedResourceAccess(ref cause) => cause,
+            UpdateFolderError::ConcurrentModification(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::ConflictingOperation(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::EntityAlreadyExists(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::LimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::ProhibitedState(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            UpdateFolderError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFolderError {}
 /// Errors returned by UpdateUser
 #[derive(Debug, PartialEq)]
 pub enum UpdateUserError {
@@ -4616,23 +4546,19 @@ impl UpdateUserError {
 }
 impl fmt::Display for UpdateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateUserError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateUserError::DeactivatingLastSystemUser(ref cause) => cause,
-            UpdateUserError::EntityNotExists(ref cause) => cause,
-            UpdateUserError::FailedDependency(ref cause) => cause,
-            UpdateUserError::IllegalUserState(ref cause) => cause,
-            UpdateUserError::InvalidArgument(ref cause) => cause,
-            UpdateUserError::ServiceUnavailable(ref cause) => cause,
-            UpdateUserError::UnauthorizedOperation(ref cause) => cause,
-            UpdateUserError::UnauthorizedResourceAccess(ref cause) => cause,
+            UpdateUserError::DeactivatingLastSystemUser(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::EntityNotExists(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::FailedDependency(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::IllegalUserState(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::InvalidArgument(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::ServiceUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::UnauthorizedOperation(ref cause) => write!(f, "{}", cause),
+            UpdateUserError::UnauthorizedResourceAccess(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateUserError {}
 /// Trait representing the capabilities of the Amazon WorkDocs API. Amazon WorkDocs clients implement this trait.
 pub trait Workdocs {
     /// <p>Aborts the upload of the specified document version that was previously initiated by <a>InitiateDocumentVersionUpload</a>. The client should make this call only when it no longer intends to upload the document version, or fails to do so.</p>

--- a/rusoto/services/worklink/src/generated.rs
+++ b/rusoto/services/worklink/src/generated.rs
@@ -840,21 +840,17 @@ impl AssociateDomainError {
 }
 impl fmt::Display for AssociateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDomainError::InternalServerError(ref cause) => cause,
-            AssociateDomainError::InvalidRequest(ref cause) => cause,
-            AssociateDomainError::ResourceAlreadyExists(ref cause) => cause,
-            AssociateDomainError::ResourceNotFound(ref cause) => cause,
-            AssociateDomainError::TooManyRequests(ref cause) => cause,
-            AssociateDomainError::Unauthorized(ref cause) => cause,
+            AssociateDomainError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            AssociateDomainError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            AssociateDomainError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            AssociateDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateDomainError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            AssociateDomainError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateDomainError {}
 /// Errors returned by AssociateWebsiteAuthorizationProvider
 #[derive(Debug, PartialEq)]
 pub enum AssociateWebsiteAuthorizationProviderError {
@@ -917,21 +913,29 @@ impl AssociateWebsiteAuthorizationProviderError {
 }
 impl fmt::Display for AssociateWebsiteAuthorizationProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateWebsiteAuthorizationProviderError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateWebsiteAuthorizationProviderError::InternalServerError(ref cause) => cause,
-            AssociateWebsiteAuthorizationProviderError::InvalidRequest(ref cause) => cause,
-            AssociateWebsiteAuthorizationProviderError::ResourceAlreadyExists(ref cause) => cause,
-            AssociateWebsiteAuthorizationProviderError::ResourceNotFound(ref cause) => cause,
-            AssociateWebsiteAuthorizationProviderError::TooManyRequests(ref cause) => cause,
-            AssociateWebsiteAuthorizationProviderError::Unauthorized(ref cause) => cause,
+            AssociateWebsiteAuthorizationProviderError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteAuthorizationProviderError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteAuthorizationProviderError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteAuthorizationProviderError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteAuthorizationProviderError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteAuthorizationProviderError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateWebsiteAuthorizationProviderError {}
 /// Errors returned by AssociateWebsiteCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum AssociateWebsiteCertificateAuthorityError {
@@ -994,21 +998,29 @@ impl AssociateWebsiteCertificateAuthorityError {
 }
 impl fmt::Display for AssociateWebsiteCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateWebsiteCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateWebsiteCertificateAuthorityError::InternalServerError(ref cause) => cause,
-            AssociateWebsiteCertificateAuthorityError::InvalidRequest(ref cause) => cause,
-            AssociateWebsiteCertificateAuthorityError::ResourceAlreadyExists(ref cause) => cause,
-            AssociateWebsiteCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
-            AssociateWebsiteCertificateAuthorityError::TooManyRequests(ref cause) => cause,
-            AssociateWebsiteCertificateAuthorityError::Unauthorized(ref cause) => cause,
+            AssociateWebsiteCertificateAuthorityError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteCertificateAuthorityError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteCertificateAuthorityError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteCertificateAuthorityError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteCertificateAuthorityError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateWebsiteCertificateAuthorityError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateWebsiteCertificateAuthorityError {}
 /// Errors returned by CreateFleet
 #[derive(Debug, PartialEq)]
 pub enum CreateFleetError {
@@ -1057,21 +1069,17 @@ impl CreateFleetError {
 }
 impl fmt::Display for CreateFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateFleetError {
-    fn description(&self) -> &str {
         match *self {
-            CreateFleetError::InternalServerError(ref cause) => cause,
-            CreateFleetError::InvalidRequest(ref cause) => cause,
-            CreateFleetError::ResourceAlreadyExists(ref cause) => cause,
-            CreateFleetError::ResourceNotFound(ref cause) => cause,
-            CreateFleetError::TooManyRequests(ref cause) => cause,
-            CreateFleetError::Unauthorized(ref cause) => cause,
+            CreateFleetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            CreateFleetError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateFleetError {}
 /// Errors returned by DeleteFleet
 #[derive(Debug, PartialEq)]
 pub enum DeleteFleetError {
@@ -1115,20 +1123,16 @@ impl DeleteFleetError {
 }
 impl fmt::Display for DeleteFleetError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteFleetError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteFleetError::InternalServerError(ref cause) => cause,
-            DeleteFleetError::InvalidRequest(ref cause) => cause,
-            DeleteFleetError::ResourceNotFound(ref cause) => cause,
-            DeleteFleetError::TooManyRequests(ref cause) => cause,
-            DeleteFleetError::Unauthorized(ref cause) => cause,
+            DeleteFleetError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DeleteFleetError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteFleetError {}
 /// Errors returned by DescribeAuditStreamConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeAuditStreamConfigurationError {
@@ -1184,20 +1188,26 @@ impl DescribeAuditStreamConfigurationError {
 }
 impl fmt::Display for DescribeAuditStreamConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAuditStreamConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAuditStreamConfigurationError::InternalServerError(ref cause) => cause,
-            DescribeAuditStreamConfigurationError::InvalidRequest(ref cause) => cause,
-            DescribeAuditStreamConfigurationError::ResourceNotFound(ref cause) => cause,
-            DescribeAuditStreamConfigurationError::TooManyRequests(ref cause) => cause,
-            DescribeAuditStreamConfigurationError::Unauthorized(ref cause) => cause,
+            DescribeAuditStreamConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAuditStreamConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAuditStreamConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAuditStreamConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeAuditStreamConfigurationError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeAuditStreamConfigurationError {}
 /// Errors returned by DescribeCompanyNetworkConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeCompanyNetworkConfigurationError {
@@ -1253,20 +1263,26 @@ impl DescribeCompanyNetworkConfigurationError {
 }
 impl fmt::Display for DescribeCompanyNetworkConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeCompanyNetworkConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeCompanyNetworkConfigurationError::InternalServerError(ref cause) => cause,
-            DescribeCompanyNetworkConfigurationError::InvalidRequest(ref cause) => cause,
-            DescribeCompanyNetworkConfigurationError::ResourceNotFound(ref cause) => cause,
-            DescribeCompanyNetworkConfigurationError::TooManyRequests(ref cause) => cause,
-            DescribeCompanyNetworkConfigurationError::Unauthorized(ref cause) => cause,
+            DescribeCompanyNetworkConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCompanyNetworkConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCompanyNetworkConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCompanyNetworkConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeCompanyNetworkConfigurationError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeCompanyNetworkConfigurationError {}
 /// Errors returned by DescribeDevice
 #[derive(Debug, PartialEq)]
 pub enum DescribeDeviceError {
@@ -1310,20 +1326,16 @@ impl DescribeDeviceError {
 }
 impl fmt::Display for DescribeDeviceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDeviceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDeviceError::InternalServerError(ref cause) => cause,
-            DescribeDeviceError::InvalidRequest(ref cause) => cause,
-            DescribeDeviceError::ResourceNotFound(ref cause) => cause,
-            DescribeDeviceError::TooManyRequests(ref cause) => cause,
-            DescribeDeviceError::Unauthorized(ref cause) => cause,
+            DescribeDeviceError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeDeviceError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeDeviceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDeviceError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeDeviceError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDeviceError {}
 /// Errors returned by DescribeDevicePolicyConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeDevicePolicyConfigurationError {
@@ -1379,20 +1391,26 @@ impl DescribeDevicePolicyConfigurationError {
 }
 impl fmt::Display for DescribeDevicePolicyConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDevicePolicyConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDevicePolicyConfigurationError::InternalServerError(ref cause) => cause,
-            DescribeDevicePolicyConfigurationError::InvalidRequest(ref cause) => cause,
-            DescribeDevicePolicyConfigurationError::ResourceNotFound(ref cause) => cause,
-            DescribeDevicePolicyConfigurationError::TooManyRequests(ref cause) => cause,
-            DescribeDevicePolicyConfigurationError::Unauthorized(ref cause) => cause,
+            DescribeDevicePolicyConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDevicePolicyConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDevicePolicyConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDevicePolicyConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeDevicePolicyConfigurationError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeDevicePolicyConfigurationError {}
 /// Errors returned by DescribeDomain
 #[derive(Debug, PartialEq)]
 pub enum DescribeDomainError {
@@ -1436,20 +1454,16 @@ impl DescribeDomainError {
 }
 impl fmt::Display for DescribeDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeDomainError::InternalServerError(ref cause) => cause,
-            DescribeDomainError::InvalidRequest(ref cause) => cause,
-            DescribeDomainError::ResourceNotFound(ref cause) => cause,
-            DescribeDomainError::TooManyRequests(ref cause) => cause,
-            DescribeDomainError::Unauthorized(ref cause) => cause,
+            DescribeDomainError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeDomainError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeDomainError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeDomainError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeDomainError {}
 /// Errors returned by DescribeFleetMetadata
 #[derive(Debug, PartialEq)]
 pub enum DescribeFleetMetadataError {
@@ -1501,20 +1515,16 @@ impl DescribeFleetMetadataError {
 }
 impl fmt::Display for DescribeFleetMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeFleetMetadataError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeFleetMetadataError::InternalServerError(ref cause) => cause,
-            DescribeFleetMetadataError::InvalidRequest(ref cause) => cause,
-            DescribeFleetMetadataError::ResourceNotFound(ref cause) => cause,
-            DescribeFleetMetadataError::TooManyRequests(ref cause) => cause,
-            DescribeFleetMetadataError::Unauthorized(ref cause) => cause,
+            DescribeFleetMetadataError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DescribeFleetMetadataError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DescribeFleetMetadataError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeFleetMetadataError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DescribeFleetMetadataError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeFleetMetadataError {}
 /// Errors returned by DescribeIdentityProviderConfiguration
 #[derive(Debug, PartialEq)]
 pub enum DescribeIdentityProviderConfigurationError {
@@ -1570,20 +1580,26 @@ impl DescribeIdentityProviderConfigurationError {
 }
 impl fmt::Display for DescribeIdentityProviderConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIdentityProviderConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIdentityProviderConfigurationError::InternalServerError(ref cause) => cause,
-            DescribeIdentityProviderConfigurationError::InvalidRequest(ref cause) => cause,
-            DescribeIdentityProviderConfigurationError::ResourceNotFound(ref cause) => cause,
-            DescribeIdentityProviderConfigurationError::TooManyRequests(ref cause) => cause,
-            DescribeIdentityProviderConfigurationError::Unauthorized(ref cause) => cause,
+            DescribeIdentityProviderConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeIdentityProviderConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeIdentityProviderConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeIdentityProviderConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeIdentityProviderConfigurationError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeIdentityProviderConfigurationError {}
 /// Errors returned by DescribeWebsiteCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum DescribeWebsiteCertificateAuthorityError {
@@ -1639,20 +1655,26 @@ impl DescribeWebsiteCertificateAuthorityError {
 }
 impl fmt::Display for DescribeWebsiteCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWebsiteCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWebsiteCertificateAuthorityError::InternalServerError(ref cause) => cause,
-            DescribeWebsiteCertificateAuthorityError::InvalidRequest(ref cause) => cause,
-            DescribeWebsiteCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
-            DescribeWebsiteCertificateAuthorityError::TooManyRequests(ref cause) => cause,
-            DescribeWebsiteCertificateAuthorityError::Unauthorized(ref cause) => cause,
+            DescribeWebsiteCertificateAuthorityError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeWebsiteCertificateAuthorityError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeWebsiteCertificateAuthorityError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeWebsiteCertificateAuthorityError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeWebsiteCertificateAuthorityError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeWebsiteCertificateAuthorityError {}
 /// Errors returned by DisassociateDomain
 #[derive(Debug, PartialEq)]
 pub enum DisassociateDomainError {
@@ -1698,20 +1720,16 @@ impl DisassociateDomainError {
 }
 impl fmt::Display for DisassociateDomainError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateDomainError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateDomainError::InternalServerError(ref cause) => cause,
-            DisassociateDomainError::InvalidRequest(ref cause) => cause,
-            DisassociateDomainError::ResourceNotFound(ref cause) => cause,
-            DisassociateDomainError::TooManyRequests(ref cause) => cause,
-            DisassociateDomainError::Unauthorized(ref cause) => cause,
+            DisassociateDomainError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            DisassociateDomainError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DisassociateDomainError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            DisassociateDomainError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            DisassociateDomainError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateDomainError {}
 /// Errors returned by DisassociateWebsiteAuthorizationProvider
 #[derive(Debug, PartialEq)]
 pub enum DisassociateWebsiteAuthorizationProviderError {
@@ -1776,23 +1794,29 @@ impl DisassociateWebsiteAuthorizationProviderError {
 }
 impl fmt::Display for DisassociateWebsiteAuthorizationProviderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateWebsiteAuthorizationProviderError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateWebsiteAuthorizationProviderError::InternalServerError(ref cause) => cause,
-            DisassociateWebsiteAuthorizationProviderError::InvalidRequest(ref cause) => cause,
-            DisassociateWebsiteAuthorizationProviderError::ResourceAlreadyExists(ref cause) => {
-                cause
+            DisassociateWebsiteAuthorizationProviderError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
             }
-            DisassociateWebsiteAuthorizationProviderError::ResourceNotFound(ref cause) => cause,
-            DisassociateWebsiteAuthorizationProviderError::TooManyRequests(ref cause) => cause,
-            DisassociateWebsiteAuthorizationProviderError::Unauthorized(ref cause) => cause,
+            DisassociateWebsiteAuthorizationProviderError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteAuthorizationProviderError::ResourceAlreadyExists(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteAuthorizationProviderError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteAuthorizationProviderError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteAuthorizationProviderError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateWebsiteAuthorizationProviderError {}
 /// Errors returned by DisassociateWebsiteCertificateAuthority
 #[derive(Debug, PartialEq)]
 pub enum DisassociateWebsiteCertificateAuthorityError {
@@ -1848,20 +1872,26 @@ impl DisassociateWebsiteCertificateAuthorityError {
 }
 impl fmt::Display for DisassociateWebsiteCertificateAuthorityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateWebsiteCertificateAuthorityError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateWebsiteCertificateAuthorityError::InternalServerError(ref cause) => cause,
-            DisassociateWebsiteCertificateAuthorityError::InvalidRequest(ref cause) => cause,
-            DisassociateWebsiteCertificateAuthorityError::ResourceNotFound(ref cause) => cause,
-            DisassociateWebsiteCertificateAuthorityError::TooManyRequests(ref cause) => cause,
-            DisassociateWebsiteCertificateAuthorityError::Unauthorized(ref cause) => cause,
+            DisassociateWebsiteCertificateAuthorityError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteCertificateAuthorityError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteCertificateAuthorityError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteCertificateAuthorityError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateWebsiteCertificateAuthorityError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateWebsiteCertificateAuthorityError {}
 /// Errors returned by ListDevices
 #[derive(Debug, PartialEq)]
 pub enum ListDevicesError {
@@ -1905,20 +1935,16 @@ impl ListDevicesError {
 }
 impl fmt::Display for ListDevicesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDevicesError {
-    fn description(&self) -> &str {
         match *self {
-            ListDevicesError::InternalServerError(ref cause) => cause,
-            ListDevicesError::InvalidRequest(ref cause) => cause,
-            ListDevicesError::ResourceNotFound(ref cause) => cause,
-            ListDevicesError::TooManyRequests(ref cause) => cause,
-            ListDevicesError::Unauthorized(ref cause) => cause,
+            ListDevicesError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListDevicesError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDevicesError {}
 /// Errors returned by ListDomains
 #[derive(Debug, PartialEq)]
 pub enum ListDomainsError {
@@ -1957,19 +1983,15 @@ impl ListDomainsError {
 }
 impl fmt::Display for ListDomainsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListDomainsError {
-    fn description(&self) -> &str {
         match *self {
-            ListDomainsError::InternalServerError(ref cause) => cause,
-            ListDomainsError::InvalidRequest(ref cause) => cause,
-            ListDomainsError::TooManyRequests(ref cause) => cause,
-            ListDomainsError::Unauthorized(ref cause) => cause,
+            ListDomainsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListDomainsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListDomainsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListDomainsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListDomainsError {}
 /// Errors returned by ListFleets
 #[derive(Debug, PartialEq)]
 pub enum ListFleetsError {
@@ -2008,19 +2030,15 @@ impl ListFleetsError {
 }
 impl fmt::Display for ListFleetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListFleetsError {
-    fn description(&self) -> &str {
         match *self {
-            ListFleetsError::InternalServerError(ref cause) => cause,
-            ListFleetsError::InvalidRequest(ref cause) => cause,
-            ListFleetsError::TooManyRequests(ref cause) => cause,
-            ListFleetsError::Unauthorized(ref cause) => cause,
+            ListFleetsError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            ListFleetsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            ListFleetsError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            ListFleetsError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListFleetsError {}
 /// Errors returned by ListWebsiteAuthorizationProviders
 #[derive(Debug, PartialEq)]
 pub enum ListWebsiteAuthorizationProvidersError {
@@ -2076,20 +2094,26 @@ impl ListWebsiteAuthorizationProvidersError {
 }
 impl fmt::Display for ListWebsiteAuthorizationProvidersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWebsiteAuthorizationProvidersError {
-    fn description(&self) -> &str {
         match *self {
-            ListWebsiteAuthorizationProvidersError::InternalServerError(ref cause) => cause,
-            ListWebsiteAuthorizationProvidersError::InvalidRequest(ref cause) => cause,
-            ListWebsiteAuthorizationProvidersError::ResourceNotFound(ref cause) => cause,
-            ListWebsiteAuthorizationProvidersError::TooManyRequests(ref cause) => cause,
-            ListWebsiteAuthorizationProvidersError::Unauthorized(ref cause) => cause,
+            ListWebsiteAuthorizationProvidersError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWebsiteAuthorizationProvidersError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWebsiteAuthorizationProvidersError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWebsiteAuthorizationProvidersError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWebsiteAuthorizationProvidersError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListWebsiteAuthorizationProvidersError {}
 /// Errors returned by ListWebsiteCertificateAuthorities
 #[derive(Debug, PartialEq)]
 pub enum ListWebsiteCertificateAuthoritiesError {
@@ -2138,19 +2162,23 @@ impl ListWebsiteCertificateAuthoritiesError {
 }
 impl fmt::Display for ListWebsiteCertificateAuthoritiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListWebsiteCertificateAuthoritiesError {
-    fn description(&self) -> &str {
         match *self {
-            ListWebsiteCertificateAuthoritiesError::InternalServerError(ref cause) => cause,
-            ListWebsiteCertificateAuthoritiesError::InvalidRequest(ref cause) => cause,
-            ListWebsiteCertificateAuthoritiesError::TooManyRequests(ref cause) => cause,
-            ListWebsiteCertificateAuthoritiesError::Unauthorized(ref cause) => cause,
+            ListWebsiteCertificateAuthoritiesError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWebsiteCertificateAuthoritiesError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWebsiteCertificateAuthoritiesError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListWebsiteCertificateAuthoritiesError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListWebsiteCertificateAuthoritiesError {}
 /// Errors returned by RestoreDomainAccess
 #[derive(Debug, PartialEq)]
 pub enum RestoreDomainAccessError {
@@ -2198,20 +2226,16 @@ impl RestoreDomainAccessError {
 }
 impl fmt::Display for RestoreDomainAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreDomainAccessError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreDomainAccessError::InternalServerError(ref cause) => cause,
-            RestoreDomainAccessError::InvalidRequest(ref cause) => cause,
-            RestoreDomainAccessError::ResourceNotFound(ref cause) => cause,
-            RestoreDomainAccessError::TooManyRequests(ref cause) => cause,
-            RestoreDomainAccessError::Unauthorized(ref cause) => cause,
+            RestoreDomainAccessError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RestoreDomainAccessError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RestoreDomainAccessError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RestoreDomainAccessError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            RestoreDomainAccessError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreDomainAccessError {}
 /// Errors returned by RevokeDomainAccess
 #[derive(Debug, PartialEq)]
 pub enum RevokeDomainAccessError {
@@ -2257,20 +2281,16 @@ impl RevokeDomainAccessError {
 }
 impl fmt::Display for RevokeDomainAccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeDomainAccessError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeDomainAccessError::InternalServerError(ref cause) => cause,
-            RevokeDomainAccessError::InvalidRequest(ref cause) => cause,
-            RevokeDomainAccessError::ResourceNotFound(ref cause) => cause,
-            RevokeDomainAccessError::TooManyRequests(ref cause) => cause,
-            RevokeDomainAccessError::Unauthorized(ref cause) => cause,
+            RevokeDomainAccessError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            RevokeDomainAccessError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            RevokeDomainAccessError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RevokeDomainAccessError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            RevokeDomainAccessError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RevokeDomainAccessError {}
 /// Errors returned by SignOutUser
 #[derive(Debug, PartialEq)]
 pub enum SignOutUserError {
@@ -2314,20 +2334,16 @@ impl SignOutUserError {
 }
 impl fmt::Display for SignOutUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for SignOutUserError {
-    fn description(&self) -> &str {
         match *self {
-            SignOutUserError::InternalServerError(ref cause) => cause,
-            SignOutUserError::InvalidRequest(ref cause) => cause,
-            SignOutUserError::ResourceNotFound(ref cause) => cause,
-            SignOutUserError::TooManyRequests(ref cause) => cause,
-            SignOutUserError::Unauthorized(ref cause) => cause,
+            SignOutUserError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            SignOutUserError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            SignOutUserError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            SignOutUserError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            SignOutUserError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for SignOutUserError {}
 /// Errors returned by UpdateAuditStreamConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateAuditStreamConfigurationError {
@@ -2383,20 +2399,24 @@ impl UpdateAuditStreamConfigurationError {
 }
 impl fmt::Display for UpdateAuditStreamConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateAuditStreamConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateAuditStreamConfigurationError::InternalServerError(ref cause) => cause,
-            UpdateAuditStreamConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateAuditStreamConfigurationError::ResourceNotFound(ref cause) => cause,
-            UpdateAuditStreamConfigurationError::TooManyRequests(ref cause) => cause,
-            UpdateAuditStreamConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateAuditStreamConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAuditStreamConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAuditStreamConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAuditStreamConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateAuditStreamConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateAuditStreamConfigurationError {}
 /// Errors returned by UpdateCompanyNetworkConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateCompanyNetworkConfigurationError {
@@ -2452,20 +2472,26 @@ impl UpdateCompanyNetworkConfigurationError {
 }
 impl fmt::Display for UpdateCompanyNetworkConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateCompanyNetworkConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateCompanyNetworkConfigurationError::InternalServerError(ref cause) => cause,
-            UpdateCompanyNetworkConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateCompanyNetworkConfigurationError::ResourceNotFound(ref cause) => cause,
-            UpdateCompanyNetworkConfigurationError::TooManyRequests(ref cause) => cause,
-            UpdateCompanyNetworkConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateCompanyNetworkConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCompanyNetworkConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCompanyNetworkConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCompanyNetworkConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateCompanyNetworkConfigurationError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateCompanyNetworkConfigurationError {}
 /// Errors returned by UpdateDevicePolicyConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateDevicePolicyConfigurationError {
@@ -2521,20 +2547,24 @@ impl UpdateDevicePolicyConfigurationError {
 }
 impl fmt::Display for UpdateDevicePolicyConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDevicePolicyConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDevicePolicyConfigurationError::InternalServerError(ref cause) => cause,
-            UpdateDevicePolicyConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateDevicePolicyConfigurationError::ResourceNotFound(ref cause) => cause,
-            UpdateDevicePolicyConfigurationError::TooManyRequests(ref cause) => cause,
-            UpdateDevicePolicyConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateDevicePolicyConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDevicePolicyConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDevicePolicyConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDevicePolicyConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateDevicePolicyConfigurationError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDevicePolicyConfigurationError {}
 /// Errors returned by UpdateDomainMetadata
 #[derive(Debug, PartialEq)]
 pub enum UpdateDomainMetadataError {
@@ -2584,20 +2614,16 @@ impl UpdateDomainMetadataError {
 }
 impl fmt::Display for UpdateDomainMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateDomainMetadataError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateDomainMetadataError::InternalServerError(ref cause) => cause,
-            UpdateDomainMetadataError::InvalidRequest(ref cause) => cause,
-            UpdateDomainMetadataError::ResourceNotFound(ref cause) => cause,
-            UpdateDomainMetadataError::TooManyRequests(ref cause) => cause,
-            UpdateDomainMetadataError::Unauthorized(ref cause) => cause,
+            UpdateDomainMetadataError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateDomainMetadataError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateDomainMetadataError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateDomainMetadataError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateDomainMetadataError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateDomainMetadataError {}
 /// Errors returned by UpdateFleetMetadata
 #[derive(Debug, PartialEq)]
 pub enum UpdateFleetMetadataError {
@@ -2645,20 +2671,16 @@ impl UpdateFleetMetadataError {
 }
 impl fmt::Display for UpdateFleetMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateFleetMetadataError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateFleetMetadataError::InternalServerError(ref cause) => cause,
-            UpdateFleetMetadataError::InvalidRequest(ref cause) => cause,
-            UpdateFleetMetadataError::ResourceNotFound(ref cause) => cause,
-            UpdateFleetMetadataError::TooManyRequests(ref cause) => cause,
-            UpdateFleetMetadataError::Unauthorized(ref cause) => cause,
+            UpdateFleetMetadataError::InternalServerError(ref cause) => write!(f, "{}", cause),
+            UpdateFleetMetadataError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateFleetMetadataError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateFleetMetadataError::TooManyRequests(ref cause) => write!(f, "{}", cause),
+            UpdateFleetMetadataError::Unauthorized(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateFleetMetadataError {}
 /// Errors returned by UpdateIdentityProviderConfiguration
 #[derive(Debug, PartialEq)]
 pub enum UpdateIdentityProviderConfigurationError {
@@ -2714,20 +2736,26 @@ impl UpdateIdentityProviderConfigurationError {
 }
 impl fmt::Display for UpdateIdentityProviderConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateIdentityProviderConfigurationError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateIdentityProviderConfigurationError::InternalServerError(ref cause) => cause,
-            UpdateIdentityProviderConfigurationError::InvalidRequest(ref cause) => cause,
-            UpdateIdentityProviderConfigurationError::ResourceNotFound(ref cause) => cause,
-            UpdateIdentityProviderConfigurationError::TooManyRequests(ref cause) => cause,
-            UpdateIdentityProviderConfigurationError::Unauthorized(ref cause) => cause,
+            UpdateIdentityProviderConfigurationError::InternalServerError(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateIdentityProviderConfigurationError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateIdentityProviderConfigurationError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateIdentityProviderConfigurationError::TooManyRequests(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdateIdentityProviderConfigurationError::Unauthorized(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdateIdentityProviderConfigurationError {}
 /// Trait representing the capabilities of the WorkLink API. WorkLink clients implement this trait.
 pub trait Worklink {
     /// <p>Specifies a domain to be associated to Amazon WorkLink.</p>

--- a/rusoto/services/workmail/src/generated.rs
+++ b/rusoto/services/workmail/src/generated.rs
@@ -1060,20 +1060,20 @@ impl AssociateDelegateToResourceError {
 }
 impl fmt::Display for AssociateDelegateToResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateDelegateToResourceError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateDelegateToResourceError::EntityNotFound(ref cause) => cause,
-            AssociateDelegateToResourceError::EntityState(ref cause) => cause,
-            AssociateDelegateToResourceError::InvalidParameter(ref cause) => cause,
-            AssociateDelegateToResourceError::OrganizationNotFound(ref cause) => cause,
-            AssociateDelegateToResourceError::OrganizationState(ref cause) => cause,
+            AssociateDelegateToResourceError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateDelegateToResourceError::EntityState(ref cause) => write!(f, "{}", cause),
+            AssociateDelegateToResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateDelegateToResourceError::OrganizationNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateDelegateToResourceError::OrganizationState(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for AssociateDelegateToResourceError {}
 /// Errors returned by AssociateMemberToGroup
 #[derive(Debug, PartialEq)]
 pub enum AssociateMemberToGroupError {
@@ -1146,23 +1146,21 @@ impl AssociateMemberToGroupError {
 }
 impl fmt::Display for AssociateMemberToGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateMemberToGroupError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateMemberToGroupError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            AssociateMemberToGroupError::DirectoryUnavailable(ref cause) => cause,
-            AssociateMemberToGroupError::EntityNotFound(ref cause) => cause,
-            AssociateMemberToGroupError::EntityState(ref cause) => cause,
-            AssociateMemberToGroupError::InvalidParameter(ref cause) => cause,
-            AssociateMemberToGroupError::OrganizationNotFound(ref cause) => cause,
-            AssociateMemberToGroupError::OrganizationState(ref cause) => cause,
-            AssociateMemberToGroupError::UnsupportedOperation(ref cause) => cause,
+            AssociateMemberToGroupError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            AssociateMemberToGroupError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            AssociateMemberToGroupError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateMemberToGroupError::EntityState(ref cause) => write!(f, "{}", cause),
+            AssociateMemberToGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            AssociateMemberToGroupError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            AssociateMemberToGroupError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            AssociateMemberToGroupError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateMemberToGroupError {}
 /// Errors returned by CreateAlias
 #[derive(Debug, PartialEq)]
 pub enum CreateAliasError {
@@ -1221,23 +1219,19 @@ impl CreateAliasError {
 }
 impl fmt::Display for CreateAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateAliasError {
-    fn description(&self) -> &str {
         match *self {
-            CreateAliasError::EmailAddressInUse(ref cause) => cause,
-            CreateAliasError::EntityNotFound(ref cause) => cause,
-            CreateAliasError::EntityState(ref cause) => cause,
-            CreateAliasError::InvalidParameter(ref cause) => cause,
-            CreateAliasError::MailDomainNotFound(ref cause) => cause,
-            CreateAliasError::MailDomainState(ref cause) => cause,
-            CreateAliasError::OrganizationNotFound(ref cause) => cause,
-            CreateAliasError::OrganizationState(ref cause) => cause,
+            CreateAliasError::EmailAddressInUse(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::EntityState(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::MailDomainNotFound(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::MailDomainState(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            CreateAliasError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateAliasError {}
 /// Errors returned by CreateGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupError {
@@ -1298,23 +1292,21 @@ impl CreateGroupError {
 }
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            CreateGroupError::DirectoryUnavailable(ref cause) => cause,
-            CreateGroupError::InvalidParameter(ref cause) => cause,
-            CreateGroupError::NameAvailability(ref cause) => cause,
-            CreateGroupError::OrganizationNotFound(ref cause) => cause,
-            CreateGroupError::OrganizationState(ref cause) => cause,
-            CreateGroupError::ReservedName(ref cause) => cause,
-            CreateGroupError::UnsupportedOperation(ref cause) => cause,
+            CreateGroupError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateGroupError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::NameAvailability(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::ReservedName(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGroupError {}
 /// Errors returned by CreateResource
 #[derive(Debug, PartialEq)]
 pub enum CreateResourceError {
@@ -1370,22 +1362,20 @@ impl CreateResourceError {
 }
 impl fmt::Display for CreateResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateResourceError {
-    fn description(&self) -> &str {
         match *self {
-            CreateResourceError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            CreateResourceError::DirectoryUnavailable(ref cause) => cause,
-            CreateResourceError::InvalidParameter(ref cause) => cause,
-            CreateResourceError::NameAvailability(ref cause) => cause,
-            CreateResourceError::OrganizationNotFound(ref cause) => cause,
-            CreateResourceError::OrganizationState(ref cause) => cause,
-            CreateResourceError::ReservedName(ref cause) => cause,
+            CreateResourceError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateResourceError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::NameAvailability(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            CreateResourceError::ReservedName(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateResourceError {}
 /// Errors returned by CreateUser
 #[derive(Debug, PartialEq)]
 pub enum CreateUserError {
@@ -1451,24 +1441,22 @@ impl CreateUserError {
 }
 impl fmt::Display for CreateUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateUserError {
-    fn description(&self) -> &str {
         match *self {
-            CreateUserError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            CreateUserError::DirectoryUnavailable(ref cause) => cause,
-            CreateUserError::InvalidParameter(ref cause) => cause,
-            CreateUserError::InvalidPassword(ref cause) => cause,
-            CreateUserError::NameAvailability(ref cause) => cause,
-            CreateUserError::OrganizationNotFound(ref cause) => cause,
-            CreateUserError::OrganizationState(ref cause) => cause,
-            CreateUserError::ReservedName(ref cause) => cause,
-            CreateUserError::UnsupportedOperation(ref cause) => cause,
+            CreateUserError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            CreateUserError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            CreateUserError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            CreateUserError::NameAvailability(ref cause) => write!(f, "{}", cause),
+            CreateUserError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            CreateUserError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            CreateUserError::ReservedName(ref cause) => write!(f, "{}", cause),
+            CreateUserError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateUserError {}
 /// Errors returned by DeleteAlias
 #[derive(Debug, PartialEq)]
 pub enum DeleteAliasError {
@@ -1512,20 +1500,16 @@ impl DeleteAliasError {
 }
 impl fmt::Display for DeleteAliasError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteAliasError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteAliasError::EntityNotFound(ref cause) => cause,
-            DeleteAliasError::EntityState(ref cause) => cause,
-            DeleteAliasError::InvalidParameter(ref cause) => cause,
-            DeleteAliasError::OrganizationNotFound(ref cause) => cause,
-            DeleteAliasError::OrganizationState(ref cause) => cause,
+            DeleteAliasError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::EntityState(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteAliasError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteAliasError {}
 /// Errors returned by DeleteGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteGroupError {
@@ -1581,22 +1565,20 @@ impl DeleteGroupError {
 }
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGroupError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            DeleteGroupError::DirectoryUnavailable(ref cause) => cause,
-            DeleteGroupError::EntityState(ref cause) => cause,
-            DeleteGroupError::InvalidParameter(ref cause) => cause,
-            DeleteGroupError::OrganizationNotFound(ref cause) => cause,
-            DeleteGroupError::OrganizationState(ref cause) => cause,
-            DeleteGroupError::UnsupportedOperation(ref cause) => cause,
+            DeleteGroupError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteGroupError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::EntityState(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGroupError {}
 /// Errors returned by DeleteMailboxPermissions
 #[derive(Debug, PartialEq)]
 pub enum DeleteMailboxPermissionsError {
@@ -1650,20 +1632,18 @@ impl DeleteMailboxPermissionsError {
 }
 impl fmt::Display for DeleteMailboxPermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteMailboxPermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteMailboxPermissionsError::EntityNotFound(ref cause) => cause,
-            DeleteMailboxPermissionsError::EntityState(ref cause) => cause,
-            DeleteMailboxPermissionsError::InvalidParameter(ref cause) => cause,
-            DeleteMailboxPermissionsError::OrganizationNotFound(ref cause) => cause,
-            DeleteMailboxPermissionsError::OrganizationState(ref cause) => cause,
+            DeleteMailboxPermissionsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteMailboxPermissionsError::EntityState(ref cause) => write!(f, "{}", cause),
+            DeleteMailboxPermissionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteMailboxPermissionsError::OrganizationNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteMailboxPermissionsError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteMailboxPermissionsError {}
 /// Errors returned by DeleteResource
 #[derive(Debug, PartialEq)]
 pub enum DeleteResourceError {
@@ -1702,19 +1682,15 @@ impl DeleteResourceError {
 }
 impl fmt::Display for DeleteResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteResourceError::EntityState(ref cause) => cause,
-            DeleteResourceError::InvalidParameter(ref cause) => cause,
-            DeleteResourceError::OrganizationNotFound(ref cause) => cause,
-            DeleteResourceError::OrganizationState(ref cause) => cause,
+            DeleteResourceError::EntityState(ref cause) => write!(f, "{}", cause),
+            DeleteResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteResourceError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteResourceError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteResourceError {}
 /// Errors returned by DeleteUser
 #[derive(Debug, PartialEq)]
 pub enum DeleteUserError {
@@ -1770,22 +1746,20 @@ impl DeleteUserError {
 }
 impl fmt::Display for DeleteUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteUserError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteUserError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            DeleteUserError::DirectoryUnavailable(ref cause) => cause,
-            DeleteUserError::EntityState(ref cause) => cause,
-            DeleteUserError::InvalidParameter(ref cause) => cause,
-            DeleteUserError::OrganizationNotFound(ref cause) => cause,
-            DeleteUserError::OrganizationState(ref cause) => cause,
-            DeleteUserError::UnsupportedOperation(ref cause) => cause,
+            DeleteUserError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeleteUserError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::EntityState(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            DeleteUserError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteUserError {}
 /// Errors returned by DeregisterFromWorkMail
 #[derive(Debug, PartialEq)]
 pub enum DeregisterFromWorkMailError {
@@ -1837,20 +1811,16 @@ impl DeregisterFromWorkMailError {
 }
 impl fmt::Display for DeregisterFromWorkMailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterFromWorkMailError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterFromWorkMailError::EntityNotFound(ref cause) => cause,
-            DeregisterFromWorkMailError::EntityState(ref cause) => cause,
-            DeregisterFromWorkMailError::InvalidParameter(ref cause) => cause,
-            DeregisterFromWorkMailError::OrganizationNotFound(ref cause) => cause,
-            DeregisterFromWorkMailError::OrganizationState(ref cause) => cause,
+            DeregisterFromWorkMailError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DeregisterFromWorkMailError::EntityState(ref cause) => write!(f, "{}", cause),
+            DeregisterFromWorkMailError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DeregisterFromWorkMailError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DeregisterFromWorkMailError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeregisterFromWorkMailError {}
 /// Errors returned by DescribeGroup
 #[derive(Debug, PartialEq)]
 pub enum DescribeGroupError {
@@ -1889,19 +1859,15 @@ impl DescribeGroupError {
 }
 impl fmt::Display for DescribeGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeGroupError::EntityNotFound(ref cause) => cause,
-            DescribeGroupError::InvalidParameter(ref cause) => cause,
-            DescribeGroupError::OrganizationNotFound(ref cause) => cause,
-            DescribeGroupError::OrganizationState(ref cause) => cause,
+            DescribeGroupError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeGroupError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeGroupError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeGroupError {}
 /// Errors returned by DescribeOrganization
 #[derive(Debug, PartialEq)]
 pub enum DescribeOrganizationError {
@@ -1934,17 +1900,13 @@ impl DescribeOrganizationError {
 }
 impl fmt::Display for DescribeOrganizationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeOrganizationError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeOrganizationError::InvalidParameter(ref cause) => cause,
-            DescribeOrganizationError::OrganizationNotFound(ref cause) => cause,
+            DescribeOrganizationError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeOrganizationError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeOrganizationError {}
 /// Errors returned by DescribeResource
 #[derive(Debug, PartialEq)]
 pub enum DescribeResourceError {
@@ -1985,19 +1947,15 @@ impl DescribeResourceError {
 }
 impl fmt::Display for DescribeResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeResourceError::EntityNotFound(ref cause) => cause,
-            DescribeResourceError::InvalidParameter(ref cause) => cause,
-            DescribeResourceError::OrganizationNotFound(ref cause) => cause,
-            DescribeResourceError::OrganizationState(ref cause) => cause,
+            DescribeResourceError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeResourceError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeResourceError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeResourceError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeResourceError {}
 /// Errors returned by DescribeUser
 #[derive(Debug, PartialEq)]
 pub enum DescribeUserError {
@@ -2036,19 +1994,15 @@ impl DescribeUserError {
 }
 impl fmt::Display for DescribeUserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeUserError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeUserError::EntityNotFound(ref cause) => cause,
-            DescribeUserError::InvalidParameter(ref cause) => cause,
-            DescribeUserError::OrganizationNotFound(ref cause) => cause,
-            DescribeUserError::OrganizationState(ref cause) => cause,
+            DescribeUserError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            DescribeUserError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeUserError {}
 /// Errors returned by DisassociateDelegateFromResource
 #[derive(Debug, PartialEq)]
 pub enum DisassociateDelegateFromResourceError {
@@ -2104,20 +2058,24 @@ impl DisassociateDelegateFromResourceError {
 }
 impl fmt::Display for DisassociateDelegateFromResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateDelegateFromResourceError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateDelegateFromResourceError::EntityNotFound(ref cause) => cause,
-            DisassociateDelegateFromResourceError::EntityState(ref cause) => cause,
-            DisassociateDelegateFromResourceError::InvalidParameter(ref cause) => cause,
-            DisassociateDelegateFromResourceError::OrganizationNotFound(ref cause) => cause,
-            DisassociateDelegateFromResourceError::OrganizationState(ref cause) => cause,
+            DisassociateDelegateFromResourceError::EntityNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDelegateFromResourceError::EntityState(ref cause) => write!(f, "{}", cause),
+            DisassociateDelegateFromResourceError::InvalidParameter(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDelegateFromResourceError::OrganizationNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateDelegateFromResourceError::OrganizationState(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateDelegateFromResourceError {}
 /// Errors returned by DisassociateMemberFromGroup
 #[derive(Debug, PartialEq)]
 pub enum DisassociateMemberFromGroupError {
@@ -2196,25 +2154,29 @@ impl DisassociateMemberFromGroupError {
 }
 impl fmt::Display for DisassociateMemberFromGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateMemberFromGroupError {
-    fn description(&self) -> &str {
         match *self {
             DisassociateMemberFromGroupError::DirectoryServiceAuthenticationFailed(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            DisassociateMemberFromGroupError::DirectoryUnavailable(ref cause) => cause,
-            DisassociateMemberFromGroupError::EntityNotFound(ref cause) => cause,
-            DisassociateMemberFromGroupError::EntityState(ref cause) => cause,
-            DisassociateMemberFromGroupError::InvalidParameter(ref cause) => cause,
-            DisassociateMemberFromGroupError::OrganizationNotFound(ref cause) => cause,
-            DisassociateMemberFromGroupError::OrganizationState(ref cause) => cause,
-            DisassociateMemberFromGroupError::UnsupportedOperation(ref cause) => cause,
+            DisassociateMemberFromGroupError::DirectoryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateMemberFromGroupError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            DisassociateMemberFromGroupError::EntityState(ref cause) => write!(f, "{}", cause),
+            DisassociateMemberFromGroupError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            DisassociateMemberFromGroupError::OrganizationNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateMemberFromGroupError::OrganizationState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DisassociateMemberFromGroupError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DisassociateMemberFromGroupError {}
 /// Errors returned by GetMailboxDetails
 #[derive(Debug, PartialEq)]
 pub enum GetMailboxDetailsError {
@@ -2250,18 +2212,14 @@ impl GetMailboxDetailsError {
 }
 impl fmt::Display for GetMailboxDetailsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetMailboxDetailsError {
-    fn description(&self) -> &str {
         match *self {
-            GetMailboxDetailsError::EntityNotFound(ref cause) => cause,
-            GetMailboxDetailsError::OrganizationNotFound(ref cause) => cause,
-            GetMailboxDetailsError::OrganizationState(ref cause) => cause,
+            GetMailboxDetailsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            GetMailboxDetailsError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            GetMailboxDetailsError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetMailboxDetailsError {}
 /// Errors returned by ListAliases
 #[derive(Debug, PartialEq)]
 pub enum ListAliasesError {
@@ -2305,20 +2263,16 @@ impl ListAliasesError {
 }
 impl fmt::Display for ListAliasesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAliasesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAliasesError::EntityNotFound(ref cause) => cause,
-            ListAliasesError::EntityState(ref cause) => cause,
-            ListAliasesError::InvalidParameter(ref cause) => cause,
-            ListAliasesError::OrganizationNotFound(ref cause) => cause,
-            ListAliasesError::OrganizationState(ref cause) => cause,
+            ListAliasesError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::EntityState(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ListAliasesError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListAliasesError {}
 /// Errors returned by ListGroupMembers
 #[derive(Debug, PartialEq)]
 pub enum ListGroupMembersError {
@@ -2364,20 +2318,16 @@ impl ListGroupMembersError {
 }
 impl fmt::Display for ListGroupMembersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupMembersError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupMembersError::EntityNotFound(ref cause) => cause,
-            ListGroupMembersError::EntityState(ref cause) => cause,
-            ListGroupMembersError::InvalidParameter(ref cause) => cause,
-            ListGroupMembersError::OrganizationNotFound(ref cause) => cause,
-            ListGroupMembersError::OrganizationState(ref cause) => cause,
+            ListGroupMembersError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListGroupMembersError::EntityState(ref cause) => write!(f, "{}", cause),
+            ListGroupMembersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListGroupMembersError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ListGroupMembersError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupMembersError {}
 /// Errors returned by ListGroups
 #[derive(Debug, PartialEq)]
 pub enum ListGroupsError {
@@ -2416,19 +2366,15 @@ impl ListGroupsError {
 }
 impl fmt::Display for ListGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            ListGroupsError::EntityNotFound(ref cause) => cause,
-            ListGroupsError::InvalidParameter(ref cause) => cause,
-            ListGroupsError::OrganizationNotFound(ref cause) => cause,
-            ListGroupsError::OrganizationState(ref cause) => cause,
+            ListGroupsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ListGroupsError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListGroupsError {}
 /// Errors returned by ListMailboxPermissions
 #[derive(Debug, PartialEq)]
 pub enum ListMailboxPermissionsError {
@@ -2475,19 +2421,15 @@ impl ListMailboxPermissionsError {
 }
 impl fmt::Display for ListMailboxPermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListMailboxPermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            ListMailboxPermissionsError::EntityNotFound(ref cause) => cause,
-            ListMailboxPermissionsError::InvalidParameter(ref cause) => cause,
-            ListMailboxPermissionsError::OrganizationNotFound(ref cause) => cause,
-            ListMailboxPermissionsError::OrganizationState(ref cause) => cause,
+            ListMailboxPermissionsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListMailboxPermissionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListMailboxPermissionsError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ListMailboxPermissionsError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListMailboxPermissionsError {}
 /// Errors returned by ListOrganizations
 #[derive(Debug, PartialEq)]
 pub enum ListOrganizationsError {
@@ -2511,16 +2453,12 @@ impl ListOrganizationsError {
 }
 impl fmt::Display for ListOrganizationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListOrganizationsError {
-    fn description(&self) -> &str {
         match *self {
-            ListOrganizationsError::InvalidParameter(ref cause) => cause,
+            ListOrganizationsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListOrganizationsError {}
 /// Errors returned by ListResourceDelegates
 #[derive(Debug, PartialEq)]
 pub enum ListResourceDelegatesError {
@@ -2572,20 +2510,16 @@ impl ListResourceDelegatesError {
 }
 impl fmt::Display for ListResourceDelegatesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourceDelegatesError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourceDelegatesError::EntityNotFound(ref cause) => cause,
-            ListResourceDelegatesError::EntityState(ref cause) => cause,
-            ListResourceDelegatesError::InvalidParameter(ref cause) => cause,
-            ListResourceDelegatesError::OrganizationNotFound(ref cause) => cause,
-            ListResourceDelegatesError::OrganizationState(ref cause) => cause,
+            ListResourceDelegatesError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ListResourceDelegatesError::EntityState(ref cause) => write!(f, "{}", cause),
+            ListResourceDelegatesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListResourceDelegatesError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ListResourceDelegatesError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourceDelegatesError {}
 /// Errors returned by ListResources
 #[derive(Debug, PartialEq)]
 pub enum ListResourcesError {
@@ -2619,18 +2553,14 @@ impl ListResourcesError {
 }
 impl fmt::Display for ListResourcesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListResourcesError {
-    fn description(&self) -> &str {
         match *self {
-            ListResourcesError::InvalidParameter(ref cause) => cause,
-            ListResourcesError::OrganizationNotFound(ref cause) => cause,
-            ListResourcesError::OrganizationState(ref cause) => cause,
+            ListResourcesError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ListResourcesError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListResourcesError {}
 /// Errors returned by ListUsers
 #[derive(Debug, PartialEq)]
 pub enum ListUsersError {
@@ -2664,18 +2594,14 @@ impl ListUsersError {
 }
 impl fmt::Display for ListUsersError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListUsersError {
-    fn description(&self) -> &str {
         match *self {
-            ListUsersError::InvalidParameter(ref cause) => cause,
-            ListUsersError::OrganizationNotFound(ref cause) => cause,
-            ListUsersError::OrganizationState(ref cause) => cause,
+            ListUsersError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ListUsersError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ListUsersError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ListUsersError {}
 /// Errors returned by PutMailboxPermissions
 #[derive(Debug, PartialEq)]
 pub enum PutMailboxPermissionsError {
@@ -2727,20 +2653,16 @@ impl PutMailboxPermissionsError {
 }
 impl fmt::Display for PutMailboxPermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutMailboxPermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            PutMailboxPermissionsError::EntityNotFound(ref cause) => cause,
-            PutMailboxPermissionsError::EntityState(ref cause) => cause,
-            PutMailboxPermissionsError::InvalidParameter(ref cause) => cause,
-            PutMailboxPermissionsError::OrganizationNotFound(ref cause) => cause,
-            PutMailboxPermissionsError::OrganizationState(ref cause) => cause,
+            PutMailboxPermissionsError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            PutMailboxPermissionsError::EntityState(ref cause) => write!(f, "{}", cause),
+            PutMailboxPermissionsError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            PutMailboxPermissionsError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            PutMailboxPermissionsError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutMailboxPermissionsError {}
 /// Errors returned by RegisterToWorkMail
 #[derive(Debug, PartialEq)]
 pub enum RegisterToWorkMailError {
@@ -2828,26 +2750,24 @@ impl RegisterToWorkMailError {
 }
 impl fmt::Display for RegisterToWorkMailError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterToWorkMailError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterToWorkMailError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            RegisterToWorkMailError::DirectoryUnavailable(ref cause) => cause,
-            RegisterToWorkMailError::EmailAddressInUse(ref cause) => cause,
-            RegisterToWorkMailError::EntityAlreadyRegistered(ref cause) => cause,
-            RegisterToWorkMailError::EntityNotFound(ref cause) => cause,
-            RegisterToWorkMailError::EntityState(ref cause) => cause,
-            RegisterToWorkMailError::InvalidParameter(ref cause) => cause,
-            RegisterToWorkMailError::MailDomainNotFound(ref cause) => cause,
-            RegisterToWorkMailError::MailDomainState(ref cause) => cause,
-            RegisterToWorkMailError::OrganizationNotFound(ref cause) => cause,
-            RegisterToWorkMailError::OrganizationState(ref cause) => cause,
+            RegisterToWorkMailError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterToWorkMailError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::EmailAddressInUse(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::EntityAlreadyRegistered(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::EntityState(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::MailDomainNotFound(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::MailDomainState(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            RegisterToWorkMailError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RegisterToWorkMailError {}
 /// Errors returned by ResetPassword
 #[derive(Debug, PartialEq)]
 pub enum ResetPasswordError {
@@ -2913,24 +2833,22 @@ impl ResetPasswordError {
 }
 impl fmt::Display for ResetPasswordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ResetPasswordError {
-    fn description(&self) -> &str {
         match *self {
-            ResetPasswordError::DirectoryServiceAuthenticationFailed(ref cause) => cause,
-            ResetPasswordError::DirectoryUnavailable(ref cause) => cause,
-            ResetPasswordError::EntityNotFound(ref cause) => cause,
-            ResetPasswordError::EntityState(ref cause) => cause,
-            ResetPasswordError::InvalidParameter(ref cause) => cause,
-            ResetPasswordError::InvalidPassword(ref cause) => cause,
-            ResetPasswordError::OrganizationNotFound(ref cause) => cause,
-            ResetPasswordError::OrganizationState(ref cause) => cause,
-            ResetPasswordError::UnsupportedOperation(ref cause) => cause,
+            ResetPasswordError::DirectoryServiceAuthenticationFailed(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ResetPasswordError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            ResetPasswordError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            ResetPasswordError::EntityState(ref cause) => write!(f, "{}", cause),
+            ResetPasswordError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            ResetPasswordError::InvalidPassword(ref cause) => write!(f, "{}", cause),
+            ResetPasswordError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            ResetPasswordError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            ResetPasswordError::UnsupportedOperation(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ResetPasswordError {}
 /// Errors returned by UpdateMailboxQuota
 #[derive(Debug, PartialEq)]
 pub enum UpdateMailboxQuotaError {
@@ -2978,20 +2896,16 @@ impl UpdateMailboxQuotaError {
 }
 impl fmt::Display for UpdateMailboxQuotaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateMailboxQuotaError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateMailboxQuotaError::EntityNotFound(ref cause) => cause,
-            UpdateMailboxQuotaError::EntityState(ref cause) => cause,
-            UpdateMailboxQuotaError::InvalidParameter(ref cause) => cause,
-            UpdateMailboxQuotaError::OrganizationNotFound(ref cause) => cause,
-            UpdateMailboxQuotaError::OrganizationState(ref cause) => cause,
+            UpdateMailboxQuotaError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMailboxQuotaError::EntityState(ref cause) => write!(f, "{}", cause),
+            UpdateMailboxQuotaError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdateMailboxQuotaError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateMailboxQuotaError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateMailboxQuotaError {}
 /// Errors returned by UpdatePrimaryEmailAddress
 #[derive(Debug, PartialEq)]
 pub enum UpdatePrimaryEmailAddressError {
@@ -3089,28 +3003,30 @@ impl UpdatePrimaryEmailAddressError {
 }
 impl fmt::Display for UpdatePrimaryEmailAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdatePrimaryEmailAddressError {
-    fn description(&self) -> &str {
         match *self {
             UpdatePrimaryEmailAddressError::DirectoryServiceAuthenticationFailed(ref cause) => {
-                cause
+                write!(f, "{}", cause)
             }
-            UpdatePrimaryEmailAddressError::DirectoryUnavailable(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::EmailAddressInUse(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::EntityNotFound(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::EntityState(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::InvalidParameter(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::MailDomainNotFound(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::MailDomainState(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::OrganizationNotFound(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::OrganizationState(ref cause) => cause,
-            UpdatePrimaryEmailAddressError::UnsupportedOperation(ref cause) => cause,
+            UpdatePrimaryEmailAddressError::DirectoryUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePrimaryEmailAddressError::EmailAddressInUse(ref cause) => write!(f, "{}", cause),
+            UpdatePrimaryEmailAddressError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePrimaryEmailAddressError::EntityState(ref cause) => write!(f, "{}", cause),
+            UpdatePrimaryEmailAddressError::InvalidParameter(ref cause) => write!(f, "{}", cause),
+            UpdatePrimaryEmailAddressError::MailDomainNotFound(ref cause) => write!(f, "{}", cause),
+            UpdatePrimaryEmailAddressError::MailDomainState(ref cause) => write!(f, "{}", cause),
+            UpdatePrimaryEmailAddressError::OrganizationNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            UpdatePrimaryEmailAddressError::OrganizationState(ref cause) => write!(f, "{}", cause),
+            UpdatePrimaryEmailAddressError::UnsupportedOperation(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for UpdatePrimaryEmailAddressError {}
 /// Errors returned by UpdateResource
 #[derive(Debug, PartialEq)]
 pub enum UpdateResourceError {
@@ -3179,25 +3095,21 @@ impl UpdateResourceError {
 }
 impl fmt::Display for UpdateResourceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateResourceError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateResourceError::DirectoryUnavailable(ref cause) => cause,
-            UpdateResourceError::EmailAddressInUse(ref cause) => cause,
-            UpdateResourceError::EntityNotFound(ref cause) => cause,
-            UpdateResourceError::EntityState(ref cause) => cause,
-            UpdateResourceError::InvalidConfiguration(ref cause) => cause,
-            UpdateResourceError::MailDomainNotFound(ref cause) => cause,
-            UpdateResourceError::MailDomainState(ref cause) => cause,
-            UpdateResourceError::NameAvailability(ref cause) => cause,
-            UpdateResourceError::OrganizationNotFound(ref cause) => cause,
-            UpdateResourceError::OrganizationState(ref cause) => cause,
+            UpdateResourceError::DirectoryUnavailable(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::EmailAddressInUse(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::EntityNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::EntityState(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::InvalidConfiguration(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::MailDomainNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::MailDomainState(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::NameAvailability(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::OrganizationNotFound(ref cause) => write!(f, "{}", cause),
+            UpdateResourceError::OrganizationState(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateResourceError {}
 /// Trait representing the capabilities of the Amazon WorkMail API. Amazon WorkMail clients implement this trait.
 pub trait Workmail {
     /// <p>Adds a member (user or group) to the resource's set of delegates.</p>

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -1489,21 +1489,17 @@ impl AssociateIpGroupsError {
 }
 impl fmt::Display for AssociateIpGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AssociateIpGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            AssociateIpGroupsError::AccessDenied(ref cause) => cause,
-            AssociateIpGroupsError::InvalidParameterValues(ref cause) => cause,
-            AssociateIpGroupsError::InvalidResourceState(ref cause) => cause,
-            AssociateIpGroupsError::OperationNotSupported(ref cause) => cause,
-            AssociateIpGroupsError::ResourceLimitExceeded(ref cause) => cause,
-            AssociateIpGroupsError::ResourceNotFound(ref cause) => cause,
+            AssociateIpGroupsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AssociateIpGroupsError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            AssociateIpGroupsError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            AssociateIpGroupsError::OperationNotSupported(ref cause) => write!(f, "{}", cause),
+            AssociateIpGroupsError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            AssociateIpGroupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AssociateIpGroupsError {}
 /// Errors returned by AuthorizeIpRules
 #[derive(Debug, PartialEq)]
 pub enum AuthorizeIpRulesError {
@@ -1553,20 +1549,16 @@ impl AuthorizeIpRulesError {
 }
 impl fmt::Display for AuthorizeIpRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for AuthorizeIpRulesError {
-    fn description(&self) -> &str {
         match *self {
-            AuthorizeIpRulesError::AccessDenied(ref cause) => cause,
-            AuthorizeIpRulesError::InvalidParameterValues(ref cause) => cause,
-            AuthorizeIpRulesError::InvalidResourceState(ref cause) => cause,
-            AuthorizeIpRulesError::ResourceLimitExceeded(ref cause) => cause,
-            AuthorizeIpRulesError::ResourceNotFound(ref cause) => cause,
+            AuthorizeIpRulesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            AuthorizeIpRulesError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            AuthorizeIpRulesError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            AuthorizeIpRulesError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            AuthorizeIpRulesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for AuthorizeIpRulesError {}
 /// Errors returned by CopyWorkspaceImage
 #[derive(Debug, PartialEq)]
 pub enum CopyWorkspaceImageError {
@@ -1630,22 +1622,18 @@ impl CopyWorkspaceImageError {
 }
 impl fmt::Display for CopyWorkspaceImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CopyWorkspaceImageError {
-    fn description(&self) -> &str {
         match *self {
-            CopyWorkspaceImageError::AccessDenied(ref cause) => cause,
-            CopyWorkspaceImageError::InvalidParameterValues(ref cause) => cause,
-            CopyWorkspaceImageError::OperationNotSupported(ref cause) => cause,
-            CopyWorkspaceImageError::ResourceAlreadyExists(ref cause) => cause,
-            CopyWorkspaceImageError::ResourceLimitExceeded(ref cause) => cause,
-            CopyWorkspaceImageError::ResourceNotFound(ref cause) => cause,
-            CopyWorkspaceImageError::ResourceUnavailable(ref cause) => cause,
+            CopyWorkspaceImageError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CopyWorkspaceImageError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            CopyWorkspaceImageError::OperationNotSupported(ref cause) => write!(f, "{}", cause),
+            CopyWorkspaceImageError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CopyWorkspaceImageError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CopyWorkspaceImageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            CopyWorkspaceImageError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CopyWorkspaceImageError {}
 /// Errors returned by CreateIpGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateIpGroupError {
@@ -1693,20 +1681,16 @@ impl CreateIpGroupError {
 }
 impl fmt::Display for CreateIpGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateIpGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateIpGroupError::AccessDenied(ref cause) => cause,
-            CreateIpGroupError::InvalidParameterValues(ref cause) => cause,
-            CreateIpGroupError::ResourceAlreadyExists(ref cause) => cause,
-            CreateIpGroupError::ResourceCreationFailed(ref cause) => cause,
-            CreateIpGroupError::ResourceLimitExceeded(ref cause) => cause,
+            CreateIpGroupError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CreateIpGroupError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            CreateIpGroupError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            CreateIpGroupError::ResourceCreationFailed(ref cause) => write!(f, "{}", cause),
+            CreateIpGroupError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateIpGroupError {}
 /// Errors returned by CreateTags
 #[derive(Debug, PartialEq)]
 pub enum CreateTagsError {
@@ -1740,18 +1724,14 @@ impl CreateTagsError {
 }
 impl fmt::Display for CreateTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateTagsError {
-    fn description(&self) -> &str {
         match *self {
-            CreateTagsError::InvalidParameterValues(ref cause) => cause,
-            CreateTagsError::ResourceLimitExceeded(ref cause) => cause,
-            CreateTagsError::ResourceNotFound(ref cause) => cause,
+            CreateTagsError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateTagsError {}
 /// Errors returned by CreateWorkspaces
 #[derive(Debug, PartialEq)]
 pub enum CreateWorkspacesError {
@@ -1784,17 +1764,13 @@ impl CreateWorkspacesError {
 }
 impl fmt::Display for CreateWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateWorkspacesError {
-    fn description(&self) -> &str {
         match *self {
-            CreateWorkspacesError::InvalidParameterValues(ref cause) => cause,
-            CreateWorkspacesError::ResourceLimitExceeded(ref cause) => cause,
+            CreateWorkspacesError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            CreateWorkspacesError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateWorkspacesError {}
 /// Errors returned by DeleteIpGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteIpGroupError {
@@ -1835,19 +1811,15 @@ impl DeleteIpGroupError {
 }
 impl fmt::Display for DeleteIpGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteIpGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteIpGroupError::AccessDenied(ref cause) => cause,
-            DeleteIpGroupError::InvalidParameterValues(ref cause) => cause,
-            DeleteIpGroupError::ResourceAssociated(ref cause) => cause,
-            DeleteIpGroupError::ResourceNotFound(ref cause) => cause,
+            DeleteIpGroupError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteIpGroupError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            DeleteIpGroupError::ResourceAssociated(ref cause) => write!(f, "{}", cause),
+            DeleteIpGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteIpGroupError {}
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
@@ -1876,17 +1848,13 @@ impl DeleteTagsError {
 }
 impl fmt::Display for DeleteTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteTagsError::InvalidParameterValues(ref cause) => cause,
-            DeleteTagsError::ResourceNotFound(ref cause) => cause,
+            DeleteTagsError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            DeleteTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteTagsError {}
 /// Errors returned by DeleteWorkspaceImage
 #[derive(Debug, PartialEq)]
 pub enum DeleteWorkspaceImageError {
@@ -1924,18 +1892,14 @@ impl DeleteWorkspaceImageError {
 }
 impl fmt::Display for DeleteWorkspaceImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteWorkspaceImageError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteWorkspaceImageError::AccessDenied(ref cause) => cause,
-            DeleteWorkspaceImageError::InvalidResourceState(ref cause) => cause,
-            DeleteWorkspaceImageError::ResourceAssociated(ref cause) => cause,
+            DeleteWorkspaceImageError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeleteWorkspaceImageError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            DeleteWorkspaceImageError::ResourceAssociated(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteWorkspaceImageError {}
 /// Errors returned by DeregisterWorkspaceDirectory
 #[derive(Debug, PartialEq)]
 pub enum DeregisterWorkspaceDirectoryError {
@@ -1991,20 +1955,24 @@ impl DeregisterWorkspaceDirectoryError {
 }
 impl fmt::Display for DeregisterWorkspaceDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeregisterWorkspaceDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            DeregisterWorkspaceDirectoryError::AccessDenied(ref cause) => cause,
-            DeregisterWorkspaceDirectoryError::InvalidParameterValues(ref cause) => cause,
-            DeregisterWorkspaceDirectoryError::InvalidResourceState(ref cause) => cause,
-            DeregisterWorkspaceDirectoryError::OperationNotSupported(ref cause) => cause,
-            DeregisterWorkspaceDirectoryError::ResourceNotFound(ref cause) => cause,
+            DeregisterWorkspaceDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DeregisterWorkspaceDirectoryError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterWorkspaceDirectoryError::InvalidResourceState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterWorkspaceDirectoryError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DeregisterWorkspaceDirectoryError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DeregisterWorkspaceDirectoryError {}
 /// Errors returned by DescribeAccount
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountError {
@@ -2028,16 +1996,12 @@ impl DescribeAccountError {
 }
 impl fmt::Display for DescribeAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAccountError::AccessDenied(ref cause) => cause,
+            DescribeAccountError::AccessDenied(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAccountError {}
 /// Errors returned by DescribeAccountModifications
 #[derive(Debug, PartialEq)]
 pub enum DescribeAccountModificationsError {
@@ -2065,16 +2029,12 @@ impl DescribeAccountModificationsError {
 }
 impl fmt::Display for DescribeAccountModificationsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeAccountModificationsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeAccountModificationsError::AccessDenied(ref cause) => cause,
+            DescribeAccountModificationsError::AccessDenied(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeAccountModificationsError {}
 /// Errors returned by DescribeClientProperties
 #[derive(Debug, PartialEq)]
 pub enum DescribeClientPropertiesError {
@@ -2114,18 +2074,16 @@ impl DescribeClientPropertiesError {
 }
 impl fmt::Display for DescribeClientPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeClientPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeClientPropertiesError::AccessDenied(ref cause) => cause,
-            DescribeClientPropertiesError::InvalidParameterValues(ref cause) => cause,
-            DescribeClientPropertiesError::ResourceNotFound(ref cause) => cause,
+            DescribeClientPropertiesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeClientPropertiesError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeClientPropertiesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeClientPropertiesError {}
 /// Errors returned by DescribeIpGroups
 #[derive(Debug, PartialEq)]
 pub enum DescribeIpGroupsError {
@@ -2156,17 +2114,13 @@ impl DescribeIpGroupsError {
 }
 impl fmt::Display for DescribeIpGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeIpGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeIpGroupsError::AccessDenied(ref cause) => cause,
-            DescribeIpGroupsError::InvalidParameterValues(ref cause) => cause,
+            DescribeIpGroupsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeIpGroupsError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeIpGroupsError {}
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
@@ -2190,16 +2144,12 @@ impl DescribeTagsError {
 }
 impl fmt::Display for DescribeTagsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeTagsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::ResourceNotFound(ref cause) => cause,
+            DescribeTagsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeTagsError {}
 /// Errors returned by DescribeWorkspaceBundles
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkspaceBundlesError {
@@ -2225,16 +2175,14 @@ impl DescribeWorkspaceBundlesError {
 }
 impl fmt::Display for DescribeWorkspaceBundlesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkspaceBundlesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkspaceBundlesError::InvalidParameterValues(ref cause) => cause,
+            DescribeWorkspaceBundlesError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeWorkspaceBundlesError {}
 /// Errors returned by DescribeWorkspaceDirectories
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkspaceDirectoriesError {
@@ -2262,16 +2210,14 @@ impl DescribeWorkspaceDirectoriesError {
 }
 impl fmt::Display for DescribeWorkspaceDirectoriesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkspaceDirectoriesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkspaceDirectoriesError::InvalidParameterValues(ref cause) => cause,
+            DescribeWorkspaceDirectoriesError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeWorkspaceDirectoriesError {}
 /// Errors returned by DescribeWorkspaceImages
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkspaceImagesError {
@@ -2297,16 +2243,12 @@ impl DescribeWorkspaceImagesError {
 }
 impl fmt::Display for DescribeWorkspaceImagesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkspaceImagesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkspaceImagesError::AccessDenied(ref cause) => cause,
+            DescribeWorkspaceImagesError::AccessDenied(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeWorkspaceImagesError {}
 /// Errors returned by DescribeWorkspaceSnapshots
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkspaceSnapshotsError {
@@ -2348,18 +2290,16 @@ impl DescribeWorkspaceSnapshotsError {
 }
 impl fmt::Display for DescribeWorkspaceSnapshotsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkspaceSnapshotsError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkspaceSnapshotsError::AccessDenied(ref cause) => cause,
-            DescribeWorkspaceSnapshotsError::InvalidParameterValues(ref cause) => cause,
-            DescribeWorkspaceSnapshotsError::ResourceNotFound(ref cause) => cause,
+            DescribeWorkspaceSnapshotsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DescribeWorkspaceSnapshotsError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            DescribeWorkspaceSnapshotsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeWorkspaceSnapshotsError {}
 /// Errors returned by DescribeWorkspaces
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkspacesError {
@@ -2392,17 +2332,13 @@ impl DescribeWorkspacesError {
 }
 impl fmt::Display for DescribeWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkspacesError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkspacesError::InvalidParameterValues(ref cause) => cause,
-            DescribeWorkspacesError::ResourceUnavailable(ref cause) => cause,
+            DescribeWorkspacesError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            DescribeWorkspacesError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DescribeWorkspacesError {}
 /// Errors returned by DescribeWorkspacesConnectionStatus
 #[derive(Debug, PartialEq)]
 pub enum DescribeWorkspacesConnectionStatusError {
@@ -2430,16 +2366,14 @@ impl DescribeWorkspacesConnectionStatusError {
 }
 impl fmt::Display for DescribeWorkspacesConnectionStatusError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DescribeWorkspacesConnectionStatusError {
-    fn description(&self) -> &str {
         match *self {
-            DescribeWorkspacesConnectionStatusError::InvalidParameterValues(ref cause) => cause,
+            DescribeWorkspacesConnectionStatusError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for DescribeWorkspacesConnectionStatusError {}
 /// Errors returned by DisassociateIpGroups
 #[derive(Debug, PartialEq)]
 pub enum DisassociateIpGroupsError {
@@ -2484,19 +2418,15 @@ impl DisassociateIpGroupsError {
 }
 impl fmt::Display for DisassociateIpGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DisassociateIpGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            DisassociateIpGroupsError::AccessDenied(ref cause) => cause,
-            DisassociateIpGroupsError::InvalidParameterValues(ref cause) => cause,
-            DisassociateIpGroupsError::InvalidResourceState(ref cause) => cause,
-            DisassociateIpGroupsError::ResourceNotFound(ref cause) => cause,
+            DisassociateIpGroupsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            DisassociateIpGroupsError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            DisassociateIpGroupsError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            DisassociateIpGroupsError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DisassociateIpGroupsError {}
 /// Errors returned by ImportWorkspaceImage
 #[derive(Debug, PartialEq)]
 pub enum ImportWorkspaceImageError {
@@ -2555,21 +2485,17 @@ impl ImportWorkspaceImageError {
 }
 impl fmt::Display for ImportWorkspaceImageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ImportWorkspaceImageError {
-    fn description(&self) -> &str {
         match *self {
-            ImportWorkspaceImageError::AccessDenied(ref cause) => cause,
-            ImportWorkspaceImageError::InvalidParameterValues(ref cause) => cause,
-            ImportWorkspaceImageError::OperationNotSupported(ref cause) => cause,
-            ImportWorkspaceImageError::ResourceAlreadyExists(ref cause) => cause,
-            ImportWorkspaceImageError::ResourceLimitExceeded(ref cause) => cause,
-            ImportWorkspaceImageError::ResourceNotFound(ref cause) => cause,
+            ImportWorkspaceImageError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ImportWorkspaceImageError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            ImportWorkspaceImageError::OperationNotSupported(ref cause) => write!(f, "{}", cause),
+            ImportWorkspaceImageError::ResourceAlreadyExists(ref cause) => write!(f, "{}", cause),
+            ImportWorkspaceImageError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            ImportWorkspaceImageError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ImportWorkspaceImageError {}
 /// Errors returned by ListAvailableManagementCidrRanges
 #[derive(Debug, PartialEq)]
 pub enum ListAvailableManagementCidrRangesError {
@@ -2604,17 +2530,17 @@ impl ListAvailableManagementCidrRangesError {
 }
 impl fmt::Display for ListAvailableManagementCidrRangesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ListAvailableManagementCidrRangesError {
-    fn description(&self) -> &str {
         match *self {
-            ListAvailableManagementCidrRangesError::AccessDenied(ref cause) => cause,
-            ListAvailableManagementCidrRangesError::InvalidParameterValues(ref cause) => cause,
+            ListAvailableManagementCidrRangesError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ListAvailableManagementCidrRangesError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ListAvailableManagementCidrRangesError {}
 /// Errors returned by ModifyAccount
 #[derive(Debug, PartialEq)]
 pub enum ModifyAccountError {
@@ -2660,20 +2586,16 @@ impl ModifyAccountError {
 }
 impl fmt::Display for ModifyAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyAccountError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyAccountError::AccessDenied(ref cause) => cause,
-            ModifyAccountError::InvalidParameterValues(ref cause) => cause,
-            ModifyAccountError::InvalidResourceState(ref cause) => cause,
-            ModifyAccountError::ResourceNotFound(ref cause) => cause,
-            ModifyAccountError::ResourceUnavailable(ref cause) => cause,
+            ModifyAccountError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ModifyAccountError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            ModifyAccountError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            ModifyAccountError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyAccountError::ResourceUnavailable(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyAccountError {}
 /// Errors returned by ModifyClientProperties
 #[derive(Debug, PartialEq)]
 pub enum ModifyClientPropertiesError {
@@ -2711,18 +2633,16 @@ impl ModifyClientPropertiesError {
 }
 impl fmt::Display for ModifyClientPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyClientPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyClientPropertiesError::AccessDenied(ref cause) => cause,
-            ModifyClientPropertiesError::InvalidParameterValues(ref cause) => cause,
-            ModifyClientPropertiesError::ResourceNotFound(ref cause) => cause,
+            ModifyClientPropertiesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ModifyClientPropertiesError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyClientPropertiesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyClientPropertiesError {}
 /// Errors returned by ModifySelfservicePermissions
 #[derive(Debug, PartialEq)]
 pub enum ModifySelfservicePermissionsError {
@@ -2764,18 +2684,18 @@ impl ModifySelfservicePermissionsError {
 }
 impl fmt::Display for ModifySelfservicePermissionsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifySelfservicePermissionsError {
-    fn description(&self) -> &str {
         match *self {
-            ModifySelfservicePermissionsError::AccessDenied(ref cause) => cause,
-            ModifySelfservicePermissionsError::InvalidParameterValues(ref cause) => cause,
-            ModifySelfservicePermissionsError::ResourceNotFound(ref cause) => cause,
+            ModifySelfservicePermissionsError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ModifySelfservicePermissionsError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifySelfservicePermissionsError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifySelfservicePermissionsError {}
 /// Errors returned by ModifyWorkspaceAccessProperties
 #[derive(Debug, PartialEq)]
 pub enum ModifyWorkspaceAccessPropertiesError {
@@ -2810,17 +2730,15 @@ impl ModifyWorkspaceAccessPropertiesError {
 }
 impl fmt::Display for ModifyWorkspaceAccessPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyWorkspaceAccessPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyWorkspaceAccessPropertiesError::AccessDenied(ref cause) => cause,
-            ModifyWorkspaceAccessPropertiesError::ResourceNotFound(ref cause) => cause,
+            ModifyWorkspaceAccessPropertiesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ModifyWorkspaceAccessPropertiesError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyWorkspaceAccessPropertiesError {}
 /// Errors returned by ModifyWorkspaceCreationProperties
 #[derive(Debug, PartialEq)]
 pub enum ModifyWorkspaceCreationPropertiesError {
@@ -2862,18 +2780,20 @@ impl ModifyWorkspaceCreationPropertiesError {
 }
 impl fmt::Display for ModifyWorkspaceCreationPropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyWorkspaceCreationPropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyWorkspaceCreationPropertiesError::AccessDenied(ref cause) => cause,
-            ModifyWorkspaceCreationPropertiesError::InvalidParameterValues(ref cause) => cause,
-            ModifyWorkspaceCreationPropertiesError::ResourceNotFound(ref cause) => cause,
+            ModifyWorkspaceCreationPropertiesError::AccessDenied(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyWorkspaceCreationPropertiesError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyWorkspaceCreationPropertiesError::ResourceNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyWorkspaceCreationPropertiesError {}
 /// Errors returned by ModifyWorkspaceProperties
 #[derive(Debug, PartialEq)]
 pub enum ModifyWorkspacePropertiesError {
@@ -2941,22 +2861,28 @@ impl ModifyWorkspacePropertiesError {
 }
 impl fmt::Display for ModifyWorkspacePropertiesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyWorkspacePropertiesError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyWorkspacePropertiesError::AccessDenied(ref cause) => cause,
-            ModifyWorkspacePropertiesError::InvalidParameterValues(ref cause) => cause,
-            ModifyWorkspacePropertiesError::InvalidResourceState(ref cause) => cause,
-            ModifyWorkspacePropertiesError::OperationInProgress(ref cause) => cause,
-            ModifyWorkspacePropertiesError::ResourceNotFound(ref cause) => cause,
-            ModifyWorkspacePropertiesError::ResourceUnavailable(ref cause) => cause,
-            ModifyWorkspacePropertiesError::UnsupportedWorkspaceConfiguration(ref cause) => cause,
+            ModifyWorkspacePropertiesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            ModifyWorkspacePropertiesError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyWorkspacePropertiesError::InvalidResourceState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyWorkspacePropertiesError::OperationInProgress(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyWorkspacePropertiesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            ModifyWorkspacePropertiesError::ResourceUnavailable(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            ModifyWorkspacePropertiesError::UnsupportedWorkspaceConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for ModifyWorkspacePropertiesError {}
 /// Errors returned by ModifyWorkspaceState
 #[derive(Debug, PartialEq)]
 pub enum ModifyWorkspaceStateError {
@@ -2996,18 +2922,14 @@ impl ModifyWorkspaceStateError {
 }
 impl fmt::Display for ModifyWorkspaceStateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for ModifyWorkspaceStateError {
-    fn description(&self) -> &str {
         match *self {
-            ModifyWorkspaceStateError::InvalidParameterValues(ref cause) => cause,
-            ModifyWorkspaceStateError::InvalidResourceState(ref cause) => cause,
-            ModifyWorkspaceStateError::ResourceNotFound(ref cause) => cause,
+            ModifyWorkspaceStateError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            ModifyWorkspaceStateError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            ModifyWorkspaceStateError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for ModifyWorkspaceStateError {}
 /// Errors returned by RebootWorkspaces
 #[derive(Debug, PartialEq)]
 pub enum RebootWorkspacesError {}
@@ -3025,14 +2947,10 @@ impl RebootWorkspacesError {
 }
 impl fmt::Display for RebootWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebootWorkspacesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RebootWorkspacesError {}
 /// Errors returned by RebuildWorkspaces
 #[derive(Debug, PartialEq)]
 pub enum RebuildWorkspacesError {}
@@ -3050,14 +2968,10 @@ impl RebuildWorkspacesError {
 }
 impl fmt::Display for RebuildWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RebuildWorkspacesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for RebuildWorkspacesError {}
 /// Errors returned by RegisterWorkspaceDirectory
 #[derive(Debug, PartialEq)]
 pub enum RegisterWorkspaceDirectoryError {
@@ -3134,23 +3048,31 @@ impl RegisterWorkspaceDirectoryError {
 }
 impl fmt::Display for RegisterWorkspaceDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RegisterWorkspaceDirectoryError {
-    fn description(&self) -> &str {
         match *self {
-            RegisterWorkspaceDirectoryError::AccessDenied(ref cause) => cause,
-            RegisterWorkspaceDirectoryError::InvalidParameterValues(ref cause) => cause,
-            RegisterWorkspaceDirectoryError::InvalidResourceState(ref cause) => cause,
-            RegisterWorkspaceDirectoryError::OperationNotSupported(ref cause) => cause,
-            RegisterWorkspaceDirectoryError::ResourceLimitExceeded(ref cause) => cause,
-            RegisterWorkspaceDirectoryError::ResourceNotFound(ref cause) => cause,
-            RegisterWorkspaceDirectoryError::UnsupportedNetworkConfiguration(ref cause) => cause,
-            RegisterWorkspaceDirectoryError::WorkspacesDefaultRoleNotFound(ref cause) => cause,
+            RegisterWorkspaceDirectoryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RegisterWorkspaceDirectoryError::InvalidParameterValues(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterWorkspaceDirectoryError::InvalidResourceState(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterWorkspaceDirectoryError::OperationNotSupported(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterWorkspaceDirectoryError::ResourceLimitExceeded(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterWorkspaceDirectoryError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
+            RegisterWorkspaceDirectoryError::UnsupportedNetworkConfiguration(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            RegisterWorkspaceDirectoryError::WorkspacesDefaultRoleNotFound(ref cause) => {
+                write!(f, "{}", cause)
+            }
         }
     }
 }
+impl Error for RegisterWorkspaceDirectoryError {}
 /// Errors returned by RestoreWorkspace
 #[derive(Debug, PartialEq)]
 pub enum RestoreWorkspaceError {
@@ -3186,18 +3108,14 @@ impl RestoreWorkspaceError {
 }
 impl fmt::Display for RestoreWorkspaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RestoreWorkspaceError {
-    fn description(&self) -> &str {
         match *self {
-            RestoreWorkspaceError::AccessDenied(ref cause) => cause,
-            RestoreWorkspaceError::InvalidParameterValues(ref cause) => cause,
-            RestoreWorkspaceError::ResourceNotFound(ref cause) => cause,
+            RestoreWorkspaceError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RestoreWorkspaceError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            RestoreWorkspaceError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RestoreWorkspaceError {}
 /// Errors returned by RevokeIpRules
 #[derive(Debug, PartialEq)]
 pub enum RevokeIpRulesError {
@@ -3238,19 +3156,15 @@ impl RevokeIpRulesError {
 }
 impl fmt::Display for RevokeIpRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for RevokeIpRulesError {
-    fn description(&self) -> &str {
         match *self {
-            RevokeIpRulesError::AccessDenied(ref cause) => cause,
-            RevokeIpRulesError::InvalidParameterValues(ref cause) => cause,
-            RevokeIpRulesError::InvalidResourceState(ref cause) => cause,
-            RevokeIpRulesError::ResourceNotFound(ref cause) => cause,
+            RevokeIpRulesError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            RevokeIpRulesError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            RevokeIpRulesError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            RevokeIpRulesError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for RevokeIpRulesError {}
 /// Errors returned by StartWorkspaces
 #[derive(Debug, PartialEq)]
 pub enum StartWorkspacesError {}
@@ -3268,14 +3182,10 @@ impl StartWorkspacesError {
 }
 impl fmt::Display for StartWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StartWorkspacesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for StartWorkspacesError {}
 /// Errors returned by StopWorkspaces
 #[derive(Debug, PartialEq)]
 pub enum StopWorkspacesError {}
@@ -3293,14 +3203,10 @@ impl StopWorkspacesError {
 }
 impl fmt::Display for StopWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for StopWorkspacesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for StopWorkspacesError {}
 /// Errors returned by TerminateWorkspaces
 #[derive(Debug, PartialEq)]
 pub enum TerminateWorkspacesError {}
@@ -3318,14 +3224,10 @@ impl TerminateWorkspacesError {
 }
 impl fmt::Display for TerminateWorkspacesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for TerminateWorkspacesError {
-    fn description(&self) -> &str {
         match *self {}
     }
 }
+impl Error for TerminateWorkspacesError {}
 /// Errors returned by UpdateRulesOfIpGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateRulesOfIpGroupError {
@@ -3377,20 +3279,16 @@ impl UpdateRulesOfIpGroupError {
 }
 impl fmt::Display for UpdateRulesOfIpGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateRulesOfIpGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateRulesOfIpGroupError::AccessDenied(ref cause) => cause,
-            UpdateRulesOfIpGroupError::InvalidParameterValues(ref cause) => cause,
-            UpdateRulesOfIpGroupError::InvalidResourceState(ref cause) => cause,
-            UpdateRulesOfIpGroupError::ResourceLimitExceeded(ref cause) => cause,
-            UpdateRulesOfIpGroupError::ResourceNotFound(ref cause) => cause,
+            UpdateRulesOfIpGroupError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            UpdateRulesOfIpGroupError::InvalidParameterValues(ref cause) => write!(f, "{}", cause),
+            UpdateRulesOfIpGroupError::InvalidResourceState(ref cause) => write!(f, "{}", cause),
+            UpdateRulesOfIpGroupError::ResourceLimitExceeded(ref cause) => write!(f, "{}", cause),
+            UpdateRulesOfIpGroupError::ResourceNotFound(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateRulesOfIpGroupError {}
 /// Trait representing the capabilities of the Amazon WorkSpaces API. Amazon WorkSpaces clients implement this trait.
 pub trait Workspaces {
     /// <p>Associates the specified IP access control group with the specified directory.</p>

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -1549,17 +1549,13 @@ impl BatchGetTracesError {
 }
 impl fmt::Display for BatchGetTracesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for BatchGetTracesError {
-    fn description(&self) -> &str {
         match *self {
-            BatchGetTracesError::InvalidRequest(ref cause) => cause,
-            BatchGetTracesError::Throttled(ref cause) => cause,
+            BatchGetTracesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            BatchGetTracesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for BatchGetTracesError {}
 /// Errors returned by CreateGroup
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupError {
@@ -1588,17 +1584,13 @@ impl CreateGroupError {
 }
 impl fmt::Display for CreateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            CreateGroupError::InvalidRequest(ref cause) => cause,
-            CreateGroupError::Throttled(ref cause) => cause,
+            CreateGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateGroupError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateGroupError {}
 /// Errors returned by CreateSamplingRule
 #[derive(Debug, PartialEq)]
 pub enum CreateSamplingRuleError {
@@ -1634,18 +1626,14 @@ impl CreateSamplingRuleError {
 }
 impl fmt::Display for CreateSamplingRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for CreateSamplingRuleError {
-    fn description(&self) -> &str {
         match *self {
-            CreateSamplingRuleError::InvalidRequest(ref cause) => cause,
-            CreateSamplingRuleError::RuleLimitExceeded(ref cause) => cause,
-            CreateSamplingRuleError::Throttled(ref cause) => cause,
+            CreateSamplingRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            CreateSamplingRuleError::RuleLimitExceeded(ref cause) => write!(f, "{}", cause),
+            CreateSamplingRuleError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for CreateSamplingRuleError {}
 /// Errors returned by DeleteGroup
 #[derive(Debug, PartialEq)]
 pub enum DeleteGroupError {
@@ -1674,17 +1662,13 @@ impl DeleteGroupError {
 }
 impl fmt::Display for DeleteGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteGroupError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteGroupError::InvalidRequest(ref cause) => cause,
-            DeleteGroupError::Throttled(ref cause) => cause,
+            DeleteGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteGroupError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteGroupError {}
 /// Errors returned by DeleteSamplingRule
 #[derive(Debug, PartialEq)]
 pub enum DeleteSamplingRuleError {
@@ -1713,17 +1697,13 @@ impl DeleteSamplingRuleError {
 }
 impl fmt::Display for DeleteSamplingRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for DeleteSamplingRuleError {
-    fn description(&self) -> &str {
         match *self {
-            DeleteSamplingRuleError::InvalidRequest(ref cause) => cause,
-            DeleteSamplingRuleError::Throttled(ref cause) => cause,
+            DeleteSamplingRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            DeleteSamplingRuleError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for DeleteSamplingRuleError {}
 /// Errors returned by GetEncryptionConfig
 #[derive(Debug, PartialEq)]
 pub enum GetEncryptionConfigError {
@@ -1752,17 +1732,13 @@ impl GetEncryptionConfigError {
 }
 impl fmt::Display for GetEncryptionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetEncryptionConfigError {
-    fn description(&self) -> &str {
         match *self {
-            GetEncryptionConfigError::InvalidRequest(ref cause) => cause,
-            GetEncryptionConfigError::Throttled(ref cause) => cause,
+            GetEncryptionConfigError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetEncryptionConfigError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetEncryptionConfigError {}
 /// Errors returned by GetGroup
 #[derive(Debug, PartialEq)]
 pub enum GetGroupError {
@@ -1791,17 +1767,13 @@ impl GetGroupError {
 }
 impl fmt::Display for GetGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupError::InvalidRequest(ref cause) => cause,
-            GetGroupError::Throttled(ref cause) => cause,
+            GetGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetGroupError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupError {}
 /// Errors returned by GetGroups
 #[derive(Debug, PartialEq)]
 pub enum GetGroupsError {
@@ -1830,17 +1802,13 @@ impl GetGroupsError {
 }
 impl fmt::Display for GetGroupsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetGroupsError {
-    fn description(&self) -> &str {
         match *self {
-            GetGroupsError::InvalidRequest(ref cause) => cause,
-            GetGroupsError::Throttled(ref cause) => cause,
+            GetGroupsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetGroupsError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetGroupsError {}
 /// Errors returned by GetSamplingRules
 #[derive(Debug, PartialEq)]
 pub enum GetSamplingRulesError {
@@ -1869,17 +1837,13 @@ impl GetSamplingRulesError {
 }
 impl fmt::Display for GetSamplingRulesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSamplingRulesError {
-    fn description(&self) -> &str {
         match *self {
-            GetSamplingRulesError::InvalidRequest(ref cause) => cause,
-            GetSamplingRulesError::Throttled(ref cause) => cause,
+            GetSamplingRulesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetSamplingRulesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSamplingRulesError {}
 /// Errors returned by GetSamplingStatisticSummaries
 #[derive(Debug, PartialEq)]
 pub enum GetSamplingStatisticSummariesError {
@@ -1914,17 +1878,13 @@ impl GetSamplingStatisticSummariesError {
 }
 impl fmt::Display for GetSamplingStatisticSummariesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSamplingStatisticSummariesError {
-    fn description(&self) -> &str {
         match *self {
-            GetSamplingStatisticSummariesError::InvalidRequest(ref cause) => cause,
-            GetSamplingStatisticSummariesError::Throttled(ref cause) => cause,
+            GetSamplingStatisticSummariesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetSamplingStatisticSummariesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSamplingStatisticSummariesError {}
 /// Errors returned by GetSamplingTargets
 #[derive(Debug, PartialEq)]
 pub enum GetSamplingTargetsError {
@@ -1953,17 +1913,13 @@ impl GetSamplingTargetsError {
 }
 impl fmt::Display for GetSamplingTargetsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetSamplingTargetsError {
-    fn description(&self) -> &str {
         match *self {
-            GetSamplingTargetsError::InvalidRequest(ref cause) => cause,
-            GetSamplingTargetsError::Throttled(ref cause) => cause,
+            GetSamplingTargetsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetSamplingTargetsError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetSamplingTargetsError {}
 /// Errors returned by GetServiceGraph
 #[derive(Debug, PartialEq)]
 pub enum GetServiceGraphError {
@@ -1992,17 +1948,13 @@ impl GetServiceGraphError {
 }
 impl fmt::Display for GetServiceGraphError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetServiceGraphError {
-    fn description(&self) -> &str {
         match *self {
-            GetServiceGraphError::InvalidRequest(ref cause) => cause,
-            GetServiceGraphError::Throttled(ref cause) => cause,
+            GetServiceGraphError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetServiceGraphError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetServiceGraphError {}
 /// Errors returned by GetTimeSeriesServiceStatistics
 #[derive(Debug, PartialEq)]
 pub enum GetTimeSeriesServiceStatisticsError {
@@ -2037,17 +1989,15 @@ impl GetTimeSeriesServiceStatisticsError {
 }
 impl fmt::Display for GetTimeSeriesServiceStatisticsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTimeSeriesServiceStatisticsError {
-    fn description(&self) -> &str {
         match *self {
-            GetTimeSeriesServiceStatisticsError::InvalidRequest(ref cause) => cause,
-            GetTimeSeriesServiceStatisticsError::Throttled(ref cause) => cause,
+            GetTimeSeriesServiceStatisticsError::InvalidRequest(ref cause) => {
+                write!(f, "{}", cause)
+            }
+            GetTimeSeriesServiceStatisticsError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTimeSeriesServiceStatisticsError {}
 /// Errors returned by GetTraceGraph
 #[derive(Debug, PartialEq)]
 pub enum GetTraceGraphError {
@@ -2076,17 +2026,13 @@ impl GetTraceGraphError {
 }
 impl fmt::Display for GetTraceGraphError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTraceGraphError {
-    fn description(&self) -> &str {
         match *self {
-            GetTraceGraphError::InvalidRequest(ref cause) => cause,
-            GetTraceGraphError::Throttled(ref cause) => cause,
+            GetTraceGraphError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetTraceGraphError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTraceGraphError {}
 /// Errors returned by GetTraceSummaries
 #[derive(Debug, PartialEq)]
 pub enum GetTraceSummariesError {
@@ -2115,17 +2061,13 @@ impl GetTraceSummariesError {
 }
 impl fmt::Display for GetTraceSummariesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for GetTraceSummariesError {
-    fn description(&self) -> &str {
         match *self {
-            GetTraceSummariesError::InvalidRequest(ref cause) => cause,
-            GetTraceSummariesError::Throttled(ref cause) => cause,
+            GetTraceSummariesError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            GetTraceSummariesError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for GetTraceSummariesError {}
 /// Errors returned by PutEncryptionConfig
 #[derive(Debug, PartialEq)]
 pub enum PutEncryptionConfigError {
@@ -2154,17 +2096,13 @@ impl PutEncryptionConfigError {
 }
 impl fmt::Display for PutEncryptionConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutEncryptionConfigError {
-    fn description(&self) -> &str {
         match *self {
-            PutEncryptionConfigError::InvalidRequest(ref cause) => cause,
-            PutEncryptionConfigError::Throttled(ref cause) => cause,
+            PutEncryptionConfigError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutEncryptionConfigError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutEncryptionConfigError {}
 /// Errors returned by PutTelemetryRecords
 #[derive(Debug, PartialEq)]
 pub enum PutTelemetryRecordsError {
@@ -2193,17 +2131,13 @@ impl PutTelemetryRecordsError {
 }
 impl fmt::Display for PutTelemetryRecordsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutTelemetryRecordsError {
-    fn description(&self) -> &str {
         match *self {
-            PutTelemetryRecordsError::InvalidRequest(ref cause) => cause,
-            PutTelemetryRecordsError::Throttled(ref cause) => cause,
+            PutTelemetryRecordsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutTelemetryRecordsError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutTelemetryRecordsError {}
 /// Errors returned by PutTraceSegments
 #[derive(Debug, PartialEq)]
 pub enum PutTraceSegmentsError {
@@ -2232,17 +2166,13 @@ impl PutTraceSegmentsError {
 }
 impl fmt::Display for PutTraceSegmentsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for PutTraceSegmentsError {
-    fn description(&self) -> &str {
         match *self {
-            PutTraceSegmentsError::InvalidRequest(ref cause) => cause,
-            PutTraceSegmentsError::Throttled(ref cause) => cause,
+            PutTraceSegmentsError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            PutTraceSegmentsError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for PutTraceSegmentsError {}
 /// Errors returned by UpdateGroup
 #[derive(Debug, PartialEq)]
 pub enum UpdateGroupError {
@@ -2271,17 +2201,13 @@ impl UpdateGroupError {
 }
 impl fmt::Display for UpdateGroupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateGroupError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateGroupError::InvalidRequest(ref cause) => cause,
-            UpdateGroupError::Throttled(ref cause) => cause,
+            UpdateGroupError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateGroupError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateGroupError {}
 /// Errors returned by UpdateSamplingRule
 #[derive(Debug, PartialEq)]
 pub enum UpdateSamplingRuleError {
@@ -2310,17 +2236,13 @@ impl UpdateSamplingRuleError {
 }
 impl fmt::Display for UpdateSamplingRuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-impl Error for UpdateSamplingRuleError {
-    fn description(&self) -> &str {
         match *self {
-            UpdateSamplingRuleError::InvalidRequest(ref cause) => cause,
-            UpdateSamplingRuleError::Throttled(ref cause) => cause,
+            UpdateSamplingRuleError::InvalidRequest(ref cause) => write!(f, "{}", cause),
+            UpdateSamplingRuleError::Throttled(ref cause) => write!(f, "{}", cause),
         }
     }
 }
+impl Error for UpdateSamplingRuleError {}
 /// Trait representing the capabilities of the AWS X-Ray API. AWS X-Ray clients implement this trait.
 pub trait XRay {
     /// <p>Retrieves a list of traces specified by ID. Each trace is a collection of segment documents that originates from a single request. Use <code>GetTraceSummaries</code> to get a list of trace IDs.</p>

--- a/rusoto/signature/src/region.rs
+++ b/rusoto/signature/src/region.rs
@@ -266,11 +266,7 @@ impl ParseRegionError {
     }
 }
 
-impl Error for ParseRegionError {
-    fn description(&self) -> &str {
-        &self.message
-    }
-}
+impl Error for ParseRegionError {}
 
 impl Display for ParseRegionError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {

--- a/service_crategen/src/config.rs
+++ b/service_crategen/src/config.rs
@@ -66,13 +66,6 @@ impl fmt::Display for ConfigError {
 }
 
 impl Error for ConfigError {
-    fn description(&self) -> &str {
-        match *self {
-            ConfigError::Io(ref e) => e.description(),
-            ConfigError::Format(ref e) => e.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             ConfigError::Io(ref e) => Some(e),


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes all implementations of `description` in all error types
- Replaces all `description` usage

Related PR: https://github.com/rust-lang/rust/pull/66919