### PR TITLE
Add Milan (eu-south-1) region

### DIFF
--- a/rusoto/signature/src/region.rs
+++ b/rusoto/signature/src/region.rs
@@ -77,6 +77,9 @@ pub enum Region {
     /// Region that covers Northern Europe
     EuNorth1,
 
+    /// Region that covers Southern Europe
+    EuSouth1,
+
     /// Bahrain, Middle East South
     MeSouth1,
 
@@ -147,6 +150,7 @@ impl Region {
             Region::EuWest2 => "eu-west-2",
             Region::EuWest3 => "eu-west-3",
             Region::EuNorth1 => "eu-north-1",
+            Region::EuSouth1 => "eu-south-1",
             Region::MeSouth1 => "me-south-1",
             Region::SaEast1 => "sa-east-1",
             Region::UsEast1 => "us-east-1",
@@ -246,6 +250,7 @@ impl FromStr for Region {
             "eu-west-2" | "euwest2" => Ok(Region::EuWest2),
             "eu-west-3" | "euwest3" => Ok(Region::EuWest3),
             "eu-north-1" | "eunorth1" => Ok(Region::EuNorth1),
+            "eu-south-1" | "eusouth1" => Ok(Region::EuSouth1),
             "me-south-1" | "mesouth1" => Ok(Region::MeSouth1),
             "sa-east-1" | "saeast1" => Ok(Region::SaEast1),
             "us-east-1" | "useast1" => Ok(Region::UsEast1),
@@ -320,6 +325,7 @@ mod tests {
         assert_eq!("eu-west-2".parse(), Ok(Region::EuWest2));
         assert_eq!("eu-west-3".parse(), Ok(Region::EuWest3));
         assert_eq!("eu-north-1".parse(), Ok(Region::EuNorth1));
+        assert_eq!("eu-south-1".parse(), Ok(Region::EuSouth1));
         assert_eq!("me-south-1".parse(), Ok(Region::MeSouth1));
         assert_eq!("sa-east-1".parse(), Ok(Region::SaEast1));
         assert_eq!("us-east-1".parse(), Ok(Region::UsEast1));
@@ -348,6 +354,7 @@ mod tests {
         assert_tokens(&Region::EuWest2, &tokens_for_region("eu-west-2"));
         assert_tokens(&Region::EuWest3, &tokens_for_region("eu-west-3"));
         assert_tokens(&Region::EuNorth1, &tokens_for_region("eu-north-1"));
+        assert_tokens(&Region::EuSouth1, &tokens_for_region("eu-south-1"));
         assert_tokens(&Region::MeSouth1, &tokens_for_region("me-south-1"));
         assert_tokens(&Region::SaEast1, &tokens_for_region("sa-east-1"));
         assert_tokens(&Region::UsEast1, &tokens_for_region("us-east-1"));


### PR DESCRIPTION
Fixes #1737 

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
* Add support for new Milan region (`eu-south-1`)
