### PR TITLE
Fix serialize features

### DIFF
--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -45,7 +45,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use std::io::Write;
 use std::str::FromStr;
 use xml;

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/docdb/src/generated.rs
+++ b/rusoto/services/docdb/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -45,7 +45,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use std::io::Write;
 use std::str::FromStr;
 use xml;

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -45,7 +45,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use std::io::Write;
 use std::str::FromStr;
 use xml;

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -48,7 +48,7 @@ default-features = false
 
 [features]
 default = ["native-tls"]
-deserialize_structs = ["bytes/serde"]
+deserialize_structs = ["bytes/serde", "serde", "serde_derive"]
 native-tls = ["rusoto_core/native-tls"]
 rustls = ["rusoto_core/rustls"]
-serialize_structs = ["bytes/serde"]
+serialize_structs = ["bytes/serde", "serde", "serde_derive"]

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -27,6 +27,10 @@ use rusoto_core::proto::xml::util::{
 };
 use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
 use rusoto_core::signature::SignedRequest;
+#[cfg(feature = "deserialize_structs")]
+use serde::Deserialize;
+#[cfg(feature = "serialize_structs")]
+use serde::Serialize;
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/test-features.sh
+++ b/rusoto/services/test-features.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for D in `find . -maxdepth 1 -mindepth 1 -type d | sort`;
+do
+    (cd $D ; cargo check --features serialize_structs,deserialize_structs )
+done

--- a/rusoto/services/test-select-features.sh
+++ b/rusoto/services/test-select-features.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for D in cloudwatch cloudfront lambda kinesis ec2;
+do
+    cd $D && cargo check --features serialize_structs,deserialize_structs && cd .. || exit $?
+done

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -82,6 +82,10 @@ impl GenerateProtocol for QueryGenerator {
             use rusoto_core::proto::xml::util::{{characters, end_element, find_start_element, start_element, skip_tree, peek_at_name, deserialize_elements}};
             use rusoto_core::proto::xml::error::*;
             use serde_urlencoded;
+            #[cfg(feature = \"serialize_structs\")]
+            use serde::Serialize;
+            #[cfg(feature = \"deserialize_structs\")]
+            use serde::Deserialize;
             ")
     }
 

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -96,6 +96,10 @@ impl GenerateProtocol for RestXmlGenerator {
             use rusoto_core::proto::xml::error::*;
             use rusoto_core::proto::xml::util::{Next, Peek, XmlParseError, XmlResponse};
             use rusoto_core::proto::xml::util::{peek_at_name, characters, end_element, find_start_element, start_element, skip_tree, deserialize_elements};
+            #[cfg(feature = \"serialize_structs\")]
+            use serde::Serialize;
+            #[cfg(feature = \"deserialize_structs\")]
+            use serde::Deserialize;
             "
             .to_owned();
 

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -89,10 +89,18 @@ pub fn generate_services(
         features.insert("native-tls".into(), vec!["rusoto_core/native-tls".into()]);
         features.insert("rustls".into(), vec!["rusoto_core/rustls".into()]);
 
-        let serialize_feature_dependencies = vec!["bytes/serde".into()];
+        let mut serialize_feature_dependencies = vec!["bytes/serde".into()];
 
         let service_dependencies = service.get_dependencies();
         let service_dev_dependencies = service.get_dev_dependencies();
+
+        for (name, dep_obj) in service_dependencies.iter() {
+            if let cargo::Dependency::Extended { optional: Some(is_optional), .. } = dep_obj {
+                if *is_optional && (name == "serde" || name == "serde_derive") {
+                    serialize_feature_dependencies.push(name.into());
+                }
+            }
+        }
 
         features.insert("serialize_structs".into(), serialize_feature_dependencies.clone());
         features.insert("deserialize_structs".into(), serialize_feature_dependencies.clone());


### PR DESCRIPTION
This PR restores a small block of the deleted code that loops through the service dependencies to determine if an individual crate's `serialize_structs` and `deserialize_structs` features need to specify `serde` and `serde_derive` in the feature dependencies in order to build with the features enabled, as well as a few `cfg`-protected `use` blocks in a few of the generators. All of the crates now build with the features enabled on my system.

As I mentioned in Discord, I am checking in a script I wrote that builds all of the crates with the features enabled to test that they were generated properly. This probably wouldn't be a good fit for CI, since it's rather time-consuming to run. Since we managed to break this functionality without noticing, I think it does justify some kind of CI testing, so I wrote a version of the script that tests 5 selected crates, one of each type of generator. This should be a representative test of the feature without taking excessive time to run. It would probably be a good idea to manually run the full check locally on anything that might affect that part of the generator too.

I am open to trying to update the CI scripts as needed to run this if the project maintainers think that is a good solution. Is the plan to stick with the Semaphore CI, or switch to Github Actions longer-term?