### PR TITLE
Omit unnecessary XML deserialisation code where action has no response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Please put changes here)
+- Omit generating XML-deseralization code for actions without a response body
 
 ## [0.43.0] - 2020-03-15
 

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -10528,24 +10528,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = AttachLoadBalancerTargetGroupsResultType::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = AttachLoadBalancerTargetGroupsResultTypeDeserializer::deserialize(
-                "AttachLoadBalancerTargetGroupsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = AttachLoadBalancerTargetGroupsResultType::default();
         // parse non-payload
         Ok(result)
     }
@@ -10577,24 +10560,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = AttachLoadBalancersResultType::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = AttachLoadBalancersResultTypeDeserializer::deserialize(
-                "AttachLoadBalancersResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = AttachLoadBalancersResultType::default();
         // parse non-payload
         Ok(result)
     }
@@ -10730,24 +10696,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CompleteLifecycleActionAnswer::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CompleteLifecycleActionAnswerDeserializer::deserialize(
-                "CompleteLifecycleActionResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CompleteLifecycleActionAnswer::default();
         // parse non-payload
         Ok(result)
     }
@@ -10919,24 +10868,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteLifecycleHookAnswer::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteLifecycleHookAnswerDeserializer::deserialize(
-                "DeleteLifecycleHookResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteLifecycleHookAnswer::default();
         // parse non-payload
         Ok(result)
     }
@@ -12020,24 +11952,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DetachLoadBalancerTargetGroupsResultType::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DetachLoadBalancerTargetGroupsResultTypeDeserializer::deserialize(
-                "DetachLoadBalancerTargetGroupsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DetachLoadBalancerTargetGroupsResultType::default();
         // parse non-payload
         Ok(result)
     }
@@ -12069,24 +11984,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DetachLoadBalancersResultType::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DetachLoadBalancersResultTypeDeserializer::deserialize(
-                "DetachLoadBalancersResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DetachLoadBalancersResultType::default();
         // parse non-payload
         Ok(result)
     }
@@ -12294,24 +12192,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = PutLifecycleHookAnswer::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = PutLifecycleHookAnswerDeserializer::deserialize(
-                "PutLifecycleHookResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = PutLifecycleHookAnswer::default();
         // parse non-payload
         Ok(result)
     }
@@ -12448,24 +12329,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = RecordLifecycleActionHeartbeatAnswer::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = RecordLifecycleActionHeartbeatAnswerDeserializer::deserialize(
-                "RecordLifecycleActionHeartbeatResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = RecordLifecycleActionHeartbeatAnswer::default();
         // parse non-payload
         Ok(result)
     }
