### PR TITLE
Fix s3 us-east-1 region endpoint

### DIFF
--- a/rusoto/signature/src/signature.rs
+++ b/rusoto/signature/src/signature.rs
@@ -821,11 +821,10 @@ fn build_hostname(service: &str, region: &Region) -> String {
         },
         "s3" => match *region {
             Region::Custom { ref endpoint, .. } => extract_hostname(endpoint).to_owned(),
-            Region::UsEast1 => "s3.amazonaws.com".to_string(),
             Region::CnNorth1 | Region::CnNorthwest1 => {
                 format!("s3.{}.amazonaws.com.cn", region.name())
             }
-            _ => format!("s3-{}.amazonaws.com", region.name()),
+            _ => format!("s3.{}.amazonaws.com", region.name()),
         },
         "route53" => match *region {
             Region::Custom { ref endpoint, .. } => extract_hostname(endpoint).to_owned(),


### PR DESCRIPTION
Changes the UsEast1 s3 region domain from `s3.amazonaws.com` to `s3.us-east-1.amazonaws.com
`

I did a quick test in the aws console by creating a bucket in us-east-1 and they always use `s3.us-east-1.amazonaws.com` to access it, not `s3.amazonaws.com`

Fixes #1695 