### PR TITLE
Change OffsetDateTime::now() calls to OffsetDateTime::now_utc()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 (Please put changes here)
+- Fix OffsetDateTime::now() deprecation warning
 
 ## [0.43.0] - 2020-03-15
 

--- a/rusoto/signature/src/signature.rs
+++ b/rusoto/signature/src/signature.rs
@@ -274,7 +274,7 @@ impl SignedRequest {
         self.sign(creds);
         let hostname = self.hostname();
 
-        let current_time = OffsetDateTime::now();
+        let current_time = OffsetDateTime::now_utc();
         let current_time_fmted = current_time.format("%Y%m%dT%H%M%SZ");
         let current_date = current_time.format("%Y%m%d");
 
@@ -439,7 +439,7 @@ impl SignedRequest {
     /// Authorization header uses AWS4-HMAC-SHA256 for signing.
     pub fn sign_with_plus(&mut self, creds: &AwsCredentials, should_treat_plus_literally: bool) {
         self.complement_with_plus(should_treat_plus_literally);
-        let date = OffsetDateTime::now();
+        let date = OffsetDateTime::now_utc();
         self.remove_header("x-amz-date");
         self.add_header("x-amz-date", &date.format("%Y%m%dT%H%M%SZ"));
 


### PR DESCRIPTION
OffsetDateTime::now() is deprecated; it is suggested to use
OffsetDateTime::now_utc().

This fixes the broken `master` branch build.

`cargo test --lib` passes; I feel this is a pretty unobtrusive change.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
* Fix OffsetDateTime::now() deprecation warning
