### PR TITLE
Fix serializing jwt token when sending request

### DIFF
--- a/rusoto/services/sts/src/custom/web_identity.rs
+++ b/rusoto/services/sts/src/custom/web_identity.rs
@@ -108,7 +108,7 @@ impl ProvideAwsCredentials for WebIdentityProvider {
         let mut req = AssumeRoleWithWebIdentityRequest::default();
 
         req.role_arn = self.role_arn.resolve()?;
-        req.web_identity_token = self.web_identity_token.resolve()?.to_string();
+        req.web_identity_token = self.web_identity_token.resolve()?.as_ref().to_string();
         req.role_session_name = self.role_session_name.resolve()?;
 
         let assume_role = sts.assume_role_with_web_identity(req).await;


### PR DESCRIPTION
This is a small fix for `WebIdentityProvider` to correctly convert the JWT that it sends in the `sts.assume_role_with_web_identity` request to a `String`.
Previously, it was converting the JWT `Secret` to a `String` using `Secret.to_string`, which will return the masked secret instead of the actual token.

Fixes: #1692 