### PR TITLE
Always encode + in query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add features `serialize_structs` and `deserialize_structs`
 - Implement Clone on various Credential structs.
 - Fix incorrect encoding of Session Token when pre-signing URLs
+- Always encode + in query strings
 
 ## [0.42.0] - 2019-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - Introduce `Secret` type to automatically zero-out memory use to stored secret credentials. So far, 
   only used in the new web identity provider.
 - Introduce `Variable` to abstract over certain credential provider input parameters.
-
 - Encode request payload optionally with Gzip : https://github.com/rusoto/rusoto/pull/1615
 - Add Debug trait to generated Clients
 - Add `rusoto_ec2::filter!` macro
@@ -20,6 +19,7 @@
 - Remove deprecated `Error::description` implementations
 - Add features `serialize_structs` and `deserialize_structs`
 - Implement Clone on various Credential structs.
+- Fix incorrect encoding of Session Token when pre-signing URLs
 
 ## [0.42.0] - 2019-11-18
 

--- a/rusoto/core/src/client.rs
+++ b/rusoto/core/src/client.rs
@@ -219,7 +219,7 @@ where
                             Some(SignAndDispatchState::FetchingCredentials { future, request });
                     }
                     None => {
-                        request.complement_with_plus(true);
+                        request.complement();
                         let future = self.inner.dispatcher.dispatch(request, self.timeout);
                         self.state = Some(SignAndDispatchState::Dispatching { future });
                     }
@@ -239,9 +239,9 @@ where
                 Ok(Async::Ready(credentials)) => {
                     self.inner.content_encoding.encode(&mut request);
                     if credentials.is_anonymous() {
-                        request.complement_with_plus(true);
+                        request.complement();
                     } else {
-                        request.sign_with_plus(&credentials, true);
+                        request.sign(&credentials);
                     }
                     let future = self.inner.dispatcher.dispatch(request, self.timeout);
                     self.state = Some(SignAndDispatchState::Dispatching { future });


### PR DESCRIPTION
When a plus ("`+`") appears in a query string (prior to urlencoding) that plus should always be encoded ("`%2B`").

Previously, there was an option to allow the plus to be treated as a space. Treating plus as a space (ASCII `0x20`) makes no sense since every character in the string _prior to encoding_ is exactly what you expect out of the string at the other end (i.e. after encoding then decoding again), and this special behavior meant that the string on the other end would be different than how it started.

* For example, the string "`a+b`" should be encoded as a "`a%2Bb`" and then decoded to "`a+b`"
* If you (incorrectly) treated the plus as a space, "`a+b`" would be encoded as "`a%20b`" and later decoded to "`a b`" which can't possibly be what anyone intended...
