### PR TITLE
added a cognito credential provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 (Please put changes here)
+- Added a Cognito credential provider
 
 ## [0.43.0-beta.0] - 2020-02-07
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -659,6 +659,7 @@ time = "0.2"
 reqwest = { version = "0.10", features = ["json"] }
 http = "0.2"
 tokio = { version = "0.2", features = ["time", "rt-core", "fs"] }
+chrono = "0.4.10"
 
 [features]
 all = [
@@ -850,7 +851,7 @@ codecommit = ["rusoto_codecommit"]
 codedeploy = ["rusoto_codedeploy"]
 codepipeline = ["rusoto_codepipeline"]
 codestar = ["rusoto_codestar"]
-cognito-identity = ["rusoto_cognito_identity"]
+cognito-identity = ["rusoto_cognito_identity", "rusoto_iam"]
 cognito-idp = ["rusoto_cognito_idp"]
 cognito-sync = ["rusoto_cognito_sync"]
 comprehend = ["rusoto_comprehend"]

--- a/integration_tests/tests/cognitoidentity.rs
+++ b/integration_tests/tests/cognitoidentity.rs
@@ -1,12 +1,39 @@
 #![cfg(feature = "cognito-identity")]
 
 extern crate rusoto_cognito_identity;
+extern crate rusoto_iam;
 extern crate rusoto_core;
+extern crate time;
 
 use rusoto_cognito_identity::{
-    CognitoIdentity, CognitoIdentityClient, ListIdentitiesInput, ListIdentityPoolsInput,
+    SetIdentityPoolRolesInput, 
+    CognitoIdentity, 
+    CognitoIdentityClient, 
+    ListIdentitiesInput, 
+    ListIdentityPoolsInput, 
+    GetOpenIdTokenForDeveloperIdentityInput, 
+    CreateIdentityPoolInput, 
+    DeleteIdentityPoolInput, 
+    CognitoProvider
 };
+
+use rusoto_iam::{
+    Iam, 
+    IamClient, 
+    CreateRoleRequest, 
+    PutRolePolicyRequest, 
+    DeleteRoleRequest, 
+    DeleteRolePolicyRequest
+};
+
 use rusoto_core::{Region, RusotoError};
+use rusoto_credential::ProvideAwsCredentials;
+
+use time::Time;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::delay_for;
+use chrono::offset::Utc;
 
 #[tokio::test]
 async fn should_list_identity_pools() {
@@ -30,4 +57,140 @@ async fn should_handle_validation_errors_gracefully() {
         Err(RusotoError::Validation(msg)) => assert!(msg.contains("identityPoolId")),
         err @ _ => panic!("Expected Validation error - got {:#?}", err),
     };
+}
+
+#[tokio::test]
+async fn should_work_with_credential_provider() {
+    let region = Region::UsEast1;
+    let client_cognito = CognitoIdentityClient::new(region.clone());
+    let client_iam = IamClient::new(region.clone());
+    let tag = Time::now().nanosecond();
+    let identity_pool_name = format!("cognito-provider-identity-tst-{}", tag);
+    let role_name = format!("cognito-provider-auth-role-tst-{}", tag);
+    let policy_name = format!("cognito-provider-auth-policy-tst-{}", tag);
+    let developper_provider_name = "test_rusoto";
+
+    // In order to perform this test, we have to create an identity pool, an IAM role, and link them together
+
+    // Creating the identity pool
+    let create_identity_input = CreateIdentityPoolInput {
+        identity_pool_name: identity_pool_name.clone(),
+        developer_provider_name: Some(developper_provider_name.to_string()),
+        ..Default::default()
+    };
+    let identity_pool = client_cognito.create_identity_pool(create_identity_input).await.unwrap();
+
+    // Creating a role for the identity pool
+    let policy = format!("{{
+        'Version': '2012-10-17',
+        'Statement': [
+          {{
+            'Effect': 'Allow',
+            'Principal': {{
+              'Federated': 'cognito-identity.amazonaws.com'
+            }},
+            'Action': 'sts:AssumeRoleWithWebIdentity',
+            'Condition': {{
+              'StringEquals': {{
+                'cognito-identity.amazonaws.com:aud': '{}'
+              }}
+            }}
+          }}
+        ]
+      }}", identity_pool.identity_pool_id).replace("'", "\"");
+      
+    let input_create_role = CreateRoleRequest {
+        assume_role_policy_document: policy,
+        role_name: role_name,
+        ..Default::default()
+    };
+    let role = client_iam.create_role(input_create_role).await.unwrap().role;
+
+    // Adding a policy to the role
+    let role_policy = "{
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Effect': 'Allow',
+                'Action': [
+                    'cognito-sync:*',
+                    'cognito-identity:*'
+                ],
+                'Resource': [
+                    '*'
+                ]
+            }
+        ]
+    }".replace("'", "\"");
+
+    let role_policy_input = PutRolePolicyRequest {
+        policy_document: role_policy,
+        policy_name: policy_name.clone(),
+        role_name: role.role_name.clone(),
+        ..Default::default()
+    };
+
+    client_iam.put_role_policy(role_policy_input).await.unwrap();
+    
+    // Assigning the role to the identity pool
+    let mut roles = HashMap::new();
+    roles.insert("authenticated".to_string(), role.arn.clone());
+    roles.insert("unauthenticated".to_string(), role.arn.clone());
+    let roles_input = SetIdentityPoolRolesInput {
+        identity_pool_id: identity_pool.identity_pool_id.clone(),
+        roles: roles,
+        ..Default::default()
+    };
+    client_cognito.set_identity_pool_roles(roles_input).await.unwrap();
+
+    
+    // Registering a user whose credentials will be tested
+    let login = "login";
+    let mut logins = HashMap::new();
+    logins.insert(developper_provider_name.to_string(), login.to_string());
+    let register_input = GetOpenIdTokenForDeveloperIdentityInput {
+        identity_pool_id: identity_pool.identity_pool_id.clone(),
+        logins: logins,
+        token_duration: Some(3600),
+        ..Default::default()
+    };
+    let response = client_cognito.get_open_id_token_for_developer_identity(register_input).await.unwrap();
+
+    // It can take time for IAM role to be ready for use
+    delay_for(Duration::from_secs(10)).await;
+
+    // The test itself
+    let provider = CognitoProvider::builder()
+         .identity_id(response.identity_id.unwrap())
+         .region(region.clone())
+         .login("cognito-identity.amazonaws.com".to_string(), response.token.unwrap())
+         .build();
+    let creds = provider.credentials().await.unwrap();
+    assert!(creds.token().is_some());
+    assert!(creds.expires_at().is_some());
+    assert!(creds.expires_at().unwrap().time() > Utc::now().time());
+
+    // Cleaning time
+
+    // Deleting the identity pool
+    let delete_identity_pool_input = DeleteIdentityPoolInput {
+        identity_pool_id: identity_pool.identity_pool_id.clone(),
+        ..Default::default()
+    };
+    client_cognito.delete_identity_pool(delete_identity_pool_input).await.unwrap();
+
+    // In order to delete the role, the policy must be deleted first
+    let delete_policy_input = DeleteRolePolicyRequest {
+        policy_name: policy_name,
+        role_name: role.role_name.clone(),
+        ..Default::default()
+    };
+    client_iam.delete_role_policy(delete_policy_input).await.unwrap();
+
+    // Deleting the role
+    let delete_role_input = DeleteRoleRequest {
+        role_name: role.role_name,
+        ..Default::default()
+    };
+    client_iam.delete_role(delete_role_input).await.unwrap();
 }

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -18,6 +18,7 @@ exclude = ["test_resources/*"]
 async-trait = "0.1"
 bytes = "0.5"
 serde_json = "1.0"
