### PR TITLE
Add MultipleMockRequestDispatcher

### DIFF
--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -220,10 +220,7 @@ where
         _timeout: Option<Duration>,
     ) -> rusoto_core::request::DispatchSignedRequestFuture {
         unsafe {
-            let self_ptr: *const Self = self;
-            let mut_self_ptr: *mut Self = self_ptr as *mut Self;
-
-            (*mut_self_ptr)
+            (*(self as *const Self as *mut Self))
                 .iterator
                 .next()
                 .unwrap()

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -212,13 +212,12 @@ impl<I> DispatchSignedRequest for MultipleMockRequestDispatcher<I>
 where
     I: Iterator<Item = MockRequestDispatcher>,
 {
-    //type Future = FutureResult<HttpResponse, HttpDispatchError>;
-
     fn dispatch(
         &self,
         request: SignedRequest,
         _timeout: Option<Duration>,
     ) -> rusoto_core::request::DispatchSignedRequestFuture {
+        // Unsafe code required to increment iterator due to non-mutable &self
         unsafe {
             (*(self as *const Self as *mut Self))
                 .iterator

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -183,3 +183,51 @@ impl ReadMockResponse for MockResponseReader {
         mock_response
     }
 }
+
+/// Returns sequential mock API responses consuming a collection of MockRequestDispatch
+pub struct MultipleMockRequestDispatcher<I>
+where
+    I: Iterator<Item = MockRequestDispatcher>,
+{
+    iterator: I,
+}
+
+impl<I> MultipleMockRequestDispatcher<I>
+where
+    I: Iterator<Item = MockRequestDispatcher>,
+{
+    /// Constructs a new MultipleMockRequestDispatcher with a collection of MockRequestDispatch as input
+    pub fn new<C>(collection: C) -> MultipleMockRequestDispatcher<I>
+    where
+        C: IntoIterator<Item = MockRequestDispatcher>,
+        C: IntoIterator<IntoIter = I>,
+    {
+        MultipleMockRequestDispatcher {
+            iterator: collection.into_iter(),
+        }
+    }
+}
+
+impl<I> DispatchSignedRequest for MultipleMockRequestDispatcher<I>
+where
+    I: Iterator<Item = MockRequestDispatcher>,
+{
+    //type Future = FutureResult<HttpResponse, HttpDispatchError>;
+
+    fn dispatch(
+        &self,
+        request: SignedRequest,
+        _timeout: Option<Duration>,
+    ) -> rusoto_core::request::DispatchSignedRequestFuture {
+        unsafe {
+            let self_ptr: *const Self = self;
+            let mut_self_ptr: *mut Self = self_ptr as *mut Self;
+
+            (*mut_self_ptr)
+                .iterator
+                .next()
+                .unwrap()
+                .dispatch(request, _timeout)
+        }
+    }
+}

--- a/rusoto/services/s3/src/custom/custom_tests.rs
+++ b/rusoto/services/s3/src/custom/custom_tests.rs
@@ -520,3 +520,29 @@ async fn test_parse_no_such_bucket_error() {
         err
     );
 }
+
+#[tokio::test]
+async fn test_multiple_mock() {
+    let mock = MultipleMockRequestDispatcher::new(vec![
+        MockRequestDispatcher::with_status(200)
+            .with_body("")
+            .with_header("x-amz-expiration", "foo1")
+            .with_header("x-amz-restore", "bar1"),
+        MockRequestDispatcher::with_status(200)
+            .with_body("")
+            .with_header("x-amz-expiration", "foo2")
+            .with_header("x-amz-restore", "bar2"),
+    ]);
+
+    let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
+
+    let mut request = HeadObjectRequest::default();
+    let mut result = client.head_object(request).await.unwrap();
+    assert_eq!(result.expiration, Some("foo1".to_string()));
+    assert_eq!(result.restore, Some("bar1".to_string()));
+
+    request = HeadObjectRequest::default();
+    result = client.head_object(request).await.unwrap();
+    assert_eq!(result.expiration, Some("foo2".to_string()));
+    assert_eq!(result.restore, Some("bar2".to_string()));
+}


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Add `MultipleMockRequestDispatcher` to permit mocking multiple requests using the same client.
