### PR TITLE
Add support for generating a RDS IAM DB authentication token

### DIFF
--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -30,6 +30,16 @@ version = "0.43.0"
 path = "../../core"
 default-features = false
 
+[dependencies.rusoto_credential]
+version = "0.43.0"
+path = "../../credential"
+default-features = false
+
+[dependencies.rusoto_signature]
+version = "0.43.0"
+path = "../../signature"
+default-features = false
+
 [dependencies.serde]
 version = "1.0.2"
 optional = true

--- a/rusoto/services/rds/src/custom/mod.rs
+++ b/rusoto/services/rds/src/custom/mod.rs
@@ -1,1 +1,55 @@
+use std::time::Duration;
 
+use rusoto_core::region::Region;
+use rusoto_credential::{CredentialsError, ProvideAwsCredentials};
+use rusoto_signature::signature::SignedRequest;
+
+// TODO: should these be constants, perhaps they'd just be better inline?
+const RDS_GENERATE_DB_AUTH_TOKEN_ACTION: &'static str = "connect";
+const RDS_GENERATE_DB_AUTH_TOKEN_METHOD: &'static str = "GET";
+const RDS_GENERATE_DB_AUTH_TOKEN_PATH: &'static str = "/";
+const RDS_GENERATE_DB_AUTH_TOKEN_SERVICE: &'static str = "rds-db";
+
+pub struct GenerateDbAuthTokenAttributes {
+    pub region: Region,
+    pub hostname: String,
+    pub port: u16,
+    pub username: String,
+}
+
+async fn generate_db_auth_token<P>(provider: P, attributes: GenerateDbAuthTokenAttributes) -> Result<String, CredentialsError>
+where
+    P: ProvideAwsCredentials + Send + Sync + 'static
+{
+    // TODO: should this use also have a configurable timeout. See: client.rs#sign_and_dispatch
+    let credentials = provider.credentials().await?;
+
+    let mut request = SignedRequest::new(RDS_GENERATE_DB_AUTH_TOKEN_METHOD, RDS_GENERATE_DB_AUTH_TOKEN_SERVICE, &attributes.region, RDS_GENERATE_DB_AUTH_TOKEN_PATH);
+
+    let hostname = format!("{}:{}", attributes.hostname, attributes.port);
+    request.set_hostname(Some(hostname));
+
+    request.add_param("Action", RDS_GENERATE_DB_AUTH_TOKEN_ACTION);
+    request.add_param("DBUser", &attributes.username);
+
+    // TODO: should this expiration time be configurable
+    let expires_in = Duration::from_secs(15 * 60);
+
+    let signature = request.generate_presigned_url(&credentials, &expires_in, true);
+
+    // remove the leading scheme
+    // TODO: is there a more idiomatic way to remove the prefix?
+    //       should we parse as a URL an then format it?
+    //       `strip_prefix` is closer in behaviour to what we want, but is a
+    //       nightly feature.
+    let signature = signature.trim_start_matches("https://");
+
+    Ok(signature.to_owned())
+}
+
+#[cfg(test)]
+mod test {
+    // TODO: how should we test this?
+    // With a way to inject the current time, and static credentials this could
+    // be deterministic.
+}


### PR DESCRIPTION
This is very much a proof-of-concept at this stage. I'm reasonably new to rust, and while I've used rusoto, I've not done any development on it before and so am not familiar with the style and conventions of the project.

If someone has some time available I got use a little guidance to get this to the point where it could be merged.

---

Connecting to an RDS instance using IAM authentication requires signing a URL with AWS V4 signing, and then subsequently using that as the password when connecting to a MySQL or PostgreSQL database.

This is broadly just a convenience function, which makes use of the `credential` & `signature` modules. I chose to locate it in the RDS module at it seemed most appropriate – although there's possibly an argument to be made that this is most-likely to be used by a client connecting to the database with little other need for the rest of the AWS SDK apparatus, and so would appreciate it being part of the smaller `signature` crate.

Initially I wanted this method to be method on `RdsClient` and re-use that `ProvideAwsCredentials` instance there, however that isn't accessible from there. Next I looked at using a method on core's `Client`, but as far as I understood only `sign_and_dispatch` is available there.

For now then, before building some consensus on how this should ultimately be architected, I left it as a standalone method that takes a `ProvideAwsCredentials`.

As this doesn't require a request / response (compared to most of the public API), I don't think it makes sense for this to be generated code; therefore I added it to the `custom` module. Does that make sense?

There is, however, the potential for the credentials provider to make a network request. So perhaps we should consider adding an optional timeout as in [core's `Client#sign_and_dispatch`](https://github.com/rusoto/rusoto/blob/e7ed8eabbb758bda4a857436ca572114de2bf283/rusoto/core/src/client.rs#L153-L172). This perhaps points towards a re-factoring of that code to make it re-usable for this case?

I chose to structure the attributes as a struct passed to the function mainly to make it more consistent with the rest of the current API, but perhaps it'd be cleaner for the caller to pass these values to the function directly.

There's also the question of whether the expiration time for the token should be configurable. I'm not sure whether this is supported by the backend, and it's hardcoded in the [`Ruby AWS SDK`](https://github.com/aws/aws-sdk-ruby/blob/6d9fd32436410e7bf16e04950ed431627b098504/gems/aws-sdk-rds/lib/aws-sdk-rds/customizations/auth_token_generator.rb#L58) and in the [`boto Python library`](https://github.com/boto/botocore/blob/5d06293532ef9f61f49b38b24998584a49668666/botocore/signers.py#L407). So this is probably unnecessary.

Then there's a couple of questions surrounding idiomatic rust & project style which are marked as `TODO` comments in the source.

See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html

---

As I said above, if someone is able to provide some guidance here, I can probably get this to a point where it can be merged in.

Thanks