### PR TITLE
Fix incorrect encoding of Session Token when pre-signing URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Introduce `Secret` type to automatically zero-out memory use to stored secret credentials. So far, 
   only used in the new web identity provider.
 - Introduce `Variable` to abstract over certain credential provider input parameters.
-
 - Encode request payload optionally with Gzip : https://github.com/rusoto/rusoto/pull/1615
 - Add Debug trait to generated Clients
 - Add `rusoto_ec2::filter!` macro
@@ -20,6 +19,7 @@
 - Remove deprecated `Error::description` implementations
 - Add features `serialize_structs` and `deserialize_structs`
 - Implement Clone on various Credential structs.
+- Fix incorrect encoding of Session Token when pre-signing URLs
 
 ## [0.42.0] - 2019-11-18
 


### PR DESCRIPTION
There were two problems with pre-signed URLs when using temporary credentials (that include a Session Token):
* The Session Token was being encoded at insertion time into the list of parameters (`SignedRequest.params`) and then _again_ on output (`build_canonical_query_string()`) so it was double-encoded
* The urlencoding that was being used on the query parameters did not encode the plus sign ("`+`") correctly. Except for an issue with S3 paths (which is a [known bug](https://forums.aws.amazon.com/thread.jspa?threadID=55746)) the plus sign is always a literal plus sign and should therefore always be escaped in the query string as a plus sign ("`%2B`")

I took the liberty of forcing all users of `build_canonical_query_string()` to explicitly specify how they want the plus sign to be handled (by overwriting that function with `build_canonical_query_string_with_plus()`) and adding a test.

References:
* [Task 1: Create a Canonical Request for Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html)
* [Task 4: Add the Signature to the HTTP Request](https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html)