@@ -12581,24 +12445,7 @@ impl Autoscaling for AutoscalingClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetInstanceProtectionAnswer::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetInstanceProtectionAnswerDeserializer::deserialize(
-                "SetInstanceProtectionResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetInstanceProtectionAnswer::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -12059,24 +12059,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = ContinueUpdateRollbackOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = ContinueUpdateRollbackOutputDeserializer::deserialize(
-                "ContinueUpdateRollbackResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = ContinueUpdateRollbackOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -12299,24 +12282,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteChangeSetOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteChangeSetOutputDeserializer::deserialize(
-                "DeleteChangeSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteChangeSetOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -12425,22 +12391,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteStackSetOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result =
-                DeleteStackSetOutputDeserializer::deserialize("DeleteStackSetResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteStackSetOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -12472,22 +12423,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeregisterTypeOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result =
-                DeregisterTypeOutputDeserializer::deserialize("DeregisterTypeResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeregisterTypeOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -13353,24 +13289,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = ExecuteChangeSetOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = ExecuteChangeSetOutputDeserializer::deserialize(
-                "ExecuteChangeSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = ExecuteChangeSetOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -14117,24 +14036,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = RecordHandlerProgressOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = RecordHandlerProgressOutputDeserializer::deserialize(
-                "RecordHandlerProgressResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = RecordHandlerProgressOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -14240,24 +14142,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetTypeDefaultVersionOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetTypeDefaultVersionOutputDeserializer::deserialize(
-                "SetTypeDefaultVersionResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetTypeDefaultVersionOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -14317,24 +14202,7 @@ impl CloudFormation for CloudFormationClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = StopStackSetOperationOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = StopStackSetOperationOutputDeserializer::deserialize(
-                "StopStackSetOperationResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = StopStackSetOperationOutput::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -6356,24 +6356,7 @@ impl CloudWatch for CloudWatchClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteAnomalyDetectorOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteAnomalyDetectorOutputDeserializer::deserialize(
-                "DeleteAnomalyDetectorResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteAnomalyDetectorOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6405,24 +6388,7 @@ impl CloudWatch for CloudWatchClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteDashboardsOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteDashboardsOutputDeserializer::deserialize(
-                "DeleteDashboardsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteDashboardsOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7282,24 +7248,7 @@ impl CloudWatch for CloudWatchClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = PutAnomalyDetectorOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = PutAnomalyDetectorOutputDeserializer::deserialize(
-                "PutAnomalyDetectorResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = PutAnomalyDetectorOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7377,22 +7326,7 @@ impl CloudWatch for CloudWatchClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = PutInsightRuleOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result =
-                PutInsightRuleOutputDeserializer::deserialize("PutInsightRuleResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = PutInsightRuleOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7508,21 +7442,7 @@ impl CloudWatch for CloudWatchClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = TagResourceOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = TagResourceOutputDeserializer::deserialize("TagResourceResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = TagResourceOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7554,22 +7474,7 @@ impl CloudWatch for CloudWatchClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = UntagResourceOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result =
-                UntagResourceOutputDeserializer::deserialize("UntagResourceResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = UntagResourceOutput::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -6336,21 +6336,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = AddTagsOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = AddTagsOutputDeserializer::deserialize("AddTagsResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = AddTagsOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6540,24 +6526,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateAppCookieStickinessPolicyOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateAppCookieStickinessPolicyOutputDeserializer::deserialize(
-                "CreateAppCookieStickinessPolicyResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateAppCookieStickinessPolicyOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6592,24 +6561,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateLBCookieStickinessPolicyOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateLBCookieStickinessPolicyOutputDeserializer::deserialize(
-                "CreateLBCookieStickinessPolicyResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateLBCookieStickinessPolicyOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6691,24 +6643,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateLoadBalancerListenerOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateLoadBalancerListenerOutputDeserializer::deserialize(
-                "CreateLoadBalancerListenersResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateLoadBalancerListenerOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6740,24 +6675,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateLoadBalancerPolicyOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateLoadBalancerPolicyOutputDeserializer::deserialize(
-                "CreateLoadBalancerPolicyResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateLoadBalancerPolicyOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6789,24 +6707,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteAccessPointOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteAccessPointOutputDeserializer::deserialize(
-                "DeleteLoadBalancerResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteAccessPointOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6839,24 +6740,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteLoadBalancerListenerOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteLoadBalancerListenerOutputDeserializer::deserialize(
-                "DeleteLoadBalancerListenersResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteLoadBalancerListenerOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -6888,24 +6772,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteLoadBalancerPolicyOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteLoadBalancerPolicyOutputDeserializer::deserialize(
-                "DeleteLoadBalancerPolicyResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteLoadBalancerPolicyOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7595,21 +7462,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = RemoveTagsOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = RemoveTagsOutputDeserializer::deserialize("RemoveTagsResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = RemoveTagsOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7646,24 +7499,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetLoadBalancerListenerSSLCertificateOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetLoadBalancerListenerSSLCertificateOutputDeserializer::deserialize(
-                "SetLoadBalancerListenerSSLCertificateResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetLoadBalancerListenerSSLCertificateOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7700,24 +7536,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetLoadBalancerPoliciesForBackendServerOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetLoadBalancerPoliciesForBackendServerOutputDeserializer::deserialize(
-                "SetLoadBalancerPoliciesForBackendServerResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetLoadBalancerPoliciesForBackendServerOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -7754,24 +7573,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetLoadBalancerPoliciesOfListenerOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetLoadBalancerPoliciesOfListenerOutputDeserializer::deserialize(
-                "SetLoadBalancerPoliciesOfListenerResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetLoadBalancerPoliciesOfListenerOutput::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -9165,21 +9165,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = AddTagsOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = AddTagsOutputDeserializer::deserialize("AddTagsResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = AddTagsOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -9402,22 +9388,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteListenerOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result =
-                DeleteListenerOutputDeserializer::deserialize("DeleteListenerResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteListenerOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -9449,24 +9420,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteLoadBalancerOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteLoadBalancerOutputDeserializer::deserialize(
-                "DeleteLoadBalancerResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteLoadBalancerOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -9498,21 +9452,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteRuleOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteRuleOutputDeserializer::deserialize("DeleteRuleResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteRuleOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -9544,24 +9484,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteTargetGroupOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteTargetGroupOutputDeserializer::deserialize(
-                "DeleteTargetGroupResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteTargetGroupOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -9593,24 +9516,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeregisterTargetsOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeregisterTargetsOutputDeserializer::deserialize(
-                "DeregisterTargetsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeregisterTargetsOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -10423,24 +10329,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = RegisterTargetsOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = RegisterTargetsOutputDeserializer::deserialize(
-                "RegisterTargetsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = RegisterTargetsOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -10473,24 +10362,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = RemoveListenerCertificatesOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = RemoveListenerCertificatesOutputDeserializer::deserialize(
-                "RemoveListenerCertificatesResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = RemoveListenerCertificatesOutput::default();
         // parse non-payload
         Ok(result)
     }
@@ -10522,21 +10394,7 @@ impl Elb for ElbClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = RemoveTagsOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = RemoveTagsOutputDeserializer::deserialize("RemoveTagsResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = RemoveTagsOutput::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -26070,21 +26070,7 @@ impl Iam for IamClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = UpdateRoleResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = UpdateRoleResponseDeserializer::deserialize("UpdateRoleResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = UpdateRoleResponse::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -31407,24 +31407,7 @@ impl Rds for RdsClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeregisterDBProxyTargetsResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeregisterDBProxyTargetsResponseDeserializer::deserialize(
-                "DeregisterDBProxyTargetsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeregisterDBProxyTargetsResponse::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -12151,21 +12151,7 @@ impl Route53 for Route53Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = ChangeTagsForResourceResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = ChangeTagsForResourceResponseDeserializer::deserialize(
-                &actual_tag_name,
-                &mut stack,
-            )?;
-        }
+        result = ChangeTagsForResourceResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -12625,19 +12611,7 @@ impl Route53 for Route53Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteHealthCheckResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result =
-                DeleteHealthCheckResponseDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteHealthCheckResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -12711,21 +12685,7 @@ impl Route53 for Route53Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteQueryLoggingConfigResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = DeleteQueryLoggingConfigResponseDeserializer::deserialize(
-                &actual_tag_name,
-                &mut stack,
-            )?;
-        }
+        result = DeleteQueryLoggingConfigResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -12757,21 +12717,7 @@ impl Route53 for Route53Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteReusableDelegationSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = DeleteReusableDelegationSetResponseDeserializer::deserialize(
-                &actual_tag_name,
-                &mut stack,
-            )?;
-        }
+        result = DeleteReusableDelegationSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -12806,19 +12752,7 @@ impl Route53 for Route53Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteTrafficPolicyResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result =
-                DeleteTrafficPolicyResponseDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteTrafficPolicyResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -12850,21 +12784,7 @@ impl Route53 for Route53Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteTrafficPolicyInstanceResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = DeleteTrafficPolicyInstanceResponseDeserializer::deserialize(
-                &actual_tag_name,
-                &mut stack,
-            )?;
-        }
+        result = DeleteTrafficPolicyInstanceResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -12912,21 +12832,7 @@ impl Route53 for Route53Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteVPCAssociationAuthorizationResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = DeleteVPCAssociationAuthorizationResponseDeserializer::deserialize(
-                &actual_tag_name,
-                &mut stack,
-            )?;
-        }
+        result = DeleteVPCAssociationAuthorizationResponse::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -19463,19 +19463,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = AbortMultipartUploadOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result =
-                AbortMultipartUploadOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = AbortMultipartUploadOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
             result.request_charged = Some(value)
@@ -19906,18 +19894,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = CreateBucketOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = CreateBucketOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateBucketOutput::default();
         if let Some(location) = response.headers.get("Location") {
             let value = location.to_owned();
             result.location = Some(value)
@@ -20496,18 +20473,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteObjectOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = DeleteObjectOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteObjectOutput::default();
         if let Some(delete_marker) = response.headers.get("x-amz-delete-marker") {
             let value = delete_marker.to_owned();
             result.delete_marker = Some(value.parse::<bool>().unwrap())
@@ -20553,19 +20519,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteObjectTaggingOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result =
-                DeleteObjectTaggingOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteObjectTaggingOutput::default();
         if let Some(version_id) = response.headers.get("x-amz-version-id") {
             let value = version_id.to_owned();
             result.version_id = Some(value)
@@ -22233,18 +22187,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = HeadObjectOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = HeadObjectOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = HeadObjectOutput::default();
         if let Some(accept_ranges) = response.headers.get("accept-ranges") {
             let value = accept_ranges.to_owned();
             result.accept_ranges = Some(value)
@@ -23784,18 +23727,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = PutObjectOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = PutObjectOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = PutObjectOutput::default();
         if let Some(e_tag) = response.headers.get("ETag") {
             let value = e_tag.to_owned();
             result.e_tag = Some(value)
@@ -23918,18 +23850,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = PutObjectAclOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = PutObjectAclOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = PutObjectAclOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
             result.request_charged = Some(value)
@@ -23985,19 +23906,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = PutObjectLegalHoldOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result =
-                PutObjectLegalHoldOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = PutObjectLegalHoldOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
             result.request_charged = Some(value)
@@ -24055,21 +23964,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = PutObjectLockConfigurationOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = PutObjectLockConfigurationOutputDeserializer::deserialize(
-                &actual_tag_name,
-                &mut stack,
-            )?;
-        }
+        result = PutObjectLockConfigurationOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
             result.request_charged = Some(value)
@@ -24132,19 +24027,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = PutObjectRetentionOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result =
-                PutObjectRetentionOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = PutObjectRetentionOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
             result.request_charged = Some(value)
@@ -24188,18 +24071,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = PutObjectTaggingOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = PutObjectTaggingOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = PutObjectTaggingOutput::default();
         if let Some(version_id) = response.headers.get("x-amz-version-id") {
             let value = version_id.to_owned();
             result.version_id = Some(value)
@@ -24289,18 +24161,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = RestoreObjectOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = RestoreObjectOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = RestoreObjectOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
             result.request_charged = Some(value)
@@ -24448,18 +24309,7 @@ impl S3 for S3Client {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
 
-        if xml_response.body.is_empty() {
-            result = UploadPartOutput::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            result = UploadPartOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
-        }
+        result = UploadPartOutput::default();
         if let Some(e_tag) = response.headers.get("ETag") {
             let value = e_tag.to_owned();
             result.e_tag = Some(value)

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -11084,24 +11084,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CloneReceiptRuleSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CloneReceiptRuleSetResponseDeserializer::deserialize(
-                "CloneReceiptRuleSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CloneReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11133,24 +11116,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateConfigurationSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateConfigurationSetResponseDeserializer::deserialize(
-                "CreateConfigurationSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateConfigurationSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11187,24 +11153,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateConfigurationSetEventDestinationResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateConfigurationSetEventDestinationResponseDeserializer::deserialize(
-                "CreateConfigurationSetEventDestinationResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateConfigurationSetEventDestinationResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11241,24 +11190,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateConfigurationSetTrackingOptionsResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateConfigurationSetTrackingOptionsResponseDeserializer::deserialize(
-                "CreateConfigurationSetTrackingOptionsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateConfigurationSetTrackingOptionsResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11320,24 +11252,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateReceiptFilterResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateReceiptFilterResponseDeserializer::deserialize(
-                "CreateReceiptFilterResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateReceiptFilterResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11369,24 +11284,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateReceiptRuleResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateReceiptRuleResponseDeserializer::deserialize(
-                "CreateReceiptRuleResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateReceiptRuleResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11418,24 +11316,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateReceiptRuleSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateReceiptRuleSetResponseDeserializer::deserialize(
-                "CreateReceiptRuleSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11467,24 +11348,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = CreateTemplateResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = CreateTemplateResponseDeserializer::deserialize(
-                "CreateTemplateResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = CreateTemplateResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11516,24 +11380,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteConfigurationSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteConfigurationSetResponseDeserializer::deserialize(
-                "DeleteConfigurationSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteConfigurationSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11570,24 +11417,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteConfigurationSetEventDestinationResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteConfigurationSetEventDestinationResponseDeserializer::deserialize(
-                "DeleteConfigurationSetEventDestinationResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteConfigurationSetEventDestinationResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11624,24 +11454,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteConfigurationSetTrackingOptionsResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteConfigurationSetTrackingOptionsResponseDeserializer::deserialize(
-                "DeleteConfigurationSetTrackingOptionsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteConfigurationSetTrackingOptionsResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11703,24 +11516,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteIdentityResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteIdentityResponseDeserializer::deserialize(
-                "DeleteIdentityResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteIdentityResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11752,24 +11548,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteIdentityPolicyResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteIdentityPolicyResponseDeserializer::deserialize(
-                "DeleteIdentityPolicyResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteIdentityPolicyResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11801,24 +11580,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteReceiptFilterResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteReceiptFilterResponseDeserializer::deserialize(
-                "DeleteReceiptFilterResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteReceiptFilterResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11850,24 +11612,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteReceiptRuleResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteReceiptRuleResponseDeserializer::deserialize(
-                "DeleteReceiptRuleResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteReceiptRuleResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11899,24 +11644,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteReceiptRuleSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteReceiptRuleSetResponseDeserializer::deserialize(
-                "DeleteReceiptRuleSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -11948,24 +11676,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = DeleteTemplateResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = DeleteTemplateResponseDeserializer::deserialize(
-                "DeleteTemplateResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = DeleteTemplateResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13123,24 +12834,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = PutConfigurationSetDeliveryOptionsResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = PutConfigurationSetDeliveryOptionsResponseDeserializer::deserialize(
-                "PutConfigurationSetDeliveryOptionsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = PutConfigurationSetDeliveryOptionsResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13172,24 +12866,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = PutIdentityPolicyResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = PutIdentityPolicyResponseDeserializer::deserialize(
-                "PutIdentityPolicyResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = PutIdentityPolicyResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13221,24 +12898,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = ReorderReceiptRuleSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = ReorderReceiptRuleSetResponseDeserializer::deserialize(
-                "ReorderReceiptRuleSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = ReorderReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13557,24 +13217,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetActiveReceiptRuleSetResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetActiveReceiptRuleSetResponseDeserializer::deserialize(
-                "SetActiveReceiptRuleSetResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetActiveReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13606,24 +13249,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetIdentityDkimEnabledResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetIdentityDkimEnabledResponseDeserializer::deserialize(
-                "SetIdentityDkimEnabledResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetIdentityDkimEnabledResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13660,24 +13286,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetIdentityFeedbackForwardingEnabledResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetIdentityFeedbackForwardingEnabledResponseDeserializer::deserialize(
-                "SetIdentityFeedbackForwardingEnabledResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetIdentityFeedbackForwardingEnabledResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13716,24 +13325,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetIdentityHeadersInNotificationsEnabledResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetIdentityHeadersInNotificationsEnabledResponseDeserializer::deserialize(
-                "SetIdentityHeadersInNotificationsEnabledResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetIdentityHeadersInNotificationsEnabledResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13766,24 +13358,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetIdentityMailFromDomainResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetIdentityMailFromDomainResponseDeserializer::deserialize(
-                "SetIdentityMailFromDomainResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetIdentityMailFromDomainResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13816,24 +13391,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetIdentityNotificationTopicResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetIdentityNotificationTopicResponseDeserializer::deserialize(
-                "SetIdentityNotificationTopicResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetIdentityNotificationTopicResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13865,24 +13423,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetReceiptRulePositionResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetReceiptRulePositionResponseDeserializer::deserialize(
-                "SetReceiptRulePositionResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetReceiptRulePositionResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -13996,24 +13537,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = UpdateConfigurationSetEventDestinationResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = UpdateConfigurationSetEventDestinationResponseDeserializer::deserialize(
-                "UpdateConfigurationSetEventDestinationResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = UpdateConfigurationSetEventDestinationResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -14114,24 +13638,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = UpdateConfigurationSetTrackingOptionsResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = UpdateConfigurationSetTrackingOptionsResponseDeserializer::deserialize(
-                "UpdateConfigurationSetTrackingOptionsResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = UpdateConfigurationSetTrackingOptionsResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -14193,24 +13700,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = UpdateReceiptRuleResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = UpdateReceiptRuleResponseDeserializer::deserialize(
-                "UpdateReceiptRuleResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = UpdateReceiptRuleResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -14242,24 +13732,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = UpdateTemplateResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = UpdateTemplateResponseDeserializer::deserialize(
-                "UpdateTemplateResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = UpdateTemplateResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -14417,24 +13890,7 @@ impl Ses for SesClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = VerifyEmailIdentityResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = VerifyEmailIdentityResponseDeserializer::deserialize(
-                "VerifyEmailIdentityResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = VerifyEmailIdentityResponse::default();
         // parse non-payload
         Ok(result)
     }

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -6060,24 +6060,7 @@ impl Sns for SnsClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = OptInPhoneNumberResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = OptInPhoneNumberResponseDeserializer::deserialize(
-                "OptInPhoneNumberResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = OptInPhoneNumberResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -6241,24 +6224,7 @@ impl Sns for SnsClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = SetSMSAttributesResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = SetSMSAttributesResponseDeserializer::deserialize(
-                "SetSMSAttributesResult",
-                &mut stack,
-            )?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = SetSMSAttributesResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -6392,21 +6358,7 @@ impl Sns for SnsClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = TagResourceResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result = TagResourceResponseDeserializer::deserialize("TagResourceResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = TagResourceResponse::default();
         // parse non-payload
         Ok(result)
     }
@@ -6466,22 +6418,7 @@ impl Sns for SnsClient {
         let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
 
-        if xml_response.body.is_empty() {
-            result = UntagResourceResponse::default();
-        } else {
-            let reader = EventReader::new_with_config(
-                xml_response.body.as_ref(),
-                ParserConfig::new().trim_whitespace(false),
-            );
-            let mut stack = XmlResponse::new(reader.into_iter().peekable());
-            let _start_document = stack.next();
-            let actual_tag_name = peek_at_name(&mut stack)?;
-            start_element(&actual_tag_name, &mut stack)?;
-            result =
-                UntagResourceResponseDeserializer::deserialize("UntagResourceResult", &mut stack)?;
-            skip_tree(&mut stack);
-            end_element(&actual_tag_name, &mut stack)?;
-        }
+        result = UntagResourceResponse::default();
         // parse non-payload
         Ok(result)
     }


### PR DESCRIPTION
Rusoto currently emits code for deseralising XML responses even when no XML response is expected (e.g. any response data is in HTTP headers only).  The amount of generated code can be reduced a little by skipping generation of more of this.

This first-attempt at a change doesn't suppress the generated `{output_shape}Deserializer` because a naive attempt suppressed some instances that were actually still needed.  There are many new `never constructed` / `never used` warnings as a result.

The fact that the code _was_ generated caused me to hit the problem in https://github.com/rusoto/rusoto/issues/1377 because moto (as used by localstack) incorrectly produces an XML response to an S3 `PutObject`, and the failure parsing that response causes rusoto_s3 to error.  This is clearly a fault with with moto (I will try to follow up to https://github.com/spulec/moto/pull/2866 to address this), but this change to rusoto happily mitigates the problem.
