### PR TITLE
Fix rusoto_sts::WebIdentityProvider::from_k8s_env always require AWS_ROLE_SESSION_NAME env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Please put changes here)
 
+- Fix `rusoto_sts::WebIdentityProvider::from_k8s_env` not allowing AWS_ROLE_SESSION_NAME env var being optional.
+
 ## [0.43.0] - 2020-03-15
 
 - Fix minimum version of hyper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Please put changes here)
 
-- Fix `rusoto_sts::WebIdentityProvider::from_k8s_env` not allowing AWS_ROLE_SESSION_NAME env var being optional.
+- Fix `rusoto_sts::WebIdentityProvider::from_k8s_env` always require AWS_ROLE_SESSION_NAME env var which should be optional.
 
 ## [0.43.0] - 2020-03-15
 

--- a/rusoto/credential/src/variable.rs
+++ b/rusoto/credential/src/variable.rs
@@ -134,6 +134,23 @@ where
     }
 }
 
+impl<T, E> Variable<Option<T>, E>
+where
+    T: From<String> + 'static,
+    E: From<VarError> + 'static,
+{
+    /// Variable which dynamically resolves to the value of a given environment variable.
+    pub fn from_env_var_optional<K: AsRef<std::ffi::OsStr>>(key: K) -> Self {
+        let tmp = key.as_ref().to_os_string();
+        Self::dynamic(move || match var(&tmp) {
+            Ok(ref v) if !v.trim().is_empty() => Ok(Some(T::from(v.trim().to_string()))),
+            Ok(_) => Ok(None),
+            Err(VarError::NotPresent) => Ok(None),
+            Err(e) => Err(E::from(e)),
+        })
+    }
+}
+
 impl<T, E> Variable<T, E>
 where
     T: From<String> + 'static,

--- a/rusoto/credential/src/variable.rs
+++ b/rusoto/credential/src/variable.rs
@@ -144,8 +144,7 @@ where
         let tmp = key.as_ref().to_os_string();
         Self::dynamic(move || match var(&tmp) {
             Ok(ref v) if !v.trim().is_empty() => Ok(Some(T::from(v.trim().to_string()))),
-            Ok(_) => Ok(None),
-            Err(VarError::NotPresent) => Ok(None),
+            Ok(_) | Err(VarError::NotPresent) => Ok(None),
             Err(e) => Err(E::from(e)),
         })
     }


### PR DESCRIPTION
The `AWS_ROLE_SESSION_NAME` env var is optional for `rusoto_sts::WebIdentityProvider::from_k8s_env`, but currently it will always complain if the env var is missing. Fixing it.