### PR TITLE
Re-add versions for Rusoto dependencies

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -36,6 +36,7 @@ version = "0.0"
 
 [dependencies.rusoto_core]
 path = "../rusoto/core"
+version = "0.43.0-beta.1"
 default_features = false
 
 [features]

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -49,9 +49,11 @@ flate2 = { version = "1.0", optional = true }
 
 [dependencies.rusoto_credential]
 path = "../credential"
+version = "0.43.0-beta.1"
 
 [dependencies.rusoto_signature]
 path = "../signature"
+version = "0.43.0-beta.1"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros"] }

--- a/rusoto/services/accessanalyzer/Cargo.toml
+++ b/rusoto/services/accessanalyzer/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -24,6 +24,7 @@ serde_derive = "1.0.2"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -31,6 +32,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/appconfig/Cargo.toml
+++ b/rusoto/services/appconfig/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/application-insights/Cargo.toml
+++ b/rusoto/services/application-insights/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/appmesh/Cargo.toml
+++ b/rusoto/services/appmesh/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/backup/Cargo.toml
+++ b/rusoto/services/backup/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -23,6 +23,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -38,6 +39,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -24,6 +24,7 @@ serde_derive = "1.0.2"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -31,6 +32,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codeguru-reviewer/Cargo.toml
+++ b/rusoto/services/codeguru-reviewer/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codeguruprofiler/Cargo.toml
+++ b/rusoto/services/codeguruprofiler/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codestar-connections/Cargo.toml
+++ b/rusoto/services/codestar-connections/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codestar-notifications/Cargo.toml
+++ b/rusoto/services/codestar-notifications/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/compute-optimizer/Cargo.toml
+++ b/rusoto/services/compute-optimizer/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/connectparticipant/Cargo.toml
+++ b/rusoto/services/connectparticipant/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/dataexchange/Cargo.toml
+++ b/rusoto/services/dataexchange/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/datasync/Cargo.toml
+++ b/rusoto/services/datasync/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/detective/Cargo.toml
+++ b/rusoto/services/detective/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/dlm/Cargo.toml
+++ b/rusoto/services/dlm/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ebs/Cargo.toml
+++ b/rusoto/services/ebs/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ec2-instance-connect/Cargo.toml
+++ b/rusoto/services/ec2-instance-connect/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/elastic-inference/Cargo.toml
+++ b/rusoto/services/elastic-inference/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/es/Cargo.toml
+++ b/rusoto/services/es/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/forecast/Cargo.toml
+++ b/rusoto/services/forecast/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/forecastquery/Cargo.toml
+++ b/rusoto/services/forecastquery/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/frauddetector/Cargo.toml
+++ b/rusoto/services/frauddetector/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/globalaccelerator/Cargo.toml
+++ b/rusoto/services/globalaccelerator/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/groundstation/Cargo.toml
+++ b/rusoto/services/groundstation/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/imagebuilder/Cargo.toml
+++ b/rusoto/services/imagebuilder/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -24,6 +24,7 @@ serde_derive = "1.0.2"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -31,6 +32,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iotevents-data/Cargo.toml
+++ b/rusoto/services/iotevents-data/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iotevents/Cargo.toml
+++ b/rusoto/services/iotevents/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iotsecuretunneling/Cargo.toml
+++ b/rusoto/services/iotsecuretunneling/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/iotthingsgraph/Cargo.toml
+++ b/rusoto/services/iotthingsgraph/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kendra/Cargo.toml
+++ b/rusoto/services/kendra/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kinesis-video-signaling/Cargo.toml
+++ b/rusoto/services/kinesis-video-signaling/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kinesisanalyticsv2/Cargo.toml
+++ b/rusoto/services/kinesisanalyticsv2/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/lakeformation/Cargo.toml
+++ b/rusoto/services/lakeformation/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -35,6 +36,7 @@ chrono = "0.4"
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/managedblockchain/Cargo.toml
+++ b/rusoto/services/managedblockchain/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/marketplace-catalog/Cargo.toml
+++ b/rusoto/services/marketplace-catalog/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mediaconnect/Cargo.toml
+++ b/rusoto/services/mediaconnect/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mediapackage-vod/Cargo.toml
+++ b/rusoto/services/mediapackage-vod/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/migrationhub-config/Cargo.toml
+++ b/rusoto/services/migrationhub-config/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -24,6 +24,7 @@ serde_derive = "1.0.2"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -31,6 +32,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/networkmanager/Cargo.toml
+++ b/rusoto/services/networkmanager/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/outposts/Cargo.toml
+++ b/rusoto/services/outposts/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/personalize-events/Cargo.toml
+++ b/rusoto/services/personalize-events/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/personalize-runtime/Cargo.toml
+++ b/rusoto/services/personalize-runtime/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/personalize/Cargo.toml
+++ b/rusoto/services/personalize/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/pinpoint-email/Cargo.toml
+++ b/rusoto/services/pinpoint-email/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/pinpoint-sms-voice/Cargo.toml
+++ b/rusoto/services/pinpoint-sms-voice/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/qldb-session/Cargo.toml
+++ b/rusoto/services/qldb-session/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/qldb/Cargo.toml
+++ b/rusoto/services/qldb/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/quicksight/Cargo.toml
+++ b/rusoto/services/quicksight/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/robomaker/Cargo.toml
+++ b/rusoto/services/robomaker/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -23,6 +23,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -38,6 +39,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/route53resolver/Cargo.toml
+++ b/rusoto/services/route53resolver/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -23,6 +23,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -38,6 +39,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -24,6 +24,7 @@ serde_derive = "1.0.2"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -31,6 +32,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/savingsplans/Cargo.toml
+++ b/rusoto/services/savingsplans/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/schemas/Cargo.toml
+++ b/rusoto/services/schemas/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/securityhub/Cargo.toml
+++ b/rusoto/services/securityhub/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/service-quotas/Cargo.toml
+++ b/rusoto/services/service-quotas/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sesv2/Cargo.toml
+++ b/rusoto/services/sesv2/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/signer/Cargo.toml
+++ b/rusoto/services/signer/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sms-voice/Cargo.toml
+++ b/rusoto/services/sms-voice/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -39,6 +40,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sso-oidc/Cargo.toml
+++ b/rusoto/services/sso-oidc/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sso/Cargo.toml
+++ b/rusoto/services/sso/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -26,6 +26,7 @@ xml-rs = "0.8"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -41,6 +42,7 @@ optional = true
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/textract/Cargo.toml
+++ b/rusoto/services/textract/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/transfer/Cargo.toml
+++ b/rusoto/services/transfer/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/workmailmessageflow/Cargo.toml
+++ b/rusoto/services/workmailmessageflow/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -34,6 +35,7 @@ features = ["derive"]
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 version = "0.3"
 
 [dependencies.rusoto_core]
