### PR TITLE
Fix `credential_process` again

### DIFF
--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -68,7 +68,7 @@ pub struct AwsCredentials {
     key: String,
     #[serde(rename = "SecretAccessKey")]
     secret: String,
-    #[serde(rename = "Token")]
+    #[serde(rename = "SessionToken", alias = "Token")]
     token: Option<String>,
     #[serde(rename = "Expiration")]
     expires_at: Option<DateTime<Utc>>,
@@ -536,6 +536,7 @@ mod tests {
             credentials.aws_secret_access_key(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         );
+        assert!(credentials.token().is_some());
 
         assert_eq!(
             credentials.expires_at().expect(""),

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -588,6 +588,11 @@ mod tests {
         let creds = result.ok().unwrap();
         assert_eq!(creds.aws_access_key_id(), "baz_access_key");
         assert_eq!(creds.aws_secret_access_key(), "baz_secret_key");
+        assert_eq!(
+            creds.token().as_ref().expect("session token not parsed"),
+            "baz_session_token"
+        );
+        assert!(creds.expires_at().is_some());
         env::remove_var(AWS_CONFIG_FILE);
     }
 


### PR DESCRIPTION
This re-applies commits 3969784e75bb687ca975c1d118d8634eddc71ad6 and ebd309f8e6e679761890cd1b49e48ad9bcefdb48 post async/.await merge.