+chrono = "0.4.*"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/cognito-identity/src/custom/mod.rs
+++ b/rusoto/services/cognito-identity/src/custom/mod.rs
@@ -1,1 +1,209 @@
 
+//! The Credentials provider from Cognito.
+
+use rusoto_core::Region;
+use async_trait::async_trait;
+
+use rusoto_core::credential::{
+    AwsCredentials, 
+    CredentialsError,
+    ProvideAwsCredentials,
+    StaticProvider
+};
+
+use crate::generated::{
+    GetCredentialsForIdentityInput,
+    CognitoIdentityClient,
+    CognitoIdentity
+};
+
+use chrono::{
+    offset::Utc,
+    DateTime,
+    NaiveDateTime
+};
+
+use std::collections::HashMap;
+
+/// Provides AWS credentials from aws Cognito.
+///
+/// For further information about Cognito Identities check https://docs.aws.amazon.com/cognito/index.html
+///
+/// # Example
+///
+/// ```rust
+/// use rusoto_core::Region;
+/// use rusoto_cognito_identity::CognitoProvider;
+/// let provider = CognitoProvider::builder()
+///     .identity_id("IDENTITY_POOL_ID".to_string())
+///     .region(Region::EuCentral1)
+///     .login("graph.facebook.com".to_string(), "FBTOKEN".to_string())
+///     .build();
+/// 
+/// ```
+
+/// <p>The Cognito credential provider.</p>
+#[derive(Debug, Clone)]
+pub struct CognitoProvider {
+    /// <p>A unique identifier in the format REGION:GUID.</p>
+    identity_id: String,
+    /// <p>The region of the identity pool.</p>
+    region: Region,
+    /// <p>A set of optional name-value pairs that map provider names to provider tokens. The name-value pair will follow the syntax "provider_name": "provider_user_identifier".</p> <p>Logins should not be specified when trying to get credentials for an unauthenticated identity.</p> <p>The Logins parameter is required when using identities associated with external identity providers such as FaceBook. For examples of <code>Logins</code> maps, see the code examples in the <a href="http://docs.aws.amazon.com/cognito/latest/developerguide/external-identity-providers.html">External Identity Providers</a> section of the Amazon Cognito Developer Guide.</p>
+    logins: Option<HashMap<String, String>>,
+    /// <p>The Amazon Resource Name (ARN) of the role to be assumed when multiple roles were received in the token from the identity provider. For example, a SAML-based identity provider. This parameter is optional for identity providers that do not support role customization.</p>
+    custom_role_arn: Option<String>
+}
+
+/// <p>A builder for the Cognito credential provider.</p>
+#[derive(Default)]
+pub struct CognitoProviderBuilder {
+    identity_id: Option<String>,
+    region: Option<Region>,
+    logins: Option<HashMap<String, String>>,
+    custom_role_arn: Option<String>
+}
+
+impl CognitoProviderBuilder {
+    /// <p>Build the provider.</p>
+    pub fn build(self) -> CognitoProvider { 
+        CognitoProvider {
+            identity_id: self.identity_id.expect("no identity id provided"),
+            region: self.region.unwrap_or(Region::default()),
+            logins: self.logins,
+            custom_role_arn: self.custom_role_arn
+        }
+    }
+
+    /// <p>Set the identity id.</p>
+    pub fn identity_id(mut self, identity_id: String)-> Self {
+        self.identity_id = Some(identity_id);
+        self
+    }
+
+    /// <p>Set the region.</p>
+    pub fn region(mut self, region: Region)-> Self {
+        self.region = Some(region);
+        self
+    }
+
+    /// <p>Set the custom role arn.</p>
+    pub fn custom_role_arn(mut self, arn: String)-> Self {
+        self.custom_role_arn = Some(arn);
+        self
+    }
+
+    /// <p>Add a pair provider/token.</p>
+    pub fn login(mut self, provider: String, token: String)-> Self {
+        if self.logins == None {
+            self.logins = Some(HashMap::new());
+        }
+        self.logins.as_mut().unwrap().insert(provider, token);
+        self
+    }
+}
+
+impl CognitoProvider {
+    /// Get a builder.
+    pub fn builder() -> CognitoProviderBuilder {
+        CognitoProviderBuilder::default()
+    }
+}
+
+#[async_trait]
+impl ProvideAwsCredentials for CognitoProvider {
+
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        let client = CognitoIdentityClient::new_with(
+            rusoto_core::request::HttpClient::new().map_err(|e| CredentialsError::new(format!("{:?}", e)))?,
+            StaticProvider::from(AwsCredentials::default()),
+            self.region.clone()
+        );
+        let input = GetCredentialsForIdentityInput {
+            identity_id: self.identity_id.clone(),
+            logins: self.logins.clone(),
+            custom_role_arn: self.custom_role_arn.clone(),
+            ..Default::default()
+        };
+
+        let resp = client.get_credentials_for_identity(input).await.map_err(|e| CredentialsError::new(format!("{:?}", e)))?;
+        
+        let creds = resp.credentials.ok_or(CredentialsError::new("no credentials were found in the response"))?;
+        Ok(
+            AwsCredentials::new(
+                creds.access_key_id.ok_or(CredentialsError::new("no access key id was found in the response"))?, 
+                creds.secret_key.ok_or(CredentialsError::new("no secret key was found in the response"))?, 
+                creds.session_token, 
+                creds.expiration.map(|x| DateTime::from_utc(NaiveDateTime::from_timestamp(x as i64, 0), Utc)) 
+            )
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+        
+    #[test]
+    #[should_panic(expected = "no identity id provided")]
+    fn builder_empty() {
+        CognitoProvider::builder().build();
+    }
+
+    #[test]
+    #[should_panic(expected = "no identity id provided")]
+    fn builder_no_identity_id() {
+        CognitoProvider::builder()
+        .login("provider".to_string(), "token".to_string())
+        .build();
+    }
+
+    #[test]
+    fn builder_simple() {
+        let provider = CognitoProvider::builder().identity_id("id_id".to_string()).build();
+        assert_eq!(provider.identity_id, "id_id");
+        assert_eq!(provider.region, Region::default());
+        assert_eq!(provider.logins, None);
+        assert_eq!(provider.custom_role_arn, None);
+    }
+
+    #[test]
+    fn builder_complete() {
+        let provider = CognitoProvider::builder()
+            .identity_id("id_id".to_string())
+            .region(Region::EuCentral1)
+            .login("provider".to_string(), "token".to_string())
+            .custom_role_arn("arn".to_string())
+            .build();
+        assert_eq!(provider.identity_id, "id_id");
+        assert_eq!(provider.region, Region::EuCentral1);
+        assert!(provider.custom_role_arn.is_some());
+        assert_eq!(provider.custom_role_arn.unwrap(), "arn");
+        assert!(provider.logins.is_some());
+        let logins = provider.logins.unwrap();
+        assert_eq!(logins.len(), 1);
+        assert!(logins.get("provider").is_some());
+        assert_eq!(logins.get("provider").unwrap(), "token");
+    }
+
+    #[test]
+    fn builder_two_providers() {
+        let provider = CognitoProvider::builder()
+            .identity_id("id_id".to_string())
+            .region(Region::EuCentral1)
+            .login("provider1".to_string(), "token1".to_string())
+            .login("provider2".to_string(), "token2".to_string())
+            .build();
+        assert_eq!(provider.identity_id, "id_id");
+        assert_eq!(provider.region, Region::EuCentral1);
+        assert!(provider.logins.is_some());
+        let logins = provider.logins.unwrap();
+        assert_eq!(logins.len(), 2);
+        assert!(logins.get("provider1").is_some());
+        assert_eq!(logins.get("provider1").unwrap(), "token1");
+        assert!(logins.get("provider2").is_some());
+        assert_eq!(logins.get("provider2").unwrap(), "token2");
+        assert_eq!(provider.custom_role_arn, None);
+    }
+}
+


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
- Added a Cognito credential provider

Hello,

I rewrote one of our tools which is dealing with AWS in Rust. I was missing a cognito credential provider when using rusoto so I wrote one.
Thank you for the rusoto crate.
Regards,
benoît