+version = "0.43.0-beta.1"
 path = "../../core"
 default-features = false
 
@@ -32,6 +33,7 @@ default-features = false
 tokio = "0.2"
 
 [dev-dependencies.rusoto_mock]
+version = "0.43.0-beta.1"
 path = "../../../mock"
 default-features = false
 

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -41,6 +41,7 @@ percent-encoding = "2"
 tokio = { version = "0.2", features = ["macros"] }
 
 [dependencies.rusoto_credential]
+version = "0.43.0-beta.1"
 path = "../credential"
 
 [dev-dependencies]

--- a/service_crategen/services.json
+++ b/service_crategen/services.json
@@ -1,631 +1,757 @@
 {
   "accessanalyzer": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-11-01",
     "baseTypeName": "AccessAnalyzer"
   },
   "acm": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-12-08",
     "baseTypeName": "Acm"
   },
   "acm-pca": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-08-22",
     "baseTypeName": "AcmPca"
   },
   "alexaforbusiness": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-11-09",
     "baseTypeName": "AlexaForBusiness"
   },
   "amplify": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-07-25",
     "baseTypeName": "Amplify"
   },
   "apigateway": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-07-09",
     "baseTypeName": "ApiGateway"
   },
   "apigatewaymanagementapi": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-29",
     "baseTypeName": "ApiGatewayManagementApi"
   },
   "apigatewayv2": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-29",
     "baseTypeName": "ApiGatewayV2"
   },
   "appconfig": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-10-09",
     "baseTypeName": "AppConfig"
   },
   "application-autoscaling": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-02-06",
     "baseTypeName": "ApplicationAutoScaling"
   },
   "application-insights": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-25",
     "baseTypeName": "ApplicationInsights"
   },
   "appmesh": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-01-25",
     "baseTypeName": "AppMesh"
   },
   "appstream": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-12-01",
     "baseTypeName": "AppStream"
   },
   "appsync": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-07-25",
     "baseTypeName": "AppSync"
   },
   "athena": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-05-18",
     "baseTypeName": "Athena"
   },
   "autoscaling": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2011-01-01",
     "baseTypeName": "Autoscaling"
   },
   "autoscaling-plans": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-01-06",
     "baseTypeName": "AutoscalingPlans"
   },
   "backup": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-15",
     "baseTypeName": "Backup"
   },
   "batch": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-08-10",
     "baseTypeName": "Batch"
   },
   "budgets": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-10-20",
     "baseTypeName": "Budgets"
   },
   "ce": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-10-25",
     "baseTypeName": "CostExplorer"
   },
   "chime": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-05-01",
     "baseTypeName": "Chime"
   },
   "cloud9": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-09-23",
     "baseTypeName": "Cloud9"
   },
   "clouddirectory": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-01-11",
     "baseTypeName": "CloudDirectory"
   },
   "cloudformation": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2010-05-15",
     "baseTypeName": "CloudFormation"
   },
   "cloudfront": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-03-26",
     "baseTypeName": "CloudFront"
   },
   "cloudhsm": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-05-30",
     "baseTypeName": "CloudHsm"
   },
   "cloudhsmv2": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-04-28",
     "baseTypeName": "CloudHsmv2"
   },
   "cloudsearch": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-01-01",
     "baseTypeName": "CloudSearch"
   },
   "cloudsearchdomain": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-01-01",
     "baseTypeName": "CloudSearchDomain"
   },
   "cloudtrail": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-11-01",
     "baseTypeName": "CloudTrail"
   },
   "cloudwatch": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2010-08-01",
     "baseTypeName": "CloudWatch"
   },
   "codebuild": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-10-06",
     "baseTypeName": "CodeBuild"
   },
   "codecommit": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-04-13",
     "baseTypeName": "CodeCommit"
   },
   "codedeploy": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-10-06",
     "baseTypeName": "CodeDeploy"
   },
   "codeguru-reviewer": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-09-19",
     "baseTypeName": "CodeGuruReviewer"
   },
   "codeguruprofiler": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-07-18",
     "baseTypeName": "CodeGuruProfiler"
   },
   "codepipeline": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-07-09",
     "baseTypeName": "CodePipeline"
   },
   "codestar": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-04-19",
     "baseTypeName": "CodeStar"
   },
   "codestar-connections": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-12-01",
     "baseTypeName": "CodeStarConnections"
   },
   "codestar-notifications": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-10-15",
     "baseTypeName": "CodeStarNotifications"
   },
   "cognito-identity": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-06-30",
     "baseTypeName": "CognitoIdentity"
   },
   "cognito-idp": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-04-18",
     "baseTypeName": "CognitoIdentityProvider"
   },
   "cognito-sync": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-06-30",
     "baseTypeName": "CognitoSync"
   },
   "comprehend": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "Comprehend"
   },
   "comprehendmedical": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-10-30",
     "baseTypeName": "ComprehendMedical"
   },
   "compute-optimizer": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-11-01",
     "baseTypeName": "ComputeOptimizer"
   },
   "config": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-11-12",
     "baseTypeName": "ConfigService"
   },
   "connect": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-08-08",
     "baseTypeName": "Connect"
   },
   "connectparticipant": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-09-07",
     "baseTypeName": "ConnectParticipant"
   },
   "cur": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-01-06",
     "baseTypeName": "CostAndUsageReport"
   },
   "dataexchange": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-07-25",
     "baseTypeName": "DataExchange"
   },
   "datapipeline": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-10-29",
     "baseTypeName": "DataPipeline"
   },
   "datasync": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-09",
     "baseTypeName": "DataSync"
   },
   "dax": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-04-19",
     "baseTypeName": "DynamodbAccelerator"
   },
   "detective": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-10-26",
     "baseTypeName": "Detective"
   },
   "devicefarm": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-06-23",
     "baseTypeName": "DeviceFarm"
   },
   "directconnect": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-10-25",
     "baseTypeName": "DirectConnect"
   },
   "discovery": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-11-01",
     "baseTypeName": "Discovery"
   },
   "dlm": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-01-12",
     "baseTypeName": "Dlm"
   },
   "dms": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-01-01",
     "baseTypeName": "DatabaseMigrationService"
   },
   "docdb": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-10-31",
     "baseTypeName": "Docdb"
   },
   "ds": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-04-16",
     "baseTypeName": "DirectoryService"
   },
   "dynamodb": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-08-10",
     "baseTypeName": "DynamoDb"
   },
   "dynamodbstreams": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-08-10",
     "baseTypeName": "DynamoDbStreams"
   },
   "ebs": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-11-02",
     "baseTypeName": "Ebs"
   },
   "ec2": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-11-15",
     "baseTypeName": "Ec2"
   },
   "ec2-instance-connect": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-04-02",
     "baseTypeName": "Ec2InstanceConnect"
   },
   "ecr": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-09-21",
     "baseTypeName": "Ecr"
   },
   "ecs": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-11-13",
     "baseTypeName": "Ecs"
   },
   "efs": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-02-01",
     "baseTypeName": "Efs"
   },
   "eks": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-11-01",
     "baseTypeName": "Eks"
   },
   "elastic-inference": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-07-25",
     "baseTypeName": "ElasticInference"
   },
   "elasticache": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-02-02",
     "baseTypeName": "ElastiCache"
   },
   "elasticbeanstalk": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2010-12-01",
     "baseTypeName": "ElasticBeanstalk"
   },
   "elastictranscoder": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-09-25",
     "baseTypeName": "Ets"
   },
   "elb": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-06-01",
     "baseTypeName": "Elb"
   },
   "elbv2": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-12-01",
     "baseTypeName": "Elb"
   },
   "emr": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2009-03-31",
     "baseTypeName": "Emr"
   },
   "es": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-01-01",
     "baseTypeName": "Es"
   },
   "events": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-10-07",
     "baseTypeName": "EventBridge"
   },
   "firehose": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-08-04",
     "baseTypeName": "KinesisFirehose"
   },
   "fms": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-01-01",
     "baseTypeName": "Fms"
   },
   "forecast": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-06-26",
     "baseTypeName": "Forecast"
   },
   "forecastquery": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-06-26",
     "baseTypeName": "ForecastQuery"
   },
   "frauddetector": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-11-15",
     "baseTypeName": "FraudDetector"
   },
   "fsx": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-03-01",
     "baseTypeName": "Fsx"
   },
   "gamelift": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-10-01",
     "baseTypeName": "GameLift"
   },
   "glacier": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-06-01",
     "baseTypeName": "Glacier"
   },
   "globalaccelerator": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-08-08",
     "baseTypeName": "GlobalAccelerator"
   },
   "glue": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-03-31",
     "baseTypeName": "Glue"
   },
   "greengrass": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-06-07",
     "baseTypeName": "GreenGrass"
   },
   "groundstation": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-05-23",
     "baseTypeName": "GroundStation"
   },
   "guardduty": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-11-28",
     "baseTypeName": "GuardDuty"
   },
   "health": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-08-04",
     "baseTypeName": "AWSHealth"
   },
   "iam": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2010-05-08",
     "baseTypeName": "Iam"
   },
   "imagebuilder": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-12-02",
     "baseTypeName": "ImageBuilder"
   },
   "importexport": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2010-06-01",
     "baseTypeName": "ImportExport"
   },
   "inspector": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-02-16",
     "baseTypeName": "Inspector"
   },
   "iot": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-05-28",
     "baseTypeName": "Iot"
   },
   "iot-data": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-05-28",
     "baseTypeName": "IotData"
   },
   "iot-jobs-data": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-09-29",
     "baseTypeName": "IotJobsData"
   },
   "iot1click-devices": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-05-14",
     "baseTypeName": "Iot1ClickDevices"
   },
   "iot1click-projects": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-05-14",
     "baseTypeName": "Iot1ClickProjects"
   },
   "iotanalytics": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "IotAnalytics"
   },
   "iotevents": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-07-27",
     "baseTypeName": "IotEvents"
   },
   "iotevents-data": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-10-23",
     "baseTypeName": "IotEventsData"
   },
   "iotsecuretunneling": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-10-05",
     "baseTypeName": "IoTSecureTunneling"
   },
   "iotthingsgraph": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-09-06",
     "baseTypeName": "IotThingsGraph"
   },
   "kafka": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-14",
     "baseTypeName": "Kafka"
   },
   "kendra": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-02-03",
     "baseTypeName": "Kendra"
   },
   "kinesis": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-12-02",
     "baseTypeName": "Kinesis"
   },
   "kinesis-video-archived-media": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-09-30",
     "baseTypeName": "KinesisVideoArchivedMedia"
   },
   "kinesis-video-media": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-09-30",
     "baseTypeName": "KinesisVideoMedia"
   },
   "kinesis-video-signaling": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-12-04",
     "baseTypeName": "KinesisVideoSignaling"
   },
   "kinesisanalytics": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-08-14",
     "baseTypeName": "KinesisAnalytics"
   },
   "kinesisanalyticsv2": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-05-23",
     "baseTypeName": "KinesisAnalyticsV2"
   },
   "kinesisvideo": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-09-30",
     "baseTypeName": "KinesisVideo"
   },
   "kms": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-11-01",
     "baseTypeName": "Kms"
   },
   "lakeformation": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-03-31",
     "baseTypeName": "LakeFormation"
   },
   "lambda": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-03-31",
     "baseTypeName": "Lambda"
   },
   "lex-models": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-04-19",
     "baseTypeName": "LexModels"
   },
   "lex-runtime": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "LexRuntime"
   },
   "license-manager": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-08-01",
     "baseTypeName": "LicenseManager"
   },
   "lightsail": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "Lightsail"
   },
   "logs": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-03-28",
     "baseTypeName": "CloudWatchLogs",
     "customDevDependencies": {
@@ -634,376 +760,451 @@
   },
   "machinelearning": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-12-12",
     "baseTypeName": "MachineLearning"
   },
   "macie": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-12-19",
     "baseTypeName": "Macie"
   },
   "managedblockchain": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-09-24",
     "baseTypeName": "ManagedBlockchain"
   },
   "marketplace-catalog": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-09-17",
     "baseTypeName": "MarketplaceCatalog"
   },
   "marketplace-entitlement": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-01-11",
     "baseTypeName": "MarketplaceEntitlement"
   },
   "marketplacecommerceanalytics": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-07-01",
     "baseTypeName": "MarketplaceCommerceAnalytics"
   },
   "mediaconnect": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-14",
     "baseTypeName": "MediaConnect"
   },
   "mediaconvert": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-08-29",
     "baseTypeName": "MediaConvert"
   },
   "medialive": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-10-14",
     "baseTypeName": "MediaLive"
   },
   "mediapackage": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-10-12",
     "baseTypeName": "MediaPackage"
   },
   "mediapackage-vod": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-07",
     "baseTypeName": "MediaPackageVod"
   },
   "mediastore": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-09-01",
     "baseTypeName": "MediaStore"
   },
   "mediatailor": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-04-23",
     "baseTypeName": "MediaTailor"
   },
   "meteringmarketplace": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-01-14",
     "baseTypeName": "MarketplaceMetering"
   },
   "mgh": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-05-31",
     "baseTypeName": "MigrationHub"
   },
   "migrationhub-config": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-06-30",
     "baseTypeName": "MigrationHubConfig"
   },
   "mobile": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-07-01",
     "baseTypeName": "Mobile"
   },
   "mq": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "MQ"
   },
   "mturk": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-01-17",
     "baseTypeName": "MechanicalTurk"
   },
   "neptune": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-10-31",
     "baseTypeName": "Neptune"
   },
   "networkmanager": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-07-05",
     "baseTypeName": "NetworkManager"
   },
   "opsworks": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-02-18",
     "baseTypeName": "OpsWorks"
   },
   "opsworkscm": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-11-01",
     "baseTypeName": "OpsWorksCM"
   },
   "organizations": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "Organizations"
   },
   "outposts": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-12-03",
     "baseTypeName": "Outposts"
   },
   "personalize": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-05-22",
     "baseTypeName": "Personalize"
   },
   "personalize-events": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-03-22",
     "baseTypeName": "PersonalizeEvents"
   },
   "personalize-runtime": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-05-22",
     "baseTypeName": "PersonalizeRuntime"
   },
   "pi": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-02-27",
     "baseTypeName": "PerformanceInsights"
   },
   "pinpoint-email": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-07-26",
     "baseTypeName": "PinpointEmail"
   },
   "pinpoint-sms-voice": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-09-05",
     "baseTypeName": "PinpointSmsVoice"
   },
   "polly": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-06-10",
     "baseTypeName": "Polly"
   },
   "pricing": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-10-15",
     "baseTypeName": "Pricing"
   },
   "qldb": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-01-02",
     "baseTypeName": "Qldb"
   },
   "qldb-session": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-07-11",
     "baseTypeName": "QldbSession"
   },
   "quicksight": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-04-01",
     "baseTypeName": "Quicksight"
   },
   "ram": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-01-04",
     "baseTypeName": "Ram"
   },
   "rds": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-10-31",
     "baseTypeName": "Rds"
   },
   "rds-data": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-08-01",
     "baseTypeName": "RdsData"
   },
   "redshift": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-12-01",
     "baseTypeName": "Redshift"
   },
   "rekognition": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-06-27",
     "baseTypeName": "Rekognition"
   },
   "resource-groups": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "ResourceGroups"
   },
   "resourcegroupstaggingapi": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-01-26",
     "baseTypeName": "ResourceGroupsTaggingApi"
   },
   "robomaker": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-06-29",
     "baseTypeName": "Robomaker"
   },
   "route53": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-04-01",
     "baseTypeName": "Route53"
   },
   "route53domains": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-05-15",
     "baseTypeName": "Route53Domains"
   },
   "route53resolver": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-04-01",
     "baseTypeName": "Route53Resolver"
   },
   "s3": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2006-03-01",
     "baseTypeName": "S3"
   },
   "sagemaker": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-07-24",
     "baseTypeName": "SageMaker"
   },
   "sagemaker-a2i-runtime": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-11-07",
     "baseTypeName": "SagemakerA2iRuntime"
   },
   "sagemaker-runtime": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-05-13",
     "baseTypeName": "SageMakerRuntime"
   },
   "savingsplans": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-06-28",
     "baseTypeName": "SavingsPlans"
   },
   "schemas": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-12-02",
     "baseTypeName": "Schemas"
   },
   "sdb": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2009-04-15",
     "baseTypeName": "SimpleDb"
   },
   "secretsmanager": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-10-17",
     "baseTypeName": "SecretsManager"
   },
   "securityhub": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-10-26",
     "baseTypeName": "SecurityHub"
   },
   "serverlessrepo": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-09-08",
     "baseTypeName": "ServerlessRepo"
   },
   "service-quotas": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-06-24",
     "baseTypeName": "ServiceQuotas"
   },
   "servicecatalog": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-12-10",
     "baseTypeName": "ServiceCatalog"
   },
   "servicediscovery": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-03-14",
     "baseTypeName": "ServiceDiscovery"
   },
   "ses": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2010-12-01",
     "baseTypeName": "Ses"
   },
   "sesv2": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-09-27",
     "baseTypeName": "SesV2"
   },
   "shield": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-06-02",
     "baseTypeName": "Shield"
   },
   "signer": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-08-25",
     "baseTypeName": "Signer"
   },
   "sms": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-10-24",
     "baseTypeName": "ServerMigrationService"
   },
   "sms-voice": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-09-05",
     "baseTypeName": "SmsVoice"
   },
   "snowball": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-06-30",
     "baseTypeName": "Snowball"
   },
   "sns": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2010-03-31",
     "baseTypeName": "Sns"
   },
   "sqs": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-11-05",
     "baseTypeName": "Sqs"
   },
   "ssm": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2014-11-06",
     "baseTypeName": "Ssm"
   },
   "sso": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-06-10",
     "baseTypeName": "Sso"
   },
   "sso-oidc": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-06-10",
     "baseTypeName": "SsoOidc"
   },
   "stepfunctions": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-11-23",
     "baseTypeName": "StepFunctions"
   },
   "storagegateway": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-06-30",
     "baseTypeName": "StorageGateway"
   },
   "sts": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2011-06-15",
     "customDependencies": {
       "chrono": "0.4.0",
@@ -1013,71 +1214,85 @@
   },
   "support": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2013-04-15",
     "baseTypeName": "AWSSupport"
   },
   "swf": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2012-01-25",
     "baseTypeName": "Swf"
   },
   "textract": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-06-27",
     "baseTypeName": "Textract"
   },
   "transcribe": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-10-26",
     "baseTypeName": "Transcribe"
   },
   "transfer": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-11-05",
     "baseTypeName": "Transfer"
   },
   "translate": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-07-01",
     "baseTypeName": "Translate"
   },
   "waf": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-08-24",
     "baseTypeName": "Waf"
   },
   "waf-regional": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "WAFRegional"
   },
   "workdocs": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-05-01",
     "baseTypeName": "Workdocs"
   },
   "worklink": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2018-09-25",
     "baseTypeName": "Worklink"
   },
   "workmail": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2017-10-01",
     "baseTypeName": "Workmail"
   },
   "workmailmessageflow": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2019-05-01",
     "baseTypeName": "WorkmailMessageFlow"
   },
   "workspaces": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2015-04-08",
     "baseTypeName": "Workspaces"
   },
   "xray": {
     "version": "0.43.0-beta.1",
+    "coreVersion": "0.43.0-beta.1",
     "protocolVersion": "2016-04-12",
     "baseTypeName": "XRay"
   }

--- a/service_crategen/src/config.rs
+++ b/service_crategen/src/config.rs
@@ -13,6 +13,8 @@ use crate::cargo;
 #[derive(Debug, Deserialize)]
 pub struct ServiceConfig {
     pub version: String,
+    #[serde(rename = "coreVersion")]
+    pub core_version: String,
     #[serde(rename = "protocolVersion")]
     pub protocol_version: String,
     #[serde(rename = "customDependencies")]

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -133,8 +133,8 @@ impl<'b> Service<'b> {
             "rusoto_core".to_owned(),
             cargo::Dependency::Extended {
                 path: Some("../../core".into()),
+                version: Some(self.config.core_version.clone()),
                 optional: None,
-                version: None,
                 default_features: Some(false),
                 features: None,
             },
@@ -241,7 +241,7 @@ impl<'b> Service<'b> {
             "rusoto_mock".to_owned(),
             cargo::Dependency::Extended {
                 path: Some("../../../mock".into()),
-                version: None,
+                version: Some(self.config.core_version.clone()),
                 optional: None,
                 default_features: Some(false),
                 features: None,


### PR DESCRIPTION
`cargo publish` fails without these.