### PR TITLE
Add MultipleMockRequestDispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-(Please put changes here)
+- Add `MultipleMockRequestDispatcher` to permit mocking multiple requests to the same client.
 
 ## [0.42.0] - 2019-11-18
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Add `MultipleMockRequestDispatcher` to permit mocking multiple requests to the same client.
