### PR TITLE
Fix up dead code warnings after #1728

### DIFF
--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -10685,9 +10685,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(AttachLoadBalancerTargetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = AttachLoadBalancerTargetGroupsResultType::default();
         // parse non-payload
         Ok(result)
@@ -10717,9 +10715,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(AttachLoadBalancersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = AttachLoadBalancersResultType::default();
         // parse non-payload
         Ok(result)
@@ -10750,9 +10746,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(BatchDeleteScheduledActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = BatchDeleteScheduledActionAnswer::default();
         } else {
@@ -10804,9 +10799,8 @@ impl Autoscaling for AutoscalingClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = BatchPutScheduledUpdateGroupActionAnswer::default();
         } else {
@@ -10853,9 +10847,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(CompleteLifecycleActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CompleteLifecycleActionAnswer::default();
         // parse non-payload
         Ok(result)
@@ -11025,9 +11017,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(DeleteLifecycleHookError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteLifecycleHookAnswer::default();
         // parse non-payload
         Ok(result)
@@ -11167,9 +11157,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeAccountLimitsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAccountLimitsAnswer::default();
         } else {
@@ -11215,9 +11204,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeAdjustmentTypesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAdjustmentTypesAnswer::default();
         } else {
@@ -11264,9 +11252,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeAutoScalingGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AutoScalingGroupsType::default();
         } else {
@@ -11313,9 +11300,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeAutoScalingInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AutoScalingInstancesType::default();
         } else {
@@ -11366,9 +11352,8 @@ impl Autoscaling for AutoscalingClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAutoScalingNotificationTypesAnswer::default();
         } else {
@@ -11415,9 +11400,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeLaunchConfigurationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = LaunchConfigurationsType::default();
         } else {
@@ -11464,9 +11448,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeLifecycleHookTypesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLifecycleHookTypesAnswer::default();
         } else {
@@ -11513,9 +11496,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeLifecycleHooksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLifecycleHooksAnswer::default();
         } else {
@@ -11567,9 +11549,8 @@ impl Autoscaling for AutoscalingClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLoadBalancerTargetGroupsResponse::default();
         } else {
@@ -11616,9 +11597,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeLoadBalancersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLoadBalancersResponse::default();
         } else {
@@ -11665,9 +11645,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeMetricCollectionTypesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeMetricCollectionTypesAnswer::default();
         } else {
@@ -11719,9 +11698,8 @@ impl Autoscaling for AutoscalingClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeNotificationConfigurationsAnswer::default();
         } else {
@@ -11768,9 +11746,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribePoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PoliciesType::default();
         } else {
@@ -11814,9 +11791,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeScalingActivitiesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ActivitiesType::default();
         } else {
@@ -11862,9 +11838,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeScalingProcessTypesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ProcessesType::default();
         } else {
@@ -11911,9 +11886,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeScheduledActionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ScheduledActionsType::default();
         } else {
@@ -11960,9 +11934,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TagsType::default();
         } else {
@@ -12008,9 +11981,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DescribeTerminationPolicyTypesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTerminationPolicyTypesAnswer::default();
         } else {
@@ -12057,9 +12029,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(DetachInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DetachInstancesAnswer::default();
         } else {
@@ -12109,9 +12080,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(DetachLoadBalancerTargetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DetachLoadBalancerTargetGroupsResultType::default();
         // parse non-payload
         Ok(result)
@@ -12141,9 +12110,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(DetachLoadBalancersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DetachLoadBalancersResultType::default();
         // parse non-payload
         Ok(result)
@@ -12229,9 +12196,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(EnterStandbyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnterStandbyAnswer::default();
         } else {
@@ -12303,9 +12269,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(ExitStandbyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ExitStandbyAnswer::default();
         } else {
@@ -12349,9 +12314,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(PutLifecycleHookError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = PutLifecycleHookAnswer::default();
         // parse non-payload
         Ok(result)
@@ -12409,9 +12372,8 @@ impl Autoscaling for AutoscalingClient {
             return Err(PutScalingPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PolicyARNType::default();
         } else {
@@ -12486,9 +12448,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(RecordLifecycleActionHeartbeatError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = RecordLifecycleActionHeartbeatAnswer::default();
         // parse non-payload
         Ok(result)
@@ -12602,9 +12562,7 @@ impl Autoscaling for AutoscalingClient {
             return Err(SetInstanceProtectionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetInstanceProtectionAnswer::default();
         // parse non-payload
         Ok(result)
@@ -12664,9 +12622,8 @@ impl Autoscaling for AutoscalingClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ActivityType::default();
         } else {

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -36,9 +36,10 @@ use std::str::FromStr;
 use xml::reader::ParserConfig;
 use xml::EventReader;
 
+#[allow(dead_code)]
 struct ActivitiesDeserializer;
 impl ActivitiesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -62,9 +63,10 @@ pub struct ActivitiesType {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ActivitiesTypeDeserializer;
 impl ActivitiesTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -110,9 +112,10 @@ pub struct Activity {
     pub status_message: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ActivityDeserializer;
 impl ActivityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -180,9 +183,10 @@ pub struct ActivityType {
     pub activity: Option<Activity>,
 }
 
+#[allow(dead_code)]
 struct ActivityTypeDeserializer;
 impl ActivityTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -206,9 +210,10 @@ pub struct AdjustmentType {
     pub adjustment_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AdjustmentTypeDeserializer;
 impl AdjustmentTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -227,9 +232,10 @@ impl AdjustmentTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AdjustmentTypesDeserializer;
 impl AdjustmentTypesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -254,9 +260,10 @@ pub struct Alarm {
     pub alarm_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AlarmDeserializer;
 impl AlarmDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Alarm, XmlParseError> {
         deserialize_elements::<_, Alarm, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -275,9 +282,10 @@ impl AlarmDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AlarmsDeserializer;
 impl AlarmsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -292,9 +300,10 @@ impl AlarmsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AsciiStringMaxLen255Deserializer;
 impl AsciiStringMaxLen255Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -303,9 +312,10 @@ impl AsciiStringMaxLen255Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AssociatePublicIpAddressDeserializer;
 impl AssociatePublicIpAddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -350,9 +360,10 @@ impl AttachInstancesQuerySerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct AttachLoadBalancerTargetGroupsResultType {}
 
+#[allow(dead_code)]
 struct AttachLoadBalancerTargetGroupsResultTypeDeserializer;
 impl AttachLoadBalancerTargetGroupsResultTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -400,9 +411,10 @@ impl AttachLoadBalancerTargetGroupsTypeSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct AttachLoadBalancersResultType {}
 
+#[allow(dead_code)]
 struct AttachLoadBalancersResultTypeDeserializer;
 impl AttachLoadBalancersResultTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -504,9 +516,10 @@ pub struct AutoScalingGroup {
     pub vpc_zone_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AutoScalingGroupDeserializer;
 impl AutoScalingGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -662,9 +675,10 @@ impl AutoScalingGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AutoScalingGroupDesiredCapacityDeserializer;
 impl AutoScalingGroupDesiredCapacityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -673,9 +687,10 @@ impl AutoScalingGroupDesiredCapacityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AutoScalingGroupMaxSizeDeserializer;
 impl AutoScalingGroupMaxSizeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -684,9 +699,10 @@ impl AutoScalingGroupMaxSizeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AutoScalingGroupMinSizeDeserializer;
 impl AutoScalingGroupMinSizeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -743,9 +759,10 @@ impl AutoScalingGroupNamesTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AutoScalingGroupsDeserializer;
 impl AutoScalingGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -769,9 +786,10 @@ pub struct AutoScalingGroupsType {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AutoScalingGroupsTypeDeserializer;
 impl AutoScalingGroupsTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -820,9 +838,10 @@ pub struct AutoScalingInstanceDetails {
     pub weighted_capacity: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AutoScalingInstanceDetailsDeserializer;
 impl AutoScalingInstanceDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -893,9 +912,10 @@ impl AutoScalingInstanceDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AutoScalingInstancesDeserializer;
 impl AutoScalingInstancesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -921,9 +941,10 @@ pub struct AutoScalingInstancesType {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AutoScalingInstancesTypeDeserializer;
 impl AutoScalingInstancesTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -952,9 +973,10 @@ impl AutoScalingInstancesTypeDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AutoScalingNotificationTypesDeserializer;
 impl AutoScalingNotificationTypesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -983,9 +1005,10 @@ impl AutoScalingNotificationTypesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AvailabilityZonesDeserializer;
 impl AvailabilityZonesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1021,9 +1044,10 @@ pub struct BatchDeleteScheduledActionAnswer {
     pub failed_scheduled_actions: Option<Vec<FailedScheduledUpdateGroupActionRequest>>,
 }
 
+#[allow(dead_code)]
 struct BatchDeleteScheduledActionAnswerDeserializer;
 impl BatchDeleteScheduledActionAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1085,9 +1109,10 @@ pub struct BatchPutScheduledUpdateGroupActionAnswer {
     pub failed_scheduled_update_group_actions: Option<Vec<FailedScheduledUpdateGroupActionRequest>>,
 }
 
+#[allow(dead_code)]
 struct BatchPutScheduledUpdateGroupActionAnswerDeserializer;
 impl BatchPutScheduledUpdateGroupActionAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1144,9 +1169,10 @@ impl BatchPutScheduledUpdateGroupActionTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BlockDeviceEbsDeleteOnTerminationDeserializer;
 impl BlockDeviceEbsDeleteOnTerminationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1155,9 +1181,10 @@ impl BlockDeviceEbsDeleteOnTerminationDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BlockDeviceEbsEncryptedDeserializer;
 impl BlockDeviceEbsEncryptedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1166,9 +1193,10 @@ impl BlockDeviceEbsEncryptedDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BlockDeviceEbsIopsDeserializer;
 impl BlockDeviceEbsIopsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1177,9 +1205,10 @@ impl BlockDeviceEbsIopsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BlockDeviceEbsVolumeSizeDeserializer;
 impl BlockDeviceEbsVolumeSizeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1188,9 +1217,10 @@ impl BlockDeviceEbsVolumeSizeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BlockDeviceEbsVolumeTypeDeserializer;
 impl BlockDeviceEbsVolumeTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1214,9 +1244,10 @@ pub struct BlockDeviceMapping {
     pub virtual_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct BlockDeviceMappingDeserializer;
 impl BlockDeviceMappingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1268,9 +1299,10 @@ impl BlockDeviceMappingSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BlockDeviceMappingsDeserializer;
 impl BlockDeviceMappingsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1299,9 +1331,10 @@ impl BlockDeviceMappingsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ClassicLinkVPCSecurityGroupsDeserializer;
 impl ClassicLinkVPCSecurityGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1334,9 +1367,10 @@ impl ClassicLinkVPCSecurityGroupsSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CompleteLifecycleActionAnswer {}
 
+#[allow(dead_code)]
 struct CompleteLifecycleActionAnswerDeserializer;
 impl CompleteLifecycleActionAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1398,9 +1432,10 @@ impl CompleteLifecycleActionTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CooldownDeserializer;
 impl CooldownDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1740,9 +1775,10 @@ pub struct CustomizedMetricSpecification {
     pub unit: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CustomizedMetricSpecificationDeserializer;
 impl CustomizedMetricSpecificationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1836,9 +1872,10 @@ impl DeleteAutoScalingGroupTypeSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteLifecycleHookAnswer {}
 
+#[allow(dead_code)]
 struct DeleteLifecycleHookAnswerDeserializer;
 impl DeleteLifecycleHookAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1997,9 +2034,10 @@ pub struct DescribeAccountLimitsAnswer {
     pub number_of_launch_configurations: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DescribeAccountLimitsAnswerDeserializer;
 impl DescribeAccountLimitsAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2051,9 +2089,10 @@ pub struct DescribeAdjustmentTypesAnswer {
     pub adjustment_types: Option<Vec<AdjustmentType>>,
 }
 
+#[allow(dead_code)]
 struct DescribeAdjustmentTypesAnswerDeserializer;
 impl DescribeAdjustmentTypesAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2118,9 +2157,10 @@ pub struct DescribeAutoScalingNotificationTypesAnswer {
     pub auto_scaling_notification_types: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DescribeAutoScalingNotificationTypesAnswerDeserializer;
 impl DescribeAutoScalingNotificationTypesAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2152,9 +2192,10 @@ pub struct DescribeLifecycleHookTypesAnswer {
     pub lifecycle_hook_types: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DescribeLifecycleHookTypesAnswerDeserializer;
 impl DescribeLifecycleHookTypesAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2186,9 +2227,10 @@ pub struct DescribeLifecycleHooksAnswer {
     pub lifecycle_hooks: Option<Vec<LifecycleHook>>,
 }
 
+#[allow(dead_code)]
 struct DescribeLifecycleHooksAnswerDeserializer;
 impl DescribeLifecycleHooksAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2284,9 +2326,10 @@ pub struct DescribeLoadBalancerTargetGroupsResponse {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeLoadBalancerTargetGroupsResponseDeserializer;
 impl DescribeLoadBalancerTargetGroupsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2357,9 +2400,10 @@ pub struct DescribeLoadBalancersResponse {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeLoadBalancersResponseDeserializer;
 impl DescribeLoadBalancersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2394,9 +2438,10 @@ pub struct DescribeMetricCollectionTypesAnswer {
     pub metrics: Option<Vec<MetricCollectionType>>,
 }
 
+#[allow(dead_code)]
 struct DescribeMetricCollectionTypesAnswerDeserializer;
 impl DescribeMetricCollectionTypesAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2435,9 +2480,10 @@ pub struct DescribeNotificationConfigurationsAnswer {
     pub notification_configurations: Vec<NotificationConfiguration>,
 }
 
+#[allow(dead_code)]
 struct DescribeNotificationConfigurationsAnswerDeserializer;
 impl DescribeNotificationConfigurationsAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2692,9 +2738,10 @@ pub struct DescribeTerminationPolicyTypesAnswer {
     pub termination_policy_types: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DescribeTerminationPolicyTypesAnswerDeserializer;
 impl DescribeTerminationPolicyTypesAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2726,9 +2773,10 @@ pub struct DetachInstancesAnswer {
     pub activities: Option<Vec<Activity>>,
 }
 
+#[allow(dead_code)]
 struct DetachInstancesAnswerDeserializer;
 impl DetachInstancesAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2788,9 +2836,10 @@ impl DetachInstancesQuerySerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DetachLoadBalancerTargetGroupsResultType {}
 
+#[allow(dead_code)]
 struct DetachLoadBalancerTargetGroupsResultTypeDeserializer;
 impl DetachLoadBalancerTargetGroupsResultTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2838,9 +2887,10 @@ impl DetachLoadBalancerTargetGroupsTypeSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DetachLoadBalancersResultType {}
 
+#[allow(dead_code)]
 struct DetachLoadBalancersResultTypeDeserializer;
 impl DetachLoadBalancersResultTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2912,9 +2962,10 @@ impl DisableMetricsCollectionQuerySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DisableScaleInDeserializer;
 impl DisableScaleInDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2942,9 +2993,10 @@ pub struct Ebs {
     pub volume_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EbsDeserializer;
 impl EbsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Ebs, XmlParseError> {
         deserialize_elements::<_, Ebs, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -3022,9 +3074,10 @@ impl EbsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EbsOptimizedDeserializer;
 impl EbsOptimizedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3074,9 +3127,10 @@ pub struct EnabledMetric {
     pub metric: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EnabledMetricDeserializer;
 impl EnabledMetricDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3100,9 +3154,10 @@ impl EnabledMetricDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EnabledMetricsDeserializer;
 impl EnabledMetricsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3124,9 +3179,10 @@ pub struct EnterStandbyAnswer {
     pub activities: Option<Vec<Activity>>,
 }
 
+#[allow(dead_code)]
 struct EnterStandbyAnswerDeserializer;
 impl EnterStandbyAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3182,9 +3238,10 @@ impl EnterStandbyQuerySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EstimatedInstanceWarmupDeserializer;
 impl EstimatedInstanceWarmupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3243,9 +3300,10 @@ pub struct ExitStandbyAnswer {
     pub activities: Option<Vec<Activity>>,
 }
 
+#[allow(dead_code)]
 struct ExitStandbyAnswerDeserializer;
 impl ExitStandbyAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3307,9 +3365,10 @@ pub struct FailedScheduledUpdateGroupActionRequest {
     pub scheduled_action_name: String,
 }
 
+#[allow(dead_code)]
 struct FailedScheduledUpdateGroupActionRequestDeserializer;
 impl FailedScheduledUpdateGroupActionRequestDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3342,9 +3401,10 @@ impl FailedScheduledUpdateGroupActionRequestDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct FailedScheduledUpdateGroupActionRequestsDeserializer;
 impl FailedScheduledUpdateGroupActionRequestsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3402,9 +3462,10 @@ impl FiltersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct GlobalTimeoutDeserializer;
 impl GlobalTimeoutDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3413,9 +3474,10 @@ impl GlobalTimeoutDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckGracePeriodDeserializer;
 impl HealthCheckGracePeriodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3424,9 +3486,10 @@ impl HealthCheckGracePeriodDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HeartbeatTimeoutDeserializer;
 impl HeartbeatTimeoutDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3459,9 +3522,10 @@ pub struct Instance {
     pub weighted_capacity: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstanceDeserializer;
 impl InstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3541,9 +3605,10 @@ pub struct InstanceMonitoring {
     pub enabled: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct InstanceMonitoringDeserializer;
 impl InstanceMonitoringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3577,9 +3642,10 @@ impl InstanceMonitoringSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InstanceProtectedDeserializer;
 impl InstanceProtectedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3588,9 +3654,10 @@ impl InstanceProtectedDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InstancesDeserializer;
 impl InstancesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3624,9 +3691,10 @@ pub struct InstancesDistribution {
     pub spot_max_price: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstancesDistributionDeserializer;
 impl InstancesDistributionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3765,9 +3833,10 @@ pub struct LaunchConfiguration {
     pub user_data: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LaunchConfigurationDeserializer;
 impl LaunchConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3952,9 +4021,10 @@ impl LaunchConfigurationNamesTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LaunchConfigurationsDeserializer;
 impl LaunchConfigurationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3980,9 +4050,10 @@ pub struct LaunchConfigurationsType {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LaunchConfigurationsTypeDeserializer;
 impl LaunchConfigurationsTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4022,9 +4093,10 @@ pub struct LaunchTemplate {
     pub overrides: Option<Vec<LaunchTemplateOverrides>>,
 }
 
+#[allow(dead_code)]
 struct LaunchTemplateDeserializer;
 impl LaunchTemplateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4076,9 +4148,10 @@ impl LaunchTemplateSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LaunchTemplateNameDeserializer;
 impl LaunchTemplateNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4098,9 +4171,10 @@ pub struct LaunchTemplateOverrides {
     pub weighted_capacity: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LaunchTemplateOverridesDeserializer;
 impl LaunchTemplateOverridesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4161,9 +4235,10 @@ pub struct LaunchTemplateSpecification {
     pub version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LaunchTemplateSpecificationDeserializer;
 impl LaunchTemplateSpecificationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4220,9 +4295,10 @@ impl LaunchTemplateSpecificationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LifecycleActionResultDeserializer;
 impl LifecycleActionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4255,9 +4331,10 @@ pub struct LifecycleHook {
     pub role_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LifecycleHookDeserializer;
 impl LifecycleHookDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4405,9 +4482,10 @@ impl LifecycleHookSpecificationsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LifecycleHooksDeserializer;
 impl LifecycleHooksDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4422,9 +4500,10 @@ impl LifecycleHooksDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LifecycleStateDeserializer;
 impl LifecycleStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4433,9 +4512,10 @@ impl LifecycleStateDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LifecycleTransitionDeserializer;
 impl LifecycleTransitionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4444,9 +4524,10 @@ impl LifecycleTransitionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerNamesDeserializer;
 impl LoadBalancerNamesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4485,9 +4566,10 @@ pub struct LoadBalancerState {
     pub state: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerStateDeserializer;
 impl LoadBalancerStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4509,9 +4591,10 @@ impl LoadBalancerStateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerStatesDeserializer;
 impl LoadBalancerStatesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4536,9 +4619,10 @@ pub struct LoadBalancerTargetGroupState {
     pub state: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerTargetGroupStateDeserializer;
 impl LoadBalancerTargetGroupStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4566,9 +4650,10 @@ impl LoadBalancerTargetGroupStateDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerTargetGroupStatesDeserializer;
 impl LoadBalancerTargetGroupStatesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4585,9 +4670,10 @@ impl LoadBalancerTargetGroupStatesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MaxInstanceLifetimeDeserializer;
 impl MaxInstanceLifetimeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4596,9 +4682,10 @@ impl MaxInstanceLifetimeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaxNumberOfAutoScalingGroupsDeserializer;
 impl MaxNumberOfAutoScalingGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4607,9 +4694,10 @@ impl MaxNumberOfAutoScalingGroupsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaxNumberOfLaunchConfigurationsDeserializer;
 impl MaxNumberOfLaunchConfigurationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4626,9 +4714,10 @@ pub struct MetricCollectionType {
     pub metric: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MetricCollectionTypeDeserializer;
 impl MetricCollectionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4646,9 +4735,10 @@ impl MetricCollectionTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MetricCollectionTypesDeserializer;
 impl MetricCollectionTypesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4676,9 +4766,10 @@ pub struct MetricDimension {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct MetricDimensionDeserializer;
 impl MetricDimensionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4712,9 +4803,10 @@ impl MetricDimensionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MetricDimensionNameDeserializer;
 impl MetricDimensionNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4723,9 +4815,10 @@ impl MetricDimensionNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricDimensionValueDeserializer;
 impl MetricDimensionValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4734,9 +4827,10 @@ impl MetricDimensionValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricDimensionsDeserializer;
 impl MetricDimensionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4771,9 +4865,10 @@ pub struct MetricGranularityType {
     pub granularity: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MetricGranularityTypeDeserializer;
 impl MetricGranularityTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4792,9 +4887,10 @@ impl MetricGranularityTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MetricGranularityTypesDeserializer;
 impl MetricGranularityTypesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4811,9 +4907,10 @@ impl MetricGranularityTypesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MetricNameDeserializer;
 impl MetricNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4822,9 +4919,10 @@ impl MetricNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricNamespaceDeserializer;
 impl MetricNamespaceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4833,9 +4931,10 @@ impl MetricNamespaceDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricScaleDeserializer;
 impl MetricScaleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4844,9 +4943,10 @@ impl MetricScaleDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricStatisticDeserializer;
 impl MetricStatisticDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4855,9 +4955,10 @@ impl MetricStatisticDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricTypeDeserializer;
 impl MetricTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4866,9 +4967,10 @@ impl MetricTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricUnitDeserializer;
 impl MetricUnitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4889,9 +4991,10 @@ impl MetricsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MinAdjustmentMagnitudeDeserializer;
 impl MinAdjustmentMagnitudeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4900,9 +5003,10 @@ impl MinAdjustmentMagnitudeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MinAdjustmentStepDeserializer;
 impl MinAdjustmentStepDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4911,9 +5015,10 @@ impl MinAdjustmentStepDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MixedInstanceSpotPriceDeserializer;
 impl MixedInstanceSpotPriceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4933,9 +5038,10 @@ pub struct MixedInstancesPolicy {
     pub launch_template: Option<LaunchTemplate>,
 }
 
+#[allow(dead_code)]
 struct MixedInstancesPolicyDeserializer;
 impl MixedInstancesPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4988,9 +5094,10 @@ impl MixedInstancesPolicySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MonitoringEnabledDeserializer;
 impl MonitoringEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4999,9 +5106,10 @@ impl MonitoringEnabledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NoDeviceDeserializer;
 impl NoDeviceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5022,9 +5130,10 @@ pub struct NotificationConfiguration {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct NotificationConfigurationDeserializer;
 impl NotificationConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5057,9 +5166,10 @@ impl NotificationConfigurationDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct NotificationConfigurationsDeserializer;
 impl NotificationConfigurationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5076,9 +5186,10 @@ impl NotificationConfigurationsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct NumberOfAutoScalingGroupsDeserializer;
 impl NumberOfAutoScalingGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5087,9 +5198,10 @@ impl NumberOfAutoScalingGroupsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NumberOfLaunchConfigurationsDeserializer;
 impl NumberOfLaunchConfigurationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5098,9 +5210,10 @@ impl NumberOfLaunchConfigurationsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OnDemandBaseCapacityDeserializer;
 impl OnDemandBaseCapacityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5109,9 +5222,10 @@ impl OnDemandBaseCapacityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OnDemandPercentageAboveBaseCapacityDeserializer;
 impl OnDemandPercentageAboveBaseCapacityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5120,9 +5234,10 @@ impl OnDemandPercentageAboveBaseCapacityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OverridesDeserializer;
 impl OverridesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5160,9 +5275,10 @@ pub struct PoliciesType {
     pub scaling_policies: Option<Vec<ScalingPolicy>>,
 }
 
+#[allow(dead_code)]
 struct PoliciesTypeDeserializer;
 impl PoliciesTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5193,9 +5309,10 @@ pub struct PolicyARNType {
     pub policy_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyARNTypeDeserializer;
 impl PolicyARNTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5217,9 +5334,10 @@ impl PolicyARNTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyIncrementDeserializer;
 impl PolicyIncrementDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5262,9 +5380,10 @@ pub struct PredefinedMetricSpecification {
     pub resource_label: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PredefinedMetricSpecificationDeserializer;
 impl PredefinedMetricSpecificationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5330,9 +5449,10 @@ pub struct ProcessType {
     pub process_name: String,
 }
 
+#[allow(dead_code)]
 struct ProcessTypeDeserializer;
 impl ProcessTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5349,9 +5469,10 @@ impl ProcessTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ProcessesDeserializer;
 impl ProcessesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5373,9 +5494,10 @@ pub struct ProcessesType {
     pub processes: Option<Vec<ProcessType>>,
 }
 
+#[allow(dead_code)]
 struct ProcessesTypeDeserializer;
 impl ProcessesTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5393,9 +5515,10 @@ impl ProcessesTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ProgressDeserializer;
 impl ProgressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5404,9 +5527,10 @@ impl ProgressDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PropagateAtLaunchDeserializer;
 impl PropagateAtLaunchDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5419,9 +5543,10 @@ impl PropagateAtLaunchDeserializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct PutLifecycleHookAnswer {}
 
+#[allow(dead_code)]
 struct PutLifecycleHookAnswerDeserializer;
 impl PutLifecycleHookAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5697,9 +5822,10 @@ impl PutScheduledUpdateGroupActionTypeSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct RecordLifecycleActionHeartbeatAnswer {}
 
+#[allow(dead_code)]
 struct RecordLifecycleActionHeartbeatAnswerDeserializer;
 impl RecordLifecycleActionHeartbeatAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5755,9 +5881,10 @@ impl RecordLifecycleActionHeartbeatTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceNameDeserializer;
 impl ResourceNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5766,9 +5893,10 @@ impl ResourceNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ScalingActivityStatusCodeDeserializer;
 impl ScalingActivityStatusCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5777,9 +5905,10 @@ impl ScalingActivityStatusCodeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ScalingPoliciesDeserializer;
 impl ScalingPoliciesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5828,9 +5957,10 @@ pub struct ScalingPolicy {
     pub target_tracking_configuration: Option<TargetTrackingConfiguration>,
 }
 
+#[allow(dead_code)]
 struct ScalingPolicyDeserializer;
 impl ScalingPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5974,9 +6104,10 @@ pub struct ScheduledActionsType {
     pub scheduled_update_group_actions: Option<Vec<ScheduledUpdateGroupAction>>,
 }
 
+#[allow(dead_code)]
 struct ScheduledActionsTypeDeserializer;
 impl ScheduledActionsTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6026,9 +6157,10 @@ pub struct ScheduledUpdateGroupAction {
     pub time: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ScheduledUpdateGroupActionDeserializer;
 impl ScheduledUpdateGroupActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6164,9 +6296,10 @@ impl ScheduledUpdateGroupActionRequestsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ScheduledUpdateGroupActionsDeserializer;
 impl ScheduledUpdateGroupActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6183,9 +6316,10 @@ impl ScheduledUpdateGroupActionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupsDeserializer;
 impl SecurityGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6281,9 +6415,10 @@ impl SetInstanceHealthQuerySerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetInstanceProtectionAnswer {}
 
+#[allow(dead_code)]
 struct SetInstanceProtectionAnswerDeserializer;
 impl SetInstanceProtectionAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6333,9 +6468,10 @@ impl SetInstanceProtectionQuerySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SpotInstancePoolsDeserializer;
 impl SpotInstancePoolsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6344,9 +6480,10 @@ impl SpotInstancePoolsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SpotPriceDeserializer;
 impl SpotPriceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6368,9 +6505,10 @@ pub struct StepAdjustment {
     pub scaling_adjustment: i64,
 }
 
+#[allow(dead_code)]
 struct StepAdjustmentDeserializer;
 impl StepAdjustmentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6428,9 +6566,10 @@ impl StepAdjustmentSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StepAdjustmentsDeserializer;
 impl StepAdjustmentsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6467,9 +6606,10 @@ pub struct SuspendedProcess {
     pub suspension_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SuspendedProcessDeserializer;
 impl SuspendedProcessDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6494,9 +6634,10 @@ impl SuspendedProcessDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SuspendedProcessesDeserializer;
 impl SuspendedProcessesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6568,9 +6709,10 @@ pub struct TagDescription {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDescriptionDeserializer;
 impl TagDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6603,9 +6745,10 @@ impl TagDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TagDescriptionListDeserializer;
 impl TagDescriptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6620,9 +6763,10 @@ impl TagDescriptionListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6631,9 +6775,10 @@ impl TagKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6663,9 +6808,10 @@ pub struct TagsType {
     pub tags: Option<Vec<TagDescription>>,
 }
 
+#[allow(dead_code)]
 struct TagsTypeDeserializer;
 impl TagsTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6686,9 +6832,10 @@ impl TagsTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TargetGroupARNsDeserializer;
 impl TargetGroupARNsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6732,9 +6879,10 @@ pub struct TargetTrackingConfiguration {
     pub target_value: f64,
 }
 
+#[allow(dead_code)]
 struct TargetTrackingConfigurationDeserializer;
 impl TargetTrackingConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6832,9 +6980,10 @@ impl TerminateInstanceInAutoScalingGroupTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TerminationPoliciesDeserializer;
 impl TerminationPoliciesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6863,9 +7012,10 @@ impl TerminationPoliciesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TimestampTypeDeserializer;
 impl TimestampTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7019,9 +7169,10 @@ impl ValuesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct XmlStringDeserializer;
 impl XmlStringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7030,9 +7181,10 @@ impl XmlStringDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen1023Deserializer;
 impl XmlStringMaxLen1023Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7041,9 +7193,10 @@ impl XmlStringMaxLen1023Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen1600Deserializer;
 impl XmlStringMaxLen1600Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7052,9 +7205,10 @@ impl XmlStringMaxLen1600Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen19Deserializer;
 impl XmlStringMaxLen19Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7063,9 +7217,10 @@ impl XmlStringMaxLen19Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen2047Deserializer;
 impl XmlStringMaxLen2047Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7074,9 +7229,10 @@ impl XmlStringMaxLen2047Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen255Deserializer;
 impl XmlStringMaxLen255Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7085,9 +7241,10 @@ impl XmlStringMaxLen255Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen32Deserializer;
 impl XmlStringMaxLen32Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7096,9 +7253,10 @@ impl XmlStringMaxLen32Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen511Deserializer;
 impl XmlStringMaxLen511Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7107,9 +7265,10 @@ impl XmlStringMaxLen511Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringMaxLen64Deserializer;
 impl XmlStringMaxLen64Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7118,9 +7277,10 @@ impl XmlStringMaxLen64Deserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct XmlStringUserDataDeserializer;
 impl XmlStringUserDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -12303,9 +12303,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(ContinueUpdateRollbackError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = ContinueUpdateRollbackOutput::default();
         // parse non-payload
         Ok(result)
@@ -12335,9 +12333,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(CreateChangeSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateChangeSetOutput::default();
         } else {
@@ -12384,9 +12381,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(CreateStackError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateStackOutput::default();
         } else {
@@ -12430,9 +12426,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(CreateStackInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateStackInstancesOutput::default();
         } else {
@@ -12479,9 +12474,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(CreateStackSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateStackSetOutput::default();
         } else {
@@ -12526,9 +12520,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(DeleteChangeSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteChangeSetOutput::default();
         // parse non-payload
         Ok(result)
@@ -12586,9 +12578,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DeleteStackInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteStackInstancesOutput::default();
         } else {
@@ -12635,9 +12626,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(DeleteStackSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteStackSetOutput::default();
         // parse non-payload
         Ok(result)
@@ -12667,9 +12656,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(DeregisterTypeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeregisterTypeOutput::default();
         // parse non-payload
         Ok(result)
@@ -12699,9 +12686,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeAccountLimitsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAccountLimitsOutput::default();
         } else {
@@ -12748,9 +12734,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeChangeSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeChangeSetOutput::default();
         } else {
@@ -12802,9 +12787,8 @@ impl CloudFormation for CloudFormationClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackDriftDetectionStatusOutput::default();
         } else {
@@ -12851,9 +12835,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStackEventsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackEventsOutput::default();
         } else {
@@ -12900,9 +12883,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStackInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackInstanceOutput::default();
         } else {
@@ -12949,9 +12931,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStackResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackResourceOutput::default();
         } else {
@@ -12999,9 +12980,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStackResourceDriftsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackResourceDriftsOutput::default();
         } else {
@@ -13048,9 +13028,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStackResourcesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackResourcesOutput::default();
         } else {
@@ -13097,9 +13076,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStackSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackSetOutput::default();
         } else {
@@ -13146,9 +13124,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStackSetOperationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStackSetOperationOutput::default();
         } else {
@@ -13195,9 +13172,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeStacksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeStacksOutput::default();
         } else {
@@ -13242,9 +13218,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeTypeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTypeOutput::default();
         } else {
@@ -13288,9 +13263,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DescribeTypeRegistrationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTypeRegistrationOutput::default();
         } else {
@@ -13337,9 +13311,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DetectStackDriftError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DetectStackDriftOutput::default();
         } else {
@@ -13386,9 +13359,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DetectStackResourceDriftError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DetectStackResourceDriftOutput::default();
         } else {
@@ -13435,9 +13407,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(DetectStackSetDriftError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DetectStackSetDriftOutput::default();
         } else {
@@ -13484,9 +13455,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(EstimateTemplateCostError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EstimateTemplateCostOutput::default();
         } else {
@@ -13533,9 +13503,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(ExecuteChangeSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = ExecuteChangeSetOutput::default();
         // parse non-payload
         Ok(result)
@@ -13565,9 +13533,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(GetStackPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetStackPolicyOutput::default();
         } else {
@@ -13612,9 +13579,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(GetTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetTemplateOutput::default();
         } else {
@@ -13658,9 +13624,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(GetTemplateSummaryError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetTemplateSummaryOutput::default();
         } else {
@@ -13707,9 +13672,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListChangeSetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListChangeSetsOutput::default();
         } else {
@@ -13754,9 +13718,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListExportsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListExportsOutput::default();
         } else {
@@ -13800,9 +13763,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListImportsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListImportsOutput::default();
         } else {
@@ -13846,9 +13808,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListStackInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListStackInstancesOutput::default();
         } else {
@@ -13895,9 +13856,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListStackResourcesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListStackResourcesOutput::default();
         } else {
@@ -13945,9 +13905,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListStackSetOperationResultsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListStackSetOperationResultsOutput::default();
         } else {
@@ -13994,9 +13953,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListStackSetOperationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListStackSetOperationsOutput::default();
         } else {
@@ -14043,9 +14001,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListStackSetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListStackSetsOutput::default();
         } else {
@@ -14090,9 +14047,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListStacksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListStacksOutput::default();
         } else {
@@ -14136,9 +14092,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListTypeRegistrationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTypeRegistrationsOutput::default();
         } else {
@@ -14185,9 +14140,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListTypeVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTypeVersionsOutput::default();
         } else {
@@ -14234,9 +14188,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ListTypesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTypesOutput::default();
         } else {
@@ -14280,9 +14233,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(RecordHandlerProgressError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = RecordHandlerProgressOutput::default();
         // parse non-payload
         Ok(result)
@@ -14312,9 +14263,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(RegisterTypeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RegisterTypeOutput::default();
         } else {
@@ -14386,9 +14336,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(SetTypeDefaultVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetTypeDefaultVersionOutput::default();
         // parse non-payload
         Ok(result)
@@ -14446,9 +14394,7 @@ impl CloudFormation for CloudFormationClient {
             return Err(StopStackSetOperationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = StopStackSetOperationOutput::default();
         // parse non-payload
         Ok(result)
@@ -14478,9 +14424,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(UpdateStackError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateStackOutput::default();
         } else {
@@ -14524,9 +14469,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(UpdateStackInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateStackInstancesOutput::default();
         } else {
@@ -14573,9 +14517,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(UpdateStackSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateStackSetOutput::default();
         } else {
@@ -14621,9 +14564,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(UpdateTerminationProtectionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateTerminationProtectionOutput::default();
         } else {
@@ -14670,9 +14612,8 @@ impl CloudFormation for CloudFormationClient {
             return Err(ValidateTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ValidateTemplateOutput::default();
         } else {

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -36,9 +36,10 @@ use std::str::FromStr;
 use xml::reader::ParserConfig;
 use xml::EventReader;
 
+#[allow(dead_code)]
 struct AccountDeserializer;
 impl AccountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -57,9 +58,10 @@ pub struct AccountGateResult {
     pub status_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AccountGateResultDeserializer;
 impl AccountGateResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -81,9 +83,10 @@ impl AccountGateResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccountGateStatusDeserializer;
 impl AccountGateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -92,9 +95,10 @@ impl AccountGateStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccountGateStatusReasonDeserializer;
 impl AccountGateStatusReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -113,9 +117,10 @@ pub struct AccountLimit {
     pub value: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct AccountLimitDeserializer;
 impl AccountLimitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -134,9 +139,10 @@ impl AccountLimitDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccountLimitListDeserializer;
 impl AccountLimitListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -163,9 +169,10 @@ impl AccountListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedValueDeserializer;
 impl AllowedValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -174,9 +181,10 @@ impl AllowedValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AllowedValuesDeserializer;
 impl AllowedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -191,9 +199,10 @@ impl AllowedValuesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ArnDeserializer;
 impl ArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -202,9 +211,10 @@ impl ArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BoxedIntegerDeserializer;
 impl BoxedIntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -239,9 +249,10 @@ impl CancelUpdateStackInputSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CapabilitiesDeserializer;
 impl CapabilitiesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -268,9 +279,10 @@ impl CapabilitiesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CapabilitiesReasonDeserializer;
 impl CapabilitiesReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -279,9 +291,10 @@ impl CapabilitiesReasonDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CapabilityDeserializer;
 impl CapabilityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -290,9 +303,10 @@ impl CapabilityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CausingEntityDeserializer;
 impl CausingEntityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -311,9 +325,10 @@ pub struct Change {
     pub type_: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ChangeDeserializer;
 impl ChangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Change, XmlParseError> {
         deserialize_elements::<_, Change, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -332,9 +347,10 @@ impl ChangeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ChangeActionDeserializer;
 impl ChangeActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -343,9 +359,10 @@ impl ChangeActionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ChangeSetIdDeserializer;
 impl ChangeSetIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -354,9 +371,10 @@ impl ChangeSetIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ChangeSetNameDeserializer;
 impl ChangeSetNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -365,9 +383,10 @@ impl ChangeSetNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ChangeSetStatusDeserializer;
 impl ChangeSetStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -376,9 +395,10 @@ impl ChangeSetStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ChangeSetStatusReasonDeserializer;
 impl ChangeSetStatusReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -387,9 +407,10 @@ impl ChangeSetStatusReasonDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ChangeSetSummariesDeserializer;
 impl ChangeSetSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -428,9 +449,10 @@ pub struct ChangeSetSummary {
     pub status_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ChangeSetSummaryDeserializer;
 impl ChangeSetSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -484,9 +506,10 @@ impl ChangeSetSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ChangeSourceDeserializer;
 impl ChangeSourceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -495,9 +518,10 @@ impl ChangeSourceDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ChangeTypeDeserializer;
 impl ChangeTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -506,9 +530,10 @@ impl ChangeTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ChangesDeserializer;
 impl ChangesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -523,9 +548,10 @@ impl ChangesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ClientRequestTokenDeserializer;
 impl ClientRequestTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -579,9 +605,10 @@ impl ContinueUpdateRollbackInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct ContinueUpdateRollbackOutput {}
 
+#[allow(dead_code)]
 struct ContinueUpdateRollbackOutputDeserializer;
 impl ContinueUpdateRollbackOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -729,9 +756,10 @@ pub struct CreateChangeSetOutput {
     pub stack_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateChangeSetOutputDeserializer;
 impl CreateChangeSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -937,9 +965,10 @@ pub struct CreateStackInstancesOutput {
     pub operation_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateStackInstancesOutputDeserializer;
 impl CreateStackInstancesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -970,9 +999,10 @@ pub struct CreateStackOutput {
     pub stack_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateStackOutputDeserializer;
 impl CreateStackOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1074,9 +1104,10 @@ pub struct CreateStackSetOutput {
     pub stack_set_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateStackSetOutputDeserializer;
 impl CreateStackSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1093,9 +1124,10 @@ impl CreateStackSetOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CreationTimeDeserializer;
 impl CreationTimeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1138,9 +1170,10 @@ impl DeleteChangeSetInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteChangeSetOutput {}
 
+#[allow(dead_code)]
 struct DeleteChangeSetOutputDeserializer;
 impl DeleteChangeSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1251,9 +1284,10 @@ pub struct DeleteStackInstancesOutput {
     pub operation_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeleteStackInstancesOutputDeserializer;
 impl DeleteStackInstancesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1303,9 +1337,10 @@ impl DeleteStackSetInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteStackSetOutput {}
 
+#[allow(dead_code)]
 struct DeleteStackSetOutputDeserializer;
 impl DeleteStackSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1319,9 +1354,10 @@ impl DeleteStackSetOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DeletionTimeDeserializer;
 impl DeletionTimeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1330,9 +1366,10 @@ impl DeletionTimeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DeprecatedStatusDeserializer;
 impl DeprecatedStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1382,9 +1419,10 @@ impl DeregisterTypeInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeregisterTypeOutput {}
 
+#[allow(dead_code)]
 struct DeregisterTypeOutputDeserializer;
 impl DeregisterTypeOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1431,9 +1469,10 @@ pub struct DescribeAccountLimitsOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeAccountLimitsOutputDeserializer;
 impl DescribeAccountLimitsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1531,9 +1570,10 @@ pub struct DescribeChangeSetOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct DescribeChangeSetOutputDeserializer;
 impl DescribeChangeSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1671,9 +1711,10 @@ pub struct DescribeStackDriftDetectionStatusOutput {
     pub timestamp: String,
 }
 
+#[allow(dead_code)]
 struct DescribeStackDriftDetectionStatusOutputDeserializer;
 impl DescribeStackDriftDetectionStatusOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1767,9 +1808,10 @@ pub struct DescribeStackEventsOutput {
     pub stack_events: Option<Vec<StackEvent>>,
 }
 
+#[allow(dead_code)]
 struct DescribeStackEventsOutputDeserializer;
 impl DescribeStackEventsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1837,9 +1879,10 @@ pub struct DescribeStackInstanceOutput {
     pub stack_instance: Option<StackInstance>,
 }
 
+#[allow(dead_code)]
 struct DescribeStackInstanceOutputDeserializer;
 impl DescribeStackInstanceOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1910,9 +1953,10 @@ pub struct DescribeStackResourceDriftsOutput {
     pub stack_resource_drifts: Vec<StackResourceDrift>,
 }
 
+#[allow(dead_code)]
 struct DescribeStackResourceDriftsOutputDeserializer;
 impl DescribeStackResourceDriftsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1976,9 +2020,10 @@ pub struct DescribeStackResourceOutput {
     pub stack_resource_detail: Option<StackResourceDetail>,
 }
 
+#[allow(dead_code)]
 struct DescribeStackResourceOutputDeserializer;
 impl DescribeStackResourceOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2043,9 +2088,10 @@ pub struct DescribeStackResourcesOutput {
     pub stack_resources: Option<Vec<StackResource>>,
 }
 
+#[allow(dead_code)]
 struct DescribeStackResourcesOutputDeserializer;
 impl DescribeStackResourcesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2123,9 +2169,10 @@ pub struct DescribeStackSetOperationOutput {
     pub stack_set_operation: Option<StackSetOperation>,
 }
 
+#[allow(dead_code)]
 struct DescribeStackSetOperationOutputDeserializer;
 impl DescribeStackSetOperationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2155,9 +2202,10 @@ pub struct DescribeStackSetOutput {
     pub stack_set: Option<StackSet>,
 }
 
+#[allow(dead_code)]
 struct DescribeStackSetOutputDeserializer;
 impl DescribeStackSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2211,9 +2259,10 @@ pub struct DescribeStacksOutput {
     pub stacks: Option<Vec<Stack>>,
 }
 
+#[allow(dead_code)]
 struct DescribeStacksOutputDeserializer;
 impl DescribeStacksOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2306,9 +2355,10 @@ pub struct DescribeTypeOutput {
     pub visibility: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeTypeOutputDeserializer;
 impl DescribeTypeOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2425,9 +2475,10 @@ pub struct DescribeTypeRegistrationOutput {
     pub type_version_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeTypeRegistrationOutputDeserializer;
 impl DescribeTypeRegistrationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2461,9 +2512,10 @@ impl DescribeTypeRegistrationOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DescriptionDeserializer;
 impl DescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2508,9 +2560,10 @@ pub struct DetectStackDriftOutput {
     pub stack_drift_detection_id: String,
 }
 
+#[allow(dead_code)]
 struct DetectStackDriftOutputDeserializer;
 impl DetectStackDriftOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2562,9 +2615,10 @@ pub struct DetectStackResourceDriftOutput {
     pub stack_resource_drift: StackResourceDrift,
 }
 
+#[allow(dead_code)]
 struct DetectStackResourceDriftOutputDeserializer;
 impl DetectStackResourceDriftOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2630,9 +2684,10 @@ pub struct DetectStackSetDriftOutput {
     pub operation_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DetectStackSetDriftOutputDeserializer;
 impl DetectStackSetDriftOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2655,9 +2710,10 @@ impl DetectStackSetDriftOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DifferenceTypeDeserializer;
 impl DifferenceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2666,9 +2722,10 @@ impl DifferenceTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DisableRollbackDeserializer;
 impl DisableRollbackDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2677,9 +2734,10 @@ impl DisableRollbackDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DriftedStackInstancesCountDeserializer;
 impl DriftedStackInstancesCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2688,9 +2746,10 @@ impl DriftedStackInstancesCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EnableTerminationProtectionDeserializer;
 impl EnableTerminationProtectionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2744,9 +2803,10 @@ pub struct EstimateTemplateCostOutput {
     pub url: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EstimateTemplateCostOutputDeserializer;
 impl EstimateTemplateCostOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2766,9 +2826,10 @@ impl EstimateTemplateCostOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct EvaluationTypeDeserializer;
 impl EvaluationTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2777,9 +2838,10 @@ impl EvaluationTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EventIdDeserializer;
 impl EventIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2827,9 +2889,10 @@ impl ExecuteChangeSetInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct ExecuteChangeSetOutput {}
 
+#[allow(dead_code)]
 struct ExecuteChangeSetOutputDeserializer;
 impl ExecuteChangeSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2843,9 +2906,10 @@ impl ExecuteChangeSetOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ExecutionRoleNameDeserializer;
 impl ExecutionRoleNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2854,9 +2918,10 @@ impl ExecutionRoleNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ExecutionStatusDeserializer;
 impl ExecutionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2877,9 +2942,10 @@ pub struct Export {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ExportDeserializer;
 impl ExportDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Export, XmlParseError> {
         deserialize_elements::<_, Export, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -2899,9 +2965,10 @@ impl ExportDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ExportNameDeserializer;
 impl ExportNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2910,9 +2977,10 @@ impl ExportNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ExportValueDeserializer;
 impl ExportValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2921,9 +2989,10 @@ impl ExportValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ExportsDeserializer;
 impl ExportsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2938,9 +3007,10 @@ impl ExportsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct FailedStackInstancesCountDeserializer;
 impl FailedStackInstancesCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2949,9 +3019,10 @@ impl FailedStackInstancesCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FailureToleranceCountDeserializer;
 impl FailureToleranceCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2960,9 +3031,10 @@ impl FailureToleranceCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FailureTolerancePercentageDeserializer;
 impl FailureTolerancePercentageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3000,9 +3072,10 @@ pub struct GetStackPolicyOutput {
     pub stack_policy_body: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetStackPolicyOutputDeserializer;
 impl GetStackPolicyOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3064,9 +3137,10 @@ pub struct GetTemplateOutput {
     pub template_body: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetTemplateOutputDeserializer;
 impl GetTemplateOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3152,9 +3226,10 @@ pub struct GetTemplateSummaryOutput {
     pub version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetTemplateSummaryOutputDeserializer;
 impl GetTemplateSummaryOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3216,9 +3291,10 @@ impl GetTemplateSummaryOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ImportsDeserializer;
 impl ImportsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3233,9 +3309,10 @@ impl ImportsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InProgressStackInstancesCountDeserializer;
 impl InProgressStackInstancesCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3244,9 +3321,10 @@ impl InProgressStackInstancesCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InSyncStackInstancesCountDeserializer;
 impl InSyncStackInstancesCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3255,9 +3333,10 @@ impl InSyncStackInstancesCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct KeyDeserializer;
 impl KeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3266,9 +3345,10 @@ impl KeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LastUpdatedTimeDeserializer;
 impl LastUpdatedTimeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3277,9 +3357,10 @@ impl LastUpdatedTimeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LimitNameDeserializer;
 impl LimitNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3288,9 +3369,10 @@ impl LimitNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LimitValueDeserializer;
 impl LimitValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3335,9 +3417,10 @@ pub struct ListChangeSetsOutput {
     pub summaries: Option<Vec<ChangeSetSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListChangeSetsOutputDeserializer;
 impl ListChangeSetsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3389,9 +3472,10 @@ pub struct ListExportsOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListExportsOutputDeserializer;
 impl ListExportsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3446,9 +3530,10 @@ pub struct ListImportsOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListImportsOutputDeserializer;
 impl ListImportsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3527,9 +3612,10 @@ pub struct ListStackInstancesOutput {
     pub summaries: Option<Vec<StackInstanceSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListStackInstancesOutputDeserializer;
 impl ListStackInstancesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3591,9 +3677,10 @@ pub struct ListStackResourcesOutput {
     pub stack_resource_summaries: Option<Vec<StackResourceSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListStackResourcesOutputDeserializer;
 impl ListStackResourcesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3667,9 +3754,10 @@ pub struct ListStackSetOperationResultsOutput {
     pub summaries: Option<Vec<StackSetOperationResultSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListStackSetOperationResultsOutputDeserializer;
 impl ListStackSetOperationResultsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3740,9 +3828,10 @@ pub struct ListStackSetOperationsOutput {
     pub summaries: Option<Vec<StackSetOperationSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListStackSetOperationsOutputDeserializer;
 impl ListStackSetOperationsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3812,9 +3901,10 @@ pub struct ListStackSetsOutput {
     pub summaries: Option<Vec<StackSetSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListStackSetsOutputDeserializer;
 impl ListStackSetsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3877,9 +3967,10 @@ pub struct ListStacksOutput {
     pub stack_summaries: Option<Vec<StackSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListStacksOutputDeserializer;
 impl ListStacksOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3959,9 +4050,10 @@ pub struct ListTypeRegistrationsOutput {
     pub registration_token_list: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ListTypeRegistrationsOutputDeserializer;
 impl ListTypeRegistrationsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4046,9 +4138,10 @@ pub struct ListTypeVersionsOutput {
     pub type_version_summaries: Option<Vec<TypeVersionSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListTypeVersionsOutputDeserializer;
 impl ListTypeVersionsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4123,9 +4216,10 @@ pub struct ListTypesOutput {
     pub type_summaries: Option<Vec<TypeSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListTypesOutputDeserializer;
 impl ListTypesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4146,9 +4240,10 @@ impl ListTypesOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LogGroupNameDeserializer;
 impl LogGroupNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4168,9 +4263,10 @@ pub struct LoggingConfig {
     pub log_role_arn: String,
 }
 
+#[allow(dead_code)]
 struct LoggingConfigDeserializer;
 impl LoggingConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4208,9 +4304,10 @@ impl LoggingConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LogicalResourceIdDeserializer;
 impl LogicalResourceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4219,9 +4316,10 @@ impl LogicalResourceIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LogicalResourceIdsDeserializer;
 impl LogicalResourceIdsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4248,9 +4346,10 @@ impl LogicalResourceIdsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MaxConcurrentCountDeserializer;
 impl MaxConcurrentCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4259,9 +4358,10 @@ impl MaxConcurrentCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaxConcurrentPercentageDeserializer;
 impl MaxConcurrentPercentageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4270,9 +4370,10 @@ impl MaxConcurrentPercentageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetadataDeserializer;
 impl MetadataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4281,9 +4382,10 @@ impl MetadataDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MonitoringTimeInMinutesDeserializer;
 impl MonitoringTimeInMinutesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4292,9 +4394,10 @@ impl MonitoringTimeInMinutesDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextTokenDeserializer;
 impl NextTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4303,9 +4406,10 @@ impl NextTokenDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NoEchoDeserializer;
 impl NoEchoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4314,9 +4418,10 @@ impl NoEchoDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NotificationARNDeserializer;
 impl NotificationARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4325,9 +4430,10 @@ impl NotificationARNDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NotificationARNsDeserializer;
 impl NotificationARNsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4354,9 +4460,10 @@ impl NotificationARNsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OptionalSecureUrlDeserializer;
 impl OptionalSecureUrlDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4379,9 +4486,10 @@ pub struct Output {
     pub output_value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OutputDeserializer;
 impl OutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Output, XmlParseError> {
         deserialize_elements::<_, Output, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -4406,9 +4514,10 @@ impl OutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OutputKeyDeserializer;
 impl OutputKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4417,9 +4526,10 @@ impl OutputKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OutputValueDeserializer;
 impl OutputValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4428,9 +4538,10 @@ impl OutputValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OutputsDeserializer;
 impl OutputsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4460,9 +4571,10 @@ pub struct Parameter {
     pub use_previous_value: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct ParameterDeserializer;
 impl ParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4532,9 +4644,10 @@ pub struct ParameterConstraints {
     pub allowed_values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ParameterConstraintsDeserializer;
 impl ParameterConstraintsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4570,9 +4683,10 @@ pub struct ParameterDeclaration {
     pub parameter_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ParameterDeclarationDeserializer;
 impl ParameterDeclarationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4617,9 +4731,10 @@ impl ParameterDeclarationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ParameterDeclarationsDeserializer;
 impl ParameterDeclarationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4636,9 +4751,10 @@ impl ParameterDeclarationsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ParameterKeyDeserializer;
 impl ParameterKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4647,9 +4763,10 @@ impl ParameterKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ParameterTypeDeserializer;
 impl ParameterTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4658,9 +4775,10 @@ impl ParameterTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ParameterValueDeserializer;
 impl ParameterValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4669,9 +4787,10 @@ impl ParameterValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ParametersDeserializer;
 impl ParametersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4698,9 +4817,10 @@ impl ParametersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PhysicalResourceIdDeserializer;
 impl PhysicalResourceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4709,9 +4829,10 @@ impl PhysicalResourceIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PhysicalResourceIdContextDeserializer;
 impl PhysicalResourceIdContextDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4740,9 +4861,10 @@ pub struct PhysicalResourceIdContextKeyValuePair {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct PhysicalResourceIdContextKeyValuePairDeserializer;
 impl PhysicalResourceIdContextKeyValuePairDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4765,9 +4887,10 @@ impl PhysicalResourceIdContextKeyValuePairDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PropertiesDeserializer;
 impl PropertiesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4790,9 +4913,10 @@ pub struct PropertyDifference {
     pub property_path: String,
 }
 
+#[allow(dead_code)]
 struct PropertyDifferenceDeserializer;
 impl PropertyDifferenceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4821,9 +4945,10 @@ impl PropertyDifferenceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PropertyDifferencesDeserializer;
 impl PropertyDifferencesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4840,9 +4965,10 @@ impl PropertyDifferencesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PropertyNameDeserializer;
 impl PropertyNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4851,9 +4977,10 @@ impl PropertyNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PropertyPathDeserializer;
 impl PropertyPathDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4862,9 +4989,10 @@ impl PropertyPathDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PropertyValueDeserializer;
 impl PropertyValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4873,9 +5001,10 @@ impl PropertyValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ProvisioningTypeDeserializer;
 impl ProvisioningTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4884,9 +5013,10 @@ impl ProvisioningTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReasonDeserializer;
 impl ReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4953,9 +5083,10 @@ impl RecordHandlerProgressInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct RecordHandlerProgressOutput {}
 
+#[allow(dead_code)]
 struct RecordHandlerProgressOutputDeserializer;
 impl RecordHandlerProgressOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4969,9 +5100,10 @@ impl RecordHandlerProgressOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RegionDeserializer;
 impl RegionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4980,9 +5112,10 @@ impl RegionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RegionListDeserializer;
 impl RegionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5066,9 +5199,10 @@ pub struct RegisterTypeOutput {
     pub registration_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RegisterTypeOutputDeserializer;
 impl RegisterTypeOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5087,9 +5221,10 @@ impl RegisterTypeOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RegistrationStatusDeserializer;
 impl RegistrationStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5098,9 +5233,10 @@ impl RegistrationStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RegistrationTokenDeserializer;
 impl RegistrationTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5109,9 +5245,10 @@ impl RegistrationTokenDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RegistrationTokenListDeserializer;
 impl RegistrationTokenListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5126,9 +5263,10 @@ impl RegistrationTokenListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RegistryTypeDeserializer;
 impl RegistryTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5137,9 +5275,10 @@ impl RegistryTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReplacementDeserializer;
 impl ReplacementDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5148,9 +5287,10 @@ impl ReplacementDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RequiresRecreationDeserializer;
 impl RequiresRecreationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5159,9 +5299,10 @@ impl RequiresRecreationDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceAttributeDeserializer;
 impl ResourceAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5190,9 +5331,10 @@ pub struct ResourceChange {
     pub scope: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ResourceChangeDeserializer;
 impl ResourceChangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5254,9 +5396,10 @@ pub struct ResourceChangeDetail {
     pub target: Option<ResourceTargetDefinition>,
 }
 
+#[allow(dead_code)]
 struct ResourceChangeDetailDeserializer;
 impl ResourceChangeDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5292,9 +5435,10 @@ impl ResourceChangeDetailDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ResourceChangeDetailsDeserializer;
 impl ResourceChangeDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5328,9 +5472,10 @@ impl ResourceIdentifierPropertiesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceIdentifierPropertyKeyDeserializer;
 impl ResourceIdentifierPropertyKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5339,9 +5484,10 @@ impl ResourceIdentifierPropertyKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceIdentifierSummariesDeserializer;
 impl ResourceIdentifierSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5370,9 +5516,10 @@ pub struct ResourceIdentifierSummary {
     pub resource_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ResourceIdentifierSummaryDeserializer;
 impl ResourceIdentifierSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5411,9 +5558,10 @@ impl ResourceIdentifierSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ResourceIdentifiersDeserializer;
 impl ResourceIdentifiersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5430,9 +5578,10 @@ impl ResourceIdentifiersDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ResourcePropertiesDeserializer;
 impl ResourcePropertiesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5441,9 +5590,10 @@ impl ResourcePropertiesDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceStatusDeserializer;
 impl ResourceStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5452,9 +5602,10 @@ impl ResourceStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceStatusReasonDeserializer;
 impl ResourceStatusReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5475,9 +5626,10 @@ pub struct ResourceTargetDefinition {
     pub requires_recreation: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ResourceTargetDefinitionDeserializer;
 impl ResourceTargetDefinitionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5544,9 +5696,10 @@ impl ResourceToImportSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceTypeDeserializer;
 impl ResourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5555,9 +5708,10 @@ impl ResourceTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceTypesDeserializer;
 impl ResourceTypesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5617,9 +5771,10 @@ impl RetainResourcesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RetainStacksNullableDeserializer;
 impl RetainStacksNullableDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5628,9 +5783,10 @@ impl RetainStacksNullableDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RoleARNDeserializer;
 impl RoleARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5639,9 +5795,10 @@ impl RoleARNDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RoleArnDeserializer;
 impl RoleArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5661,9 +5818,10 @@ pub struct RollbackConfiguration {
     pub rollback_triggers: Option<Vec<RollbackTrigger>>,
 }
 
+#[allow(dead_code)]
 struct RollbackConfigurationDeserializer;
 impl RollbackConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5725,9 +5883,10 @@ pub struct RollbackTrigger {
     pub type_: String,
 }
 
+#[allow(dead_code)]
 struct RollbackTriggerDeserializer;
 impl RollbackTriggerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5761,9 +5920,10 @@ impl RollbackTriggerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RollbackTriggersDeserializer;
 impl RollbackTriggersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5790,9 +5950,10 @@ impl RollbackTriggersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ScopeDeserializer;
 impl ScopeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5879,9 +6040,10 @@ impl SetTypeDefaultVersionInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetTypeDefaultVersionOutput {}
 
+#[allow(dead_code)]
 struct SetTypeDefaultVersionOutputDeserializer;
 impl SetTypeDefaultVersionOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5978,9 +6140,10 @@ pub struct Stack {
     pub timeout_in_minutes: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct StackDeserializer;
 impl StackDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Stack, XmlParseError> {
         deserialize_elements::<_, Stack, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -6095,9 +6258,10 @@ impl StackDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackDriftDetectionIdDeserializer;
 impl StackDriftDetectionIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6106,9 +6270,10 @@ impl StackDriftDetectionIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackDriftDetectionStatusDeserializer;
 impl StackDriftDetectionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6117,9 +6282,10 @@ impl StackDriftDetectionStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackDriftDetectionStatusReasonDeserializer;
 impl StackDriftDetectionStatusReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6138,9 +6304,10 @@ pub struct StackDriftInformation {
     pub stack_drift_status: String,
 }
 
+#[allow(dead_code)]
 struct StackDriftInformationDeserializer;
 impl StackDriftInformationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6173,9 +6340,10 @@ pub struct StackDriftInformationSummary {
     pub stack_drift_status: String,
 }
 
+#[allow(dead_code)]
 struct StackDriftInformationSummaryDeserializer;
 impl StackDriftInformationSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6202,9 +6370,10 @@ impl StackDriftInformationSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct StackDriftStatusDeserializer;
 impl StackDriftStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6241,9 +6410,10 @@ pub struct StackEvent {
     pub timestamp: String,
 }
 
+#[allow(dead_code)]
 struct StackEventDeserializer;
 impl StackEventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6311,9 +6481,10 @@ impl StackEventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackEventsDeserializer;
 impl StackEventsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6328,9 +6499,10 @@ impl StackEventsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackIdDeserializer;
 impl StackIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6363,9 +6535,10 @@ pub struct StackInstance {
     pub status_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackInstanceDeserializer;
 impl StackInstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6417,9 +6590,10 @@ impl StackInstanceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackInstanceStatusDeserializer;
 impl StackInstanceStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6428,9 +6602,10 @@ impl StackInstanceStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackInstanceSummariesDeserializer;
 impl StackInstanceSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6469,9 +6644,10 @@ pub struct StackInstanceSummary {
     pub status_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackInstanceSummaryDeserializer;
 impl StackInstanceSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6518,9 +6694,10 @@ impl StackInstanceSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackNameDeserializer;
 impl StackNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6529,9 +6706,10 @@ impl StackNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackPolicyBodyDeserializer;
 impl StackPolicyBodyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6566,9 +6744,10 @@ pub struct StackResource {
     pub timestamp: String,
 }
 
+#[allow(dead_code)]
 struct StackResourceDeserializer;
 impl StackResourceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6654,9 +6833,10 @@ pub struct StackResourceDetail {
     pub stack_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackResourceDetailDeserializer;
 impl StackResourceDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6744,9 +6924,10 @@ pub struct StackResourceDrift {
     pub timestamp: String,
 }
 
+#[allow(dead_code)]
 struct StackResourceDriftDeserializer;
 impl StackResourceDriftDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6821,9 +7002,10 @@ pub struct StackResourceDriftInformation {
     pub stack_resource_drift_status: String,
 }
 
+#[allow(dead_code)]
 struct StackResourceDriftInformationDeserializer;
 impl StackResourceDriftInformationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6863,9 +7045,10 @@ pub struct StackResourceDriftInformationSummary {
     pub stack_resource_drift_status: String,
 }
 
+#[allow(dead_code)]
 struct StackResourceDriftInformationSummaryDeserializer;
 impl StackResourceDriftInformationSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6895,9 +7078,10 @@ impl StackResourceDriftInformationSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct StackResourceDriftStatusDeserializer;
 impl StackResourceDriftStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6918,9 +7102,10 @@ impl StackResourceDriftStatusFiltersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StackResourceDriftsDeserializer;
 impl StackResourceDriftsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6937,9 +7122,10 @@ impl StackResourceDriftsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackResourceSummariesDeserializer;
 impl StackResourceSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6976,9 +7162,10 @@ pub struct StackResourceSummary {
     pub resource_type: String,
 }
 
+#[allow(dead_code)]
 struct StackResourceSummaryDeserializer;
 impl StackResourceSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7028,9 +7215,10 @@ impl StackResourceSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackResourcesDeserializer;
 impl StackResourcesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7075,9 +7263,10 @@ pub struct StackSet {
     pub template_body: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackSetDeserializer;
 impl StackSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7151,9 +7340,10 @@ impl StackSetDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackSetARNDeserializer;
 impl StackSetARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7184,9 +7374,10 @@ pub struct StackSetDriftDetectionDetails {
     pub total_stack_instances_count: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct StackSetDriftDetectionDetailsDeserializer;
 impl StackSetDriftDetectionDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7257,9 +7448,10 @@ impl StackSetDriftDetectionDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct StackSetDriftDetectionStatusDeserializer;
 impl StackSetDriftDetectionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7268,9 +7460,10 @@ impl StackSetDriftDetectionStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackSetDriftStatusDeserializer;
 impl StackSetDriftStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7279,9 +7472,10 @@ impl StackSetDriftStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackSetIdDeserializer;
 impl StackSetIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7290,9 +7484,10 @@ impl StackSetIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackSetNameDeserializer;
 impl StackSetNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7329,9 +7524,10 @@ pub struct StackSetOperation {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackSetOperationDeserializer;
 impl StackSetOperationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7406,9 +7602,10 @@ impl StackSetOperationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackSetOperationActionDeserializer;
 impl StackSetOperationActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7434,9 +7631,10 @@ pub struct StackSetOperationPreferences {
     pub region_order: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct StackSetOperationPreferencesDeserializer;
 impl StackSetOperationPreferencesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7527,9 +7725,10 @@ impl StackSetOperationPreferencesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StackSetOperationResultStatusDeserializer;
 impl StackSetOperationResultStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7538,9 +7737,10 @@ impl StackSetOperationResultStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackSetOperationResultSummariesDeserializer;
 impl StackSetOperationResultSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7573,9 +7773,10 @@ pub struct StackSetOperationResultSummary {
     pub status_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackSetOperationResultSummaryDeserializer;
 impl StackSetOperationResultSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7613,9 +7814,10 @@ impl StackSetOperationResultSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct StackSetOperationStatusDeserializer;
 impl StackSetOperationStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7624,9 +7826,10 @@ impl StackSetOperationStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackSetOperationSummariesDeserializer;
 impl StackSetOperationSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7659,9 +7862,10 @@ pub struct StackSetOperationSummary {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackSetOperationSummaryDeserializer;
 impl StackSetOperationSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7704,9 +7908,10 @@ impl StackSetOperationSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct StackSetStatusDeserializer;
 impl StackSetStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7715,9 +7920,10 @@ impl StackSetStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackSetSummariesDeserializer;
 impl StackSetSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7750,9 +7956,10 @@ pub struct StackSetSummary {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackSetSummaryDeserializer;
 impl StackSetSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7794,9 +8001,10 @@ impl StackSetSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StackStatusDeserializer;
 impl StackStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7817,9 +8025,10 @@ impl StackStatusFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StackStatusReasonDeserializer;
 impl StackStatusReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7828,9 +8037,10 @@ impl StackStatusReasonDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StackSummariesDeserializer;
 impl StackSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7873,9 +8083,10 @@ pub struct StackSummary {
     pub template_description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StackSummaryDeserializer;
 impl StackSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7938,9 +8149,10 @@ impl StackSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StacksDeserializer;
 impl StacksDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7955,9 +8167,10 @@ impl StacksDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StageListDeserializer;
 impl StageListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8002,9 +8215,10 @@ impl StopStackSetOperationInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct StopStackSetOperationOutput {}
 
+#[allow(dead_code)]
 struct StopStackSetOperationOutputDeserializer;
 impl StopStackSetOperationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8029,9 +8243,10 @@ pub struct Tag {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -8062,9 +8277,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8073,9 +8289,10 @@ impl TagKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8084,9 +8301,10 @@ impl TagValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TagsDeserializer;
 impl TagsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8113,9 +8331,10 @@ impl TagsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TemplateBodyDeserializer;
 impl TemplateBodyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8124,9 +8343,10 @@ impl TemplateBodyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TemplateDescriptionDeserializer;
 impl TemplateDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8149,9 +8369,10 @@ pub struct TemplateParameter {
     pub parameter_key: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TemplateParameterDeserializer;
 impl TemplateParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8183,9 +8404,10 @@ impl TemplateParameterDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TemplateParametersDeserializer;
 impl TemplateParametersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8200,9 +8422,10 @@ impl TemplateParametersDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TemplateStageDeserializer;
 impl TemplateStageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8211,9 +8434,10 @@ impl TemplateStageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TimeoutMinutesDeserializer;
 impl TimeoutMinutesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8222,9 +8446,10 @@ impl TimeoutMinutesDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TimestampDeserializer;
 impl TimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8233,9 +8458,10 @@ impl TimestampDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TotalStackInstancesCountDeserializer;
 impl TotalStackInstancesCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8244,9 +8470,10 @@ impl TotalStackInstancesCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TransformNameDeserializer;
 impl TransformNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8255,9 +8482,10 @@ impl TransformNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TransformsListDeserializer;
 impl TransformsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8272,9 +8500,10 @@ impl TransformsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TypeDeserializer;
 impl TypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8283,9 +8512,10 @@ impl TypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TypeArnDeserializer;
 impl TypeArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8294,9 +8524,10 @@ impl TypeArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TypeNameDeserializer;
 impl TypeNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8305,9 +8536,10 @@ impl TypeNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TypeSchemaDeserializer;
 impl TypeSchemaDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8316,9 +8548,10 @@ impl TypeSchemaDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TypeSummariesDeserializer;
 impl TypeSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8351,9 +8584,10 @@ pub struct TypeSummary {
     pub type_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TypeSummaryDeserializer;
 impl TypeSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8389,9 +8623,10 @@ impl TypeSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TypeVersionIdDeserializer;
 impl TypeVersionIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8400,9 +8635,10 @@ impl TypeVersionIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TypeVersionSummariesDeserializer;
 impl TypeVersionSummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8437,9 +8673,10 @@ pub struct TypeVersionSummary {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TypeVersionSummaryDeserializer;
 impl TypeVersionSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8661,9 +8898,10 @@ pub struct UpdateStackInstancesOutput {
     pub operation_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateStackInstancesOutputDeserializer;
 impl UpdateStackInstancesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8694,9 +8932,10 @@ pub struct UpdateStackOutput {
     pub stack_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateStackOutputDeserializer;
 impl UpdateStackOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8833,9 +9072,10 @@ pub struct UpdateStackSetOutput {
     pub operation_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateStackSetOutputDeserializer;
 impl UpdateStackSetOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8887,9 +9127,10 @@ pub struct UpdateTerminationProtectionOutput {
     pub stack_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateTerminationProtectionOutputDeserializer;
 impl UpdateTerminationProtectionOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8909,9 +9150,10 @@ impl UpdateTerminationProtectionOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct UrlDeserializer;
 impl UrlDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8920,9 +9162,10 @@ impl UrlDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct UsePreviousValueDeserializer;
 impl UsePreviousValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8975,9 +9218,10 @@ pub struct ValidateTemplateOutput {
     pub parameters: Option<Vec<TemplateParameter>>,
 }
 
+#[allow(dead_code)]
 struct ValidateTemplateOutputDeserializer;
 impl ValidateTemplateOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9015,9 +9259,10 @@ impl ValidateTemplateOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValueDeserializer;
 impl ValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9026,9 +9271,10 @@ impl ValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VersionDeserializer;
 impl VersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9037,9 +9283,10 @@ impl VersionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VisibilityDeserializer;
 impl VisibilityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -12664,9 +12664,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateCloudFrontOriginAccessIdentityResult::default();
         } else {
@@ -12721,9 +12720,8 @@ impl CloudFront for CloudFrontClient {
             return Err(CreateDistributionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDistributionResult::default();
         } else {
@@ -12780,9 +12778,8 @@ impl CloudFront for CloudFrontClient {
             return Err(CreateDistributionWithTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDistributionWithTagsResult::default();
         } else {
@@ -12842,9 +12839,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateFieldLevelEncryptionConfigResult::default();
         } else {
@@ -12904,9 +12900,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateFieldLevelEncryptionProfileResult::default();
         } else {
@@ -12964,9 +12959,8 @@ impl CloudFront for CloudFrontClient {
             return Err(CreateInvalidationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateInvalidationResult::default();
         } else {
@@ -13015,9 +13009,8 @@ impl CloudFront for CloudFrontClient {
             return Err(CreatePublicKeyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreatePublicKeyResult::default();
         } else {
@@ -13070,9 +13063,8 @@ impl CloudFront for CloudFrontClient {
             return Err(CreateStreamingDistributionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateStreamingDistributionResult::default();
         } else {
@@ -13135,9 +13127,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateStreamingDistributionWithTagsResult::default();
         } else {
@@ -13372,9 +13363,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetCloudFrontOriginAccessIdentityResult::default();
         } else {
@@ -13425,9 +13415,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetCloudFrontOriginAccessIdentityConfigResult::default();
         } else {
@@ -13470,9 +13459,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetDistributionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetDistributionResult::default();
         } else {
@@ -13512,9 +13500,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetDistributionConfigError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetDistributionConfigResult::default();
         } else {
@@ -13555,9 +13542,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetFieldLevelEncryptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetFieldLevelEncryptionResult::default();
         } else {
@@ -13604,9 +13590,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetFieldLevelEncryptionConfigError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetFieldLevelEncryptionConfigResult::default();
         } else {
@@ -13655,9 +13640,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetFieldLevelEncryptionProfileError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetFieldLevelEncryptionProfileResult::default();
         } else {
@@ -13708,9 +13692,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetFieldLevelEncryptionProfileConfigResult::default();
         } else {
@@ -13757,9 +13740,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetInvalidationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetInvalidationResult::default();
         } else {
@@ -13796,9 +13778,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetPublicKeyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetPublicKeyResult::default();
         } else {
@@ -13838,9 +13819,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetPublicKeyConfigError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetPublicKeyConfigResult::default();
         } else {
@@ -13881,9 +13861,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetStreamingDistributionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetStreamingDistributionResult::default();
         } else {
@@ -13932,9 +13911,8 @@ impl CloudFront for CloudFrontClient {
             return Err(GetStreamingDistributionConfigError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetStreamingDistributionConfigResult::default();
         } else {
@@ -13991,9 +13969,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListCloudFrontOriginAccessIdentitiesResult::default();
         } else {
@@ -14042,9 +14019,8 @@ impl CloudFront for CloudFrontClient {
             return Err(ListDistributionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListDistributionsResult::default();
         } else {
@@ -14095,9 +14071,8 @@ impl CloudFront for CloudFrontClient {
             return Err(ListDistributionsByWebACLIdError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListDistributionsByWebACLIdResult::default();
         } else {
@@ -14151,9 +14126,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListFieldLevelEncryptionConfigsResult::default();
         } else {
@@ -14207,9 +14181,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListFieldLevelEncryptionProfilesResult::default();
         } else {
@@ -14261,9 +14234,8 @@ impl CloudFront for CloudFrontClient {
             return Err(ListInvalidationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListInvalidationsResult::default();
         } else {
@@ -14310,9 +14282,8 @@ impl CloudFront for CloudFrontClient {
             return Err(ListPublicKeysError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPublicKeysResult::default();
         } else {
@@ -14359,9 +14330,8 @@ impl CloudFront for CloudFrontClient {
             return Err(ListStreamingDistributionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListStreamingDistributionsResult::default();
         } else {
@@ -14405,9 +14375,8 @@ impl CloudFront for CloudFrontClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTagsForResourceResult::default();
         } else {
@@ -14529,9 +14498,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateCloudFrontOriginAccessIdentityResult::default();
         } else {
@@ -14586,9 +14554,8 @@ impl CloudFront for CloudFrontClient {
             return Err(UpdateDistributionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateDistributionResult::default();
         } else {
@@ -14649,9 +14616,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateFieldLevelEncryptionConfigResult::default();
         } else {
@@ -14714,9 +14680,8 @@ impl CloudFront for CloudFrontClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateFieldLevelEncryptionProfileResult::default();
         } else {
@@ -14771,9 +14736,8 @@ impl CloudFront for CloudFrontClient {
             return Err(UpdatePublicKeyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdatePublicKeyResult::default();
         } else {
@@ -14829,9 +14793,8 @@ impl CloudFront for CloudFrontClient {
             return Err(UpdateStreamingDistributionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateStreamingDistributionResult::default();
         } else {

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -50,9 +50,10 @@ pub struct ActiveTrustedSigners {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct ActiveTrustedSignersDeserializer;
 impl ActiveTrustedSignersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -86,9 +87,10 @@ pub struct AliasICPRecordal {
     pub icp_recordal_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AliasICPRecordalDeserializer;
 impl AliasICPRecordalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -110,9 +112,10 @@ impl AliasICPRecordalDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AliasICPRecordalsDeserializer;
 impl AliasICPRecordalsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -130,9 +133,10 @@ impl AliasICPRecordalsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AliasListDeserializer;
 impl AliasListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -179,9 +183,10 @@ pub struct Aliases {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct AliasesDeserializer;
 impl AliasesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -240,9 +245,10 @@ pub struct AllowedMethods {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct AllowedMethodsDeserializer;
 impl AllowedMethodsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -295,9 +301,10 @@ impl AllowedMethodsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AwsAccountNumberListDeserializer;
 impl AwsAccountNumberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -333,9 +340,10 @@ impl AwsAccountNumberListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -397,9 +405,10 @@ pub struct CacheBehavior {
     pub viewer_protocol_policy: String,
 }
 
+#[allow(dead_code)]
 struct CacheBehaviorDeserializer;
 impl CacheBehaviorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -567,9 +576,10 @@ impl CacheBehaviorSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CacheBehaviorListDeserializer;
 impl CacheBehaviorListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -619,9 +629,10 @@ pub struct CacheBehaviors {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct CacheBehaviorsDeserializer;
 impl CacheBehaviorsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -679,9 +690,10 @@ pub struct CachedMethods {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct CachedMethodsDeserializer;
 impl CachedMethodsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -737,9 +749,10 @@ pub struct CloudFrontOriginAccessIdentity {
     pub s3_canonical_user_id: String,
 }
 
+#[allow(dead_code)]
 struct CloudFrontOriginAccessIdentityDeserializer;
 impl CloudFrontOriginAccessIdentityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -782,9 +795,10 @@ pub struct CloudFrontOriginAccessIdentityConfig {
     pub comment: String,
 }
 
+#[allow(dead_code)]
 struct CloudFrontOriginAccessIdentityConfigDeserializer;
 impl CloudFrontOriginAccessIdentityConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -855,9 +869,10 @@ pub struct CloudFrontOriginAccessIdentityList {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct CloudFrontOriginAccessIdentityListDeserializer;
 impl CloudFrontOriginAccessIdentityListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -909,9 +924,10 @@ pub struct CloudFrontOriginAccessIdentitySummary {
     pub s3_canonical_user_id: String,
 }
 
+#[allow(dead_code)]
 struct CloudFrontOriginAccessIdentitySummaryDeserializer;
 impl CloudFrontOriginAccessIdentitySummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -938,9 +954,10 @@ impl CloudFrontOriginAccessIdentitySummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CloudFrontOriginAccessIdentitySummaryListDeserializer;
 impl CloudFrontOriginAccessIdentitySummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -960,9 +977,10 @@ impl CloudFrontOriginAccessIdentitySummaryListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CommentTypeDeserializer;
 impl CommentTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1005,9 +1023,10 @@ pub struct ContentTypeProfile {
     pub profile_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ContentTypeProfileDeserializer;
 impl ContentTypeProfileDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1077,9 +1096,10 @@ pub struct ContentTypeProfileConfig {
     pub forward_when_content_type_is_unknown: bool,
 }
 
+#[allow(dead_code)]
 struct ContentTypeProfileConfigDeserializer;
 impl ContentTypeProfileConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1138,9 +1158,10 @@ impl ContentTypeProfileConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ContentTypeProfileListDeserializer;
 impl ContentTypeProfileListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1190,9 +1211,10 @@ pub struct ContentTypeProfiles {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct ContentTypeProfilesDeserializer;
 impl ContentTypeProfilesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1239,9 +1261,10 @@ impl ContentTypeProfilesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CookieNameListDeserializer;
 impl CookieNameListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1288,9 +1311,10 @@ pub struct CookieNames {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct CookieNamesDeserializer;
 impl CookieNamesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1348,9 +1372,10 @@ pub struct CookiePreference {
     pub whitelisted_names: Option<CookieNames>,
 }
 
+#[allow(dead_code)]
 struct CookiePreferenceDeserializer;
 impl CookiePreferenceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1418,9 +1443,10 @@ pub struct CreateCloudFrontOriginAccessIdentityResult {
     pub location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateCloudFrontOriginAccessIdentityResultDeserializer;
 impl CreateCloudFrontOriginAccessIdentityResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1456,9 +1482,10 @@ pub struct CreateDistributionResult {
     pub location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateDistributionResultDeserializer;
 impl CreateDistributionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1492,9 +1519,10 @@ pub struct CreateDistributionWithTagsResult {
     pub location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateDistributionWithTagsResultDeserializer;
 impl CreateDistributionWithTagsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1526,9 +1554,10 @@ pub struct CreateFieldLevelEncryptionConfigResult {
     pub location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateFieldLevelEncryptionConfigResultDeserializer;
 impl CreateFieldLevelEncryptionConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1560,9 +1589,10 @@ pub struct CreateFieldLevelEncryptionProfileResult {
     pub location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateFieldLevelEncryptionProfileResultDeserializer;
 impl CreateFieldLevelEncryptionProfileResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1598,9 +1628,10 @@ pub struct CreateInvalidationResult {
     pub location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateInvalidationResultDeserializer;
 impl CreateInvalidationResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1632,9 +1663,10 @@ pub struct CreatePublicKeyResult {
     pub public_key: Option<PublicKey>,
 }
 
+#[allow(dead_code)]
 struct CreatePublicKeyResultDeserializer;
 impl CreatePublicKeyResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1665,9 +1697,10 @@ pub struct CreateStreamingDistributionResult {
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
+#[allow(dead_code)]
 struct CreateStreamingDistributionResultDeserializer;
 impl CreateStreamingDistributionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1701,9 +1734,10 @@ pub struct CreateStreamingDistributionWithTagsResult {
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
+#[allow(dead_code)]
 struct CreateStreamingDistributionWithTagsResultDeserializer;
 impl CreateStreamingDistributionWithTagsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1732,9 +1766,10 @@ pub struct CustomErrorResponse {
     pub response_page_path: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CustomErrorResponseDeserializer;
 impl CustomErrorResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1809,9 +1844,10 @@ impl CustomErrorResponseSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CustomErrorResponseListDeserializer;
 impl CustomErrorResponseListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1861,9 +1897,10 @@ pub struct CustomErrorResponses {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct CustomErrorResponsesDeserializer;
 impl CustomErrorResponsesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1921,9 +1958,10 @@ pub struct CustomHeaders {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct CustomHeadersDeserializer;
 impl CustomHeadersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1989,9 +2027,10 @@ pub struct CustomOriginConfig {
     pub origin_ssl_protocols: Option<OriginSslProtocols>,
 }
 
+#[allow(dead_code)]
 struct CustomOriginConfigDeserializer;
 impl CustomOriginConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2120,9 +2159,10 @@ pub struct DefaultCacheBehavior {
     pub viewer_protocol_policy: String,
 }
 
+#[allow(dead_code)]
 struct DefaultCacheBehaviorDeserializer;
 impl DefaultCacheBehaviorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2362,9 +2402,10 @@ pub struct Distribution {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct DistributionDeserializer;
 impl DistributionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2453,9 +2494,10 @@ pub struct DistributionConfig {
     pub web_acl_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DistributionConfigDeserializer;
 impl DistributionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2695,9 +2737,10 @@ pub struct DistributionList {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct DistributionListDeserializer;
 impl DistributionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2776,9 +2819,10 @@ pub struct DistributionSummary {
     pub web_acl_id: String,
 }
 
+#[allow(dead_code)]
 struct DistributionSummaryDeserializer;
 impl DistributionSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2866,9 +2910,10 @@ impl DistributionSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DistributionSummaryListDeserializer;
 impl DistributionSummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2897,9 +2942,10 @@ pub struct EncryptionEntities {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct EncryptionEntitiesDeserializer;
 impl EncryptionEntitiesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2959,9 +3005,10 @@ pub struct EncryptionEntity {
     pub public_key_id: String,
 }
 
+#[allow(dead_code)]
 struct EncryptionEntityDeserializer;
 impl EncryptionEntityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3014,9 +3061,10 @@ impl EncryptionEntitySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EncryptionEntityListDeserializer;
 impl EncryptionEntityListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3055,9 +3103,10 @@ impl EncryptionEntityListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3099,9 +3148,10 @@ pub struct FieldLevelEncryption {
     pub last_modified_time: String,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionDeserializer;
 impl FieldLevelEncryptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3143,9 +3193,10 @@ pub struct FieldLevelEncryptionConfig {
     pub query_arg_profile_config: Option<QueryArgProfileConfig>,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionConfigDeserializer;
 impl FieldLevelEncryptionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3242,9 +3293,10 @@ pub struct FieldLevelEncryptionList {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionListDeserializer;
 impl FieldLevelEncryptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3290,9 +3342,10 @@ pub struct FieldLevelEncryptionProfile {
     pub last_modified_time: String,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionProfileDeserializer;
 impl FieldLevelEncryptionProfileDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3338,9 +3391,10 @@ pub struct FieldLevelEncryptionProfileConfig {
     pub name: String,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionProfileConfigDeserializer;
 impl FieldLevelEncryptionProfileConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3429,9 +3483,10 @@ pub struct FieldLevelEncryptionProfileList {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionProfileListDeserializer;
 impl FieldLevelEncryptionProfileListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3481,9 +3536,10 @@ pub struct FieldLevelEncryptionProfileSummary {
     pub name: String,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionProfileSummaryDeserializer;
 impl FieldLevelEncryptionProfileSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3519,9 +3575,10 @@ impl FieldLevelEncryptionProfileSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct FieldLevelEncryptionProfileSummaryListDeserializer;
 impl FieldLevelEncryptionProfileSummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3555,9 +3612,10 @@ pub struct FieldLevelEncryptionSummary {
     pub query_arg_profile_config: Option<QueryArgProfileConfig>,
 }
 
+#[allow(dead_code)]
 struct FieldLevelEncryptionSummaryDeserializer;
 impl FieldLevelEncryptionSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3598,9 +3656,10 @@ impl FieldLevelEncryptionSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct FieldLevelEncryptionSummaryListDeserializer;
 impl FieldLevelEncryptionSummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3618,9 +3677,10 @@ impl FieldLevelEncryptionSummaryListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct FieldPatternListDeserializer;
 impl FieldPatternListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3667,9 +3727,10 @@ pub struct FieldPatterns {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct FieldPatternsDeserializer;
 impl FieldPatternsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3716,9 +3777,10 @@ impl FieldPatternsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FormatDeserializer;
 impl FormatDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3763,9 +3825,10 @@ pub struct ForwardedValues {
     pub query_string_cache_keys: Option<QueryStringCacheKeys>,
 }
 
+#[allow(dead_code)]
 struct ForwardedValuesDeserializer;
 impl ForwardedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3837,9 +3900,10 @@ pub struct GeoRestriction {
     pub restriction_type: String,
 }
 
+#[allow(dead_code)]
 struct GeoRestrictionDeserializer;
 impl GeoRestrictionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3896,9 +3960,10 @@ impl GeoRestrictionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct GeoRestrictionTypeDeserializer;
 impl GeoRestrictionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3946,9 +4011,10 @@ pub struct GetCloudFrontOriginAccessIdentityConfigResult {
     pub e_tag: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetCloudFrontOriginAccessIdentityConfigResultDeserializer;
 impl GetCloudFrontOriginAccessIdentityConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3982,9 +4048,10 @@ pub struct GetCloudFrontOriginAccessIdentityResult {
     pub e_tag: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetCloudFrontOriginAccessIdentityResultDeserializer;
 impl GetCloudFrontOriginAccessIdentityResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4018,9 +4085,10 @@ pub struct GetDistributionConfigResult {
     pub e_tag: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetDistributionConfigResultDeserializer;
 impl GetDistributionConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4052,9 +4120,10 @@ pub struct GetDistributionResult {
     pub e_tag: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetDistributionResultDeserializer;
 impl GetDistributionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4084,9 +4153,10 @@ pub struct GetFieldLevelEncryptionConfigResult {
     pub field_level_encryption_config: Option<FieldLevelEncryptionConfig>,
 }
 
+#[allow(dead_code)]
 struct GetFieldLevelEncryptionConfigResultDeserializer;
 impl GetFieldLevelEncryptionConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4118,9 +4188,10 @@ pub struct GetFieldLevelEncryptionProfileConfigResult {
     pub field_level_encryption_profile_config: Option<FieldLevelEncryptionProfileConfig>,
 }
 
+#[allow(dead_code)]
 struct GetFieldLevelEncryptionProfileConfigResultDeserializer;
 impl GetFieldLevelEncryptionProfileConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4152,9 +4223,10 @@ pub struct GetFieldLevelEncryptionProfileResult {
     pub field_level_encryption_profile: Option<FieldLevelEncryptionProfile>,
 }
 
+#[allow(dead_code)]
 struct GetFieldLevelEncryptionProfileResultDeserializer;
 impl GetFieldLevelEncryptionProfileResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4186,9 +4258,10 @@ pub struct GetFieldLevelEncryptionResult {
     pub field_level_encryption: Option<FieldLevelEncryption>,
 }
 
+#[allow(dead_code)]
 struct GetFieldLevelEncryptionResultDeserializer;
 impl GetFieldLevelEncryptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4220,9 +4293,10 @@ pub struct GetInvalidationResult {
     pub invalidation: Option<Invalidation>,
 }
 
+#[allow(dead_code)]
 struct GetInvalidationResultDeserializer;
 impl GetInvalidationResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4252,9 +4326,10 @@ pub struct GetPublicKeyConfigResult {
     pub public_key_config: Option<PublicKeyConfig>,
 }
 
+#[allow(dead_code)]
 struct GetPublicKeyConfigResultDeserializer;
 impl GetPublicKeyConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4284,9 +4359,10 @@ pub struct GetPublicKeyResult {
     pub public_key: Option<PublicKey>,
 }
 
+#[allow(dead_code)]
 struct GetPublicKeyResultDeserializer;
 impl GetPublicKeyResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4315,9 +4391,10 @@ pub struct GetStreamingDistributionConfigResult {
     pub streaming_distribution_config: Option<StreamingDistributionConfig>,
 }
 
+#[allow(dead_code)]
 struct GetStreamingDistributionConfigResultDeserializer;
 impl GetStreamingDistributionConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4351,9 +4428,10 @@ pub struct GetStreamingDistributionResult {
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
+#[allow(dead_code)]
 struct GetStreamingDistributionResultDeserializer;
 impl GetStreamingDistributionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4367,9 +4445,10 @@ impl GetStreamingDistributionResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HeaderListDeserializer;
 impl HeaderListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4416,9 +4495,10 @@ pub struct Headers {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct HeadersDeserializer;
 impl HeadersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4465,9 +4545,10 @@ impl HeadersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HttpVersionDeserializer;
 impl HttpVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4497,9 +4578,10 @@ impl HttpVersionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ICPRecordalStatusDeserializer;
 impl ICPRecordalStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4508,9 +4590,10 @@ impl ICPRecordalStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4554,9 +4637,10 @@ pub struct Invalidation {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct InvalidationDeserializer;
 impl InvalidationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4593,9 +4677,10 @@ pub struct InvalidationBatch {
     pub paths: Paths,
 }
 
+#[allow(dead_code)]
 struct InvalidationBatchDeserializer;
 impl InvalidationBatchDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4657,9 +4742,10 @@ pub struct InvalidationList {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct InvalidationListDeserializer;
 impl InvalidationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4704,9 +4790,10 @@ pub struct InvalidationSummary {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct InvalidationSummaryDeserializer;
 impl InvalidationSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4728,9 +4815,10 @@ impl InvalidationSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InvalidationSummaryListDeserializer;
 impl InvalidationSummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4748,9 +4836,10 @@ impl InvalidationSummaryListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ItemSelectionDeserializer;
 impl ItemSelectionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4780,9 +4869,10 @@ impl ItemSelectionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct KeyPairIdListDeserializer;
 impl KeyPairIdListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4807,9 +4897,10 @@ pub struct KeyPairIds {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct KeyPairIdsDeserializer;
 impl KeyPairIdsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4830,9 +4921,10 @@ impl KeyPairIdsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LambdaFunctionARNDeserializer;
 impl LambdaFunctionARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4875,9 +4967,10 @@ pub struct LambdaFunctionAssociation {
     pub lambda_function_arn: String,
 }
 
+#[allow(dead_code)]
 struct LambdaFunctionAssociationDeserializer;
 impl LambdaFunctionAssociationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4942,9 +5035,10 @@ impl LambdaFunctionAssociationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LambdaFunctionAssociationListDeserializer;
 impl LambdaFunctionAssociationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4998,9 +5092,10 @@ pub struct LambdaFunctionAssociations {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct LambdaFunctionAssociationsDeserializer;
 impl LambdaFunctionAssociationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5069,9 +5164,10 @@ pub struct ListCloudFrontOriginAccessIdentitiesResult {
     pub cloud_front_origin_access_identity_list: Option<CloudFrontOriginAccessIdentityList>,
 }
 
+#[allow(dead_code)]
 struct ListCloudFrontOriginAccessIdentitiesResultDeserializer;
 impl ListCloudFrontOriginAccessIdentitiesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5107,9 +5203,10 @@ pub struct ListDistributionsByWebACLIdResult {
     pub distribution_list: Option<DistributionList>,
 }
 
+#[allow(dead_code)]
 struct ListDistributionsByWebACLIdResultDeserializer;
 impl ListDistributionsByWebACLIdResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5141,9 +5238,10 @@ pub struct ListDistributionsResult {
     pub distribution_list: Option<DistributionList>,
 }
 
+#[allow(dead_code)]
 struct ListDistributionsResultDeserializer;
 impl ListDistributionsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5173,9 +5271,10 @@ pub struct ListFieldLevelEncryptionConfigsResult {
     pub field_level_encryption_list: Option<FieldLevelEncryptionList>,
 }
 
+#[allow(dead_code)]
 struct ListFieldLevelEncryptionConfigsResultDeserializer;
 impl ListFieldLevelEncryptionConfigsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5205,9 +5304,10 @@ pub struct ListFieldLevelEncryptionProfilesResult {
     pub field_level_encryption_profile_list: Option<FieldLevelEncryptionProfileList>,
 }
 
+#[allow(dead_code)]
 struct ListFieldLevelEncryptionProfilesResultDeserializer;
 impl ListFieldLevelEncryptionProfilesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5243,9 +5343,10 @@ pub struct ListInvalidationsResult {
     pub invalidation_list: Option<InvalidationList>,
 }
 
+#[allow(dead_code)]
 struct ListInvalidationsResultDeserializer;
 impl ListInvalidationsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5275,9 +5376,10 @@ pub struct ListPublicKeysResult {
     pub public_key_list: Option<PublicKeyList>,
 }
 
+#[allow(dead_code)]
 struct ListPublicKeysResultDeserializer;
 impl ListPublicKeysResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5309,9 +5411,10 @@ pub struct ListStreamingDistributionsResult {
     pub streaming_distribution_list: Option<StreamingDistributionList>,
 }
 
+#[allow(dead_code)]
 struct ListStreamingDistributionsResultDeserializer;
 impl ListStreamingDistributionsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5341,9 +5444,10 @@ pub struct ListTagsForResourceResult {
     pub tags: Tags,
 }
 
+#[allow(dead_code)]
 struct ListTagsForResourceResultDeserializer;
 impl ListTagsForResourceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5354,9 +5458,10 @@ impl ListTagsForResourceResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LocationListDeserializer;
 impl LocationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5407,9 +5512,10 @@ pub struct LoggingConfig {
     pub prefix: String,
 }
 
+#[allow(dead_code)]
 struct LoggingConfigDeserializer;
 impl LoggingConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5476,9 +5582,10 @@ impl LoggingConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LongDeserializer;
 impl LongDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5508,9 +5615,10 @@ impl LongSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MethodDeserializer;
 impl MethodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5540,9 +5648,10 @@ impl MethodSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MethodsListDeserializer;
 impl MethodsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5578,9 +5687,10 @@ impl MethodsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MinimumProtocolVersionDeserializer;
 impl MinimumProtocolVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5629,9 +5739,10 @@ pub struct Origin {
     pub s3_origin_config: Option<S3OriginConfig>,
 }
 
+#[allow(dead_code)]
 struct OriginDeserializer;
 impl OriginDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Origin, XmlParseError> {
         deserialize_elements::<_, Origin, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5725,9 +5836,10 @@ pub struct OriginCustomHeader {
     pub header_value: String,
 }
 
+#[allow(dead_code)]
 struct OriginCustomHeaderDeserializer;
 impl OriginCustomHeaderDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5775,9 +5887,10 @@ impl OriginCustomHeaderSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OriginCustomHeadersListDeserializer;
 impl OriginCustomHeadersListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5829,9 +5942,10 @@ pub struct OriginGroup {
     pub members: OriginGroupMembers,
 }
 
+#[allow(dead_code)]
 struct OriginGroupDeserializer;
 impl OriginGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5894,9 +6008,10 @@ pub struct OriginGroupFailoverCriteria {
     pub status_codes: StatusCodes,
 }
 
+#[allow(dead_code)]
 struct OriginGroupFailoverCriteriaDeserializer;
 impl OriginGroupFailoverCriteriaDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5935,9 +6050,10 @@ impl OriginGroupFailoverCriteriaSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OriginGroupListDeserializer;
 impl OriginGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5982,9 +6098,10 @@ pub struct OriginGroupMember {
     pub origin_id: String,
 }
 
+#[allow(dead_code)]
 struct OriginGroupMemberDeserializer;
 impl OriginGroupMemberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6023,9 +6140,10 @@ impl OriginGroupMemberSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OriginGroupMemberListDeserializer;
 impl OriginGroupMemberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6075,9 +6193,10 @@ pub struct OriginGroupMembers {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct OriginGroupMembersDeserializer;
 impl OriginGroupMembersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6134,9 +6253,10 @@ pub struct OriginGroups {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct OriginGroupsDeserializer;
 impl OriginGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6183,9 +6303,10 @@ impl OriginGroupsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OriginListDeserializer;
 impl OriginListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6221,9 +6342,10 @@ impl OriginListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OriginProtocolPolicyDeserializer;
 impl OriginProtocolPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6264,9 +6386,10 @@ pub struct OriginSslProtocols {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct OriginSslProtocolsDeserializer;
 impl OriginSslProtocolsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6321,9 +6444,10 @@ pub struct Origins {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct OriginsDeserializer;
 impl OriginsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6367,9 +6491,10 @@ impl OriginsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PathListDeserializer;
 impl PathListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6416,9 +6541,10 @@ pub struct Paths {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct PathsDeserializer;
 impl PathsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Paths, XmlParseError> {
         deserialize_elements::<_, Paths, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -6462,9 +6588,10 @@ impl PathsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PriceClassDeserializer;
 impl PriceClassDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6506,9 +6633,10 @@ pub struct PublicKey {
     pub public_key_config: PublicKeyConfig,
 }
 
+#[allow(dead_code)]
 struct PublicKeyDeserializer;
 impl PublicKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6546,9 +6674,10 @@ pub struct PublicKeyConfig {
     pub name: String,
 }
 
+#[allow(dead_code)]
 struct PublicKeyConfigDeserializer;
 impl PublicKeyConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6631,9 +6760,10 @@ pub struct PublicKeyList {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct PublicKeyListDeserializer;
 impl PublicKeyListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6676,9 +6806,10 @@ pub struct PublicKeySummary {
     pub name: String,
 }
 
+#[allow(dead_code)]
 struct PublicKeySummaryDeserializer;
 impl PublicKeySummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6706,9 +6837,10 @@ impl PublicKeySummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PublicKeySummaryListDeserializer;
 impl PublicKeySummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6737,9 +6869,10 @@ pub struct QueryArgProfile {
     pub query_arg: String,
 }
 
+#[allow(dead_code)]
 struct QueryArgProfileDeserializer;
 impl QueryArgProfileDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6798,9 +6931,10 @@ pub struct QueryArgProfileConfig {
     pub query_arg_profiles: Option<QueryArgProfiles>,
 }
 
+#[allow(dead_code)]
 struct QueryArgProfileConfigDeserializer;
 impl QueryArgProfileConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6854,9 +6988,10 @@ impl QueryArgProfileConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct QueryArgProfileListDeserializer;
 impl QueryArgProfileListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6906,9 +7041,10 @@ pub struct QueryArgProfiles {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct QueryArgProfilesDeserializer;
 impl QueryArgProfilesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6966,9 +7102,10 @@ pub struct QueryStringCacheKeys {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct QueryStringCacheKeysDeserializer;
 impl QueryStringCacheKeysDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7015,9 +7152,10 @@ impl QueryStringCacheKeysSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct QueryStringCacheKeysListDeserializer;
 impl QueryStringCacheKeysListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7082,9 +7220,10 @@ pub struct Restrictions {
     pub geo_restriction: GeoRestriction,
 }
 
+#[allow(dead_code)]
 struct RestrictionsDeserializer;
 impl RestrictionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7130,9 +7269,10 @@ pub struct S3Origin {
     pub origin_access_identity: String,
 }
 
+#[allow(dead_code)]
 struct S3OriginDeserializer;
 impl S3OriginDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7190,9 +7330,10 @@ pub struct S3OriginConfig {
     pub origin_access_identity: String,
 }
 
+#[allow(dead_code)]
 struct S3OriginConfigDeserializer;
 impl S3OriginConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7232,9 +7373,10 @@ impl S3OriginConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SSLSupportMethodDeserializer;
 impl SSLSupportMethodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7274,9 +7416,10 @@ pub struct Signer {
     pub key_pair_ids: Option<KeyPairIds>,
 }
 
+#[allow(dead_code)]
 struct SignerDeserializer;
 impl SignerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Signer, XmlParseError> {
         deserialize_elements::<_, Signer, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7294,9 +7437,10 @@ impl SignerDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SignerListDeserializer;
 impl SignerListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7311,9 +7455,10 @@ impl SignerListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SslProtocolDeserializer;
 impl SslProtocolDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7343,9 +7488,10 @@ impl SslProtocolSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SslProtocolsListDeserializer;
 impl SslProtocolsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7381,9 +7527,10 @@ impl SslProtocolsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StatusCodeListDeserializer;
 impl StatusCodeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7430,9 +7577,10 @@ pub struct StatusCodes {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct StatusCodesDeserializer;
 impl StatusCodesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7496,9 +7644,10 @@ pub struct StreamingDistribution {
     pub streaming_distribution_config: StreamingDistributionConfig,
 }
 
+#[allow(dead_code)]
 struct StreamingDistributionDeserializer;
 impl StreamingDistributionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7565,9 +7714,10 @@ pub struct StreamingDistributionConfig {
     pub trusted_signers: TrustedSigners,
 }
 
+#[allow(dead_code)]
 struct StreamingDistributionConfigDeserializer;
 impl StreamingDistributionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7714,9 +7864,10 @@ pub struct StreamingDistributionList {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct StreamingDistributionListDeserializer;
 impl StreamingDistributionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7784,9 +7935,10 @@ pub struct StreamingDistributionSummary {
     pub trusted_signers: TrustedSigners,
 }
 
+#[allow(dead_code)]
 struct StreamingDistributionSummaryDeserializer;
 impl StreamingDistributionSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7838,9 +7990,10 @@ impl StreamingDistributionSummaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct StreamingDistributionSummaryListDeserializer;
 impl StreamingDistributionSummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7871,9 +8024,10 @@ pub struct StreamingLoggingConfig {
     pub prefix: String,
 }
 
+#[allow(dead_code)]
 struct StreamingLoggingConfigDeserializer;
 impl StreamingLoggingConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7930,9 +8084,10 @@ impl StreamingLoggingConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7973,9 +8128,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -8022,9 +8178,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8101,9 +8258,10 @@ impl TagKeysSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8149,9 +8307,10 @@ pub struct TagResourceRequest {
     pub tags: Tags,
 }
 
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8190,9 +8349,10 @@ pub struct Tags {
     pub items: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct TagsDeserializer;
 impl TagsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tags, XmlParseError> {
         deserialize_elements::<_, Tags, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -8227,9 +8387,10 @@ impl TagsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TimestampDeserializer;
 impl TimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8251,9 +8412,10 @@ pub struct TrustedSigners {
     pub quantity: i64,
 }
 
+#[allow(dead_code)]
 struct TrustedSignersDeserializer;
 impl TrustedSignersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8341,9 +8503,10 @@ pub struct UpdateCloudFrontOriginAccessIdentityResult {
     pub e_tag: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateCloudFrontOriginAccessIdentityResultDeserializer;
 impl UpdateCloudFrontOriginAccessIdentityResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8381,9 +8544,10 @@ pub struct UpdateDistributionResult {
     pub e_tag: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateDistributionResultDeserializer;
 impl UpdateDistributionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8417,9 +8581,10 @@ pub struct UpdateFieldLevelEncryptionConfigResult {
     pub field_level_encryption: Option<FieldLevelEncryption>,
 }
 
+#[allow(dead_code)]
 struct UpdateFieldLevelEncryptionConfigResultDeserializer;
 impl UpdateFieldLevelEncryptionConfigResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8453,9 +8618,10 @@ pub struct UpdateFieldLevelEncryptionProfileResult {
     pub field_level_encryption_profile: Option<FieldLevelEncryptionProfile>,
 }
 
+#[allow(dead_code)]
 struct UpdateFieldLevelEncryptionProfileResultDeserializer;
 impl UpdateFieldLevelEncryptionProfileResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8491,9 +8657,10 @@ pub struct UpdatePublicKeyResult {
     pub public_key: Option<PublicKey>,
 }
 
+#[allow(dead_code)]
 struct UpdatePublicKeyResultDeserializer;
 impl UpdatePublicKeyResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8526,9 +8693,10 @@ pub struct UpdateStreamingDistributionResult {
     pub streaming_distribution: Option<StreamingDistribution>,
 }
 
+#[allow(dead_code)]
 struct UpdateStreamingDistributionResultDeserializer;
 impl UpdateStreamingDistributionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8559,9 +8727,10 @@ pub struct ViewerCertificate {
     pub ssl_support_method: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ViewerCertificateDeserializer;
 impl ViewerCertificateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8662,9 +8831,10 @@ impl ViewerCertificateSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ViewerProtocolPolicyDeserializer;
 impl ViewerProtocolPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -36,9 +36,10 @@ use std::str::FromStr;
 use xml::reader::ParserConfig;
 use xml::EventReader;
 
+#[allow(dead_code)]
 struct APIVersionDeserializer;
 impl APIVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -47,9 +48,10 @@ impl APIVersionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ARNDeserializer;
 impl ARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -66,9 +68,10 @@ pub struct AccessPoliciesStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct AccessPoliciesStatusDeserializer;
 impl AccessPoliciesStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -87,9 +90,10 @@ impl AccessPoliciesStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AlgorithmicStemmingDeserializer;
 impl AlgorithmicStemmingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -115,9 +119,10 @@ pub struct AnalysisOptions {
     pub synonyms: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AnalysisOptionsDeserializer;
 impl AnalysisOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -198,9 +203,10 @@ pub struct AnalysisScheme {
     pub analysis_scheme_name: String,
 }
 
+#[allow(dead_code)]
 struct AnalysisSchemeDeserializer;
 impl AnalysisSchemeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -257,9 +263,10 @@ impl AnalysisSchemeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AnalysisSchemeLanguageDeserializer;
 impl AnalysisSchemeLanguageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -276,9 +283,10 @@ pub struct AnalysisSchemeStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct AnalysisSchemeStatusDeserializer;
 impl AnalysisSchemeStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -297,9 +305,10 @@ impl AnalysisSchemeStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AnalysisSchemeStatusListDeserializer;
 impl AnalysisSchemeStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -325,9 +334,10 @@ pub struct AvailabilityOptionsStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct AvailabilityOptionsStatusDeserializer;
 impl AvailabilityOptionsStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -350,9 +360,10 @@ impl AvailabilityOptionsStatusDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -388,9 +399,10 @@ pub struct BuildSuggestersResponse {
     pub field_names: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct BuildSuggestersResponseDeserializer;
 impl BuildSuggestersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -440,9 +452,10 @@ pub struct CreateDomainResponse {
     pub domain_status: Option<DomainStatus>,
 }
 
+#[allow(dead_code)]
 struct CreateDomainResponseDeserializer;
 impl CreateDomainResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -478,9 +491,10 @@ pub struct DateArrayOptions {
     pub source_fields: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DateArrayOptionsDeserializer;
 impl DateArrayOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -561,9 +575,10 @@ pub struct DateOptions {
     pub source_field: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DateOptionsDeserializer;
 impl DateOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -664,9 +679,10 @@ pub struct DefineAnalysisSchemeResponse {
     pub analysis_scheme: AnalysisSchemeStatus,
 }
 
+#[allow(dead_code)]
 struct DefineAnalysisSchemeResponseDeserializer;
 impl DefineAnalysisSchemeResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -720,9 +736,10 @@ pub struct DefineExpressionResponse {
     pub expression: ExpressionStatus,
 }
 
+#[allow(dead_code)]
 struct DefineExpressionResponseDeserializer;
 impl DefineExpressionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -777,9 +794,10 @@ pub struct DefineIndexFieldResponse {
     pub index_field: IndexFieldStatus,
 }
 
+#[allow(dead_code)]
 struct DefineIndexFieldResponseDeserializer;
 impl DefineIndexFieldResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -833,9 +851,10 @@ pub struct DefineSuggesterResponse {
     pub suggester: SuggesterStatus,
 }
 
+#[allow(dead_code)]
 struct DefineSuggesterResponseDeserializer;
 impl DefineSuggesterResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -890,9 +909,10 @@ pub struct DeleteAnalysisSchemeResponse {
     pub analysis_scheme: AnalysisSchemeStatus,
 }
 
+#[allow(dead_code)]
 struct DeleteAnalysisSchemeResponseDeserializer;
 impl DeleteAnalysisSchemeResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -941,9 +961,10 @@ pub struct DeleteDomainResponse {
     pub domain_status: Option<DomainStatus>,
 }
 
+#[allow(dead_code)]
 struct DeleteDomainResponseDeserializer;
 impl DeleteDomainResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -996,9 +1017,10 @@ pub struct DeleteExpressionResponse {
     pub expression: ExpressionStatus,
 }
 
+#[allow(dead_code)]
 struct DeleteExpressionResponseDeserializer;
 impl DeleteExpressionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1053,9 +1075,10 @@ pub struct DeleteIndexFieldResponse {
     pub index_field: IndexFieldStatus,
 }
 
+#[allow(dead_code)]
 struct DeleteIndexFieldResponseDeserializer;
 impl DeleteIndexFieldResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1110,9 +1133,10 @@ pub struct DeleteSuggesterResponse {
     pub suggester: SuggesterStatus,
 }
 
+#[allow(dead_code)]
 struct DeleteSuggesterResponseDeserializer;
 impl DeleteSuggesterResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1176,9 +1200,10 @@ pub struct DescribeAnalysisSchemesResponse {
     pub analysis_schemes: Vec<AnalysisSchemeStatus>,
 }
 
+#[allow(dead_code)]
 struct DescribeAnalysisSchemesResponseDeserializer;
 impl DescribeAnalysisSchemesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1237,9 +1262,10 @@ pub struct DescribeAvailabilityOptionsResponse {
     pub availability_options: Option<AvailabilityOptionsStatus>,
 }
 
+#[allow(dead_code)]
 struct DescribeAvailabilityOptionsResponseDeserializer;
 impl DescribeAvailabilityOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1297,9 +1323,10 @@ pub struct DescribeDomainEndpointOptionsResponse {
     pub domain_endpoint_options: Option<DomainEndpointOptionsStatus>,
 }
 
+#[allow(dead_code)]
 struct DescribeDomainEndpointOptionsResponseDeserializer;
 impl DescribeDomainEndpointOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1357,9 +1384,10 @@ pub struct DescribeDomainsResponse {
     pub domain_status_list: Vec<DomainStatus>,
 }
 
+#[allow(dead_code)]
 struct DescribeDomainsResponseDeserializer;
 impl DescribeDomainsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1426,9 +1454,10 @@ pub struct DescribeExpressionsResponse {
     pub expressions: Vec<ExpressionStatus>,
 }
 
+#[allow(dead_code)]
 struct DescribeExpressionsResponseDeserializer;
 impl DescribeExpressionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1495,9 +1524,10 @@ pub struct DescribeIndexFieldsResponse {
     pub index_fields: Vec<IndexFieldStatus>,
 }
 
+#[allow(dead_code)]
 struct DescribeIndexFieldsResponseDeserializer;
 impl DescribeIndexFieldsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1548,9 +1578,10 @@ pub struct DescribeScalingParametersResponse {
     pub scaling_parameters: ScalingParametersStatus,
 }
 
+#[allow(dead_code)]
 struct DescribeScalingParametersResponseDeserializer;
 impl DescribeScalingParametersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1607,9 +1638,10 @@ pub struct DescribeServiceAccessPoliciesResponse {
     pub access_policies: AccessPoliciesStatus,
 }
 
+#[allow(dead_code)]
 struct DescribeServiceAccessPoliciesResponseDeserializer;
 impl DescribeServiceAccessPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1673,9 +1705,10 @@ pub struct DescribeSuggestersResponse {
     pub suggesters: Vec<SuggesterStatus>,
 }
 
+#[allow(dead_code)]
 struct DescribeSuggestersResponseDeserializer;
 impl DescribeSuggestersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1712,9 +1745,10 @@ pub struct DocumentSuggesterOptions {
     pub source_field: String,
 }
 
+#[allow(dead_code)]
 struct DocumentSuggesterOptionsDeserializer;
 impl DocumentSuggesterOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1776,9 +1810,10 @@ pub struct DomainEndpointOptions {
     pub tls_security_policy: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DomainEndpointOptionsDeserializer;
 impl DomainEndpointOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1830,9 +1865,10 @@ pub struct DomainEndpointOptionsStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct DomainEndpointOptionsStatusDeserializer;
 impl DomainEndpointOptionsStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1856,9 +1892,10 @@ impl DomainEndpointOptionsStatusDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DomainIdDeserializer;
 impl DomainIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1867,9 +1904,10 @@ impl DomainIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DomainNameDeserializer;
 impl DomainNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1890,9 +1928,10 @@ impl DomainNameListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DomainNameMapDeserializer;
 impl DomainNameMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1941,9 +1980,10 @@ pub struct DomainStatus {
     pub search_service: Option<ServiceEndpoint>,
 }
 
+#[allow(dead_code)]
 struct DomainStatusDeserializer;
 impl DomainStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2011,9 +2051,10 @@ impl DomainStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DomainStatusListDeserializer;
 impl DomainStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2028,9 +2069,10 @@ impl DomainStatusListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DoubleDeserializer;
 impl DoubleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2056,9 +2098,10 @@ pub struct DoubleArrayOptions {
     pub source_fields: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DoubleArrayOptionsDeserializer;
 impl DoubleArrayOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2140,9 +2183,10 @@ pub struct DoubleOptions {
     pub source_field: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DoubleOptionsDeserializer;
 impl DoubleOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2210,9 +2254,10 @@ impl DoubleOptionsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DynamicFieldNameDeserializer;
 impl DynamicFieldNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2242,9 +2287,10 @@ pub struct Expression {
     pub expression_value: String,
 }
 
+#[allow(dead_code)]
 struct ExpressionDeserializer;
 impl ExpressionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2295,9 +2341,10 @@ pub struct ExpressionStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct ExpressionStatusDeserializer;
 impl ExpressionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2316,9 +2363,10 @@ impl ExpressionStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ExpressionStatusListDeserializer;
 impl ExpressionStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2333,9 +2381,10 @@ impl ExpressionStatusListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ExpressionValueDeserializer;
 impl ExpressionValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2344,9 +2393,10 @@ impl ExpressionValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FieldNameDeserializer;
 impl FieldNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2355,9 +2405,10 @@ impl FieldNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FieldNameCommaListDeserializer;
 impl FieldNameCommaListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2366,9 +2417,10 @@ impl FieldNameCommaListDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FieldNameListDeserializer;
 impl FieldNameListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2383,9 +2435,10 @@ impl FieldNameListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct FieldValueDeserializer;
 impl FieldValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2422,9 +2475,10 @@ pub struct IndexDocumentsResponse {
     pub field_names: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct IndexDocumentsResponseDeserializer;
 impl IndexDocumentsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2463,9 +2517,10 @@ pub struct IndexField {
     pub text_options: Option<TextOptions>,
 }
 
+#[allow(dead_code)]
 struct IndexFieldDeserializer;
 impl IndexFieldDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2652,9 +2707,10 @@ pub struct IndexFieldStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct IndexFieldStatusDeserializer;
 impl IndexFieldStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2673,9 +2729,10 @@ impl IndexFieldStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IndexFieldStatusListDeserializer;
 impl IndexFieldStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2690,9 +2747,10 @@ impl IndexFieldStatusListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IndexFieldTypeDeserializer;
 impl IndexFieldTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2701,9 +2759,10 @@ impl IndexFieldTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InstanceCountDeserializer;
 impl InstanceCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2729,9 +2788,10 @@ pub struct IntArrayOptions {
     pub source_fields: Option<String>,
 }
 
+#[allow(dead_code)]
 struct IntArrayOptionsDeserializer;
 impl IntArrayOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2812,9 +2872,10 @@ pub struct IntOptions {
     pub source_field: Option<String>,
 }
 
+#[allow(dead_code)]
 struct IntOptionsDeserializer;
 impl IntOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2899,9 +2960,10 @@ pub struct LatLonOptions {
     pub source_field: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LatLonOptionsDeserializer;
 impl LatLonOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2976,9 +3038,10 @@ pub struct Limits {
     pub maximum_replication_count: i64,
 }
 
+#[allow(dead_code)]
 struct LimitsDeserializer;
 impl LimitsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Limits, XmlParseError> {
         deserialize_elements::<_, Limits, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -3009,9 +3072,10 @@ pub struct ListDomainNamesResponse {
     pub domain_names: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct ListDomainNamesResponseDeserializer;
 impl ListDomainNamesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3051,9 +3115,10 @@ pub struct LiteralArrayOptions {
     pub source_fields: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LiteralArrayOptionsDeserializer;
 impl LiteralArrayOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3134,9 +3199,10 @@ pub struct LiteralOptions {
     pub source_field: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LiteralOptionsDeserializer;
 impl LiteralOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3204,9 +3270,10 @@ impl LiteralOptionsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LongDeserializer;
 impl LongDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3215,9 +3282,10 @@ impl LongDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaximumPartitionCountDeserializer;
 impl MaximumPartitionCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3226,9 +3294,10 @@ impl MaximumPartitionCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaximumReplicationCountDeserializer;
 impl MaximumReplicationCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3237,9 +3306,10 @@ impl MaximumReplicationCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MultiAZDeserializer;
 impl MultiAZDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3248,9 +3318,10 @@ impl MultiAZDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OptionStateDeserializer;
 impl OptionStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3275,9 +3346,10 @@ pub struct OptionStatus {
     pub update_version: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct OptionStatusDeserializer;
 impl OptionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3309,9 +3381,10 @@ impl OptionStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PartitionCountDeserializer;
 impl PartitionCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3320,9 +3393,10 @@ impl PartitionCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PartitionInstanceTypeDeserializer;
 impl PartitionInstanceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3331,9 +3405,10 @@ impl PartitionInstanceTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyDocumentDeserializer;
 impl PolicyDocumentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3355,9 +3430,10 @@ pub struct ScalingParameters {
     pub desired_replication_count: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ScalingParametersDeserializer;
 impl ScalingParametersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3428,9 +3504,10 @@ pub struct ScalingParametersStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct ScalingParametersStatusDeserializer;
 impl ScalingParametersStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3453,9 +3530,10 @@ impl ScalingParametersStatusDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SearchInstanceTypeDeserializer;
 impl SearchInstanceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3471,9 +3549,10 @@ pub struct ServiceEndpoint {
     pub endpoint: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ServiceEndpointDeserializer;
 impl ServiceEndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3489,9 +3568,10 @@ impl ServiceEndpointDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ServiceUrlDeserializer;
 impl ServiceUrlDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3500,9 +3580,10 @@ impl ServiceUrlDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StandardNameDeserializer;
 impl StandardNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3523,9 +3604,10 @@ impl StandardNameListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3543,9 +3625,10 @@ pub struct Suggester {
     pub suggester_name: String,
 }
 
+#[allow(dead_code)]
 struct SuggesterDeserializer;
 impl SuggesterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3591,9 +3674,10 @@ impl SuggesterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SuggesterFuzzyMatchingDeserializer;
 impl SuggesterFuzzyMatchingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3610,9 +3694,10 @@ pub struct SuggesterStatus {
     pub status: OptionStatus,
 }
 
+#[allow(dead_code)]
 struct SuggesterStatusDeserializer;
 impl SuggesterStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3631,9 +3716,10 @@ impl SuggesterStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SuggesterStatusListDeserializer;
 impl SuggesterStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3648,9 +3734,10 @@ impl SuggesterStatusListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TLSSecurityPolicyDeserializer;
 impl TLSSecurityPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3676,9 +3763,10 @@ pub struct TextArrayOptions {
     pub source_fields: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TextArrayOptionsDeserializer;
 impl TextArrayOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3759,9 +3847,10 @@ pub struct TextOptions {
     pub source_field: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TextOptionsDeserializer;
 impl TextOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3829,9 +3918,10 @@ impl TextOptionsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct UIntValueDeserializer;
 impl UIntValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3871,9 +3961,10 @@ pub struct UpdateAvailabilityOptionsResponse {
     pub availability_options: Option<AvailabilityOptionsStatus>,
 }
 
+#[allow(dead_code)]
 struct UpdateAvailabilityOptionsResponseDeserializer;
 impl UpdateAvailabilityOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3933,9 +4024,10 @@ pub struct UpdateDomainEndpointOptionsResponse {
     pub domain_endpoint_options: Option<DomainEndpointOptionsStatus>,
 }
 
+#[allow(dead_code)]
 struct UpdateDomainEndpointOptionsResponseDeserializer;
 impl UpdateDomainEndpointOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3992,9 +4084,10 @@ pub struct UpdateScalingParametersResponse {
     pub scaling_parameters: ScalingParametersStatus,
 }
 
+#[allow(dead_code)]
 struct UpdateScalingParametersResponseDeserializer;
 impl UpdateScalingParametersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4051,9 +4144,10 @@ pub struct UpdateServiceAccessPoliciesResponse {
     pub access_policies: AccessPoliciesStatus,
 }
 
+#[allow(dead_code)]
 struct UpdateServiceAccessPoliciesResponseDeserializer;
 impl UpdateServiceAccessPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4074,9 +4168,10 @@ impl UpdateServiceAccessPoliciesResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct UpdateTimestampDeserializer;
 impl UpdateTimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4085,9 +4180,10 @@ impl UpdateTimestampDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct WordDeserializer;
 impl WordDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -6212,9 +6212,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(BuildSuggestersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = BuildSuggestersResponse::default();
         } else {
@@ -6261,9 +6260,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(CreateDomainError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDomainResponse::default();
         } else {
@@ -6308,9 +6306,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DefineAnalysisSchemeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DefineAnalysisSchemeResponse::default();
         } else {
@@ -6357,9 +6354,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DefineExpressionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DefineExpressionResponse::default();
         } else {
@@ -6406,9 +6402,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DefineIndexFieldError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DefineIndexFieldResponse::default();
         } else {
@@ -6455,9 +6450,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DefineSuggesterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DefineSuggesterResponse::default();
         } else {
@@ -6504,9 +6498,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DeleteAnalysisSchemeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteAnalysisSchemeResponse::default();
         } else {
@@ -6553,9 +6546,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DeleteDomainError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDomainResponse::default();
         } else {
@@ -6600,9 +6592,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DeleteExpressionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteExpressionResponse::default();
         } else {
@@ -6649,9 +6640,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DeleteIndexFieldError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteIndexFieldResponse::default();
         } else {
@@ -6698,9 +6688,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DeleteSuggesterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteSuggesterResponse::default();
         } else {
@@ -6747,9 +6736,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeAnalysisSchemesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAnalysisSchemesResponse::default();
         } else {
@@ -6797,9 +6785,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeAvailabilityOptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAvailabilityOptionsResponse::default();
         } else {
@@ -6849,9 +6836,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeDomainEndpointOptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDomainEndpointOptionsResponse::default();
         } else {
@@ -6898,9 +6884,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeDomainsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDomainsResponse::default();
         } else {
@@ -6947,9 +6932,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeExpressionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeExpressionsResponse::default();
         } else {
@@ -6996,9 +6980,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeIndexFieldsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeIndexFieldsResponse::default();
         } else {
@@ -7046,9 +7029,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeScalingParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeScalingParametersResponse::default();
         } else {
@@ -7098,9 +7080,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeServiceAccessPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeServiceAccessPoliciesResponse::default();
         } else {
@@ -7147,9 +7128,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(DescribeSuggestersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeSuggestersResponse::default();
         } else {
@@ -7196,9 +7176,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(IndexDocumentsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = IndexDocumentsResponse::default();
         } else {
@@ -7244,9 +7223,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(ListDomainNamesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListDomainNamesResponse::default();
         } else {
@@ -7294,9 +7272,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(UpdateAvailabilityOptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateAvailabilityOptionsResponse::default();
         } else {
@@ -7344,9 +7321,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(UpdateDomainEndpointOptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateDomainEndpointOptionsResponse::default();
         } else {
@@ -7393,9 +7369,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(UpdateScalingParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateScalingParametersResponse::default();
         } else {
@@ -7443,9 +7418,8 @@ impl CloudSearch for CloudSearchClient {
             return Err(UpdateServiceAccessPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateServiceAccessPoliciesResponse::default();
         } else {

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -6481,9 +6481,7 @@ impl CloudWatch for CloudWatchClient {
             return Err(DeleteAnomalyDetectorError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteAnomalyDetectorOutput::default();
         // parse non-payload
         Ok(result)
@@ -6513,9 +6511,7 @@ impl CloudWatch for CloudWatchClient {
             return Err(DeleteDashboardsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteDashboardsOutput::default();
         // parse non-payload
         Ok(result)
@@ -6545,9 +6541,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(DeleteInsightRulesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteInsightRulesOutput::default();
         } else {
@@ -6594,9 +6589,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(DescribeAlarmHistoryError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAlarmHistoryOutput::default();
         } else {
@@ -6643,9 +6637,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(DescribeAlarmsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAlarmsOutput::default();
         } else {
@@ -6690,9 +6683,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(DescribeAlarmsForMetricError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAlarmsForMetricOutput::default();
         } else {
@@ -6739,9 +6731,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(DescribeAnomalyDetectorsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAnomalyDetectorsOutput::default();
         } else {
@@ -6788,9 +6779,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(DescribeInsightRulesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeInsightRulesOutput::default();
         } else {
@@ -6865,9 +6855,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(DisableInsightRulesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DisableInsightRulesOutput::default();
         } else {
@@ -6942,9 +6931,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(EnableInsightRulesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnableInsightRulesOutput::default();
         } else {
@@ -6991,9 +6979,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(GetDashboardError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetDashboardOutput::default();
         } else {
@@ -7037,9 +7024,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(GetInsightRuleReportError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetInsightRuleReportOutput::default();
         } else {
@@ -7086,9 +7072,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(GetMetricDataError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetMetricDataOutput::default();
         } else {
@@ -7133,9 +7118,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(GetMetricStatisticsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetMetricStatisticsOutput::default();
         } else {
@@ -7182,9 +7166,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(GetMetricWidgetImageError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetMetricWidgetImageOutput::default();
         } else {
@@ -7231,9 +7214,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(ListDashboardsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListDashboardsOutput::default();
         } else {
@@ -7278,9 +7260,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(ListMetricsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListMetricsOutput::default();
         } else {
@@ -7324,9 +7305,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTagsForResourceOutput::default();
         } else {
@@ -7373,9 +7353,7 @@ impl CloudWatch for CloudWatchClient {
             return Err(PutAnomalyDetectorError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = PutAnomalyDetectorOutput::default();
         // parse non-payload
         Ok(result)
@@ -7405,9 +7383,8 @@ impl CloudWatch for CloudWatchClient {
             return Err(PutDashboardError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PutDashboardOutput::default();
         } else {
@@ -7451,9 +7428,7 @@ impl CloudWatch for CloudWatchClient {
             return Err(PutInsightRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = PutInsightRuleOutput::default();
         // parse non-payload
         Ok(result)
@@ -7567,9 +7542,7 @@ impl CloudWatch for CloudWatchClient {
             return Err(TagResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = TagResourceOutput::default();
         // parse non-payload
         Ok(result)
@@ -7599,9 +7572,7 @@ impl CloudWatch for CloudWatchClient {
             return Err(UntagResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = UntagResourceOutput::default();
         // parse non-payload
         Ok(result)

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -36,9 +36,10 @@ use std::str::FromStr;
 use xml::reader::ParserConfig;
 use xml::EventReader;
 
+#[allow(dead_code)]
 struct ActionsEnabledDeserializer;
 impl ActionsEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -47,9 +48,10 @@ impl ActionsEnabledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AlarmArnDeserializer;
 impl AlarmArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -58,9 +60,10 @@ impl AlarmArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AlarmDescriptionDeserializer;
 impl AlarmDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -85,9 +88,10 @@ pub struct AlarmHistoryItem {
     pub timestamp: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AlarmHistoryItemDeserializer;
 impl AlarmHistoryItemDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -122,9 +126,10 @@ impl AlarmHistoryItemDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AlarmHistoryItemsDeserializer;
 impl AlarmHistoryItemsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -139,9 +144,10 @@ impl AlarmHistoryItemsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AlarmNameDeserializer;
 impl AlarmNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -180,9 +186,10 @@ pub struct AnomalyDetector {
     pub state_value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AnomalyDetectorDeserializer;
 impl AnomalyDetectorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -234,9 +241,10 @@ pub struct AnomalyDetectorConfiguration {
     pub metric_timezone: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AnomalyDetectorConfigurationDeserializer;
 impl AnomalyDetectorConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -291,9 +299,10 @@ impl AnomalyDetectorConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AnomalyDetectorExcludedTimeRangesDeserializer;
 impl AnomalyDetectorExcludedTimeRangesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -320,9 +329,10 @@ impl AnomalyDetectorExcludedTimeRangesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AnomalyDetectorMetricTimezoneDeserializer;
 impl AnomalyDetectorMetricTimezoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -331,9 +341,10 @@ impl AnomalyDetectorMetricTimezoneDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AnomalyDetectorStateValueDeserializer;
 impl AnomalyDetectorStateValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -342,9 +353,10 @@ impl AnomalyDetectorStateValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AnomalyDetectorsDeserializer;
 impl AnomalyDetectorsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -359,9 +371,10 @@ impl AnomalyDetectorsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BatchFailuresDeserializer;
 impl BatchFailuresDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -376,9 +389,10 @@ impl BatchFailuresDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ComparisonOperatorDeserializer;
 impl ComparisonOperatorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -399,9 +413,10 @@ impl CountsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DashboardArnDeserializer;
 impl DashboardArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -410,9 +425,10 @@ impl DashboardArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DashboardBodyDeserializer;
 impl DashboardBodyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -421,9 +437,10 @@ impl DashboardBodyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DashboardEntriesDeserializer;
 impl DashboardEntriesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -452,9 +469,10 @@ pub struct DashboardEntry {
     pub size: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DashboardEntryDeserializer;
 impl DashboardEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -488,9 +506,10 @@ impl DashboardEntryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DashboardNameDeserializer;
 impl DashboardNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -521,9 +540,10 @@ pub struct DashboardValidationMessage {
     pub message: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DashboardValidationMessageDeserializer;
 impl DashboardValidationMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -546,9 +566,10 @@ impl DashboardValidationMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DashboardValidationMessagesDeserializer;
 impl DashboardValidationMessagesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -565,9 +586,10 @@ impl DashboardValidationMessagesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DataPathDeserializer;
 impl DataPathDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -598,9 +620,10 @@ pub struct Datapoint {
     pub unit: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DatapointDeserializer;
 impl DatapointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -643,9 +666,10 @@ impl DatapointDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DatapointValueDeserializer;
 impl DatapointValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -654,9 +678,10 @@ impl DatapointValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DatapointValueMapDeserializer;
 impl DatapointValueMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -677,9 +702,10 @@ impl DatapointValueMapDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DatapointValuesDeserializer;
 impl DatapointValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -694,9 +720,10 @@ impl DatapointValuesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DatapointsDeserializer;
 impl DatapointsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -711,9 +738,10 @@ impl DatapointsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DatapointsToAlarmDeserializer;
 impl DatapointsToAlarmDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -785,9 +813,10 @@ impl DeleteAnomalyDetectorInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteAnomalyDetectorOutput {}
 
+#[allow(dead_code)]
 struct DeleteAnomalyDetectorOutputDeserializer;
 impl DeleteAnomalyDetectorOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -829,9 +858,10 @@ impl DeleteDashboardsInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteDashboardsOutput {}
 
+#[allow(dead_code)]
 struct DeleteDashboardsOutputDeserializer;
 impl DeleteDashboardsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -876,9 +906,10 @@ pub struct DeleteInsightRulesOutput {
     pub failures: Option<Vec<PartialFailure>>,
 }
 
+#[allow(dead_code)]
 struct DeleteInsightRulesOutputDeserializer;
 impl DeleteInsightRulesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -956,9 +987,10 @@ pub struct DescribeAlarmHistoryOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeAlarmHistoryOutputDeserializer;
 impl DescribeAlarmHistoryOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1043,9 +1075,10 @@ pub struct DescribeAlarmsForMetricOutput {
     pub metric_alarms: Option<Vec<MetricAlarm>>,
 }
 
+#[allow(dead_code)]
 struct DescribeAlarmsForMetricOutputDeserializer;
 impl DescribeAlarmsForMetricOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1127,9 +1160,10 @@ pub struct DescribeAlarmsOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeAlarmsOutputDeserializer;
 impl DescribeAlarmsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1205,9 +1239,10 @@ pub struct DescribeAnomalyDetectorsOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeAnomalyDetectorsOutputDeserializer;
 impl DescribeAnomalyDetectorsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1269,9 +1304,10 @@ pub struct DescribeInsightRulesOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeInsightRulesOutputDeserializer;
 impl DescribeInsightRulesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1308,9 +1344,10 @@ pub struct Dimension {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct DimensionDeserializer;
 impl DimensionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1381,9 +1418,10 @@ impl DimensionFiltersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DimensionNameDeserializer;
 impl DimensionNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1392,9 +1430,10 @@ impl DimensionNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DimensionValueDeserializer;
 impl DimensionValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1403,9 +1442,10 @@ impl DimensionValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DimensionsDeserializer;
 impl DimensionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1487,9 +1527,10 @@ pub struct DisableInsightRulesOutput {
     pub failures: Option<Vec<PartialFailure>>,
 }
 
+#[allow(dead_code)]
 struct DisableInsightRulesOutputDeserializer;
 impl DisableInsightRulesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1566,9 +1607,10 @@ pub struct EnableInsightRulesOutput {
     pub failures: Option<Vec<PartialFailure>>,
 }
 
+#[allow(dead_code)]
 struct EnableInsightRulesOutputDeserializer;
 impl EnableInsightRulesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1590,9 +1632,10 @@ impl EnableInsightRulesOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct EvaluateLowSampleCountPercentileDeserializer;
 impl EvaluateLowSampleCountPercentileDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1601,9 +1644,10 @@ impl EvaluateLowSampleCountPercentileDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EvaluationPeriodsDeserializer;
 impl EvaluationPeriodsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1612,9 +1656,10 @@ impl EvaluationPeriodsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ExceptionTypeDeserializer;
 impl ExceptionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1623,9 +1668,10 @@ impl ExceptionTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ExtendedStatisticDeserializer;
 impl ExtendedStatisticDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1646,9 +1692,10 @@ impl ExtendedStatisticsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FailureCodeDeserializer;
 impl FailureCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1657,9 +1704,10 @@ impl FailureCodeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FailureDescriptionDeserializer;
 impl FailureDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1668,9 +1716,10 @@ impl FailureDescriptionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FailureResourceDeserializer;
 impl FailureResourceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1713,9 +1762,10 @@ pub struct GetDashboardOutput {
     pub dashboard_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetDashboardOutputDeserializer;
 impl GetDashboardOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1814,9 +1864,10 @@ pub struct GetInsightRuleReportOutput {
     pub metric_datapoints: Option<Vec<InsightRuleMetricDatapoint>>,
 }
 
+#[allow(dead_code)]
 struct GetInsightRuleReportOutputDeserializer;
 impl GetInsightRuleReportOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1934,9 +1985,10 @@ pub struct GetMetricDataOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetMetricDataOutputDeserializer;
 impl GetMetricDataOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2035,9 +2087,10 @@ pub struct GetMetricStatisticsOutput {
     pub label: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetMetricStatisticsOutputDeserializer;
 impl GetMetricStatisticsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2094,9 +2147,10 @@ pub struct GetMetricWidgetImageOutput {
     pub metric_widget_image: Option<bytes::Bytes>,
 }
 
+#[allow(dead_code)]
 struct GetMetricWidgetImageOutputDeserializer;
 impl GetMetricWidgetImageOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2119,9 +2173,10 @@ impl GetMetricWidgetImageOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct HistoryDataDeserializer;
 impl HistoryDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2130,9 +2185,10 @@ impl HistoryDataDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HistoryItemTypeDeserializer;
 impl HistoryItemTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2141,9 +2197,10 @@ impl HistoryItemTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HistorySummaryDeserializer;
 impl HistorySummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2166,9 +2223,10 @@ pub struct InsightRule {
     pub state: String,
 }
 
+#[allow(dead_code)]
 struct InsightRuleDeserializer;
 impl InsightRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2194,9 +2252,10 @@ impl InsightRuleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InsightRuleAggregationStatisticDeserializer;
 impl InsightRuleAggregationStatisticDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2217,9 +2276,10 @@ pub struct InsightRuleContributor {
     pub keys: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct InsightRuleContributorDeserializer;
 impl InsightRuleContributorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2263,9 +2323,10 @@ pub struct InsightRuleContributorDatapoint {
     pub timestamp: String,
 }
 
+#[allow(dead_code)]
 struct InsightRuleContributorDatapointDeserializer;
 impl InsightRuleContributorDatapointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2291,9 +2352,10 @@ impl InsightRuleContributorDatapointDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct InsightRuleContributorDatapointsDeserializer;
 impl InsightRuleContributorDatapointsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2310,9 +2372,10 @@ impl InsightRuleContributorDatapointsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InsightRuleContributorKeyDeserializer;
 impl InsightRuleContributorKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2321,9 +2384,10 @@ impl InsightRuleContributorKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InsightRuleContributorKeyLabelDeserializer;
 impl InsightRuleContributorKeyLabelDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2332,9 +2396,10 @@ impl InsightRuleContributorKeyLabelDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InsightRuleContributorKeyLabelsDeserializer;
 impl InsightRuleContributorKeyLabelsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2351,9 +2416,10 @@ impl InsightRuleContributorKeyLabelsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InsightRuleContributorKeysDeserializer;
 impl InsightRuleContributorKeysDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2370,9 +2436,10 @@ impl InsightRuleContributorKeysDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InsightRuleContributorsDeserializer;
 impl InsightRuleContributorsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2389,9 +2456,10 @@ impl InsightRuleContributorsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InsightRuleDefinitionDeserializer;
 impl InsightRuleDefinitionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2422,9 +2490,10 @@ pub struct InsightRuleMetricDatapoint {
     pub unique_contributors: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct InsightRuleMetricDatapointDeserializer;
 impl InsightRuleMetricDatapointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2484,9 +2553,10 @@ impl InsightRuleMetricDatapointDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct InsightRuleMetricDatapointsDeserializer;
 impl InsightRuleMetricDatapointsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2515,9 +2585,10 @@ impl InsightRuleMetricListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InsightRuleNameDeserializer;
 impl InsightRuleNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2538,9 +2609,10 @@ impl InsightRuleNamesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InsightRuleSchemaDeserializer;
 impl InsightRuleSchemaDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2549,9 +2621,10 @@ impl InsightRuleSchemaDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InsightRuleStateDeserializer;
 impl InsightRuleStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2560,9 +2633,10 @@ impl InsightRuleStateDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InsightRuleUnboundDoubleDeserializer;
 impl InsightRuleUnboundDoubleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2571,9 +2645,10 @@ impl InsightRuleUnboundDoubleDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InsightRuleUnboundLongDeserializer;
 impl InsightRuleUnboundLongDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2582,9 +2657,10 @@ impl InsightRuleUnboundLongDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InsightRulesDeserializer;
 impl InsightRulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2599,9 +2675,10 @@ impl InsightRulesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LastModifiedDeserializer;
 impl LastModifiedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2649,9 +2726,10 @@ pub struct ListDashboardsOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListDashboardsOutputDeserializer;
 impl ListDashboardsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2722,9 +2800,10 @@ pub struct ListMetricsOutput {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListMetricsOutputDeserializer;
 impl ListMetricsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2772,9 +2851,10 @@ pub struct ListTagsForResourceOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct ListTagsForResourceOutputDeserializer;
 impl ListTagsForResourceOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2796,9 +2876,10 @@ impl ListTagsForResourceOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct MessageDeserializer;
 impl MessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2817,9 +2898,10 @@ pub struct MessageData {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MessageDataDeserializer;
 impl MessageDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2838,9 +2920,10 @@ impl MessageDataDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MessageDataCodeDeserializer;
 impl MessageDataCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2849,9 +2932,10 @@ impl MessageDataCodeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MessageDataValueDeserializer;
 impl MessageDataValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2873,9 +2957,10 @@ pub struct Metric {
     pub namespace: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MetricDeserializer;
 impl MetricDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Metric, XmlParseError> {
         deserialize_elements::<_, Metric, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -2983,9 +3068,10 @@ pub struct MetricAlarm {
     pub unit: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MetricAlarmDeserializer;
 impl MetricAlarmDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3130,9 +3216,10 @@ impl MetricAlarmDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MetricAlarmsDeserializer;
 impl MetricAlarmsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3159,9 +3246,10 @@ impl MetricDataSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MetricDataQueriesDeserializer;
 impl MetricDataQueriesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3207,9 +3295,10 @@ pub struct MetricDataQuery {
     pub return_data: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct MetricDataQueryDeserializer;
 impl MetricDataQueryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3296,9 +3385,10 @@ pub struct MetricDataResult {
     pub values: Option<Vec<f64>>,
 }
 
+#[allow(dead_code)]
 struct MetricDataResultDeserializer;
 impl MetricDataResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3336,9 +3426,10 @@ impl MetricDataResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MetricDataResultMessagesDeserializer;
 impl MetricDataResultMessagesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3353,9 +3444,10 @@ impl MetricDataResultMessagesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MetricDataResultsDeserializer;
 impl MetricDataResultsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3439,9 +3531,10 @@ impl MetricDatumSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MetricExpressionDeserializer;
 impl MetricExpressionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3450,9 +3543,10 @@ impl MetricExpressionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricIdDeserializer;
 impl MetricIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3461,9 +3555,10 @@ impl MetricIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricLabelDeserializer;
 impl MetricLabelDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3472,9 +3567,10 @@ impl MetricLabelDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricNameDeserializer;
 impl MetricNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3498,9 +3594,10 @@ pub struct MetricStat {
     pub unit: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MetricStatDeserializer;
 impl MetricStatDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3544,9 +3641,10 @@ impl MetricStatSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MetricWidgetImageDeserializer;
 impl MetricWidgetImageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3558,9 +3656,10 @@ impl MetricWidgetImageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricsDeserializer;
 impl MetricsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3575,9 +3674,10 @@ impl MetricsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct NamespaceDeserializer;
 impl NamespaceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3586,9 +3686,10 @@ impl NamespaceDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextTokenDeserializer;
 impl NextTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3611,9 +3712,10 @@ pub struct PartialFailure {
     pub failure_resource: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PartialFailureDeserializer;
 impl PartialFailureDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3648,9 +3750,10 @@ impl PartialFailureDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PeriodDeserializer;
 impl PeriodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3707,9 +3810,10 @@ impl PutAnomalyDetectorInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct PutAnomalyDetectorOutput {}
 
+#[allow(dead_code)]
 struct PutAnomalyDetectorOutputDeserializer;
 impl PutAnomalyDetectorOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3759,9 +3863,10 @@ pub struct PutDashboardOutput {
     pub dashboard_validation_messages: Option<Vec<DashboardValidationMessage>>,
 }
 
+#[allow(dead_code)]
 struct PutDashboardOutputDeserializer;
 impl PutDashboardOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3817,9 +3922,10 @@ impl PutInsightRuleInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct PutInsightRuleOutput {}
 
+#[allow(dead_code)]
 struct PutInsightRuleOutputDeserializer;
 impl PutInsightRuleOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4021,9 +4127,10 @@ pub struct Range {
     pub start_time: String,
 }
 
+#[allow(dead_code)]
 struct RangeDeserializer;
 impl RangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Range, XmlParseError> {
         deserialize_elements::<_, Range, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -4054,9 +4161,10 @@ impl RangeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceListDeserializer;
 impl ResourceListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4083,9 +4191,10 @@ impl ResourceListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceNameDeserializer;
 impl ResourceNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4094,9 +4203,10 @@ impl ResourceNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReturnDataDeserializer;
 impl ReturnDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4136,9 +4246,10 @@ impl SetAlarmStateInputSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SizeDeserializer;
 impl SizeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4147,9 +4258,10 @@ impl SizeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StandardUnitDeserializer;
 impl StandardUnitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4158,9 +4270,10 @@ impl StandardUnitDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StatDeserializer;
 impl StatDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4169,9 +4282,10 @@ impl StatDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StateReasonDeserializer;
 impl StateReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4180,9 +4294,10 @@ impl StateReasonDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StateReasonDataDeserializer;
 impl StateReasonDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4191,9 +4306,10 @@ impl StateReasonDataDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StateValueDeserializer;
 impl StateValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4202,9 +4318,10 @@ impl StateValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StatisticDeserializer;
 impl StatisticDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4254,9 +4371,10 @@ impl StatisticsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StatusCodeDeserializer;
 impl StatusCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4276,9 +4394,10 @@ pub struct Tag {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -4309,9 +4428,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4332,9 +4452,10 @@ impl TagKeyListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4388,9 +4509,10 @@ impl TagResourceInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct TagResourceOutput {}
 
+#[allow(dead_code)]
 struct TagResourceOutputDeserializer;
 impl TagResourceOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4404,9 +4526,10 @@ impl TagResourceOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4415,9 +4538,10 @@ impl TagValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ThresholdDeserializer;
 impl ThresholdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4426,9 +4550,10 @@ impl ThresholdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TimestampDeserializer;
 impl TimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4437,9 +4562,10 @@ impl TimestampDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TimestampsDeserializer;
 impl TimestampsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4454,9 +4580,10 @@ impl TimestampsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TreatMissingDataDeserializer;
 impl TreatMissingDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4492,9 +4619,10 @@ impl UntagResourceInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct UntagResourceOutput {}
 
+#[allow(dead_code)]
 struct UntagResourceOutputDeserializer;
 impl UntagResourceOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/docdb/src/generated.rs
+++ b/rusoto/services/docdb/src/generated.rs
@@ -9449,9 +9449,8 @@ impl Docdb for DocdbClient {
             return Err(ApplyPendingMaintenanceActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplyPendingMaintenanceActionResult::default();
         } else {
@@ -9499,9 +9498,8 @@ impl Docdb for DocdbClient {
             return Err(CopyDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBClusterParameterGroupResult::default();
         } else {
@@ -9548,9 +9546,8 @@ impl Docdb for DocdbClient {
             return Err(CopyDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBClusterSnapshotResult::default();
         } else {
@@ -9597,9 +9594,8 @@ impl Docdb for DocdbClient {
             return Err(CreateDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterResult::default();
         } else {
@@ -9647,9 +9643,8 @@ impl Docdb for DocdbClient {
             return Err(CreateDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterParameterGroupResult::default();
         } else {
@@ -9696,9 +9691,8 @@ impl Docdb for DocdbClient {
             return Err(CreateDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterSnapshotResult::default();
         } else {
@@ -9745,9 +9739,8 @@ impl Docdb for DocdbClient {
             return Err(CreateDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBInstanceResult::default();
         } else {
@@ -9794,9 +9787,8 @@ impl Docdb for DocdbClient {
             return Err(CreateDBSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBSubnetGroupResult::default();
         } else {
@@ -9843,9 +9835,8 @@ impl Docdb for DocdbClient {
             return Err(DeleteDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBClusterResult::default();
         } else {
@@ -9920,9 +9911,8 @@ impl Docdb for DocdbClient {
             return Err(DeleteDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBClusterSnapshotResult::default();
         } else {
@@ -9969,9 +9959,8 @@ impl Docdb for DocdbClient {
             return Err(DeleteDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBInstanceResult::default();
         } else {
@@ -10046,9 +10035,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CertificateMessage::default();
         } else {
@@ -10098,9 +10086,8 @@ impl Docdb for DocdbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupsMessage::default();
         } else {
@@ -10147,9 +10134,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeDBClusterParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupDetails::default();
         } else {
@@ -10201,9 +10187,8 @@ impl Docdb for DocdbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBClusterSnapshotAttributesResult::default();
         } else {
@@ -10250,9 +10235,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeDBClusterSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterSnapshotMessage::default();
         } else {
@@ -10299,9 +10283,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeDBClustersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterMessage::default();
         } else {
@@ -10346,9 +10329,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeDBEngineVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBEngineVersionMessage::default();
         } else {
@@ -10395,9 +10377,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeDBInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBInstanceMessage::default();
         } else {
@@ -10444,9 +10425,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeDBSubnetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBSubnetGroupMessage::default();
         } else {
@@ -10498,9 +10478,8 @@ impl Docdb for DocdbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEngineDefaultClusterParametersResult::default();
         } else {
@@ -10547,9 +10526,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeEventCategoriesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventCategoriesMessage::default();
         } else {
@@ -10596,9 +10574,8 @@ impl Docdb for DocdbClient {
             return Err(DescribeEventsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventsMessage::default();
         } else {
@@ -10647,9 +10624,8 @@ impl Docdb for DocdbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = OrderableDBInstanceOptionsMessage::default();
         } else {
@@ -10699,9 +10675,8 @@ impl Docdb for DocdbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PendingMaintenanceActionsMessage::default();
         } else {
@@ -10748,9 +10723,8 @@ impl Docdb for DocdbClient {
             return Err(FailoverDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = FailoverDBClusterResult::default();
         } else {
@@ -10797,9 +10771,8 @@ impl Docdb for DocdbClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TagListMessage::default();
         } else {
@@ -10844,9 +10817,8 @@ impl Docdb for DocdbClient {
             return Err(ModifyDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBClusterResult::default();
         } else {
@@ -10894,9 +10866,8 @@ impl Docdb for DocdbClient {
             return Err(ModifyDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupNameMessage::default();
         } else {
@@ -10948,9 +10919,8 @@ impl Docdb for DocdbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBClusterSnapshotAttributeResult::default();
         } else {
@@ -10997,9 +10967,8 @@ impl Docdb for DocdbClient {
             return Err(ModifyDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBInstanceResult::default();
         } else {
@@ -11046,9 +11015,8 @@ impl Docdb for DocdbClient {
             return Err(ModifyDBSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBSubnetGroupResult::default();
         } else {
@@ -11095,9 +11063,8 @@ impl Docdb for DocdbClient {
             return Err(RebootDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RebootDBInstanceResult::default();
         } else {
@@ -11173,9 +11140,8 @@ impl Docdb for DocdbClient {
             return Err(ResetDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupNameMessage::default();
         } else {
@@ -11223,9 +11189,8 @@ impl Docdb for DocdbClient {
             return Err(RestoreDBClusterFromSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBClusterFromSnapshotResult::default();
         } else {
@@ -11273,9 +11238,8 @@ impl Docdb for DocdbClient {
             return Err(RestoreDBClusterToPointInTimeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBClusterToPointInTimeResult::default();
         } else {
@@ -11322,9 +11286,8 @@ impl Docdb for DocdbClient {
             return Err(StartDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StartDBClusterResult::default();
         } else {
@@ -11369,9 +11332,8 @@ impl Docdb for DocdbClient {
             return Err(StopDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StopDBClusterResult::default();
         } else {

--- a/rusoto/services/docdb/src/generated.rs
+++ b/rusoto/services/docdb/src/generated.rs
@@ -60,9 +60,10 @@ impl AddTagsToResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ApplyMethodDeserializer;
 impl ApplyMethodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -107,9 +108,10 @@ pub struct ApplyPendingMaintenanceActionResult {
     pub resource_pending_maintenance_actions: Option<ResourcePendingMaintenanceActions>,
 }
 
+#[allow(dead_code)]
 struct ApplyPendingMaintenanceActionResultDeserializer;
 impl ApplyPendingMaintenanceActionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -133,9 +135,10 @@ impl ApplyPendingMaintenanceActionResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AttributeValueListDeserializer;
 impl AttributeValueListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -170,9 +173,10 @@ pub struct AvailabilityZone {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AvailabilityZoneDeserializer;
 impl AvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -188,9 +192,10 @@ impl AvailabilityZoneDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZoneListDeserializer;
 impl AvailabilityZoneListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -208,9 +213,10 @@ impl AvailabilityZoneListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZonesDeserializer;
 impl AvailabilityZonesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -237,9 +243,10 @@ impl AvailabilityZonesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -248,9 +255,10 @@ impl BooleanDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanOptionalDeserializer;
 impl BooleanOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -277,9 +285,10 @@ pub struct Certificate {
     pub valid_till: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CertificateDeserializer;
 impl CertificateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -315,9 +324,10 @@ impl CertificateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CertificateListDeserializer;
 impl CertificateListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -341,9 +351,10 @@ pub struct CertificateMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CertificateMessageDeserializer;
 impl CertificateMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -447,9 +458,10 @@ pub struct CopyDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CopyDBClusterParameterGroupResultDeserializer;
 impl CopyDBClusterParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -529,9 +541,10 @@ pub struct CopyDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CopyDBClusterSnapshotResultDeserializer;
 impl CopyDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -731,9 +744,10 @@ pub struct CreateDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterParameterGroupResultDeserializer;
 impl CreateDBClusterParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -763,9 +777,10 @@ pub struct CreateDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterResultDeserializer;
 impl CreateDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -822,9 +837,10 @@ pub struct CreateDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterSnapshotResultDeserializer;
 impl CreateDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -923,9 +939,10 @@ pub struct CreateDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct CreateDBInstanceResultDeserializer;
 impl CreateDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -990,9 +1007,10 @@ pub struct CreateDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBSubnetGroupResultDeserializer;
 impl CreateDBSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1079,9 +1097,10 @@ pub struct DBCluster {
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterDeserializer;
 impl DBClusterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1233,9 +1252,10 @@ impl DBClusterDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterListDeserializer;
 impl DBClusterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1264,9 +1284,10 @@ pub struct DBClusterMember {
     pub promotion_tier: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DBClusterMemberDeserializer;
 impl DBClusterMemberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1301,9 +1322,10 @@ impl DBClusterMemberDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterMemberListDeserializer;
 impl DBClusterMemberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1331,9 +1353,10 @@ pub struct DBClusterMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterMessageDeserializer;
 impl DBClusterMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1368,9 +1391,10 @@ pub struct DBClusterParameterGroup {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupDeserializer;
 impl DBClusterParameterGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1418,9 +1442,10 @@ pub struct DBClusterParameterGroupDetails {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupDetailsDeserializer;
 impl DBClusterParameterGroupDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1445,9 +1470,10 @@ impl DBClusterParameterGroupDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterParameterGroupListDeserializer;
 impl DBClusterParameterGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1473,9 +1499,10 @@ pub struct DBClusterParameterGroupNameMessage {
     pub db_cluster_parameter_group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupNameMessageDeserializer;
 impl DBClusterParameterGroupNameMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1507,9 +1534,10 @@ pub struct DBClusterParameterGroupsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupsMessageDeserializer;
 impl DBClusterParameterGroupsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1547,9 +1575,10 @@ pub struct DBClusterRole {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterRoleDeserializer;
 impl DBClusterRoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1568,9 +1597,10 @@ impl DBClusterRoleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterRolesDeserializer;
 impl DBClusterRolesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1628,9 +1658,10 @@ pub struct DBClusterSnapshot {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotDeserializer;
 impl DBClusterSnapshotDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1727,9 +1758,10 @@ pub struct DBClusterSnapshotAttribute {
     pub attribute_values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributeDeserializer;
 impl DBClusterSnapshotAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1755,9 +1787,10 @@ impl DBClusterSnapshotAttributeDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributeListDeserializer;
 impl DBClusterSnapshotAttributeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1785,9 +1818,10 @@ pub struct DBClusterSnapshotAttributesResult {
     pub db_cluster_snapshot_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributesResultDeserializer;
 impl DBClusterSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1818,9 +1852,10 @@ impl DBClusterSnapshotAttributesResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterSnapshotListDeserializer;
 impl DBClusterSnapshotListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1848,9 +1883,10 @@ pub struct DBClusterSnapshotMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotMessageDeserializer;
 impl DBClusterSnapshotMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1900,9 +1936,10 @@ pub struct DBEngineVersion {
     pub valid_upgrade_target: Option<Vec<UpgradeTarget>>,
 }
 
+#[allow(dead_code)]
 struct DBEngineVersionDeserializer;
 impl DBEngineVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1960,9 +1997,10 @@ impl DBEngineVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBEngineVersionListDeserializer;
 impl DBEngineVersionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1990,9 +2028,10 @@ pub struct DBEngineVersionMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBEngineVersionMessageDeserializer;
 impl DBEngineVersionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2071,9 +2110,10 @@ pub struct DBInstance {
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceDeserializer;
 impl DBInstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2223,9 +2263,10 @@ impl DBInstanceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBInstanceListDeserializer;
 impl DBInstanceListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2250,9 +2291,10 @@ pub struct DBInstanceMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceMessageDeserializer;
 impl DBInstanceMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2287,9 +2329,10 @@ pub struct DBInstanceStatusInfo {
     pub status_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceStatusInfoDeserializer;
 impl DBInstanceStatusInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2314,9 +2357,10 @@ impl DBInstanceStatusInfoDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBInstanceStatusInfoListDeserializer;
 impl DBInstanceStatusInfoListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2352,9 +2396,10 @@ pub struct DBSubnetGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSubnetGroupDeserializer;
 impl DBSubnetGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2403,9 +2448,10 @@ pub struct DBSubnetGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSubnetGroupMessageDeserializer;
 impl DBSubnetGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2426,9 +2472,10 @@ impl DBSubnetGroupMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBSubnetGroupsDeserializer;
 impl DBSubnetGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2513,9 +2560,10 @@ pub struct DeleteDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBClusterResultDeserializer;
 impl DeleteDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2561,9 +2609,10 @@ pub struct DeleteDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBClusterSnapshotResultDeserializer;
 impl DeleteDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2616,9 +2665,10 @@ pub struct DeleteDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBInstanceResultDeserializer;
 impl DeleteDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2830,9 +2880,10 @@ pub struct DescribeDBClusterSnapshotAttributesResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBClusterSnapshotAttributesResultDeserializer;
 impl DescribeDBClusterSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3185,9 +3236,10 @@ pub struct DescribeEngineDefaultClusterParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
 
+#[allow(dead_code)]
 struct DescribeEngineDefaultClusterParametersResultDeserializer;
 impl DescribeEngineDefaultClusterParametersResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3427,9 +3479,10 @@ pub struct Endpoint {
     pub port: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct EndpointDeserializer;
 impl EndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3464,9 +3517,10 @@ pub struct EngineDefaults {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct EngineDefaultsDeserializer;
 impl EngineDefaultsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3511,9 +3565,10 @@ pub struct Event {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventDeserializer;
 impl EventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Event, XmlParseError> {
         deserialize_elements::<_, Event, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -3545,9 +3600,10 @@ impl EventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesListDeserializer;
 impl EventCategoriesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3584,9 +3640,10 @@ pub struct EventCategoriesMap {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMapDeserializer;
 impl EventCategoriesMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3607,9 +3664,10 @@ impl EventCategoriesMapDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesMapListDeserializer;
 impl EventCategoriesMapListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3635,9 +3693,10 @@ pub struct EventCategoriesMessage {
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMessageDeserializer;
 impl EventCategoriesMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3658,9 +3717,10 @@ impl EventCategoriesMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventListDeserializer;
 impl EventListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3685,9 +3745,10 @@ pub struct EventsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventsMessageDeserializer;
 impl EventsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3748,9 +3809,10 @@ pub struct FailoverDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct FailoverDBClusterResultDeserializer;
 impl FailoverDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3821,9 +3883,10 @@ impl FilterValueListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3832,9 +3895,10 @@ impl IntegerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IntegerOptionalDeserializer;
 impl IntegerOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3885,9 +3949,10 @@ impl ListTagsForResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LogTypeListDeserializer;
 impl LogTypeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4058,9 +4123,10 @@ pub struct ModifyDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBClusterResultDeserializer;
 impl ModifyDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4130,9 +4196,10 @@ pub struct ModifyDBClusterSnapshotAttributeResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBClusterSnapshotAttributeResultDeserializer;
 impl ModifyDBClusterSnapshotAttributeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4233,9 +4300,10 @@ pub struct ModifyDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBInstanceResultDeserializer;
 impl ModifyDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4297,9 +4365,10 @@ pub struct ModifyDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBSubnetGroupResultDeserializer;
 impl ModifyDBSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4340,9 +4409,10 @@ pub struct OrderableDBInstanceOption {
     pub vpc: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionDeserializer;
 impl OrderableDBInstanceOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4385,9 +4455,10 @@ impl OrderableDBInstanceOptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionsListDeserializer;
 impl OrderableDBInstanceOptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4415,9 +4486,10 @@ pub struct OrderableDBInstanceOptionsMessage {
     pub orderable_db_instance_options: Option<Vec<OrderableDBInstanceOption>>,
 }
 
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionsMessageDeserializer;
 impl OrderableDBInstanceOptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4472,9 +4544,10 @@ pub struct Parameter {
     pub source: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ParameterDeserializer;
 impl ParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4571,9 +4644,10 @@ impl ParameterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ParametersListDeserializer;
 impl ParametersListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4610,9 +4684,10 @@ pub struct PendingCloudwatchLogsExports {
     pub log_types_to_enable: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct PendingCloudwatchLogsExportsDeserializer;
 impl PendingCloudwatchLogsExportsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4657,9 +4732,10 @@ pub struct PendingMaintenanceAction {
     pub opt_in_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PendingMaintenanceActionDeserializer;
 impl PendingMaintenanceActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4701,9 +4777,10 @@ impl PendingMaintenanceActionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PendingMaintenanceActionDetailsDeserializer;
 impl PendingMaintenanceActionDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4721,9 +4798,10 @@ impl PendingMaintenanceActionDetailsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PendingMaintenanceActionsDeserializer;
 impl PendingMaintenanceActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4751,9 +4829,10 @@ pub struct PendingMaintenanceActionsMessage {
     pub pending_maintenance_actions: Option<Vec<ResourcePendingMaintenanceActions>>,
 }
 
+#[allow(dead_code)]
 struct PendingMaintenanceActionsMessageDeserializer;
 impl PendingMaintenanceActionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4815,9 +4894,10 @@ pub struct PendingModifiedValues {
     pub storage_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PendingModifiedValuesDeserializer;
 impl PendingModifiedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4931,9 +5011,10 @@ pub struct RebootDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct RebootDBInstanceResultDeserializer;
 impl RebootDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5022,9 +5103,10 @@ pub struct ResourcePendingMaintenanceActions {
     pub resource_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ResourcePendingMaintenanceActionsDeserializer;
 impl ResourcePendingMaintenanceActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5151,9 +5233,10 @@ pub struct RestoreDBClusterFromSnapshotResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBClusterFromSnapshotResultDeserializer;
 impl RestoreDBClusterFromSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5266,9 +5349,10 @@ pub struct RestoreDBClusterToPointInTimeResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBClusterToPointInTimeResultDeserializer;
 impl RestoreDBClusterToPointInTimeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5289,9 +5373,10 @@ impl RestoreDBClusterToPointInTimeResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5329,9 +5414,10 @@ pub struct StartDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct StartDBClusterResultDeserializer;
 impl StartDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5376,9 +5462,10 @@ pub struct StopDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct StopDBClusterResultDeserializer;
 impl StopDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5394,9 +5481,10 @@ impl StopDBClusterResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5417,9 +5505,10 @@ pub struct Subnet {
     pub subnet_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SubnetDeserializer;
 impl SubnetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Subnet, XmlParseError> {
         deserialize_elements::<_, Subnet, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5455,9 +5544,10 @@ impl SubnetIdentifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SubnetListDeserializer;
 impl SubnetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5472,9 +5562,10 @@ impl SubnetListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TStampDeserializer;
 impl TStampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5494,9 +5585,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5531,9 +5623,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5568,9 +5661,10 @@ pub struct TagListMessage {
     pub tag_list: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct TagListMessageDeserializer;
 impl TagListMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5604,9 +5698,10 @@ pub struct UpgradeTarget {
     pub is_major_version_upgrade: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct UpgradeTargetDeserializer;
 impl UpgradeTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5639,9 +5734,10 @@ impl UpgradeTargetDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValidUpgradeTargetListDeserializer;
 impl ValidUpgradeTargetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5681,9 +5777,10 @@ pub struct VpcSecurityGroupMembership {
     pub vpc_security_group_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipDeserializer;
 impl VpcSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5709,9 +5806,10 @@ impl VpcSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipListDeserializer;
 impl VpcSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -60,9 +60,10 @@ impl AddTagsToResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedNodeGroupIdDeserializer;
 impl AllowedNodeGroupIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -81,9 +82,10 @@ pub struct AllowedNodeTypeModificationsMessage {
     pub scale_up_modifications: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct AllowedNodeTypeModificationsMessageDeserializer;
 impl AllowedNodeTypeModificationsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -110,9 +112,10 @@ impl AllowedNodeTypeModificationsMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AuthTokenUpdateStatusDeserializer;
 impl AuthTokenUpdateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -163,9 +166,10 @@ pub struct AuthorizeCacheSecurityGroupIngressResult {
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct AuthorizeCacheSecurityGroupIngressResultDeserializer;
 impl AuthorizeCacheSecurityGroupIngressResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -189,9 +193,10 @@ impl AuthorizeCacheSecurityGroupIngressResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AutomaticFailoverStatusDeserializer;
 impl AutomaticFailoverStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -208,9 +213,10 @@ pub struct AvailabilityZone {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AvailabilityZoneDeserializer;
 impl AvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -226,9 +232,10 @@ impl AvailabilityZoneDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZonesListDeserializer;
 impl AvailabilityZonesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -337,9 +344,10 @@ impl BatchStopUpdateActionMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -348,9 +356,10 @@ impl BooleanDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanOptionalDeserializer;
 impl BooleanOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -416,9 +425,10 @@ pub struct CacheCluster {
     pub transit_encryption_enabled: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct CacheClusterDeserializer;
 impl CacheClusterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -594,9 +604,10 @@ impl CacheClusterIdListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CacheClusterListDeserializer;
 impl CacheClusterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -624,9 +635,10 @@ pub struct CacheClusterMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheClusterMessageDeserializer;
 impl CacheClusterMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -663,9 +675,10 @@ pub struct CacheEngineVersion {
     pub engine_version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheEngineVersionDeserializer;
 impl CacheEngineVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -703,9 +716,10 @@ impl CacheEngineVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CacheEngineVersionListDeserializer;
 impl CacheEngineVersionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -733,9 +747,10 @@ pub struct CacheEngineVersionMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheEngineVersionMessageDeserializer;
 impl CacheEngineVersionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -783,9 +798,10 @@ pub struct CacheNode {
     pub source_cache_node_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheNodeDeserializer;
 impl CacheNodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -831,9 +847,10 @@ impl CacheNodeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CacheNodeIdsListDeserializer;
 impl CacheNodeIdsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -860,9 +877,10 @@ impl CacheNodeIdsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CacheNodeListDeserializer;
 impl CacheNodeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -901,9 +919,10 @@ pub struct CacheNodeTypeSpecificParameter {
     pub source: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheNodeTypeSpecificParameterDeserializer;
 impl CacheNodeTypeSpecificParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -960,9 +979,10 @@ impl CacheNodeTypeSpecificParameterDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CacheNodeTypeSpecificParametersListDeserializer;
 impl CacheNodeTypeSpecificParametersListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -990,9 +1010,10 @@ pub struct CacheNodeTypeSpecificValue {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheNodeTypeSpecificValueDeserializer;
 impl CacheNodeTypeSpecificValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1016,9 +1037,10 @@ impl CacheNodeTypeSpecificValueDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CacheNodeTypeSpecificValueListDeserializer;
 impl CacheNodeTypeSpecificValueListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1058,9 +1080,10 @@ pub struct CacheNodeUpdateStatus {
     pub node_update_status_modified_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheNodeUpdateStatusDeserializer;
 impl CacheNodeUpdateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1116,9 +1139,10 @@ impl CacheNodeUpdateStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CacheNodeUpdateStatusListDeserializer;
 impl CacheNodeUpdateStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1148,9 +1172,10 @@ pub struct CacheParameterGroup {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheParameterGroupDeserializer;
 impl CacheParameterGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1190,9 +1215,10 @@ pub struct CacheParameterGroupDetails {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct CacheParameterGroupDetailsDeserializer;
 impl CacheParameterGroupDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1227,9 +1253,10 @@ impl CacheParameterGroupDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CacheParameterGroupListDeserializer;
 impl CacheParameterGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1255,9 +1282,10 @@ pub struct CacheParameterGroupNameMessage {
     pub cache_parameter_group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheParameterGroupNameMessageDeserializer;
 impl CacheParameterGroupNameMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1292,9 +1320,10 @@ pub struct CacheParameterGroupStatus {
     pub parameter_apply_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheParameterGroupStatusDeserializer;
 impl CacheParameterGroupStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1341,9 +1370,10 @@ pub struct CacheParameterGroupsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheParameterGroupsMessageDeserializer;
 impl CacheParameterGroupsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1385,9 +1415,10 @@ pub struct CacheSecurityGroup {
     pub owner_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheSecurityGroupDeserializer;
 impl CacheSecurityGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1427,9 +1458,10 @@ pub struct CacheSecurityGroupMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheSecurityGroupMembershipDeserializer;
 impl CacheSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1455,9 +1487,10 @@ impl CacheSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CacheSecurityGroupMembershipListDeserializer;
 impl CacheSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1485,9 +1518,10 @@ pub struct CacheSecurityGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheSecurityGroupMessageDeserializer;
 impl CacheSecurityGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1527,9 +1561,10 @@ impl CacheSecurityGroupNameListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CacheSecurityGroupsDeserializer;
 impl CacheSecurityGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1561,9 +1596,10 @@ pub struct CacheSubnetGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheSubnetGroupDeserializer;
 impl CacheSubnetGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1606,9 +1642,10 @@ pub struct CacheSubnetGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CacheSubnetGroupMessageDeserializer;
 impl CacheSubnetGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1633,9 +1670,10 @@ impl CacheSubnetGroupMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CacheSubnetGroupsDeserializer;
 impl CacheSubnetGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1653,9 +1691,10 @@ impl CacheSubnetGroupsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ChangeTypeDeserializer;
 impl ChangeTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1664,9 +1703,10 @@ impl ChangeTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ClusterIdListDeserializer;
 impl ClusterIdListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1715,9 +1755,10 @@ pub struct CompleteMigrationResponse {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct CompleteMigrationResponseDeserializer;
 impl CompleteMigrationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1822,9 +1863,10 @@ pub struct CopySnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct CopySnapshotResultDeserializer;
 impl CopySnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2017,9 +2059,10 @@ pub struct CreateCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
 
+#[allow(dead_code)]
 struct CreateCacheClusterResultDeserializer;
 impl CreateCacheClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2081,9 +2124,10 @@ pub struct CreateCacheParameterGroupResult {
     pub cache_parameter_group: Option<CacheParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateCacheParameterGroupResultDeserializer;
 impl CreateCacheParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2140,9 +2184,10 @@ pub struct CreateCacheSecurityGroupResult {
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateCacheSecurityGroupResultDeserializer;
 impl CreateCacheSecurityGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2209,9 +2254,10 @@ pub struct CreateCacheSubnetGroupResult {
     pub cache_subnet_group: Option<CacheSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateCacheSubnetGroupResultDeserializer;
 impl CreateCacheSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2455,9 +2501,10 @@ pub struct CreateReplicationGroupResult {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateReplicationGroupResultDeserializer;
 impl CreateReplicationGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2522,9 +2569,10 @@ pub struct CreateSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct CreateSnapshotResultDeserializer;
 impl CreateSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2637,9 +2685,10 @@ pub struct DecreaseReplicaCountResult {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct DecreaseReplicaCountResultDeserializer;
 impl DecreaseReplicaCountResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2700,9 +2749,10 @@ pub struct DeleteCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
 
+#[allow(dead_code)]
 struct DeleteCacheClusterResultDeserializer;
 impl DeleteCacheClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2843,9 +2893,10 @@ pub struct DeleteReplicationGroupResult {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct DeleteReplicationGroupResultDeserializer;
 impl DeleteReplicationGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2895,9 +2946,10 @@ pub struct DeleteSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct DeleteSnapshotResultDeserializer;
 impl DeleteSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3197,9 +3249,10 @@ pub struct DescribeEngineDefaultParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
 
+#[allow(dead_code)]
 struct DescribeEngineDefaultParametersResultDeserializer;
 impl DescribeEngineDefaultParametersResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3483,9 +3536,10 @@ pub struct DescribeSnapshotsListMessage {
     pub snapshots: Option<Vec<Snapshot>>,
 }
 
+#[allow(dead_code)]
 struct DescribeSnapshotsListMessageDeserializer;
 impl DescribeSnapshotsListMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3656,9 +3710,10 @@ impl DescribeUpdateActionsMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DoubleDeserializer;
 impl DoubleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3679,9 +3734,10 @@ pub struct EC2SecurityGroup {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EC2SecurityGroupDeserializer;
 impl EC2SecurityGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3709,9 +3765,10 @@ impl EC2SecurityGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EC2SecurityGroupListDeserializer;
 impl EC2SecurityGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3739,9 +3796,10 @@ pub struct Endpoint {
     pub port: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct EndpointDeserializer;
 impl EndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3774,9 +3832,10 @@ pub struct EngineDefaults {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct EngineDefaultsDeserializer;
 impl EngineDefaultsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3827,9 +3886,10 @@ pub struct Event {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventDeserializer;
 impl EventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Event, XmlParseError> {
         deserialize_elements::<_, Event, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -3853,9 +3913,10 @@ impl EventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventListDeserializer;
 impl EventListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3880,9 +3941,10 @@ pub struct EventsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventsMessageDeserializer;
 impl EventsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3952,9 +4014,10 @@ pub struct IncreaseReplicaCountResult {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct IncreaseReplicaCountResultDeserializer;
 impl IncreaseReplicaCountResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3977,9 +4040,10 @@ impl IncreaseReplicaCountResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3988,9 +4052,10 @@ impl IntegerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IntegerOptionalDeserializer;
 impl IntegerOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4217,9 +4282,10 @@ pub struct ModifyCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyCacheClusterResultDeserializer;
 impl ModifyCacheClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4320,9 +4386,10 @@ pub struct ModifyCacheSubnetGroupResult {
     pub cache_subnet_group: Option<CacheSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyCacheSubnetGroupResultDeserializer;
 impl ModifyCacheSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4504,9 +4571,10 @@ pub struct ModifyReplicationGroupResult {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyReplicationGroupResultDeserializer;
 impl ModifyReplicationGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4602,9 +4670,10 @@ pub struct ModifyReplicationGroupShardConfigurationResult {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyReplicationGroupShardConfigurationResultDeserializer;
 impl ModifyReplicationGroupShardConfigurationResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4645,9 +4714,10 @@ pub struct NodeGroup {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct NodeGroupDeserializer;
 impl NodeGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4700,9 +4770,10 @@ pub struct NodeGroupConfiguration {
     pub slots: Option<String>,
 }
 
+#[allow(dead_code)]
 struct NodeGroupConfigurationDeserializer;
 impl NodeGroupConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4790,9 +4861,10 @@ impl NodeGroupConfigurationListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct NodeGroupListDeserializer;
 impl NodeGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4823,9 +4895,10 @@ pub struct NodeGroupMember {
     pub read_endpoint: Option<Endpoint>,
 }
 
+#[allow(dead_code)]
 struct NodeGroupMemberDeserializer;
 impl NodeGroupMemberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4859,9 +4932,10 @@ impl NodeGroupMemberDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct NodeGroupMemberListDeserializer;
 impl NodeGroupMemberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4903,9 +4977,10 @@ pub struct NodeGroupMemberUpdateStatus {
     pub node_update_status_modified_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct NodeGroupMemberUpdateStatusDeserializer;
 impl NodeGroupMemberUpdateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4968,9 +5043,10 @@ impl NodeGroupMemberUpdateStatusDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct NodeGroupMemberUpdateStatusListDeserializer;
 impl NodeGroupMemberUpdateStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4998,9 +5074,10 @@ pub struct NodeGroupUpdateStatus {
     pub node_group_member_update_status: Option<Vec<NodeGroupMemberUpdateStatus>>,
 }
 
+#[allow(dead_code)]
 struct NodeGroupUpdateStatusDeserializer;
 impl NodeGroupUpdateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5025,9 +5102,10 @@ impl NodeGroupUpdateStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct NodeGroupUpdateStatusListDeserializer;
 impl NodeGroupUpdateStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5088,9 +5166,10 @@ pub struct NodeSnapshot {
     pub snapshot_create_time: Option<String>,
 }
 
+#[allow(dead_code)]
 struct NodeSnapshotDeserializer;
 impl NodeSnapshotDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5137,9 +5216,10 @@ impl NodeSnapshotDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct NodeSnapshotListDeserializer;
 impl NodeSnapshotListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5157,9 +5237,10 @@ impl NodeSnapshotListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct NodeTypeListDeserializer;
 impl NodeTypeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5174,9 +5255,10 @@ impl NodeTypeListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct NodeUpdateInitiatedByDeserializer;
 impl NodeUpdateInitiatedByDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5185,9 +5267,10 @@ impl NodeUpdateInitiatedByDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NodeUpdateStatusDeserializer;
 impl NodeUpdateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5206,9 +5289,10 @@ pub struct NotificationConfiguration {
     pub topic_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct NotificationConfigurationDeserializer;
 impl NotificationConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5256,9 +5340,10 @@ pub struct Parameter {
     pub source: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ParameterDeserializer;
 impl ParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5345,9 +5430,10 @@ impl ParameterNameValueListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ParametersListDeserializer;
 impl ParametersListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5362,9 +5448,10 @@ impl ParametersListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PendingAutomaticFailoverStatusDeserializer;
 impl PendingAutomaticFailoverStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5389,9 +5476,10 @@ pub struct PendingModifiedValues {
     pub num_cache_nodes: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct PendingModifiedValuesDeserializer;
 impl PendingModifiedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5455,9 +5543,10 @@ pub struct ProcessedUpdateAction {
     pub update_action_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ProcessedUpdateActionDeserializer;
 impl ProcessedUpdateActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5490,9 +5579,10 @@ impl ProcessedUpdateActionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ProcessedUpdateActionListDeserializer;
 impl ProcessedUpdateActionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5553,9 +5643,10 @@ pub struct PurchaseReservedCacheNodesOfferingResult {
     pub reserved_cache_node: Option<ReservedCacheNode>,
 }
 
+#[allow(dead_code)]
 struct PurchaseReservedCacheNodesOfferingResultDeserializer;
 impl PurchaseReservedCacheNodesOfferingResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5615,9 +5706,10 @@ pub struct RebootCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
 
+#[allow(dead_code)]
 struct RebootCacheClusterResultDeserializer;
 impl RebootCacheClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5650,9 +5742,10 @@ pub struct RecurringCharge {
     pub recurring_charge_frequency: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RecurringChargeDeserializer;
 impl RecurringChargeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5677,9 +5770,10 @@ impl RecurringChargeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RecurringChargeListDeserializer;
 impl RecurringChargeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5786,9 +5880,10 @@ pub struct ReplicationGroup {
     pub transit_encryption_enabled: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct ReplicationGroupDeserializer;
 impl ReplicationGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5909,9 +6004,10 @@ impl ReplicationGroupIdListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReplicationGroupListDeserializer;
 impl ReplicationGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5939,9 +6035,10 @@ pub struct ReplicationGroupMessage {
     pub replication_groups: Option<Vec<ReplicationGroup>>,
 }
 
+#[allow(dead_code)]
 struct ReplicationGroupMessageDeserializer;
 impl ReplicationGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5983,9 +6080,10 @@ pub struct ReplicationGroupPendingModifiedValues {
     pub resharding: Option<ReshardingStatus>,
 }
 
+#[allow(dead_code)]
 struct ReplicationGroupPendingModifiedValuesDeserializer;
 impl ReplicationGroupPendingModifiedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6058,9 +6156,10 @@ pub struct ReservedCacheNode {
     pub usage_price: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct ReservedCacheNodeDeserializer;
 impl ReservedCacheNodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6127,9 +6226,10 @@ impl ReservedCacheNodeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReservedCacheNodeListDeserializer;
 impl ReservedCacheNodeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6157,9 +6257,10 @@ pub struct ReservedCacheNodeMessage {
     pub reserved_cache_nodes: Option<Vec<ReservedCacheNode>>,
 }
 
+#[allow(dead_code)]
 struct ReservedCacheNodeMessageDeserializer;
 impl ReservedCacheNodeMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6209,9 +6310,10 @@ pub struct ReservedCacheNodesOffering {
     pub usage_price: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct ReservedCacheNodesOfferingDeserializer;
 impl ReservedCacheNodesOfferingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6266,9 +6368,10 @@ impl ReservedCacheNodesOfferingDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ReservedCacheNodesOfferingListDeserializer;
 impl ReservedCacheNodesOfferingListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6296,9 +6399,10 @@ pub struct ReservedCacheNodesOfferingMessage {
     pub reserved_cache_nodes_offerings: Option<Vec<ReservedCacheNodesOffering>>,
 }
 
+#[allow(dead_code)]
 struct ReservedCacheNodesOfferingMessageDeserializer;
 impl ReservedCacheNodesOfferingMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6415,9 +6519,10 @@ pub struct ReshardingStatus {
     pub slot_migration: Option<SlotMigration>,
 }
 
+#[allow(dead_code)]
 struct ReshardingStatusDeserializer;
 impl ReshardingStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6478,9 +6583,10 @@ pub struct RevokeCacheSecurityGroupIngressResult {
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct RevokeCacheSecurityGroupIngressResultDeserializer;
 impl RevokeCacheSecurityGroupIngressResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6526,9 +6632,10 @@ pub struct SecurityGroupMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SecurityGroupMembershipDeserializer;
 impl SecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6552,9 +6659,10 @@ impl SecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupMembershipListDeserializer;
 impl SecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6601,9 +6709,10 @@ pub struct ServiceUpdate {
     pub service_update_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ServiceUpdateDeserializer;
 impl ServiceUpdateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6684,9 +6793,10 @@ impl ServiceUpdateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ServiceUpdateListDeserializer;
 impl ServiceUpdateListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6704,9 +6814,10 @@ impl ServiceUpdateListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ServiceUpdateSeverityDeserializer;
 impl ServiceUpdateSeverityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6715,9 +6826,10 @@ impl ServiceUpdateSeverityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ServiceUpdateStatusDeserializer;
 impl ServiceUpdateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6738,9 +6850,10 @@ impl ServiceUpdateStatusListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ServiceUpdateTypeDeserializer;
 impl ServiceUpdateTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6758,9 +6871,10 @@ pub struct ServiceUpdatesMessage {
     pub service_updates: Option<Vec<ServiceUpdate>>,
 }
 
+#[allow(dead_code)]
 struct ServiceUpdatesMessageDeserializer;
 impl ServiceUpdatesMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6781,9 +6895,10 @@ impl ServiceUpdatesMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SlaMetDeserializer;
 impl SlaMetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6800,9 +6915,10 @@ pub struct SlotMigration {
     pub progress_percentage: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct SlotMigrationDeserializer;
 impl SlotMigrationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6877,9 +6993,10 @@ pub struct Snapshot {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SnapshotDeserializer;
 impl SnapshotDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7025,9 +7142,10 @@ impl SnapshotArnsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SnapshotListDeserializer;
 impl SnapshotListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7042,9 +7160,10 @@ impl SnapshotListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7089,9 +7208,10 @@ pub struct StartMigrationResponse {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct StartMigrationResponseDeserializer;
 impl StartMigrationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7110,9 +7230,10 @@ impl StartMigrationResponseDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7131,9 +7252,10 @@ pub struct Subnet {
     pub subnet_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SubnetDeserializer;
 impl SubnetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Subnet, XmlParseError> {
         deserialize_elements::<_, Subnet, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7165,9 +7287,10 @@ impl SubnetIdentifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SubnetListDeserializer;
 impl SubnetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7182,9 +7305,10 @@ impl SubnetListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TStampDeserializer;
 impl TStampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7204,9 +7328,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7241,9 +7366,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7278,9 +7404,10 @@ pub struct TagListMessage {
     pub tag_list: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct TagListMessageDeserializer;
 impl TagListMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7330,9 +7457,10 @@ pub struct TestFailoverResult {
     pub replication_group: Option<ReplicationGroup>,
 }
 
+#[allow(dead_code)]
 struct TestFailoverResultDeserializer;
 impl TestFailoverResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7395,9 +7523,10 @@ pub struct UnprocessedUpdateAction {
     pub service_update_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UnprocessedUpdateActionDeserializer;
 impl UnprocessedUpdateActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7435,9 +7564,10 @@ impl UnprocessedUpdateActionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct UnprocessedUpdateActionListDeserializer;
 impl UnprocessedUpdateActionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7495,9 +7625,10 @@ pub struct UpdateAction {
     pub update_action_status_modified_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateActionDeserializer;
 impl UpdateActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7606,9 +7737,10 @@ impl UpdateActionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct UpdateActionListDeserializer;
 impl UpdateActionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7635,9 +7767,10 @@ pub struct UpdateActionResultsMessage {
     pub unprocessed_update_actions: Option<Vec<UnprocessedUpdateAction>>,
 }
 
+#[allow(dead_code)]
 struct UpdateActionResultsMessageDeserializer;
 impl UpdateActionResultsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7670,9 +7803,10 @@ impl UpdateActionResultsMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct UpdateActionStatusDeserializer;
 impl UpdateActionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7702,9 +7836,10 @@ pub struct UpdateActionsMessage {
     pub update_actions: Option<Vec<UpdateAction>>,
 }
 
+#[allow(dead_code)]
 struct UpdateActionsMessageDeserializer;
 impl UpdateActionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -12382,9 +12382,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(AddTagsToResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TagListMessage::default();
         } else {
@@ -12434,9 +12433,8 @@ impl ElastiCache for ElastiCacheClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AuthorizeCacheSecurityGroupIngressResult::default();
         } else {
@@ -12483,9 +12481,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(BatchApplyUpdateActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateActionResultsMessage::default();
         } else {
@@ -12532,9 +12529,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(BatchStopUpdateActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateActionResultsMessage::default();
         } else {
@@ -12581,9 +12577,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CompleteMigrationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CompleteMigrationResponse::default();
         } else {
@@ -12630,9 +12625,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CopySnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopySnapshotResult::default();
         } else {
@@ -12676,9 +12670,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CreateCacheClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateCacheClusterResult::default();
         } else {
@@ -12725,9 +12718,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CreateCacheParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateCacheParameterGroupResult::default();
         } else {
@@ -12774,9 +12766,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CreateCacheSecurityGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateCacheSecurityGroupResult::default();
         } else {
@@ -12823,9 +12814,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CreateCacheSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateCacheSubnetGroupResult::default();
         } else {
@@ -12872,9 +12862,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CreateReplicationGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateReplicationGroupResult::default();
         } else {
@@ -12921,9 +12910,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(CreateSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateSnapshotResult::default();
         } else {
@@ -12968,9 +12956,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DecreaseReplicaCountError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DecreaseReplicaCountResult::default();
         } else {
@@ -13017,9 +13004,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DeleteCacheClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteCacheClusterResult::default();
         } else {
@@ -13150,9 +13136,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DeleteReplicationGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteReplicationGroupResult::default();
         } else {
@@ -13199,9 +13184,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DeleteSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteSnapshotResult::default();
         } else {
@@ -13246,9 +13230,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeCacheClustersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheClusterMessage::default();
         } else {
@@ -13295,9 +13278,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeCacheEngineVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheEngineVersionMessage::default();
         } else {
@@ -13344,9 +13326,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeCacheParameterGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheParameterGroupsMessage::default();
         } else {
@@ -13393,9 +13374,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeCacheParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheParameterGroupDetails::default();
         } else {
@@ -13442,9 +13422,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeCacheSecurityGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheSecurityGroupMessage::default();
         } else {
@@ -13491,9 +13470,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeCacheSubnetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheSubnetGroupMessage::default();
         } else {
@@ -13545,9 +13523,8 @@ impl ElastiCache for ElastiCacheClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEngineDefaultParametersResult::default();
         } else {
@@ -13594,9 +13571,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeEventsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventsMessage::default();
         } else {
@@ -13640,9 +13616,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeReplicationGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReplicationGroupMessage::default();
         } else {
@@ -13689,9 +13664,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeReservedCacheNodesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReservedCacheNodeMessage::default();
         } else {
@@ -13743,9 +13717,8 @@ impl ElastiCache for ElastiCacheClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReservedCacheNodesOfferingMessage::default();
         } else {
@@ -13792,9 +13765,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeServiceUpdatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ServiceUpdatesMessage::default();
         } else {
@@ -13841,9 +13813,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeSnapshotsListMessage::default();
         } else {
@@ -13890,9 +13861,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(DescribeUpdateActionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateActionsMessage::default();
         } else {
@@ -13939,9 +13909,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(IncreaseReplicaCountError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = IncreaseReplicaCountResult::default();
         } else {
@@ -13993,9 +13962,8 @@ impl ElastiCache for ElastiCacheClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AllowedNodeTypeModificationsMessage::default();
         } else {
@@ -14042,9 +14010,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TagListMessage::default();
         } else {
@@ -14089,9 +14056,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(ModifyCacheClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyCacheClusterResult::default();
         } else {
@@ -14138,9 +14104,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(ModifyCacheParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheParameterGroupNameMessage::default();
         } else {
@@ -14187,9 +14152,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(ModifyCacheSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyCacheSubnetGroupResult::default();
         } else {
@@ -14236,9 +14200,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(ModifyReplicationGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyReplicationGroupResult::default();
         } else {
@@ -14292,9 +14255,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(ModifyReplicationGroupShardConfigurationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyReplicationGroupShardConfigurationResult::default();
         } else {
@@ -14346,9 +14308,8 @@ impl ElastiCache for ElastiCacheClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PurchaseReservedCacheNodesOfferingResult::default();
         } else {
@@ -14395,9 +14356,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(RebootCacheClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RebootCacheClusterResult::default();
         } else {
@@ -14444,9 +14404,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(RemoveTagsFromResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TagListMessage::default();
         } else {
@@ -14493,9 +14452,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(ResetCacheParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CacheParameterGroupNameMessage::default();
         } else {
@@ -14547,9 +14505,8 @@ impl ElastiCache for ElastiCacheClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RevokeCacheSecurityGroupIngressResult::default();
         } else {
@@ -14596,9 +14553,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(StartMigrationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StartMigrationResponse::default();
         } else {
@@ -14645,9 +14601,8 @@ impl ElastiCache for ElastiCacheClient {
             return Err(TestFailoverError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TestFailoverResult::default();
         } else {

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -10267,9 +10267,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(ApplyEnvironmentManagedActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplyEnvironmentManagedActionResult::default();
         } else {
@@ -10316,9 +10315,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(CheckDNSAvailabilityError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CheckDNSAvailabilityResultMessage::default();
         } else {
@@ -10365,9 +10363,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(ComposeEnvironmentsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnvironmentDescriptionsMessage::default();
         } else {
@@ -10414,9 +10411,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(CreateApplicationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplicationDescriptionMessage::default();
         } else {
@@ -10464,9 +10460,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(CreateApplicationVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplicationVersionDescriptionMessage::default();
         } else {
@@ -10514,9 +10509,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(CreateConfigurationTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ConfigurationSettingsDescription::default();
         } else {
@@ -10563,9 +10557,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(CreateEnvironmentError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnvironmentDescription::default();
         } else {
@@ -10612,9 +10605,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(CreatePlatformVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreatePlatformVersionResult::default();
         } else {
@@ -10660,9 +10652,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(CreateStorageLocationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateStorageLocationResultMessage::default();
         } else {
@@ -10821,9 +10812,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DeletePlatformVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeletePlatformVersionResult::default();
         } else {
@@ -10869,9 +10859,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeAccountAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAccountAttributesResult::default();
         } else {
@@ -10919,9 +10908,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeApplicationVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplicationVersionDescriptionsMessage::default();
         } else {
@@ -10968,9 +10956,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeApplicationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplicationDescriptionsMessage::default();
         } else {
@@ -11018,9 +11005,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeConfigurationOptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ConfigurationOptionsDescription::default();
         } else {
@@ -11068,9 +11054,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeConfigurationSettingsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ConfigurationSettingsDescriptions::default();
         } else {
@@ -11117,9 +11102,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeEnvironmentHealthError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEnvironmentHealthResult::default();
         } else {
@@ -11175,9 +11159,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEnvironmentManagedActionHistoryResult::default();
         } else {
@@ -11229,9 +11212,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEnvironmentManagedActionsResult::default();
         } else {
@@ -11281,9 +11263,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeEnvironmentResourcesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnvironmentResourceDescriptionsMessage::default();
         } else {
@@ -11330,9 +11311,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeEnvironmentsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnvironmentDescriptionsMessage::default();
         } else {
@@ -11379,9 +11359,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeEventsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventDescriptionsMessage::default();
         } else {
@@ -11428,9 +11407,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribeInstancesHealthError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeInstancesHealthResult::default();
         } else {
@@ -11477,9 +11455,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(DescribePlatformVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribePlatformVersionResult::default();
         } else {
@@ -11528,9 +11505,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(ListAvailableSolutionStacksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListAvailableSolutionStacksResultMessage::default();
         } else {
@@ -11577,9 +11553,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(ListPlatformVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPlatformVersionsResult::default();
         } else {
@@ -11626,9 +11601,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ResourceTagsDescriptionMessage::default();
         } else {
@@ -11760,9 +11734,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(RetrieveEnvironmentInfoError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RetrieveEnvironmentInfoResultMessage::default();
         } else {
@@ -11837,9 +11810,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(TerminateEnvironmentError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnvironmentDescription::default();
         } else {
@@ -11886,9 +11858,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(UpdateApplicationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplicationDescriptionMessage::default();
         } else {
@@ -11940,9 +11911,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplicationResourceLifecycleDescriptionMessage::default();
         } else {
@@ -11990,9 +11960,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(UpdateApplicationVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplicationVersionDescriptionMessage::default();
         } else {
@@ -12040,9 +12009,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(UpdateConfigurationTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ConfigurationSettingsDescription::default();
         } else {
@@ -12089,9 +12057,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(UpdateEnvironmentError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnvironmentDescription::default();
         } else {
@@ -12169,9 +12136,8 @@ impl ElasticBeanstalk for ElasticBeanstalkClient {
             return Err(ValidateConfigurationSettingsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ConfigurationSettingsValidationMessages::default();
         } else {

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -36,9 +36,10 @@ use std::str::FromStr;
 use xml::reader::ParserConfig;
 use xml::EventReader;
 
+#[allow(dead_code)]
 struct ARNDeserializer;
 impl ARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -75,9 +76,10 @@ impl AbortEnvironmentUpdateMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AbortableOperationInProgressDeserializer;
 impl AbortableOperationInProgressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -86,9 +88,10 @@ impl AbortableOperationInProgressDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ActionHistoryStatusDeserializer;
 impl ActionHistoryStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -97,9 +100,10 @@ impl ActionHistoryStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ActionStatusDeserializer;
 impl ActionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -108,9 +112,10 @@ impl ActionStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ActionTypeDeserializer;
 impl ActionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -119,9 +124,10 @@ impl ActionTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ApplicationArnDeserializer;
 impl ApplicationArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -152,9 +158,10 @@ pub struct ApplicationDescription {
     pub versions: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ApplicationDescriptionDeserializer;
 impl ApplicationDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -211,9 +218,10 @@ impl ApplicationDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ApplicationDescriptionListDeserializer;
 impl ApplicationDescriptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -238,9 +246,10 @@ pub struct ApplicationDescriptionMessage {
     pub application: Option<ApplicationDescription>,
 }
 
+#[allow(dead_code)]
 struct ApplicationDescriptionMessageDeserializer;
 impl ApplicationDescriptionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -271,9 +280,10 @@ pub struct ApplicationDescriptionsMessage {
     pub applications: Option<Vec<ApplicationDescription>>,
 }
 
+#[allow(dead_code)]
 struct ApplicationDescriptionsMessageDeserializer;
 impl ApplicationDescriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -312,9 +322,10 @@ pub struct ApplicationMetrics {
     pub status_codes: Option<StatusCodes>,
 }
 
+#[allow(dead_code)]
 struct ApplicationMetricsDeserializer;
 impl ApplicationMetricsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -344,9 +355,10 @@ impl ApplicationMetricsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ApplicationNameDeserializer;
 impl ApplicationNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -378,9 +390,10 @@ pub struct ApplicationResourceLifecycleConfig {
     pub version_lifecycle_config: Option<ApplicationVersionLifecycleConfig>,
 }
 
+#[allow(dead_code)]
 struct ApplicationResourceLifecycleConfigDeserializer;
 impl ApplicationResourceLifecycleConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -440,9 +453,10 @@ pub struct ApplicationResourceLifecycleDescriptionMessage {
     pub resource_lifecycle_config: Option<ApplicationResourceLifecycleConfig>,
 }
 
+#[allow(dead_code)]
 struct ApplicationResourceLifecycleDescriptionMessageDeserializer;
 impl ApplicationResourceLifecycleDescriptionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -472,9 +486,10 @@ impl ApplicationResourceLifecycleDescriptionMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ApplicationVersionArnDeserializer;
 impl ApplicationVersionArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -509,9 +524,10 @@ pub struct ApplicationVersionDescription {
     pub version_label: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ApplicationVersionDescriptionDeserializer;
 impl ApplicationVersionDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -578,9 +594,10 @@ impl ApplicationVersionDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ApplicationVersionDescriptionListDeserializer;
 impl ApplicationVersionDescriptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -605,9 +622,10 @@ pub struct ApplicationVersionDescriptionMessage {
     pub application_version: Option<ApplicationVersionDescription>,
 }
 
+#[allow(dead_code)]
 struct ApplicationVersionDescriptionMessageDeserializer;
 impl ApplicationVersionDescriptionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -641,9 +659,10 @@ pub struct ApplicationVersionDescriptionsMessage {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ApplicationVersionDescriptionsMessageDeserializer;
 impl ApplicationVersionDescriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -682,9 +701,10 @@ pub struct ApplicationVersionLifecycleConfig {
     pub max_count_rule: Option<MaxCountRule>,
 }
 
+#[allow(dead_code)]
 struct ApplicationVersionLifecycleConfigDeserializer;
 impl ApplicationVersionLifecycleConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -738,9 +758,10 @@ impl ApplicationVersionLifecycleConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ApplicationVersionStatusDeserializer;
 impl ApplicationVersionStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -794,9 +815,10 @@ pub struct ApplyEnvironmentManagedActionResult {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ApplyEnvironmentManagedActionResultDeserializer;
 impl ApplyEnvironmentManagedActionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -835,9 +857,10 @@ pub struct AutoScalingGroup {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AutoScalingGroupDeserializer;
 impl AutoScalingGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -853,9 +876,10 @@ impl AutoScalingGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AutoScalingGroupListDeserializer;
 impl AutoScalingGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -870,9 +894,10 @@ impl AutoScalingGroupListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailableSolutionStackDetailsListDeserializer;
 impl AvailableSolutionStackDetailsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -889,9 +914,10 @@ impl AvailableSolutionStackDetailsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailableSolutionStackNamesListDeserializer;
 impl AvailableSolutionStackNamesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -906,9 +932,10 @@ impl AvailableSolutionStackNamesListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BoxedBooleanDeserializer;
 impl BoxedBooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -917,9 +944,10 @@ impl BoxedBooleanDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BoxedIntDeserializer;
 impl BoxedIntDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -978,9 +1006,10 @@ pub struct Builder {
     pub arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct BuilderDeserializer;
 impl BuilderDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1018,9 +1047,10 @@ pub struct CPUUtilization {
     pub user: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct CPUUtilizationDeserializer;
 impl CPUUtilizationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1060,9 +1090,10 @@ impl CPUUtilizationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CauseDeserializer;
 impl CauseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1071,9 +1102,10 @@ impl CauseDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CausesDeserializer;
 impl CausesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1119,9 +1151,10 @@ pub struct CheckDNSAvailabilityResultMessage {
     pub fully_qualified_cname: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CheckDNSAvailabilityResultMessageDeserializer;
 impl CheckDNSAvailabilityResultMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1150,9 +1183,10 @@ impl CheckDNSAvailabilityResultMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CnameAvailabilityDeserializer;
 impl CnameAvailabilityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1198,9 +1232,10 @@ impl ComposeEnvironmentsMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ConfigurationDeploymentStatusDeserializer;
 impl ConfigurationDeploymentStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1209,9 +1244,10 @@ impl ConfigurationDeploymentStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConfigurationOptionDefaultValueDeserializer;
 impl ConfigurationOptionDefaultValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1248,9 +1284,10 @@ pub struct ConfigurationOptionDescription {
     pub value_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ConfigurationOptionDescriptionDeserializer;
 impl ConfigurationOptionDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1334,9 +1371,10 @@ impl ConfigurationOptionDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ConfigurationOptionDescriptionsListDeserializer;
 impl ConfigurationOptionDescriptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1353,9 +1391,10 @@ impl ConfigurationOptionDescriptionsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ConfigurationOptionNameDeserializer;
 impl ConfigurationOptionNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1364,9 +1403,10 @@ impl ConfigurationOptionNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConfigurationOptionPossibleValueDeserializer;
 impl ConfigurationOptionPossibleValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1375,9 +1415,10 @@ impl ConfigurationOptionPossibleValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConfigurationOptionPossibleValuesDeserializer;
 impl ConfigurationOptionPossibleValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1409,9 +1450,10 @@ pub struct ConfigurationOptionSetting {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ConfigurationOptionSettingDeserializer;
 impl ConfigurationOptionSettingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1476,9 +1518,10 @@ impl ConfigurationOptionSettingSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ConfigurationOptionSettingsListDeserializer;
 impl ConfigurationOptionSettingsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1507,9 +1550,10 @@ impl ConfigurationOptionSettingsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ConfigurationOptionSeverityDeserializer;
 impl ConfigurationOptionSeverityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1518,9 +1562,10 @@ impl ConfigurationOptionSeverityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConfigurationOptionValueDeserializer;
 impl ConfigurationOptionValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1529,9 +1574,10 @@ impl ConfigurationOptionValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConfigurationOptionValueTypeDeserializer;
 impl ConfigurationOptionValueTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1552,9 +1598,10 @@ pub struct ConfigurationOptionsDescription {
     pub solution_stack_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ConfigurationOptionsDescriptionDeserializer;
 impl ConfigurationOptionsDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1614,9 +1661,10 @@ pub struct ConfigurationSettingsDescription {
     pub template_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ConfigurationSettingsDescriptionDeserializer;
 impl ConfigurationSettingsDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1689,9 +1737,10 @@ impl ConfigurationSettingsDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ConfigurationSettingsDescriptionListDeserializer;
 impl ConfigurationSettingsDescriptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1716,9 +1765,10 @@ pub struct ConfigurationSettingsDescriptions {
     pub configuration_settings: Option<Vec<ConfigurationSettingsDescription>>,
 }
 
+#[allow(dead_code)]
 struct ConfigurationSettingsDescriptionsDeserializer;
 impl ConfigurationSettingsDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1751,9 +1801,10 @@ pub struct ConfigurationSettingsValidationMessages {
     pub messages: Option<Vec<ValidationMessage>>,
 }
 
+#[allow(dead_code)]
 struct ConfigurationSettingsValidationMessagesDeserializer;
 impl ConfigurationSettingsValidationMessagesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1775,9 +1826,10 @@ impl ConfigurationSettingsValidationMessagesDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ConfigurationTemplateNameDeserializer;
 impl ConfigurationTemplateNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1786,9 +1838,10 @@ impl ConfigurationTemplateNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConfigurationTemplateNamesListDeserializer;
 impl ConfigurationTemplateNamesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2153,9 +2206,10 @@ pub struct CreatePlatformVersionResult {
     pub platform_summary: Option<PlatformSummary>,
 }
 
+#[allow(dead_code)]
 struct CreatePlatformVersionResultDeserializer;
 impl CreatePlatformVersionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2189,9 +2243,10 @@ pub struct CreateStorageLocationResultMessage {
     pub s3_bucket: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateStorageLocationResultMessageDeserializer;
 impl CreateStorageLocationResultMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2211,9 +2266,10 @@ impl CreateStorageLocationResultMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CreationDateDeserializer;
 impl CreationDateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2232,9 +2288,10 @@ pub struct CustomAmi {
     pub virtualization_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CustomAmiDeserializer;
 impl CustomAmiDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2256,9 +2313,10 @@ impl CustomAmiDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CustomAmiListDeserializer;
 impl CustomAmiListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2273,9 +2331,10 @@ impl CustomAmiListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DNSCnameDeserializer;
 impl DNSCnameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2434,9 +2493,10 @@ pub struct DeletePlatformVersionResult {
     pub platform_summary: Option<PlatformSummary>,
 }
 
+#[allow(dead_code)]
 struct DeletePlatformVersionResultDeserializer;
 impl DeletePlatformVersionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2473,9 +2533,10 @@ pub struct Deployment {
     pub version_label: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeploymentDeserializer;
 impl DeploymentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2507,9 +2568,10 @@ impl DeploymentDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DeploymentTimestampDeserializer;
 impl DeploymentTimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2525,9 +2587,10 @@ pub struct DescribeAccountAttributesResult {
     pub resource_quotas: Option<ResourceQuotas>,
 }
 
+#[allow(dead_code)]
 struct DescribeAccountAttributesResultDeserializer;
 impl DescribeAccountAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2764,9 +2827,10 @@ pub struct DescribeEnvironmentHealthResult {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeEnvironmentHealthResultDeserializer;
 impl DescribeEnvironmentHealthResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2875,9 +2939,10 @@ pub struct DescribeEnvironmentManagedActionHistoryResult {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeEnvironmentManagedActionHistoryResultDeserializer;
 impl DescribeEnvironmentManagedActionHistoryResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2946,9 +3011,10 @@ pub struct DescribeEnvironmentManagedActionsResult {
     pub managed_actions: Option<Vec<ManagedAction>>,
 }
 
+#[allow(dead_code)]
 struct DescribeEnvironmentManagedActionsResultDeserializer;
 impl DescribeEnvironmentManagedActionsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3199,9 +3265,10 @@ pub struct DescribeInstancesHealthResult {
     pub refreshed_at: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeInstancesHealthResultDeserializer;
 impl DescribeInstancesHealthResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3263,9 +3330,10 @@ pub struct DescribePlatformVersionResult {
     pub platform_description: Option<PlatformDescription>,
 }
 
+#[allow(dead_code)]
 struct DescribePlatformVersionResultDeserializer;
 impl DescribePlatformVersionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3289,9 +3357,10 @@ impl DescribePlatformVersionResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DescriptionDeserializer;
 impl DescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3300,9 +3369,10 @@ impl DescriptionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct Ec2InstanceIdDeserializer;
 impl Ec2InstanceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3311,9 +3381,10 @@ impl Ec2InstanceIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EndpointURLDeserializer;
 impl EndpointURLDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3322,9 +3393,10 @@ impl EndpointURLDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EnvironmentArnDeserializer;
 impl EnvironmentArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3379,9 +3451,10 @@ pub struct EnvironmentDescription {
     pub version_label: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentDescriptionDeserializer;
 impl EnvironmentDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3492,9 +3565,10 @@ impl EnvironmentDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EnvironmentDescriptionsListDeserializer;
 impl EnvironmentDescriptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3521,9 +3595,10 @@ pub struct EnvironmentDescriptionsMessage {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentDescriptionsMessageDeserializer;
 impl EnvironmentDescriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3551,9 +3626,10 @@ impl EnvironmentDescriptionsMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct EnvironmentHealthDeserializer;
 impl EnvironmentHealthDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3574,9 +3650,10 @@ impl EnvironmentHealthAttributesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EnvironmentHealthStatusDeserializer;
 impl EnvironmentHealthStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3585,9 +3662,10 @@ impl EnvironmentHealthStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EnvironmentIdDeserializer;
 impl EnvironmentIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3622,9 +3700,10 @@ pub struct EnvironmentInfoDescription {
     pub sample_timestamp: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentInfoDescriptionDeserializer;
 impl EnvironmentInfoDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3661,9 +3740,10 @@ impl EnvironmentInfoDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct EnvironmentInfoDescriptionListDeserializer;
 impl EnvironmentInfoDescriptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3680,9 +3760,10 @@ impl EnvironmentInfoDescriptionListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EnvironmentInfoTypeDeserializer;
 impl EnvironmentInfoTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3701,9 +3782,10 @@ pub struct EnvironmentLink {
     pub link_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentLinkDeserializer;
 impl EnvironmentLinkDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3723,9 +3805,10 @@ impl EnvironmentLinkDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EnvironmentLinksDeserializer;
 impl EnvironmentLinksDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3740,9 +3823,10 @@ impl EnvironmentLinksDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EnvironmentNameDeserializer;
 impl EnvironmentNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3785,9 +3869,10 @@ pub struct EnvironmentResourceDescription {
     pub triggers: Option<Vec<Trigger>>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentResourceDescriptionDeserializer;
 impl EnvironmentResourceDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3859,9 +3944,10 @@ pub struct EnvironmentResourceDescriptionsMessage {
     pub environment_resources: Option<EnvironmentResourceDescription>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentResourceDescriptionsMessageDeserializer;
 impl EnvironmentResourceDescriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3893,9 +3979,10 @@ pub struct EnvironmentResourcesDescription {
     pub load_balancer: Option<LoadBalancerDescription>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentResourcesDescriptionDeserializer;
 impl EnvironmentResourcesDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3918,9 +4005,10 @@ impl EnvironmentResourcesDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct EnvironmentStatusDeserializer;
 impl EnvironmentStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3942,9 +4030,10 @@ pub struct EnvironmentTier {
     pub version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EnvironmentTierDeserializer;
 impl EnvironmentTierDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3988,9 +4077,10 @@ impl EnvironmentTierSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EventDateDeserializer;
 impl EventDateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4023,9 +4113,10 @@ pub struct EventDescription {
     pub version_label: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventDescriptionDeserializer;
 impl EventDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4078,9 +4169,10 @@ impl EventDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventDescriptionListDeserializer;
 impl EventDescriptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4105,9 +4197,10 @@ pub struct EventDescriptionsMessage {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventDescriptionsMessageDeserializer;
 impl EventDescriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4132,9 +4225,10 @@ impl EventDescriptionsMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct EventMessageDeserializer;
 impl EventMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4143,9 +4237,10 @@ impl EventMessageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EventSeverityDeserializer;
 impl EventSeverityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4154,9 +4249,10 @@ impl EventSeverityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FailureTypeDeserializer;
 impl FailureTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4165,9 +4261,10 @@ impl FailureTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FileTypeExtensionDeserializer;
 impl FileTypeExtensionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4176,9 +4273,10 @@ impl FileTypeExtensionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ImageIdDeserializer;
 impl ImageIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4195,9 +4293,10 @@ pub struct Instance {
     pub id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstanceDeserializer;
 impl InstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4213,9 +4312,10 @@ impl InstanceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InstanceHealthListDeserializer;
 impl InstanceHealthListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4254,9 +4354,10 @@ pub struct InstanceHealthSummary {
     pub warning: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct InstanceHealthSummaryDeserializer;
 impl InstanceHealthSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4294,9 +4395,10 @@ impl InstanceHealthSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InstanceIdDeserializer;
 impl InstanceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4305,9 +4407,10 @@ impl InstanceIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InstanceListDeserializer;
 impl InstanceListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4334,9 +4437,10 @@ impl InstancesHealthAttributesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4367,9 +4471,10 @@ pub struct Latency {
     pub p999: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct LatencyDeserializer;
 impl LatencyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4414,9 +4519,10 @@ pub struct LaunchConfiguration {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LaunchConfigurationDeserializer;
 impl LaunchConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4432,9 +4538,10 @@ impl LaunchConfigurationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LaunchConfigurationListDeserializer;
 impl LaunchConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4459,9 +4566,10 @@ pub struct LaunchTemplate {
     pub id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LaunchTemplateDeserializer;
 impl LaunchTemplateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4477,9 +4585,10 @@ impl LaunchTemplateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LaunchTemplateListDeserializer;
 impl LaunchTemplateListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4494,9 +4603,10 @@ impl LaunchTemplateListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LaunchedAtDeserializer;
 impl LaunchedAtDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4515,9 +4625,10 @@ pub struct ListAvailableSolutionStacksResultMessage {
     pub solution_stacks: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ListAvailableSolutionStacksResultMessageDeserializer;
 impl ListAvailableSolutionStacksResultMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4595,9 +4706,10 @@ pub struct ListPlatformVersionsResult {
     pub platform_summary_list: Option<Vec<PlatformSummary>>,
 }
 
+#[allow(dead_code)]
 struct ListPlatformVersionsResultDeserializer;
 impl ListPlatformVersionsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4655,9 +4767,10 @@ pub struct Listener {
     pub protocol: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListenerDeserializer;
 impl ListenerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4676,9 +4789,10 @@ impl ListenerDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LoadAverageDeserializer;
 impl LoadAverageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4693,9 +4807,10 @@ impl LoadAverageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LoadAverageValueDeserializer;
 impl LoadAverageValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4712,9 +4827,10 @@ pub struct LoadBalancer {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerDeserializer;
 impl LoadBalancerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4742,9 +4858,10 @@ pub struct LoadBalancerDescription {
     pub load_balancer_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerDescriptionDeserializer;
 impl LoadBalancerDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4776,9 +4893,10 @@ impl LoadBalancerDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerListDeserializer;
 impl LoadBalancerListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4793,9 +4911,10 @@ impl LoadBalancerListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerListenersDescriptionDeserializer;
 impl LoadBalancerListenersDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4810,9 +4929,10 @@ impl LoadBalancerListenersDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MaintainerDeserializer;
 impl MaintainerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4837,9 +4957,10 @@ pub struct ManagedAction {
     pub window_start_time: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ManagedActionDeserializer;
 impl ManagedActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4894,9 +5015,10 @@ pub struct ManagedActionHistoryItem {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ManagedActionHistoryItemDeserializer;
 impl ManagedActionHistoryItemDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4947,9 +5069,10 @@ impl ManagedActionHistoryItemDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ManagedActionHistoryItemsDeserializer;
 impl ManagedActionHistoryItemsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4966,9 +5089,10 @@ impl ManagedActionHistoryItemsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ManagedActionsDeserializer;
 impl ManagedActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4996,9 +5120,10 @@ pub struct MaxAgeRule {
     pub max_age_in_days: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct MaxAgeRuleDeserializer;
 impl MaxAgeRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5057,9 +5182,10 @@ pub struct MaxCountRule {
     pub max_count: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct MaxCountRuleDeserializer;
 impl MaxCountRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5104,9 +5230,10 @@ impl MaxCountRuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MessageDeserializer;
 impl MessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5115,9 +5242,10 @@ impl MessageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextTokenDeserializer;
 impl NextTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5126,9 +5254,10 @@ impl NextTokenDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NullableDoubleDeserializer;
 impl NullableDoubleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5137,9 +5266,10 @@ impl NullableDoubleDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NullableIntegerDeserializer;
 impl NullableIntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5148,9 +5278,10 @@ impl NullableIntegerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NullableLongDeserializer;
 impl NullableLongDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5159,9 +5290,10 @@ impl NullableLongDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OperatingSystemNameDeserializer;
 impl OperatingSystemNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5170,9 +5302,10 @@ impl OperatingSystemNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OperatingSystemVersionDeserializer;
 impl OperatingSystemVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5181,9 +5314,10 @@ impl OperatingSystemVersionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OptionNamespaceDeserializer;
 impl OptionNamespaceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5192,9 +5326,10 @@ impl OptionNamespaceDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OptionRestrictionMaxLengthDeserializer;
 impl OptionRestrictionMaxLengthDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5203,9 +5338,10 @@ impl OptionRestrictionMaxLengthDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OptionRestrictionMaxValueDeserializer;
 impl OptionRestrictionMaxValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5214,9 +5350,10 @@ impl OptionRestrictionMaxValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct OptionRestrictionMinValueDeserializer;
 impl OptionRestrictionMinValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5235,9 +5372,10 @@ pub struct OptionRestrictionRegex {
     pub pattern: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OptionRestrictionRegexDeserializer;
 impl OptionRestrictionRegexDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5300,9 +5438,10 @@ impl OptionsSpecifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PlatformArnDeserializer;
 impl PlatformArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5311,9 +5450,10 @@ impl PlatformArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PlatformCategoryDeserializer;
 impl PlatformCategoryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5364,9 +5504,10 @@ pub struct PlatformDescription {
     pub supported_tier_list: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct PlatformDescriptionDeserializer;
 impl PlatformDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5545,9 +5686,10 @@ pub struct PlatformFramework {
     pub version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PlatformFrameworkDeserializer;
 impl PlatformFrameworkDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5566,9 +5708,10 @@ impl PlatformFrameworkDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PlatformFrameworksDeserializer;
 impl PlatformFrameworksDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5583,9 +5726,10 @@ impl PlatformFrameworksDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PlatformNameDeserializer;
 impl PlatformNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5594,9 +5738,10 @@ impl PlatformNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PlatformOwnerDeserializer;
 impl PlatformOwnerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5615,9 +5760,10 @@ pub struct PlatformProgrammingLanguage {
     pub version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PlatformProgrammingLanguageDeserializer;
 impl PlatformProgrammingLanguageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5640,9 +5786,10 @@ impl PlatformProgrammingLanguageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PlatformProgrammingLanguagesDeserializer;
 impl PlatformProgrammingLanguagesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5659,9 +5806,10 @@ impl PlatformProgrammingLanguagesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PlatformStatusDeserializer;
 impl PlatformStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5692,9 +5840,10 @@ pub struct PlatformSummary {
     pub supported_tier_list: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct PlatformSummaryDeserializer;
 impl PlatformSummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5752,9 +5901,10 @@ impl PlatformSummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PlatformSummaryListDeserializer;
 impl PlatformSummaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5769,9 +5919,10 @@ impl PlatformSummaryListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PlatformVersionDeserializer;
 impl PlatformVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5790,9 +5941,10 @@ pub struct Queue {
     pub url: Option<String>,
 }
 
+#[allow(dead_code)]
 struct QueueDeserializer;
 impl QueueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Queue, XmlParseError> {
         deserialize_elements::<_, Queue, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5808,9 +5960,10 @@ impl QueueDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct QueueListDeserializer;
 impl QueueListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5853,9 +6006,10 @@ impl RebuildEnvironmentMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RefreshedAtDeserializer;
 impl RefreshedAtDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5864,9 +6018,10 @@ impl RefreshedAtDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RegexLabelDeserializer;
 impl RegexLabelDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5875,9 +6030,10 @@ impl RegexLabelDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RegexPatternDeserializer;
 impl RegexPatternDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5886,9 +6042,10 @@ impl RegexPatternDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RequestCountDeserializer;
 impl RequestCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5928,9 +6085,10 @@ impl RequestEnvironmentInfoMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RequestIdDeserializer;
 impl RequestIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5939,9 +6097,10 @@ impl RequestIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceArnDeserializer;
 impl ResourceArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5950,9 +6109,10 @@ impl ResourceArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceIdDeserializer;
 impl ResourceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5961,9 +6121,10 @@ impl ResourceIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceNameDeserializer;
 impl ResourceNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5980,9 +6141,10 @@ pub struct ResourceQuota {
     pub maximum: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ResourceQuotaDeserializer;
 impl ResourceQuotaDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6014,9 +6176,10 @@ pub struct ResourceQuotas {
     pub environment_quota: Option<ResourceQuota>,
 }
 
+#[allow(dead_code)]
 struct ResourceQuotasDeserializer;
 impl ResourceQuotasDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6069,9 +6232,10 @@ pub struct ResourceTagsDescriptionMessage {
     pub resource_tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct ResourceTagsDescriptionMessageDeserializer;
 impl ResourceTagsDescriptionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6164,9 +6328,10 @@ pub struct RetrieveEnvironmentInfoResultMessage {
     pub environment_info: Option<Vec<EnvironmentInfoDescription>>,
 }
 
+#[allow(dead_code)]
 struct RetrieveEnvironmentInfoResultMessageDeserializer;
 impl RetrieveEnvironmentInfoResultMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6191,9 +6356,10 @@ impl RetrieveEnvironmentInfoResultMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct S3BucketDeserializer;
 impl S3BucketDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6202,9 +6368,10 @@ impl S3BucketDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct S3KeyDeserializer;
 impl S3KeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6224,9 +6391,10 @@ pub struct S3Location {
     pub s3_key: Option<String>,
 }
 
+#[allow(dead_code)]
 struct S3LocationDeserializer;
 impl S3LocationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6264,9 +6432,10 @@ impl S3LocationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SampleTimestampDeserializer;
 impl SampleTimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6301,9 +6470,10 @@ pub struct SingleInstanceHealth {
     pub system: Option<SystemStatus>,
 }
 
+#[allow(dead_code)]
 struct SingleInstanceHealthDeserializer;
 impl SingleInstanceHealthDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6367,9 +6537,10 @@ pub struct SolutionStackDescription {
     pub solution_stack_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SolutionStackDescriptionDeserializer;
 impl SolutionStackDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6400,9 +6571,10 @@ impl SolutionStackDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SolutionStackFileTypeListDeserializer;
 impl SolutionStackFileTypeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6417,9 +6589,10 @@ impl SolutionStackFileTypeListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SolutionStackNameDeserializer;
 impl SolutionStackNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6441,9 +6614,10 @@ pub struct SourceBuildInformation {
     pub source_type: String,
 }
 
+#[allow(dead_code)]
 struct SourceBuildInformationDeserializer;
 impl SourceBuildInformationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6517,9 +6691,10 @@ impl SourceConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SourceLocationDeserializer;
 impl SourceLocationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6528,9 +6703,10 @@ impl SourceLocationDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SourceRepositoryDeserializer;
 impl SourceRepositoryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6539,9 +6715,10 @@ impl SourceRepositoryDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6564,9 +6741,10 @@ pub struct StatusCodes {
     pub status_5xx: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct StatusCodesDeserializer;
 impl StatusCodesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6603,9 +6781,10 @@ impl StatusCodesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6614,9 +6793,10 @@ impl StringDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SupportedAddonDeserializer;
 impl SupportedAddonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6625,9 +6805,10 @@ impl SupportedAddonDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SupportedAddonListDeserializer;
 impl SupportedAddonListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6642,9 +6823,10 @@ impl SupportedAddonListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SupportedTierDeserializer;
 impl SupportedTierDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6653,9 +6835,10 @@ impl SupportedTierDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SupportedTierListDeserializer;
 impl SupportedTierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6730,9 +6913,10 @@ pub struct SystemStatus {
     pub load_average: Option<Vec<f64>>,
 }
 
+#[allow(dead_code)]
 struct SystemStatusDeserializer;
 impl SystemStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6767,9 +6951,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -6804,9 +6989,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6827,9 +7013,10 @@ impl TagKeyListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6856,9 +7043,10 @@ impl TagListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6917,9 +7105,10 @@ impl TerminateEnvironmentMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TimestampDeserializer;
 impl TimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6928,9 +7117,10 @@ impl TimestampDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TokenDeserializer;
 impl TokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6947,9 +7137,10 @@ pub struct Trigger {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TriggerDeserializer;
 impl TriggerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6965,9 +7156,10 @@ impl TriggerDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TriggerListDeserializer;
 impl TriggerListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7123,9 +7315,10 @@ impl UpdateConfigurationTemplateMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct UpdateDateDeserializer;
 impl UpdateDateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7262,9 +7455,10 @@ impl UpdateTagsForResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct UserDefinedOptionDeserializer;
 impl UserDefinedOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -7328,9 +7522,10 @@ pub struct ValidationMessage {
     pub severity: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ValidationMessageDeserializer;
 impl ValidationMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7365,9 +7560,10 @@ impl ValidationMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValidationMessageStringDeserializer;
 impl ValidationMessageStringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7376,9 +7572,10 @@ impl ValidationMessageStringDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ValidationMessagesListDeserializer;
 impl ValidationMessagesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7393,9 +7590,10 @@ impl ValidationMessagesListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValidationSeverityDeserializer;
 impl ValidationSeverityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7404,9 +7602,10 @@ impl ValidationSeverityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VersionLabelDeserializer;
 impl VersionLabelDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7427,9 +7626,10 @@ impl VersionLabelsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct VersionLabelsListDeserializer;
 impl VersionLabelsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7456,9 +7656,10 @@ impl VersionLabelsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct VirtualizationTypeDeserializer;
 impl VirtualizationTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -51,9 +51,10 @@ pub struct AccessLog {
     pub s3_bucket_prefix: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AccessLogDeserializer;
 impl AccessLogDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -110,9 +111,10 @@ impl AccessLogSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AccessLogEnabledDeserializer;
 impl AccessLogEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -121,9 +123,10 @@ impl AccessLogEnabledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccessLogIntervalDeserializer;
 impl AccessLogIntervalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -132,9 +135,10 @@ impl AccessLogIntervalDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccessLogPrefixDeserializer;
 impl AccessLogPrefixDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -143,9 +147,10 @@ impl AccessLogPrefixDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccessPointNameDeserializer;
 impl AccessPointNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -154,9 +159,10 @@ impl AccessPointNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccessPointPortDeserializer;
 impl AccessPointPortDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -204,9 +210,10 @@ pub struct AddAvailabilityZonesOutput {
     pub availability_zones: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct AddAvailabilityZonesOutputDeserializer;
 impl AddAvailabilityZonesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -261,9 +268,10 @@ impl AddTagsInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct AddTagsOutput {}
 
+#[allow(dead_code)]
 struct AddTagsOutputDeserializer;
 impl AddTagsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -288,9 +296,10 @@ pub struct AdditionalAttribute {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AdditionalAttributeDeserializer;
 impl AdditionalAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -332,9 +341,10 @@ impl AdditionalAttributeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AdditionalAttributeKeyDeserializer;
 impl AdditionalAttributeKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -343,9 +353,10 @@ impl AdditionalAttributeKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AdditionalAttributeValueDeserializer;
 impl AdditionalAttributeValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -354,9 +365,10 @@ impl AdditionalAttributeValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AdditionalAttributesDeserializer;
 impl AdditionalAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -385,9 +397,10 @@ impl AdditionalAttributesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AppCookieStickinessPoliciesDeserializer;
 impl AppCookieStickinessPoliciesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -414,9 +427,10 @@ pub struct AppCookieStickinessPolicy {
     pub policy_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AppCookieStickinessPolicyDeserializer;
 impl AppCookieStickinessPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -480,9 +494,10 @@ pub struct ApplySecurityGroupsToLoadBalancerOutput {
     pub security_groups: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ApplySecurityGroupsToLoadBalancerOutputDeserializer;
 impl ApplySecurityGroupsToLoadBalancerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -539,9 +554,10 @@ pub struct AttachLoadBalancerToSubnetsOutput {
     pub subnets: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct AttachLoadBalancerToSubnetsOutputDeserializer;
 impl AttachLoadBalancerToSubnetsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -563,9 +579,10 @@ impl AttachLoadBalancerToSubnetsOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AttributeNameDeserializer;
 impl AttributeNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -574,9 +591,10 @@ impl AttributeNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AttributeTypeDeserializer;
 impl AttributeTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -585,9 +603,10 @@ impl AttributeTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AttributeValueDeserializer;
 impl AttributeValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -596,9 +615,10 @@ impl AttributeValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZoneDeserializer;
 impl AvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -607,9 +627,10 @@ impl AvailabilityZoneDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZonesDeserializer;
 impl AvailabilityZonesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -646,9 +667,10 @@ pub struct BackendServerDescription {
     pub policy_names: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct BackendServerDescriptionDeserializer;
 impl BackendServerDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -676,9 +698,10 @@ impl BackendServerDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct BackendServerDescriptionsDeserializer;
 impl BackendServerDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -695,9 +718,10 @@ impl BackendServerDescriptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CardinalityDeserializer;
 impl CardinalityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -745,9 +769,10 @@ pub struct ConfigureHealthCheckOutput {
     pub health_check: Option<HealthCheck>,
 }
 
+#[allow(dead_code)]
 struct ConfigureHealthCheckOutputDeserializer;
 impl ConfigureHealthCheckOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -779,9 +804,10 @@ pub struct ConnectionDraining {
     pub timeout: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ConnectionDrainingDeserializer;
 impl ConnectionDrainingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -820,9 +846,10 @@ impl ConnectionDrainingSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ConnectionDrainingEnabledDeserializer;
 impl ConnectionDrainingEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -831,9 +858,10 @@ impl ConnectionDrainingEnabledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConnectionDrainingTimeoutDeserializer;
 impl ConnectionDrainingTimeoutDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -851,9 +879,10 @@ pub struct ConnectionSettings {
     pub idle_timeout: i64,
 }
 
+#[allow(dead_code)]
 struct ConnectionSettingsDeserializer;
 impl ConnectionSettingsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -883,9 +912,10 @@ impl ConnectionSettingsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CookieExpirationPeriodDeserializer;
 impl CookieExpirationPeriodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -894,9 +924,10 @@ impl CookieExpirationPeriodDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CookieNameDeserializer;
 impl CookieNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -977,9 +1008,10 @@ pub struct CreateAccessPointOutput {
     pub dns_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateAccessPointOutputDeserializer;
 impl CreateAccessPointOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1034,9 +1066,10 @@ impl CreateAppCookieStickinessPolicyInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateAppCookieStickinessPolicyOutput {}
 
+#[allow(dead_code)]
 struct CreateAppCookieStickinessPolicyOutputDeserializer;
 impl CreateAppCookieStickinessPolicyOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1090,9 +1123,10 @@ impl CreateLBCookieStickinessPolicyInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateLBCookieStickinessPolicyOutput {}
 
+#[allow(dead_code)]
 struct CreateLBCookieStickinessPolicyOutputDeserializer;
 impl CreateLBCookieStickinessPolicyOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1142,9 +1176,10 @@ impl CreateLoadBalancerListenerInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateLoadBalancerListenerOutput {}
 
+#[allow(dead_code)]
 struct CreateLoadBalancerListenerOutputDeserializer;
 impl CreateLoadBalancerListenerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1205,9 +1240,10 @@ impl CreateLoadBalancerPolicyInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateLoadBalancerPolicyOutput {}
 
+#[allow(dead_code)]
 struct CreateLoadBalancerPolicyOutputDeserializer;
 impl CreateLoadBalancerPolicyOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1221,9 +1257,10 @@ impl CreateLoadBalancerPolicyOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CreatedTimeDeserializer;
 impl CreatedTimeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1241,9 +1278,10 @@ pub struct CrossZoneLoadBalancing {
     pub enabled: bool,
 }
 
+#[allow(dead_code)]
 struct CrossZoneLoadBalancingDeserializer;
 impl CrossZoneLoadBalancingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1274,9 +1312,10 @@ impl CrossZoneLoadBalancingSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CrossZoneLoadBalancingEnabledDeserializer;
 impl CrossZoneLoadBalancingEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1285,9 +1324,10 @@ impl CrossZoneLoadBalancingEnabledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DNSNameDeserializer;
 impl DNSNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1296,9 +1336,10 @@ impl DNSNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DefaultValueDeserializer;
 impl DefaultValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1336,9 +1377,10 @@ impl DeleteAccessPointInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteAccessPointOutput {}
 
+#[allow(dead_code)]
 struct DeleteAccessPointOutputDeserializer;
 impl DeleteAccessPointOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1388,9 +1430,10 @@ impl DeleteLoadBalancerListenerInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteLoadBalancerListenerOutput {}
 
+#[allow(dead_code)]
 struct DeleteLoadBalancerListenerOutputDeserializer;
 impl DeleteLoadBalancerListenerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1436,9 +1479,10 @@ impl DeleteLoadBalancerPolicyInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteLoadBalancerPolicyOutput {}
 
+#[allow(dead_code)]
 struct DeleteLoadBalancerPolicyOutputDeserializer;
 impl DeleteLoadBalancerPolicyOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1491,9 +1535,10 @@ pub struct DeregisterEndPointsOutput {
     pub instances: Option<Vec<Instance>>,
 }
 
+#[allow(dead_code)]
 struct DeregisterEndPointsOutputDeserializer;
 impl DeregisterEndPointsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1562,9 +1607,10 @@ pub struct DescribeAccessPointsOutput {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeAccessPointsOutputDeserializer;
 impl DescribeAccessPointsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1629,9 +1675,10 @@ pub struct DescribeAccountLimitsOutput {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeAccountLimitsOutputDeserializer;
 impl DescribeAccountLimitsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1698,9 +1745,10 @@ pub struct DescribeEndPointStateOutput {
     pub instance_states: Option<Vec<InstanceState>>,
 }
 
+#[allow(dead_code)]
 struct DescribeEndPointStateOutputDeserializer;
 impl DescribeEndPointStateOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1754,9 +1802,10 @@ pub struct DescribeLoadBalancerAttributesOutput {
     pub load_balancer_attributes: Option<LoadBalancerAttributes>,
 }
 
+#[allow(dead_code)]
 struct DescribeLoadBalancerAttributesOutputDeserializer;
 impl DescribeLoadBalancerAttributesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1820,9 +1869,10 @@ pub struct DescribeLoadBalancerPoliciesOutput {
     pub policy_descriptions: Option<Vec<PolicyDescription>>,
 }
 
+#[allow(dead_code)]
 struct DescribeLoadBalancerPoliciesOutputDeserializer;
 impl DescribeLoadBalancerPoliciesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1882,9 +1932,10 @@ pub struct DescribeLoadBalancerPolicyTypesOutput {
     pub policy_type_descriptions: Option<Vec<PolicyTypeDescription>>,
 }
 
+#[allow(dead_code)]
 struct DescribeLoadBalancerPolicyTypesOutputDeserializer;
 impl DescribeLoadBalancerPolicyTypesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1942,9 +1993,10 @@ pub struct DescribeTagsOutput {
     pub tag_descriptions: Option<Vec<TagDescription>>,
 }
 
+#[allow(dead_code)]
 struct DescribeTagsOutputDeserializer;
 impl DescribeTagsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1962,9 +2014,10 @@ impl DescribeTagsOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DescriptionDeserializer;
 impl DescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2008,9 +2061,10 @@ pub struct DetachLoadBalancerFromSubnetsOutput {
     pub subnets: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DetachLoadBalancerFromSubnetsOutputDeserializer;
 impl DetachLoadBalancerFromSubnetsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2049,9 +2103,10 @@ pub struct HealthCheck {
     pub unhealthy_threshold: i64,
 }
 
+#[allow(dead_code)]
 struct HealthCheckDeserializer;
 impl HealthCheckDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2105,9 +2160,10 @@ impl HealthCheckSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthCheckIntervalDeserializer;
 impl HealthCheckIntervalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2116,9 +2172,10 @@ impl HealthCheckIntervalDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckTargetDeserializer;
 impl HealthCheckTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2127,9 +2184,10 @@ impl HealthCheckTargetDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckTimeoutDeserializer;
 impl HealthCheckTimeoutDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2138,9 +2196,10 @@ impl HealthCheckTimeoutDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthyThresholdDeserializer;
 impl HealthyThresholdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2149,9 +2208,10 @@ impl HealthyThresholdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IdleTimeoutDeserializer;
 impl IdleTimeoutDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2169,9 +2229,10 @@ pub struct Instance {
     pub instance_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstanceDeserializer;
 impl InstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2204,9 +2265,10 @@ impl InstanceSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InstanceIdDeserializer;
 impl InstanceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2215,9 +2277,10 @@ impl InstanceIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InstancePortDeserializer;
 impl InstancePortDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2240,9 +2303,10 @@ pub struct InstanceState {
     pub state: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstanceStateDeserializer;
 impl InstanceStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2270,9 +2334,10 @@ impl InstanceStateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InstanceStatesDeserializer;
 impl InstanceStatesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2287,9 +2352,10 @@ impl InstanceStatesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InstancesDeserializer;
 impl InstancesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2316,9 +2382,10 @@ impl InstancesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LBCookieStickinessPoliciesDeserializer;
 impl LBCookieStickinessPoliciesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2345,9 +2412,10 @@ pub struct LBCookieStickinessPolicy {
     pub policy_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LBCookieStickinessPolicyDeserializer;
 impl LBCookieStickinessPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2385,9 +2453,10 @@ pub struct Limit {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LimitDeserializer;
 impl LimitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Limit, XmlParseError> {
         deserialize_elements::<_, Limit, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -2403,9 +2472,10 @@ impl LimitDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LimitsDeserializer;
 impl LimitsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2437,9 +2507,10 @@ pub struct Listener {
     pub ssl_certificate_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListenerDeserializer;
 impl ListenerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2510,9 +2581,10 @@ pub struct ListenerDescription {
     pub policy_names: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ListenerDescriptionDeserializer;
 impl ListenerDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2533,9 +2605,10 @@ impl ListenerDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ListenerDescriptionsDeserializer;
 impl ListenerDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2581,9 +2654,10 @@ pub struct LoadBalancerAttributes {
     pub cross_zone_load_balancing: Option<CrossZoneLoadBalancing>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerAttributesDeserializer;
 impl LoadBalancerAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2712,9 +2786,10 @@ pub struct LoadBalancerDescription {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerDescriptionDeserializer;
 impl LoadBalancerDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2814,9 +2889,10 @@ impl LoadBalancerDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerDescriptionsDeserializer;
 impl LoadBalancerDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2856,9 +2932,10 @@ impl LoadBalancerNamesMax20Serializer {
     }
 }
 
+#[allow(dead_code)]
 struct LoadBalancerSchemeDeserializer;
 impl LoadBalancerSchemeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2867,9 +2944,10 @@ impl LoadBalancerSchemeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MarkerDeserializer;
 impl MarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2878,9 +2956,10 @@ impl MarkerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaxDeserializer;
 impl MaxDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2930,9 +3009,10 @@ pub struct ModifyLoadBalancerAttributesOutput {
     pub load_balancer_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ModifyLoadBalancerAttributesOutputDeserializer;
 impl ModifyLoadBalancerAttributesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2962,9 +3042,10 @@ impl ModifyLoadBalancerAttributesOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct NameDeserializer;
 impl NameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2985,9 +3066,10 @@ pub struct Policies {
     pub other_policies: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct PoliciesDeserializer;
 impl PoliciesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3059,9 +3141,10 @@ pub struct PolicyAttributeDescription {
     pub attribute_value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyAttributeDescriptionDeserializer;
 impl PolicyAttributeDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3090,9 +3173,10 @@ impl PolicyAttributeDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PolicyAttributeDescriptionsDeserializer;
 impl PolicyAttributeDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3125,9 +3209,10 @@ pub struct PolicyAttributeTypeDescription {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyAttributeTypeDescriptionDeserializer;
 impl PolicyAttributeTypeDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3170,9 +3255,10 @@ impl PolicyAttributeTypeDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PolicyAttributeTypeDescriptionsDeserializer;
 impl PolicyAttributeTypeDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3213,9 +3299,10 @@ pub struct PolicyDescription {
     pub policy_type_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyDescriptionDeserializer;
 impl PolicyDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3246,9 +3333,10 @@ impl PolicyDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyDescriptionsDeserializer;
 impl PolicyDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3263,9 +3351,10 @@ impl PolicyDescriptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyNameDeserializer;
 impl PolicyNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3274,9 +3363,10 @@ impl PolicyNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyNamesDeserializer;
 impl PolicyNamesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3315,9 +3405,10 @@ pub struct PolicyTypeDescription {
     pub policy_type_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyTypeDescriptionDeserializer;
 impl PolicyTypeDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3348,9 +3439,10 @@ impl PolicyTypeDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyTypeDescriptionsDeserializer;
 impl PolicyTypeDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3367,9 +3459,10 @@ impl PolicyTypeDescriptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyTypeNameDeserializer;
 impl PolicyTypeNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3401,9 +3494,10 @@ impl PortsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ProtocolDeserializer;
 impl ProtocolDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3412,9 +3506,10 @@ impl ProtocolDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReasonCodeDeserializer;
 impl ReasonCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3462,9 +3557,10 @@ pub struct RegisterEndPointsOutput {
     pub instances: Option<Vec<Instance>>,
 }
 
+#[allow(dead_code)]
 struct RegisterEndPointsOutputDeserializer;
 impl RegisterEndPointsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3525,9 +3621,10 @@ pub struct RemoveAvailabilityZonesOutput {
     pub availability_zones: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct RemoveAvailabilityZonesOutputDeserializer;
 impl RemoveAvailabilityZonesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3582,9 +3679,10 @@ impl RemoveTagsInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct RemoveTagsOutput {}
 
+#[allow(dead_code)]
 struct RemoveTagsOutputDeserializer;
 impl RemoveTagsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3598,9 +3696,10 @@ impl RemoveTagsOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct S3BucketNameDeserializer;
 impl S3BucketNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3609,9 +3708,10 @@ impl S3BucketNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SSLCertificateIdDeserializer;
 impl SSLCertificateIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3620,9 +3720,10 @@ impl SSLCertificateIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupIdDeserializer;
 impl SecurityGroupIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3631,9 +3732,10 @@ impl SecurityGroupIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupNameDeserializer;
 impl SecurityGroupNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3642,9 +3744,10 @@ impl SecurityGroupNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupOwnerAliasDeserializer;
 impl SecurityGroupOwnerAliasDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3653,9 +3756,10 @@ impl SecurityGroupOwnerAliasDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupsDeserializer;
 impl SecurityGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3727,9 +3831,10 @@ impl SetLoadBalancerListenerSSLCertificateInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetLoadBalancerListenerSSLCertificateOutput {}
 
+#[allow(dead_code)]
 struct SetLoadBalancerListenerSSLCertificateOutputDeserializer;
 impl SetLoadBalancerListenerSSLCertificateOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3786,9 +3891,10 @@ impl SetLoadBalancerPoliciesForBackendServerInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetLoadBalancerPoliciesForBackendServerOutput {}
 
+#[allow(dead_code)]
 struct SetLoadBalancerPoliciesForBackendServerOutputDeserializer;
 impl SetLoadBalancerPoliciesForBackendServerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3844,9 +3950,10 @@ impl SetLoadBalancerPoliciesOfListenerInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetLoadBalancerPoliciesOfListenerOutput {}
 
+#[allow(dead_code)]
 struct SetLoadBalancerPoliciesOfListenerOutputDeserializer;
 impl SetLoadBalancerPoliciesOfListenerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3870,9 +3977,10 @@ pub struct SourceSecurityGroup {
     pub owner_alias: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SourceSecurityGroupDeserializer;
 impl SourceSecurityGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3897,9 +4005,10 @@ impl SourceSecurityGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StateDeserializer;
 impl StateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3908,9 +4017,10 @@ impl StateDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SubnetIdDeserializer;
 impl SubnetIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3919,9 +4029,10 @@ impl SubnetIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SubnetsDeserializer;
 impl SubnetsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3959,9 +4070,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -4004,9 +4116,10 @@ pub struct TagDescription {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct TagDescriptionDeserializer;
 impl TagDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4030,9 +4143,10 @@ impl TagDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TagDescriptionsDeserializer;
 impl TagDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4047,9 +4161,10 @@ impl TagDescriptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4093,9 +4208,10 @@ impl TagKeyOnlySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4122,9 +4238,10 @@ impl TagListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4133,9 +4250,10 @@ impl TagValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct UnhealthyThresholdDeserializer;
 impl UnhealthyThresholdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4144,9 +4262,10 @@ impl UnhealthyThresholdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VPCIdDeserializer;
 impl VPCIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -6452,9 +6452,7 @@ impl Elb for ElbClient {
             return Err(AddTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = AddTagsOutput::default();
         // parse non-payload
         Ok(result)
@@ -6489,9 +6487,8 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplySecurityGroupsToLoadBalancerOutput::default();
         } else {
@@ -6539,9 +6536,8 @@ impl Elb for ElbClient {
             return Err(AttachLoadBalancerToSubnetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AttachLoadBalancerToSubnetsOutput::default();
         } else {
@@ -6588,9 +6584,8 @@ impl Elb for ElbClient {
             return Err(ConfigureHealthCheckError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ConfigureHealthCheckOutput::default();
         } else {
@@ -6642,9 +6637,7 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateAppCookieStickinessPolicyOutput::default();
         // parse non-payload
         Ok(result)
@@ -6677,9 +6670,7 @@ impl Elb for ElbClient {
             return Err(CreateLBCookieStickinessPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateLBCookieStickinessPolicyOutput::default();
         // parse non-payload
         Ok(result)
@@ -6709,9 +6700,8 @@ impl Elb for ElbClient {
             return Err(CreateLoadBalancerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateAccessPointOutput::default();
         } else {
@@ -6759,9 +6749,7 @@ impl Elb for ElbClient {
             return Err(CreateLoadBalancerListenersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateLoadBalancerListenerOutput::default();
         // parse non-payload
         Ok(result)
@@ -6791,9 +6779,7 @@ impl Elb for ElbClient {
             return Err(CreateLoadBalancerPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateLoadBalancerPolicyOutput::default();
         // parse non-payload
         Ok(result)
@@ -6823,9 +6809,7 @@ impl Elb for ElbClient {
             return Err(DeleteLoadBalancerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteAccessPointOutput::default();
         // parse non-payload
         Ok(result)
@@ -6856,9 +6840,7 @@ impl Elb for ElbClient {
             return Err(DeleteLoadBalancerListenersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteLoadBalancerListenerOutput::default();
         // parse non-payload
         Ok(result)
@@ -6888,9 +6870,7 @@ impl Elb for ElbClient {
             return Err(DeleteLoadBalancerPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteLoadBalancerPolicyOutput::default();
         // parse non-payload
         Ok(result)
@@ -6923,9 +6903,8 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeregisterEndPointsOutput::default();
         } else {
@@ -6972,9 +6951,8 @@ impl Elb for ElbClient {
             return Err(DescribeAccountLimitsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAccountLimitsOutput::default();
         } else {
@@ -7021,9 +6999,8 @@ impl Elb for ElbClient {
             return Err(DescribeInstanceHealthError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEndPointStateOutput::default();
         } else {
@@ -7073,9 +7050,8 @@ impl Elb for ElbClient {
             return Err(DescribeLoadBalancerAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLoadBalancerAttributesOutput::default();
         } else {
@@ -7123,9 +7099,8 @@ impl Elb for ElbClient {
             return Err(DescribeLoadBalancerPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLoadBalancerPoliciesOutput::default();
         } else {
@@ -7177,9 +7152,8 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLoadBalancerPolicyTypesOutput::default();
         } else {
@@ -7226,9 +7200,8 @@ impl Elb for ElbClient {
             return Err(DescribeLoadBalancersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAccessPointsOutput::default();
         } else {
@@ -7275,9 +7248,8 @@ impl Elb for ElbClient {
             return Err(DescribeTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTagsOutput::default();
         } else {
@@ -7322,9 +7294,8 @@ impl Elb for ElbClient {
             return Err(DetachLoadBalancerFromSubnetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DetachLoadBalancerFromSubnetsOutput::default();
         } else {
@@ -7376,9 +7347,8 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RemoveAvailabilityZonesOutput::default();
         } else {
@@ -7428,9 +7398,8 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AddAvailabilityZonesOutput::default();
         } else {
@@ -7478,9 +7447,8 @@ impl Elb for ElbClient {
             return Err(ModifyLoadBalancerAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyLoadBalancerAttributesOutput::default();
         } else {
@@ -7529,9 +7497,8 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RegisterEndPointsOutput::default();
         } else {
@@ -7578,9 +7545,7 @@ impl Elb for ElbClient {
             return Err(RemoveTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = RemoveTagsOutput::default();
         // parse non-payload
         Ok(result)
@@ -7615,9 +7580,7 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetLoadBalancerListenerSSLCertificateOutput::default();
         // parse non-payload
         Ok(result)
@@ -7652,9 +7615,7 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetLoadBalancerPoliciesForBackendServerOutput::default();
         // parse non-payload
         Ok(result)
@@ -7689,9 +7650,7 @@ impl Elb for ElbClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetLoadBalancerPoliciesOfListenerOutput::default();
         // parse non-payload
         Ok(result)

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -9299,9 +9299,8 @@ impl Elb for ElbClient {
             return Err(AddListenerCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AddListenerCertificatesOutput::default();
         } else {
@@ -9348,9 +9347,7 @@ impl Elb for ElbClient {
             return Err(AddTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = AddTagsOutput::default();
         // parse non-payload
         Ok(result)
@@ -9380,9 +9377,8 @@ impl Elb for ElbClient {
             return Err(CreateListenerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateListenerOutput::default();
         } else {
@@ -9427,9 +9423,8 @@ impl Elb for ElbClient {
             return Err(CreateLoadBalancerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateLoadBalancerOutput::default();
         } else {
@@ -9476,9 +9471,8 @@ impl Elb for ElbClient {
             return Err(CreateRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateRuleOutput::default();
         } else {
@@ -9522,9 +9516,8 @@ impl Elb for ElbClient {
             return Err(CreateTargetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateTargetGroupOutput::default();
         } else {
@@ -9571,9 +9564,7 @@ impl Elb for ElbClient {
             return Err(DeleteListenerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteListenerOutput::default();
         // parse non-payload
         Ok(result)
@@ -9603,9 +9594,7 @@ impl Elb for ElbClient {
             return Err(DeleteLoadBalancerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteLoadBalancerOutput::default();
         // parse non-payload
         Ok(result)
@@ -9635,9 +9624,7 @@ impl Elb for ElbClient {
             return Err(DeleteRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteRuleOutput::default();
         // parse non-payload
         Ok(result)
@@ -9667,9 +9654,7 @@ impl Elb for ElbClient {
             return Err(DeleteTargetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteTargetGroupOutput::default();
         // parse non-payload
         Ok(result)
@@ -9699,9 +9684,7 @@ impl Elb for ElbClient {
             return Err(DeregisterTargetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeregisterTargetsOutput::default();
         // parse non-payload
         Ok(result)
@@ -9731,9 +9714,8 @@ impl Elb for ElbClient {
             return Err(DescribeAccountLimitsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeAccountLimitsOutput::default();
         } else {
@@ -9781,9 +9763,8 @@ impl Elb for ElbClient {
             return Err(DescribeListenerCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeListenerCertificatesOutput::default();
         } else {
@@ -9830,9 +9811,8 @@ impl Elb for ElbClient {
             return Err(DescribeListenersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeListenersOutput::default();
         } else {
@@ -9882,9 +9862,8 @@ impl Elb for ElbClient {
             return Err(DescribeLoadBalancerAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLoadBalancerAttributesOutput::default();
         } else {
@@ -9931,9 +9910,8 @@ impl Elb for ElbClient {
             return Err(DescribeLoadBalancersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeLoadBalancersOutput::default();
         } else {
@@ -9980,9 +9958,8 @@ impl Elb for ElbClient {
             return Err(DescribeRulesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeRulesOutput::default();
         } else {
@@ -10027,9 +10004,8 @@ impl Elb for ElbClient {
             return Err(DescribeSSLPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeSSLPoliciesOutput::default();
         } else {
@@ -10076,9 +10052,8 @@ impl Elb for ElbClient {
             return Err(DescribeTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTagsOutput::default();
         } else {
@@ -10123,9 +10098,8 @@ impl Elb for ElbClient {
             return Err(DescribeTargetGroupAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTargetGroupAttributesOutput::default();
         } else {
@@ -10172,9 +10146,8 @@ impl Elb for ElbClient {
             return Err(DescribeTargetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTargetGroupsOutput::default();
         } else {
@@ -10221,9 +10194,8 @@ impl Elb for ElbClient {
             return Err(DescribeTargetHealthError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeTargetHealthOutput::default();
         } else {
@@ -10270,9 +10242,8 @@ impl Elb for ElbClient {
             return Err(ModifyListenerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyListenerOutput::default();
         } else {
@@ -10318,9 +10289,8 @@ impl Elb for ElbClient {
             return Err(ModifyLoadBalancerAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyLoadBalancerAttributesOutput::default();
         } else {
@@ -10367,9 +10337,8 @@ impl Elb for ElbClient {
             return Err(ModifyRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyRuleOutput::default();
         } else {
@@ -10413,9 +10382,8 @@ impl Elb for ElbClient {
             return Err(ModifyTargetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyTargetGroupOutput::default();
         } else {
@@ -10463,9 +10431,8 @@ impl Elb for ElbClient {
             return Err(ModifyTargetGroupAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyTargetGroupAttributesOutput::default();
         } else {
@@ -10512,9 +10479,7 @@ impl Elb for ElbClient {
             return Err(RegisterTargetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = RegisterTargetsOutput::default();
         // parse non-payload
         Ok(result)
@@ -10545,9 +10510,7 @@ impl Elb for ElbClient {
             return Err(RemoveListenerCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = RemoveListenerCertificatesOutput::default();
         // parse non-payload
         Ok(result)
@@ -10577,9 +10540,7 @@ impl Elb for ElbClient {
             return Err(RemoveTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = RemoveTagsOutput::default();
         // parse non-payload
         Ok(result)
@@ -10609,9 +10570,8 @@ impl Elb for ElbClient {
             return Err(SetIpAddressTypeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SetIpAddressTypeOutput::default();
         } else {
@@ -10658,9 +10618,8 @@ impl Elb for ElbClient {
             return Err(SetRulePrioritiesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SetRulePrioritiesOutput::default();
         } else {
@@ -10707,9 +10666,8 @@ impl Elb for ElbClient {
             return Err(SetSecurityGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SetSecurityGroupsOutput::default();
         } else {
@@ -10756,9 +10714,8 @@ impl Elb for ElbClient {
             return Err(SetSubnetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SetSubnetsOutput::default();
         } else {

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -59,9 +59,10 @@ pub struct Action {
     pub type_: String,
 }
 
+#[allow(dead_code)]
 struct ActionDeserializer;
 impl ActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Action, XmlParseError> {
         deserialize_elements::<_, Action, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -171,9 +172,10 @@ impl ActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ActionOrderDeserializer;
 impl ActionOrderDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -182,9 +184,10 @@ impl ActionOrderDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ActionTypeEnumDeserializer;
 impl ActionTypeEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -193,9 +196,10 @@ impl ActionTypeEnumDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ActionsDeserializer;
 impl ActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -256,9 +260,10 @@ pub struct AddListenerCertificatesOutput {
     pub certificates: Option<Vec<Certificate>>,
 }
 
+#[allow(dead_code)]
 struct AddListenerCertificatesOutputDeserializer;
 impl AddListenerCertificatesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -311,9 +316,10 @@ impl AddTagsInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct AddTagsOutput {}
 
+#[allow(dead_code)]
 struct AddTagsOutputDeserializer;
 impl AddTagsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -327,9 +333,10 @@ impl AddTagsOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AllocationIdDeserializer;
 impl AllocationIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -338,9 +345,10 @@ impl AllocationIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionAuthenticationRequestExtraParamsDeserializer;
 impl AuthenticateCognitoActionAuthenticationRequestExtraParamsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -384,9 +392,10 @@ impl AuthenticateCognitoActionAuthenticationRequestExtraParamsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AuthenticateCognitoActionAuthenticationRequestParamNameDeserializer;
 impl AuthenticateCognitoActionAuthenticationRequestParamNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -395,9 +404,10 @@ impl AuthenticateCognitoActionAuthenticationRequestParamNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionAuthenticationRequestParamValueDeserializer;
 impl AuthenticateCognitoActionAuthenticationRequestParamValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -406,9 +416,10 @@ impl AuthenticateCognitoActionAuthenticationRequestParamValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionConditionalBehaviorEnumDeserializer;
 impl AuthenticateCognitoActionConditionalBehaviorEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -440,9 +451,10 @@ pub struct AuthenticateCognitoActionConfig {
     pub user_pool_domain: String,
 }
 
+#[allow(dead_code)]
 struct AuthenticateCognitoActionConfigDeserializer;
 impl AuthenticateCognitoActionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -551,9 +563,10 @@ impl AuthenticateCognitoActionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AuthenticateCognitoActionScopeDeserializer;
 impl AuthenticateCognitoActionScopeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -562,9 +575,10 @@ impl AuthenticateCognitoActionScopeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionSessionCookieNameDeserializer;
 impl AuthenticateCognitoActionSessionCookieNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -573,9 +587,10 @@ impl AuthenticateCognitoActionSessionCookieNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionSessionTimeoutDeserializer;
 impl AuthenticateCognitoActionSessionTimeoutDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -584,9 +599,10 @@ impl AuthenticateCognitoActionSessionTimeoutDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionUserPoolArnDeserializer;
 impl AuthenticateCognitoActionUserPoolArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -595,9 +611,10 @@ impl AuthenticateCognitoActionUserPoolArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionUserPoolClientIdDeserializer;
 impl AuthenticateCognitoActionUserPoolClientIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -606,9 +623,10 @@ impl AuthenticateCognitoActionUserPoolClientIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateCognitoActionUserPoolDomainDeserializer;
 impl AuthenticateCognitoActionUserPoolDomainDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -617,9 +635,10 @@ impl AuthenticateCognitoActionUserPoolDomainDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionAuthenticationRequestExtraParamsDeserializer;
 impl AuthenticateOidcActionAuthenticationRequestExtraParamsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -663,9 +682,10 @@ impl AuthenticateOidcActionAuthenticationRequestExtraParamsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AuthenticateOidcActionAuthenticationRequestParamNameDeserializer;
 impl AuthenticateOidcActionAuthenticationRequestParamNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -674,9 +694,10 @@ impl AuthenticateOidcActionAuthenticationRequestParamNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionAuthenticationRequestParamValueDeserializer;
 impl AuthenticateOidcActionAuthenticationRequestParamValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -685,9 +706,10 @@ impl AuthenticateOidcActionAuthenticationRequestParamValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionAuthorizationEndpointDeserializer;
 impl AuthenticateOidcActionAuthorizationEndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -696,9 +718,10 @@ impl AuthenticateOidcActionAuthorizationEndpointDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionClientIdDeserializer;
 impl AuthenticateOidcActionClientIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -707,9 +730,10 @@ impl AuthenticateOidcActionClientIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionClientSecretDeserializer;
 impl AuthenticateOidcActionClientSecretDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -718,9 +742,10 @@ impl AuthenticateOidcActionClientSecretDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionConditionalBehaviorEnumDeserializer;
 impl AuthenticateOidcActionConditionalBehaviorEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -760,9 +785,10 @@ pub struct AuthenticateOidcActionConfig {
     pub user_info_endpoint: String,
 }
 
+#[allow(dead_code)]
 struct AuthenticateOidcActionConfigDeserializer;
 impl AuthenticateOidcActionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -914,9 +940,10 @@ impl AuthenticateOidcActionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AuthenticateOidcActionIssuerDeserializer;
 impl AuthenticateOidcActionIssuerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -925,9 +952,10 @@ impl AuthenticateOidcActionIssuerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionScopeDeserializer;
 impl AuthenticateOidcActionScopeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -936,9 +964,10 @@ impl AuthenticateOidcActionScopeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionSessionCookieNameDeserializer;
 impl AuthenticateOidcActionSessionCookieNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -947,9 +976,10 @@ impl AuthenticateOidcActionSessionCookieNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionSessionTimeoutDeserializer;
 impl AuthenticateOidcActionSessionTimeoutDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -958,9 +988,10 @@ impl AuthenticateOidcActionSessionTimeoutDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionTokenEndpointDeserializer;
 impl AuthenticateOidcActionTokenEndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -969,9 +1000,10 @@ impl AuthenticateOidcActionTokenEndpointDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionUseExistingClientSecretDeserializer;
 impl AuthenticateOidcActionUseExistingClientSecretDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -980,9 +1012,10 @@ impl AuthenticateOidcActionUseExistingClientSecretDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AuthenticateOidcActionUserInfoEndpointDeserializer;
 impl AuthenticateOidcActionUserInfoEndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1003,9 +1036,10 @@ pub struct AvailabilityZone {
     pub zone_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AvailabilityZoneDeserializer;
 impl AvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1032,9 +1066,10 @@ impl AvailabilityZoneDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZonesDeserializer;
 impl AvailabilityZonesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1049,9 +1084,10 @@ impl AvailabilityZonesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CanonicalHostedZoneIdDeserializer;
 impl CanonicalHostedZoneIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1071,9 +1107,10 @@ pub struct Certificate {
     pub is_default: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct CertificateDeserializer;
 impl CertificateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1114,9 +1151,10 @@ impl CertificateSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CertificateArnDeserializer;
 impl CertificateArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1125,9 +1163,10 @@ impl CertificateArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CertificateListDeserializer;
 impl CertificateListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1164,9 +1203,10 @@ pub struct Cipher {
     pub priority: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct CipherDeserializer;
 impl CipherDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Cipher, XmlParseError> {
         deserialize_elements::<_, Cipher, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -1183,9 +1223,10 @@ impl CipherDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CipherNameDeserializer;
 impl CipherNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1194,9 +1235,10 @@ impl CipherNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CipherPriorityDeserializer;
 impl CipherPriorityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1205,9 +1247,10 @@ impl CipherPriorityDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CiphersDeserializer;
 impl CiphersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1222,9 +1265,10 @@ impl CiphersDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ConditionFieldNameDeserializer;
 impl ConditionFieldNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1290,9 +1334,10 @@ pub struct CreateListenerOutput {
     pub listeners: Option<Vec<Listener>>,
 }
 
+#[allow(dead_code)]
 struct CreateListenerOutputDeserializer;
 impl CreateListenerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1380,9 +1425,10 @@ pub struct CreateLoadBalancerOutput {
     pub load_balancers: Option<Vec<LoadBalancer>>,
 }
 
+#[allow(dead_code)]
 struct CreateLoadBalancerOutputDeserializer;
 impl CreateLoadBalancerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1444,9 +1490,10 @@ pub struct CreateRuleOutput {
     pub rules: Option<Vec<Rule>>,
 }
 
+#[allow(dead_code)]
 struct CreateRuleOutputDeserializer;
 impl CreateRuleOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1571,9 +1618,10 @@ pub struct CreateTargetGroupOutput {
     pub target_groups: Option<Vec<TargetGroup>>,
 }
 
+#[allow(dead_code)]
 struct CreateTargetGroupOutputDeserializer;
 impl CreateTargetGroupOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1595,9 +1643,10 @@ impl CreateTargetGroupOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CreatedTimeDeserializer;
 impl CreatedTimeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1606,9 +1655,10 @@ impl CreatedTimeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DNSNameDeserializer;
 impl DNSNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1617,9 +1667,10 @@ impl DNSNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DefaultDeserializer;
 impl DefaultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1652,9 +1703,10 @@ impl DeleteListenerInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteListenerOutput {}
 
+#[allow(dead_code)]
 struct DeleteListenerOutputDeserializer;
 impl DeleteListenerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1695,9 +1747,10 @@ impl DeleteLoadBalancerInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteLoadBalancerOutput {}
 
+#[allow(dead_code)]
 struct DeleteLoadBalancerOutputDeserializer;
 impl DeleteLoadBalancerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1735,9 +1788,10 @@ impl DeleteRuleInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteRuleOutput {}
 
+#[allow(dead_code)]
 struct DeleteRuleOutputDeserializer;
 impl DeleteRuleOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1778,9 +1832,10 @@ impl DeleteTargetGroupInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteTargetGroupOutput {}
 
+#[allow(dead_code)]
 struct DeleteTargetGroupOutputDeserializer;
 impl DeleteTargetGroupOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1828,9 +1883,10 @@ impl DeregisterTargetsInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeregisterTargetsOutput {}
 
+#[allow(dead_code)]
 struct DeregisterTargetsOutputDeserializer;
 impl DeregisterTargetsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1880,9 +1936,10 @@ pub struct DescribeAccountLimitsOutput {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeAccountLimitsOutputDeserializer;
 impl DescribeAccountLimitsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1947,9 +2004,10 @@ pub struct DescribeListenerCertificatesOutput {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeListenerCertificatesOutputDeserializer;
 impl DescribeListenerCertificatesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2025,9 +2083,10 @@ pub struct DescribeListenersOutput {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeListenersOutputDeserializer;
 impl DescribeListenersOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2083,9 +2142,10 @@ pub struct DescribeLoadBalancerAttributesOutput {
     pub attributes: Option<Vec<LoadBalancerAttribute>>,
 }
 
+#[allow(dead_code)]
 struct DescribeLoadBalancerAttributesOutputDeserializer;
 impl DescribeLoadBalancerAttributesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2161,9 +2221,10 @@ pub struct DescribeLoadBalancersOutput {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeLoadBalancersOutputDeserializer;
 impl DescribeLoadBalancersOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2239,9 +2300,10 @@ pub struct DescribeRulesOutput {
     pub rules: Option<Vec<Rule>>,
 }
 
+#[allow(dead_code)]
 struct DescribeRulesOutputDeserializer;
 impl DescribeRulesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2307,9 +2369,10 @@ pub struct DescribeSSLPoliciesOutput {
     pub ssl_policies: Option<Vec<SslPolicy>>,
 }
 
+#[allow(dead_code)]
 struct DescribeSSLPoliciesOutputDeserializer;
 impl DescribeSSLPoliciesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2366,9 +2429,10 @@ pub struct DescribeTagsOutput {
     pub tag_descriptions: Option<Vec<TagDescription>>,
 }
 
+#[allow(dead_code)]
 struct DescribeTagsOutputDeserializer;
 impl DescribeTagsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2416,9 +2480,10 @@ pub struct DescribeTargetGroupAttributesOutput {
     pub attributes: Option<Vec<TargetGroupAttribute>>,
 }
 
+#[allow(dead_code)]
 struct DescribeTargetGroupAttributesOutputDeserializer;
 impl DescribeTargetGroupAttributesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2499,9 +2564,10 @@ pub struct DescribeTargetGroupsOutput {
     pub target_groups: Option<Vec<TargetGroup>>,
 }
 
+#[allow(dead_code)]
 struct DescribeTargetGroupsOutputDeserializer;
 impl DescribeTargetGroupsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2566,9 +2632,10 @@ pub struct DescribeTargetHealthOutput {
     pub target_health_descriptions: Option<Vec<TargetHealthDescription>>,
 }
 
+#[allow(dead_code)]
 struct DescribeTargetHealthOutputDeserializer;
 impl DescribeTargetHealthOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2593,9 +2660,10 @@ impl DescribeTargetHealthOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DescriptionDeserializer;
 impl DescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2617,9 +2685,10 @@ pub struct FixedResponseActionConfig {
     pub status_code: String,
 }
 
+#[allow(dead_code)]
 struct FixedResponseActionConfigDeserializer;
 impl FixedResponseActionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2676,9 +2745,10 @@ impl FixedResponseActionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FixedResponseActionContentTypeDeserializer;
 impl FixedResponseActionContentTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2687,9 +2757,10 @@ impl FixedResponseActionContentTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FixedResponseActionMessageDeserializer;
 impl FixedResponseActionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2698,9 +2769,10 @@ impl FixedResponseActionMessageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FixedResponseActionStatusCodeDeserializer;
 impl FixedResponseActionStatusCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2720,9 +2792,10 @@ pub struct ForwardActionConfig {
     pub target_groups: Option<Vec<TargetGroupTuple>>,
 }
 
+#[allow(dead_code)]
 struct ForwardActionConfigDeserializer;
 impl ForwardActionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2774,9 +2847,10 @@ impl ForwardActionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthCheckEnabledDeserializer;
 impl HealthCheckEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2785,9 +2859,10 @@ impl HealthCheckEnabledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckIntervalSecondsDeserializer;
 impl HealthCheckIntervalSecondsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2796,9 +2871,10 @@ impl HealthCheckIntervalSecondsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckPortDeserializer;
 impl HealthCheckPortDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2807,9 +2883,10 @@ impl HealthCheckPortDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckThresholdCountDeserializer;
 impl HealthCheckThresholdCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2818,9 +2895,10 @@ impl HealthCheckThresholdCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckTimeoutSecondsDeserializer;
 impl HealthCheckTimeoutSecondsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2838,9 +2916,10 @@ pub struct HostHeaderConditionConfig {
     pub values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct HostHeaderConditionConfigDeserializer;
 impl HostHeaderConditionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2882,9 +2961,10 @@ impl HostHeaderConditionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HttpCodeDeserializer;
 impl HttpCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2904,9 +2984,10 @@ pub struct HttpHeaderConditionConfig {
     pub values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct HttpHeaderConditionConfigDeserializer;
 impl HttpHeaderConditionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2958,9 +3039,10 @@ impl HttpHeaderConditionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HttpHeaderConditionNameDeserializer;
 impl HttpHeaderConditionNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2978,9 +3060,10 @@ pub struct HttpRequestMethodConditionConfig {
     pub values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct HttpRequestMethodConditionConfigDeserializer;
 impl HttpRequestMethodConditionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3022,9 +3105,10 @@ impl HttpRequestMethodConditionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IpAddressDeserializer;
 impl IpAddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3033,9 +3117,10 @@ impl IpAddressDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IpAddressTypeDeserializer;
 impl IpAddressTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3044,9 +3129,10 @@ impl IpAddressTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IsDefaultDeserializer;
 impl IsDefaultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3065,9 +3151,10 @@ pub struct Limit {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LimitDeserializer;
 impl LimitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Limit, XmlParseError> {
         deserialize_elements::<_, Limit, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -3083,9 +3170,10 @@ impl LimitDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LimitsDeserializer;
 impl LimitsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3100,9 +3188,10 @@ impl LimitsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ListOfStringDeserializer;
 impl ListOfStringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3149,9 +3238,10 @@ pub struct Listener {
     pub ssl_policy: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListenerDeserializer;
 impl ListenerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3194,9 +3284,10 @@ impl ListenerDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ListenerArnDeserializer;
 impl ListenerArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3217,9 +3308,10 @@ impl ListenerArnsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ListenersDeserializer;
 impl ListenersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3264,9 +3356,10 @@ pub struct LoadBalancer {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerDeserializer;
 impl LoadBalancerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3349,9 +3442,10 @@ pub struct LoadBalancerAddress {
     pub private_i_pv_4_address: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerAddressDeserializer;
 impl LoadBalancerAddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3379,9 +3473,10 @@ impl LoadBalancerAddressDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerAddressesDeserializer;
 impl LoadBalancerAddressesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3398,9 +3493,10 @@ impl LoadBalancerAddressesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerArnDeserializer;
 impl LoadBalancerArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3409,9 +3505,10 @@ impl LoadBalancerArnDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerArnsDeserializer;
 impl LoadBalancerArnsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3449,9 +3546,10 @@ pub struct LoadBalancerAttribute {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerAttributeDeserializer;
 impl LoadBalancerAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3493,9 +3591,10 @@ impl LoadBalancerAttributeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LoadBalancerAttributeKeyDeserializer;
 impl LoadBalancerAttributeKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3504,9 +3603,10 @@ impl LoadBalancerAttributeKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerAttributeValueDeserializer;
 impl LoadBalancerAttributeValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3515,9 +3615,10 @@ impl LoadBalancerAttributeValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerAttributesDeserializer;
 impl LoadBalancerAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3546,9 +3647,10 @@ impl LoadBalancerAttributesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LoadBalancerNameDeserializer;
 impl LoadBalancerNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3569,9 +3671,10 @@ impl LoadBalancerNamesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LoadBalancerSchemeEnumDeserializer;
 impl LoadBalancerSchemeEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3590,9 +3693,10 @@ pub struct LoadBalancerState {
     pub reason: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoadBalancerStateDeserializer;
 impl LoadBalancerStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3613,9 +3717,10 @@ impl LoadBalancerStateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerStateEnumDeserializer;
 impl LoadBalancerStateEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3624,9 +3729,10 @@ impl LoadBalancerStateEnumDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LoadBalancerTypeEnumDeserializer;
 impl LoadBalancerTypeEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3635,9 +3741,10 @@ impl LoadBalancerTypeEnumDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LoadBalancersDeserializer;
 impl LoadBalancersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3652,9 +3759,10 @@ impl LoadBalancersDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MarkerDeserializer;
 impl MarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3672,9 +3780,10 @@ pub struct Matcher {
     pub http_code: String,
 }
 
+#[allow(dead_code)]
 struct MatcherDeserializer;
 impl MatcherDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3704,9 +3813,10 @@ impl MatcherSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MaxDeserializer;
 impl MaxDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3775,9 +3885,10 @@ pub struct ModifyListenerOutput {
     pub listeners: Option<Vec<Listener>>,
 }
 
+#[allow(dead_code)]
 struct ModifyListenerOutputDeserializer;
 impl ModifyListenerOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3832,9 +3943,10 @@ pub struct ModifyLoadBalancerAttributesOutput {
     pub attributes: Option<Vec<LoadBalancerAttribute>>,
 }
 
+#[allow(dead_code)]
 struct ModifyLoadBalancerAttributesOutputDeserializer;
 impl ModifyLoadBalancerAttributesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3897,9 +4009,10 @@ pub struct ModifyRuleOutput {
     pub rules: Option<Vec<Rule>>,
 }
 
+#[allow(dead_code)]
 struct ModifyRuleOutputDeserializer;
 impl ModifyRuleOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3954,9 +4067,10 @@ pub struct ModifyTargetGroupAttributesOutput {
     pub attributes: Option<Vec<TargetGroupAttribute>>,
 }
 
+#[allow(dead_code)]
 struct ModifyTargetGroupAttributesOutputDeserializer;
 impl ModifyTargetGroupAttributesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4068,9 +4182,10 @@ pub struct ModifyTargetGroupOutput {
     pub target_groups: Option<Vec<TargetGroup>>,
 }
 
+#[allow(dead_code)]
 struct ModifyTargetGroupOutputDeserializer;
 impl ModifyTargetGroupOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4092,9 +4207,10 @@ impl ModifyTargetGroupOutputDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct NameDeserializer;
 impl NameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4103,9 +4219,10 @@ impl NameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PathDeserializer;
 impl PathDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4123,9 +4240,10 @@ pub struct PathPatternConditionConfig {
     pub values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct PathPatternConditionConfigDeserializer;
 impl PathPatternConditionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4167,9 +4285,10 @@ impl PathPatternConditionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PortDeserializer;
 impl PortDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4178,9 +4297,10 @@ impl PortDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PrivateIPv4AddressDeserializer;
 impl PrivateIPv4AddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4189,9 +4309,10 @@ impl PrivateIPv4AddressDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ProtocolEnumDeserializer;
 impl ProtocolEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4209,9 +4330,10 @@ pub struct QueryStringConditionConfig {
     pub values: Option<Vec<QueryStringKeyValuePair>>,
 }
 
+#[allow(dead_code)]
 struct QueryStringConditionConfigDeserializer;
 impl QueryStringConditionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4264,9 +4386,10 @@ pub struct QueryStringKeyValuePair {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct QueryStringKeyValuePairDeserializer;
 impl QueryStringKeyValuePairDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4308,9 +4431,10 @@ impl QueryStringKeyValuePairSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct QueryStringKeyValuePairListDeserializer;
 impl QueryStringKeyValuePairListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4358,9 +4482,10 @@ pub struct RedirectActionConfig {
     pub status_code: String,
 }
 
+#[allow(dead_code)]
 struct RedirectActionConfigDeserializer;
 impl RedirectActionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4425,9 +4550,10 @@ impl RedirectActionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RedirectActionHostDeserializer;
 impl RedirectActionHostDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4436,9 +4562,10 @@ impl RedirectActionHostDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RedirectActionPathDeserializer;
 impl RedirectActionPathDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4447,9 +4574,10 @@ impl RedirectActionPathDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RedirectActionPortDeserializer;
 impl RedirectActionPortDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4458,9 +4586,10 @@ impl RedirectActionPortDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RedirectActionProtocolDeserializer;
 impl RedirectActionProtocolDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4469,9 +4598,10 @@ impl RedirectActionProtocolDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RedirectActionQueryDeserializer;
 impl RedirectActionQueryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4480,9 +4610,10 @@ impl RedirectActionQueryDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RedirectActionStatusCodeEnumDeserializer;
 impl RedirectActionStatusCodeEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4525,9 +4656,10 @@ impl RegisterTargetsInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct RegisterTargetsOutput {}
 
+#[allow(dead_code)]
 struct RegisterTargetsOutputDeserializer;
 impl RegisterTargetsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4572,9 +4704,10 @@ impl RemoveListenerCertificatesInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct RemoveListenerCertificatesOutput {}
 
+#[allow(dead_code)]
 struct RemoveListenerCertificatesOutputDeserializer;
 impl RemoveListenerCertificatesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4619,9 +4752,10 @@ impl RemoveTagsInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct RemoveTagsOutput {}
 
+#[allow(dead_code)]
 struct RemoveTagsOutputDeserializer;
 impl RemoveTagsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4635,9 +4769,10 @@ impl RemoveTagsOutputDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ResourceArnDeserializer;
 impl ResourceArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4674,9 +4809,10 @@ pub struct Rule {
     pub rule_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RuleDeserializer;
 impl RuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Rule, XmlParseError> {
         deserialize_elements::<_, Rule, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -4705,9 +4841,10 @@ impl RuleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RuleArnDeserializer;
 impl RuleArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4751,9 +4888,10 @@ pub struct RuleCondition {
     pub values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct RuleConditionDeserializer;
 impl RuleConditionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4880,9 +5018,10 @@ impl RuleConditionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RuleConditionListDeserializer;
 impl RuleConditionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4948,9 +5087,10 @@ impl RulePriorityPairSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RulesDeserializer;
 impl RulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4965,9 +5105,10 @@ impl RulesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupIdDeserializer;
 impl SecurityGroupIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4976,9 +5117,10 @@ impl SecurityGroupIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SecurityGroupsDeserializer;
 impl SecurityGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5041,9 +5183,10 @@ pub struct SetIpAddressTypeOutput {
     pub ip_address_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SetIpAddressTypeOutputDeserializer;
 impl SetIpAddressTypeOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5093,9 +5236,10 @@ pub struct SetRulePrioritiesOutput {
     pub rules: Option<Vec<Rule>>,
 }
 
+#[allow(dead_code)]
 struct SetRulePrioritiesOutputDeserializer;
 impl SetRulePrioritiesOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5154,9 +5298,10 @@ pub struct SetSecurityGroupsOutput {
     pub security_group_ids: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct SetSecurityGroupsOutputDeserializer;
 impl SetSecurityGroupsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5222,9 +5367,10 @@ pub struct SetSubnetsOutput {
     pub availability_zones: Option<Vec<AvailabilityZone>>,
 }
 
+#[allow(dead_code)]
 struct SetSubnetsOutputDeserializer;
 impl SetSubnetsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5251,9 +5397,10 @@ pub struct SourceIpConditionConfig {
     pub values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct SourceIpConditionConfigDeserializer;
 impl SourceIpConditionConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5295,9 +5442,10 @@ impl SourceIpConditionConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SslPoliciesDeserializer;
 impl SslPoliciesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5324,9 +5472,10 @@ pub struct SslPolicy {
     pub ssl_protocols: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct SslPolicyDeserializer;
 impl SslPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5352,9 +5501,10 @@ impl SslPolicyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SslPolicyNameDeserializer;
 impl SslPolicyNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5375,9 +5525,10 @@ impl SslPolicyNamesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SslProtocolDeserializer;
 impl SslProtocolDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5386,9 +5537,10 @@ impl SslProtocolDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SslProtocolsDeserializer;
 impl SslProtocolsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5403,9 +5555,10 @@ impl SslProtocolsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StateReasonDeserializer;
 impl StateReasonDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5414,9 +5567,10 @@ impl StateReasonDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5425,9 +5579,10 @@ impl StringDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StringValueDeserializer;
 impl StringValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5436,9 +5591,10 @@ impl StringValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SubnetIdDeserializer;
 impl SubnetIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5513,9 +5669,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5558,9 +5715,10 @@ pub struct TagDescription {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct TagDescriptionDeserializer;
 impl TagDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5582,9 +5740,10 @@ impl TagDescriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TagDescriptionsDeserializer;
 impl TagDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5599,9 +5758,10 @@ impl TagDescriptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5622,9 +5782,10 @@ impl TagKeysSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5651,9 +5812,10 @@ impl TagListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5675,9 +5837,10 @@ pub struct TargetDescription {
     pub port: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct TargetDescriptionDeserializer;
 impl TargetDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5771,9 +5934,10 @@ pub struct TargetGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TargetGroupDeserializer;
 impl TargetGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5871,9 +6035,10 @@ impl TargetGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TargetGroupArnDeserializer;
 impl TargetGroupArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5905,9 +6070,10 @@ pub struct TargetGroupAttribute {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TargetGroupAttributeDeserializer;
 impl TargetGroupAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5949,9 +6115,10 @@ impl TargetGroupAttributeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetGroupAttributeKeyDeserializer;
 impl TargetGroupAttributeKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5960,9 +6127,10 @@ impl TargetGroupAttributeKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TargetGroupAttributeValueDeserializer;
 impl TargetGroupAttributeValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5971,9 +6139,10 @@ impl TargetGroupAttributeValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TargetGroupAttributesDeserializer;
 impl TargetGroupAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6002,9 +6171,10 @@ impl TargetGroupAttributesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetGroupListDeserializer;
 impl TargetGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6031,9 +6201,10 @@ impl TargetGroupListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetGroupNameDeserializer;
 impl TargetGroupNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6065,9 +6236,10 @@ pub struct TargetGroupStickinessConfig {
     pub enabled: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct TargetGroupStickinessConfigDeserializer;
 impl TargetGroupStickinessConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6116,9 +6288,10 @@ impl TargetGroupStickinessConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetGroupStickinessDurationSecondsDeserializer;
 impl TargetGroupStickinessDurationSecondsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6127,9 +6300,10 @@ impl TargetGroupStickinessDurationSecondsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TargetGroupStickinessEnabledDeserializer;
 impl TargetGroupStickinessEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6149,9 +6323,10 @@ pub struct TargetGroupTuple {
     pub weight: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct TargetGroupTupleDeserializer;
 impl TargetGroupTupleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6192,9 +6367,10 @@ impl TargetGroupTupleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetGroupWeightDeserializer;
 impl TargetGroupWeightDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6203,9 +6379,10 @@ impl TargetGroupWeightDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TargetGroupsDeserializer;
 impl TargetGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6232,9 +6409,10 @@ pub struct TargetHealth {
     pub state: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TargetHealthDeserializer;
 impl TargetHealthDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6273,9 +6451,10 @@ pub struct TargetHealthDescription {
     pub target_health: Option<TargetHealth>,
 }
 
+#[allow(dead_code)]
 struct TargetHealthDescriptionDeserializer;
 impl TargetHealthDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6308,9 +6487,10 @@ impl TargetHealthDescriptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct TargetHealthDescriptionsDeserializer;
 impl TargetHealthDescriptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6327,9 +6507,10 @@ impl TargetHealthDescriptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TargetHealthReasonEnumDeserializer;
 impl TargetHealthReasonEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6338,9 +6519,10 @@ impl TargetHealthReasonEnumDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TargetHealthStateEnumDeserializer;
 impl TargetHealthStateEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6349,9 +6531,10 @@ impl TargetHealthStateEnumDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TargetIdDeserializer;
 impl TargetIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6360,9 +6543,10 @@ impl TargetIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TargetTypeEnumDeserializer;
 impl TargetTypeEnumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6371,9 +6555,10 @@ impl TargetTypeEnumDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VpcIdDeserializer;
 impl VpcIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6382,9 +6567,10 @@ impl VpcIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ZoneNameDeserializer;
 impl ZoneNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -21358,9 +21358,8 @@ impl Iam for IamClient {
             return Err(CreateAccessKeyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateAccessKeyResponse::default();
         } else {
@@ -21435,9 +21434,8 @@ impl Iam for IamClient {
             return Err(CreateGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateGroupResponse::default();
         } else {
@@ -21481,9 +21479,8 @@ impl Iam for IamClient {
             return Err(CreateInstanceProfileError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateInstanceProfileResponse::default();
         } else {
@@ -21530,9 +21527,8 @@ impl Iam for IamClient {
             return Err(CreateLoginProfileError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateLoginProfileResponse::default();
         } else {
@@ -21580,9 +21576,8 @@ impl Iam for IamClient {
             return Err(CreateOpenIDConnectProviderError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateOpenIDConnectProviderResponse::default();
         } else {
@@ -21629,9 +21624,8 @@ impl Iam for IamClient {
             return Err(CreatePolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreatePolicyResponse::default();
         } else {
@@ -21676,9 +21670,8 @@ impl Iam for IamClient {
             return Err(CreatePolicyVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreatePolicyVersionResponse::default();
         } else {
@@ -21725,9 +21718,8 @@ impl Iam for IamClient {
             return Err(CreateRoleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateRoleResponse::default();
         } else {
@@ -21771,9 +21763,8 @@ impl Iam for IamClient {
             return Err(CreateSAMLProviderError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateSAMLProviderResponse::default();
         } else {
@@ -21820,9 +21811,8 @@ impl Iam for IamClient {
             return Err(CreateServiceLinkedRoleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateServiceLinkedRoleResponse::default();
         } else {
@@ -21874,9 +21864,8 @@ impl Iam for IamClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateServiceSpecificCredentialResponse::default();
         } else {
@@ -21923,9 +21912,8 @@ impl Iam for IamClient {
             return Err(CreateUserError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateUserResponse::default();
         } else {
@@ -21969,9 +21957,8 @@ impl Iam for IamClient {
             return Err(CreateVirtualMFADeviceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateVirtualMFADeviceResponse::default();
         } else {
@@ -22493,9 +22480,8 @@ impl Iam for IamClient {
             return Err(DeleteServiceLinkedRoleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteServiceLinkedRoleResponse::default();
         } else {
@@ -22823,9 +22809,8 @@ impl Iam for IamClient {
             return Err(GenerateCredentialReportError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GenerateCredentialReportResponse::default();
         } else {
@@ -22877,9 +22862,8 @@ impl Iam for IamClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GenerateOrganizationsAccessReportResponse::default();
         } else {
@@ -22931,9 +22915,8 @@ impl Iam for IamClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GenerateServiceLastAccessedDetailsResponse::default();
         } else {
@@ -22980,9 +22963,8 @@ impl Iam for IamClient {
             return Err(GetAccessKeyLastUsedError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAccessKeyLastUsedResponse::default();
         } else {
@@ -23032,9 +23014,8 @@ impl Iam for IamClient {
             return Err(GetAccountAuthorizationDetailsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAccountAuthorizationDetailsResponse::default();
         } else {
@@ -23080,9 +23061,8 @@ impl Iam for IamClient {
             return Err(GetAccountPasswordPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAccountPasswordPolicyResponse::default();
         } else {
@@ -23128,9 +23108,8 @@ impl Iam for IamClient {
             return Err(GetAccountSummaryError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAccountSummaryResponse::default();
         } else {
@@ -23178,9 +23157,8 @@ impl Iam for IamClient {
             return Err(GetContextKeysForCustomPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetContextKeysForPolicyResponse::default();
         } else {
@@ -23230,9 +23208,8 @@ impl Iam for IamClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetContextKeysForPolicyResponse::default();
         } else {
@@ -23278,9 +23255,8 @@ impl Iam for IamClient {
             return Err(GetCredentialReportError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetCredentialReportResponse::default();
         } else {
@@ -23327,9 +23303,8 @@ impl Iam for IamClient {
             return Err(GetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetGroupResponse::default();
         } else {
@@ -23373,9 +23348,8 @@ impl Iam for IamClient {
             return Err(GetGroupPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetGroupPolicyResponse::default();
         } else {
@@ -23422,9 +23396,8 @@ impl Iam for IamClient {
             return Err(GetInstanceProfileError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetInstanceProfileResponse::default();
         } else {
@@ -23471,9 +23444,8 @@ impl Iam for IamClient {
             return Err(GetLoginProfileError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetLoginProfileResponse::default();
         } else {
@@ -23520,9 +23492,8 @@ impl Iam for IamClient {
             return Err(GetOpenIDConnectProviderError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetOpenIDConnectProviderResponse::default();
         } else {
@@ -23570,9 +23541,8 @@ impl Iam for IamClient {
             return Err(GetOrganizationsAccessReportError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetOrganizationsAccessReportResponse::default();
         } else {
@@ -23619,9 +23589,8 @@ impl Iam for IamClient {
             return Err(GetPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetPolicyResponse::default();
         } else {
@@ -23665,9 +23634,8 @@ impl Iam for IamClient {
             return Err(GetPolicyVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetPolicyVersionResponse::default();
         } else {
@@ -23714,9 +23682,8 @@ impl Iam for IamClient {
             return Err(GetRoleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetRoleResponse::default();
         } else {
@@ -23760,9 +23727,8 @@ impl Iam for IamClient {
             return Err(GetRolePolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetRolePolicyResponse::default();
         } else {
@@ -23807,9 +23773,8 @@ impl Iam for IamClient {
             return Err(GetSAMLProviderError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetSAMLProviderResponse::default();
         } else {
@@ -23856,9 +23821,8 @@ impl Iam for IamClient {
             return Err(GetSSHPublicKeyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetSSHPublicKeyResponse::default();
         } else {
@@ -23905,9 +23869,8 @@ impl Iam for IamClient {
             return Err(GetServerCertificateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetServerCertificateResponse::default();
         } else {
@@ -23957,9 +23920,8 @@ impl Iam for IamClient {
             return Err(GetServiceLastAccessedDetailsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetServiceLastAccessedDetailsResponse::default();
         } else {
@@ -24013,9 +23975,8 @@ impl Iam for IamClient {
             return Err(GetServiceLastAccessedDetailsWithEntitiesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetServiceLastAccessedDetailsWithEntitiesResponse::default();
         } else {
@@ -24067,9 +24028,8 @@ impl Iam for IamClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetServiceLinkedRoleDeletionStatusResponse::default();
         } else {
@@ -24116,9 +24076,8 @@ impl Iam for IamClient {
             return Err(GetUserError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetUserResponse::default();
         } else {
@@ -24162,9 +24121,8 @@ impl Iam for IamClient {
             return Err(GetUserPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetUserPolicyResponse::default();
         } else {
@@ -24209,9 +24167,8 @@ impl Iam for IamClient {
             return Err(ListAccessKeysError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListAccessKeysResponse::default();
         } else {
@@ -24258,9 +24215,8 @@ impl Iam for IamClient {
             return Err(ListAccountAliasesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListAccountAliasesResponse::default();
         } else {
@@ -24308,9 +24264,8 @@ impl Iam for IamClient {
             return Err(ListAttachedGroupPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListAttachedGroupPoliciesResponse::default();
         } else {
@@ -24357,9 +24312,8 @@ impl Iam for IamClient {
             return Err(ListAttachedRolePoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListAttachedRolePoliciesResponse::default();
         } else {
@@ -24406,9 +24360,8 @@ impl Iam for IamClient {
             return Err(ListAttachedUserPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListAttachedUserPoliciesResponse::default();
         } else {
@@ -24455,9 +24408,8 @@ impl Iam for IamClient {
             return Err(ListEntitiesForPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListEntitiesForPolicyResponse::default();
         } else {
@@ -24504,9 +24456,8 @@ impl Iam for IamClient {
             return Err(ListGroupPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListGroupPoliciesResponse::default();
         } else {
@@ -24553,9 +24504,8 @@ impl Iam for IamClient {
             return Err(ListGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListGroupsResponse::default();
         } else {
@@ -24599,9 +24549,8 @@ impl Iam for IamClient {
             return Err(ListGroupsForUserError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListGroupsForUserResponse::default();
         } else {
@@ -24648,9 +24597,8 @@ impl Iam for IamClient {
             return Err(ListInstanceProfilesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListInstanceProfilesResponse::default();
         } else {
@@ -24698,9 +24646,8 @@ impl Iam for IamClient {
             return Err(ListInstanceProfilesForRoleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListInstanceProfilesForRoleResponse::default();
         } else {
@@ -24747,9 +24694,8 @@ impl Iam for IamClient {
             return Err(ListMFADevicesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListMFADevicesResponse::default();
         } else {
@@ -24797,9 +24743,8 @@ impl Iam for IamClient {
             return Err(ListOpenIDConnectProvidersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListOpenIDConnectProvidersResponse::default();
         } else {
@@ -24846,9 +24791,8 @@ impl Iam for IamClient {
             return Err(ListPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPoliciesResponse::default();
         } else {
@@ -24898,9 +24842,8 @@ impl Iam for IamClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPoliciesGrantingServiceAccessResponse::default();
         } else {
@@ -24947,9 +24890,8 @@ impl Iam for IamClient {
             return Err(ListPolicyVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPolicyVersionsResponse::default();
         } else {
@@ -24996,9 +24938,8 @@ impl Iam for IamClient {
             return Err(ListRolePoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListRolePoliciesResponse::default();
         } else {
@@ -25045,9 +24986,8 @@ impl Iam for IamClient {
             return Err(ListRoleTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListRoleTagsResponse::default();
         } else {
@@ -25092,9 +25032,8 @@ impl Iam for IamClient {
             return Err(ListRolesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListRolesResponse::default();
         } else {
@@ -25138,9 +25077,8 @@ impl Iam for IamClient {
             return Err(ListSAMLProvidersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListSAMLProvidersResponse::default();
         } else {
@@ -25187,9 +25125,8 @@ impl Iam for IamClient {
             return Err(ListSSHPublicKeysError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListSSHPublicKeysResponse::default();
         } else {
@@ -25236,9 +25173,8 @@ impl Iam for IamClient {
             return Err(ListServerCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListServerCertificatesResponse::default();
         } else {
@@ -25288,9 +25224,8 @@ impl Iam for IamClient {
             return Err(ListServiceSpecificCredentialsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListServiceSpecificCredentialsResponse::default();
         } else {
@@ -25337,9 +25272,8 @@ impl Iam for IamClient {
             return Err(ListSigningCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListSigningCertificatesResponse::default();
         } else {
@@ -25386,9 +25320,8 @@ impl Iam for IamClient {
             return Err(ListUserPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListUserPoliciesResponse::default();
         } else {
@@ -25435,9 +25368,8 @@ impl Iam for IamClient {
             return Err(ListUserTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListUserTagsResponse::default();
         } else {
@@ -25482,9 +25414,8 @@ impl Iam for IamClient {
             return Err(ListUsersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListUsersResponse::default();
         } else {
@@ -25528,9 +25459,8 @@ impl Iam for IamClient {
             return Err(ListVirtualMFADevicesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListVirtualMFADevicesResponse::default();
         } else {
@@ -25810,9 +25740,8 @@ impl Iam for IamClient {
             return Err(ResetServiceSpecificCredentialError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ResetServiceSpecificCredentialResponse::default();
         } else {
@@ -25945,9 +25874,8 @@ impl Iam for IamClient {
             return Err(SimulateCustomPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SimulatePolicyResponse::default();
         } else {
@@ -25994,9 +25922,8 @@ impl Iam for IamClient {
             return Err(SimulatePrincipalPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SimulatePolicyResponse::default();
         } else {
@@ -26313,9 +26240,7 @@ impl Iam for IamClient {
             return Err(UpdateRoleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = UpdateRoleResponse::default();
         // parse non-payload
         Ok(result)
@@ -26345,9 +26270,8 @@ impl Iam for IamClient {
             return Err(UpdateRoleDescriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateRoleDescriptionResponse::default();
         } else {
@@ -26394,9 +26318,8 @@ impl Iam for IamClient {
             return Err(UpdateSAMLProviderError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateSAMLProviderResponse::default();
         } else {
@@ -26585,9 +26508,8 @@ impl Iam for IamClient {
             return Err(UploadSSHPublicKeyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UploadSSHPublicKeyResponse::default();
         } else {
@@ -26634,9 +26556,8 @@ impl Iam for IamClient {
             return Err(UploadServerCertificateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UploadServerCertificateResponse::default();
         } else {
@@ -26683,9 +26604,8 @@ impl Iam for IamClient {
             return Err(UploadSigningCertificateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UploadSigningCertificateResponse::default();
         } else {

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -54,9 +54,10 @@ pub struct AccessDetail {
     pub total_authenticated_entities: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct AccessDetailDeserializer;
 impl AccessDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -98,9 +99,10 @@ impl AccessDetailDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccessDetailsDeserializer;
 impl AccessDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -131,9 +133,10 @@ pub struct AccessKey {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct AccessKeyDeserializer;
 impl AccessKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -163,9 +166,10 @@ impl AccessKeyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccessKeyIdTypeDeserializer;
 impl AccessKeyIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -186,9 +190,10 @@ pub struct AccessKeyLastUsed {
     pub service_name: String,
 }
 
+#[allow(dead_code)]
 struct AccessKeyLastUsedDeserializer;
 impl AccessKeyLastUsedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -224,9 +229,10 @@ pub struct AccessKeyMetadata {
     pub user_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AccessKeyMetadataDeserializer;
 impl AccessKeyMetadataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -254,9 +260,10 @@ impl AccessKeyMetadataDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccessKeyMetadataListTypeDeserializer;
 impl AccessKeyMetadataListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -271,9 +278,10 @@ impl AccessKeyMetadataListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccessKeySecretTypeDeserializer;
 impl AccessKeySecretTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -282,9 +290,10 @@ impl AccessKeySecretTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccountAliasListTypeDeserializer;
 impl AccountAliasListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -299,9 +308,10 @@ impl AccountAliasListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccountAliasTypeDeserializer;
 impl AccountAliasTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -322,9 +332,10 @@ impl ActionNameListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ActionNameTypeDeserializer;
 impl ActionNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -408,9 +419,10 @@ impl AddUserToGroupRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ArnListTypeDeserializer;
 impl ArnListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -425,9 +437,10 @@ impl ArnListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ArnTypeDeserializer;
 impl ArnTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -515,9 +528,10 @@ pub struct AttachedPermissionsBoundary {
     pub permissions_boundary_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AttachedPermissionsBoundaryDeserializer;
 impl AttachedPermissionsBoundaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -547,9 +561,10 @@ impl AttachedPermissionsBoundaryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AttachedPoliciesListTypeDeserializer;
 impl AttachedPoliciesListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -573,9 +588,10 @@ pub struct AttachedPolicy {
     pub policy_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AttachedPolicyDeserializer;
 impl AttachedPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -597,9 +613,10 @@ impl AttachedPolicyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AttachmentCountTypeDeserializer;
 impl AttachmentCountTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -608,9 +625,10 @@ impl AttachmentCountTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanObjectTypeDeserializer;
 impl BooleanObjectTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -619,9 +637,10 @@ impl BooleanObjectTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanTypeDeserializer;
 impl BooleanTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -630,9 +649,10 @@ impl BooleanTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BootstrapDatumDeserializer;
 impl BootstrapDatumDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -644,9 +664,10 @@ impl BootstrapDatumDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CertificateBodyTypeDeserializer;
 impl CertificateBodyTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -655,9 +676,10 @@ impl CertificateBodyTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CertificateChainTypeDeserializer;
 impl CertificateChainTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -666,9 +688,10 @@ impl CertificateChainTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CertificateIdTypeDeserializer;
 impl CertificateIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -677,9 +700,10 @@ impl CertificateIdTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CertificateListTypeDeserializer;
 impl CertificateListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -719,9 +743,10 @@ impl ChangePasswordRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ClientIDListTypeDeserializer;
 impl ClientIDListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -748,9 +773,10 @@ impl ClientIDListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ClientIDTypeDeserializer;
 impl ClientIDTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -759,9 +785,10 @@ impl ClientIDTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ColumnNumberDeserializer;
 impl ColumnNumberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -818,9 +845,10 @@ impl ContextEntryListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ContextKeyNameTypeDeserializer;
 impl ContextKeyNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -829,9 +857,10 @@ impl ContextKeyNameTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ContextKeyNamesResultListTypeDeserializer;
 impl ContextKeyNamesResultListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -890,9 +919,10 @@ pub struct CreateAccessKeyResponse {
     pub access_key: AccessKey,
 }
 
+#[allow(dead_code)]
 struct CreateAccessKeyResponseDeserializer;
 impl CreateAccessKeyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -965,9 +995,10 @@ pub struct CreateGroupResponse {
     pub group: Group,
 }
 
+#[allow(dead_code)]
 struct CreateGroupResponseDeserializer;
 impl CreateGroupResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1019,9 +1050,10 @@ pub struct CreateInstanceProfileResponse {
     pub instance_profile: InstanceProfile,
 }
 
+#[allow(dead_code)]
 struct CreateInstanceProfileResponseDeserializer;
 impl CreateInstanceProfileResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1081,9 +1113,10 @@ pub struct CreateLoginProfileResponse {
     pub login_profile: LoginProfile,
 }
 
+#[allow(dead_code)]
 struct CreateLoginProfileResponseDeserializer;
 impl CreateLoginProfileResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1148,9 +1181,10 @@ pub struct CreateOpenIDConnectProviderResponse {
     pub open_id_connect_provider_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateOpenIDConnectProviderResponseDeserializer;
 impl CreateOpenIDConnectProviderResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1217,9 +1251,10 @@ pub struct CreatePolicyResponse {
     pub policy: Option<Policy>,
 }
 
+#[allow(dead_code)]
 struct CreatePolicyResponseDeserializer;
 impl CreatePolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1274,9 +1309,10 @@ pub struct CreatePolicyVersionResponse {
     pub policy_version: Option<PolicyVersion>,
 }
 
+#[allow(dead_code)]
 struct CreatePolicyVersionResponseDeserializer;
 impl CreatePolicyVersionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1361,9 +1397,10 @@ pub struct CreateRoleResponse {
     pub role: Role,
 }
 
+#[allow(dead_code)]
 struct CreateRoleResponseDeserializer;
 impl CreateRoleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1413,9 +1450,10 @@ pub struct CreateSAMLProviderResponse {
     pub saml_provider_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateSAMLProviderResponseDeserializer;
 impl CreateSAMLProviderResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1476,9 +1514,10 @@ pub struct CreateServiceLinkedRoleResponse {
     pub role: Option<Role>,
 }
 
+#[allow(dead_code)]
 struct CreateServiceLinkedRoleResponseDeserializer;
 impl CreateServiceLinkedRoleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1528,9 +1567,10 @@ pub struct CreateServiceSpecificCredentialResponse {
     pub service_specific_credential: Option<ServiceSpecificCredential>,
 }
 
+#[allow(dead_code)]
 struct CreateServiceSpecificCredentialResponseDeserializer;
 impl CreateServiceSpecificCredentialResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1600,9 +1640,10 @@ pub struct CreateUserResponse {
     pub user: Option<User>,
 }
 
+#[allow(dead_code)]
 struct CreateUserResponseDeserializer;
 impl CreateUserResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1654,9 +1695,10 @@ pub struct CreateVirtualMFADeviceResponse {
     pub virtual_mfa_device: VirtualMFADevice,
 }
 
+#[allow(dead_code)]
 struct CreateVirtualMFADeviceResponseDeserializer;
 impl CreateVirtualMFADeviceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1677,9 +1719,10 @@ impl CreateVirtualMFADeviceResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DateTypeDeserializer;
 impl DateTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2070,9 +2113,10 @@ pub struct DeleteServiceLinkedRoleResponse {
     pub deletion_task_id: String,
 }
 
+#[allow(dead_code)]
 struct DeleteServiceLinkedRoleResponseDeserializer;
 impl DeleteServiceLinkedRoleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2242,9 +2286,10 @@ pub struct DeletionTaskFailureReasonType {
     pub role_usage_list: Option<Vec<RoleUsageType>>,
 }
 
+#[allow(dead_code)]
 struct DeletionTaskFailureReasonTypeDeserializer;
 impl DeletionTaskFailureReasonTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2269,9 +2314,10 @@ impl DeletionTaskFailureReasonTypeDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DeletionTaskIdTypeDeserializer;
 impl DeletionTaskIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2280,9 +2326,10 @@ impl DeletionTaskIdTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DeletionTaskStatusTypeDeserializer;
 impl DeletionTaskStatusTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2405,9 +2452,10 @@ pub struct EntityDetails {
     pub last_authenticated: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EntityDetailsDeserializer;
 impl EntityDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2429,9 +2477,10 @@ impl EntityDetailsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EntityDetailsListTypeDeserializer;
 impl EntityDetailsListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2461,9 +2510,10 @@ pub struct EntityInfo {
     pub type_: String,
 }
 
+#[allow(dead_code)]
 struct EntityInfoDeserializer;
 impl EntityInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2503,9 +2553,10 @@ impl EntityListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EntityNameTypeDeserializer;
 impl EntityNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2524,9 +2575,10 @@ pub struct ErrorDetails {
     pub message: String,
 }
 
+#[allow(dead_code)]
 struct ErrorDetailsDeserializer;
 impl ErrorDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2545,9 +2597,10 @@ impl ErrorDetailsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EvalDecisionDetailsTypeDeserializer;
 impl EvalDecisionDetailsTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2568,9 +2621,10 @@ impl EvalDecisionDetailsTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EvalDecisionSourceTypeDeserializer;
 impl EvalDecisionSourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2603,9 +2657,10 @@ pub struct EvaluationResult {
     pub resource_specific_results: Option<Vec<ResourceSpecificResult>>,
 }
 
+#[allow(dead_code)]
 struct EvaluationResultDeserializer;
 impl EvaluationResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2676,9 +2731,10 @@ impl EvaluationResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EvaluationResultsListTypeDeserializer;
 impl EvaluationResultsListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2693,9 +2749,10 @@ impl EvaluationResultsListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ExistingUserNameTypeDeserializer;
 impl ExistingUserNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2714,9 +2771,10 @@ pub struct GenerateCredentialReportResponse {
     pub state: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GenerateCredentialReportResponseDeserializer;
 impl GenerateCredentialReportResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2778,9 +2836,10 @@ pub struct GenerateOrganizationsAccessReportResponse {
     pub job_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GenerateOrganizationsAccessReportResponseDeserializer;
 impl GenerateOrganizationsAccessReportResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2827,9 +2886,10 @@ pub struct GenerateServiceLastAccessedDetailsResponse {
     pub job_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GenerateServiceLastAccessedDetailsResponseDeserializer;
 impl GenerateServiceLastAccessedDetailsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2879,9 +2939,10 @@ pub struct GetAccessKeyLastUsedResponse {
     pub user_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetAccessKeyLastUsedResponseDeserializer;
 impl GetAccessKeyLastUsedResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2962,9 +3023,10 @@ pub struct GetAccountAuthorizationDetailsResponse {
     pub user_detail_list: Option<Vec<UserDetail>>,
 }
 
+#[allow(dead_code)]
 struct GetAccountAuthorizationDetailsResponseDeserializer;
 impl GetAccountAuthorizationDetailsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3020,9 +3082,10 @@ pub struct GetAccountPasswordPolicyResponse {
     pub password_policy: PasswordPolicy,
 }
 
+#[allow(dead_code)]
 struct GetAccountPasswordPolicyResponseDeserializer;
 impl GetAccountPasswordPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3051,9 +3114,10 @@ pub struct GetAccountSummaryResponse {
     pub summary_map: Option<::std::collections::HashMap<String, i64>>,
 }
 
+#[allow(dead_code)]
 struct GetAccountSummaryResponseDeserializer;
 impl GetAccountSummaryResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3108,9 +3172,10 @@ pub struct GetContextKeysForPolicyResponse {
     pub context_key_names: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct GetContextKeysForPolicyResponseDeserializer;
 impl GetContextKeysForPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3179,9 +3244,10 @@ pub struct GetCredentialReportResponse {
     pub report_format: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetCredentialReportResponseDeserializer;
 impl GetCredentialReportResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3248,9 +3314,10 @@ pub struct GetGroupPolicyResponse {
     pub policy_name: String,
 }
 
+#[allow(dead_code)]
 struct GetGroupPolicyResponseDeserializer;
 impl GetGroupPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3317,9 +3384,10 @@ pub struct GetGroupResponse {
     pub users: Vec<User>,
 }
 
+#[allow(dead_code)]
 struct GetGroupResponseDeserializer;
 impl GetGroupResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3379,9 +3447,10 @@ pub struct GetInstanceProfileResponse {
     pub instance_profile: InstanceProfile,
 }
 
+#[allow(dead_code)]
 struct GetInstanceProfileResponseDeserializer;
 impl GetInstanceProfileResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3430,9 +3499,10 @@ pub struct GetLoginProfileResponse {
     pub login_profile: LoginProfile,
 }
 
+#[allow(dead_code)]
 struct GetLoginProfileResponseDeserializer;
 impl GetLoginProfileResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3490,9 +3560,10 @@ pub struct GetOpenIDConnectProviderResponse {
     pub url: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetOpenIDConnectProviderResponseDeserializer;
 impl GetOpenIDConnectProviderResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3585,9 +3656,10 @@ pub struct GetOrganizationsAccessReportResponse {
     pub number_of_services_not_accessed: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct GetOrganizationsAccessReportResponseDeserializer;
 impl GetOrganizationsAccessReportResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3678,9 +3750,10 @@ pub struct GetPolicyResponse {
     pub policy: Option<Policy>,
 }
 
+#[allow(dead_code)]
 struct GetPolicyResponseDeserializer;
 impl GetPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3727,9 +3800,10 @@ pub struct GetPolicyVersionResponse {
     pub policy_version: Option<PolicyVersion>,
 }
 
+#[allow(dead_code)]
 struct GetPolicyVersionResponseDeserializer;
 impl GetPolicyVersionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3787,9 +3861,10 @@ pub struct GetRolePolicyResponse {
     pub role_name: String,
 }
 
+#[allow(dead_code)]
 struct GetRolePolicyResponseDeserializer;
 impl GetRolePolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3840,9 +3915,10 @@ pub struct GetRoleResponse {
     pub role: Role,
 }
 
+#[allow(dead_code)]
 struct GetRoleResponseDeserializer;
 impl GetRoleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3893,9 +3969,10 @@ pub struct GetSAMLProviderResponse {
     pub valid_until: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetSAMLProviderResponseDeserializer;
 impl GetSAMLProviderResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3964,9 +4041,10 @@ pub struct GetSSHPublicKeyResponse {
     pub ssh_public_key: Option<SSHPublicKey>,
 }
 
+#[allow(dead_code)]
 struct GetSSHPublicKeyResponseDeserializer;
 impl GetSSHPublicKeyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4020,9 +4098,10 @@ pub struct GetServerCertificateResponse {
     pub server_certificate: ServerCertificate,
 }
 
+#[allow(dead_code)]
 struct GetServerCertificateResponseDeserializer;
 impl GetServerCertificateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4092,9 +4171,10 @@ pub struct GetServiceLastAccessedDetailsResponse {
     pub services_last_accessed: Vec<ServiceLastAccessed>,
 }
 
+#[allow(dead_code)]
 struct GetServiceLastAccessedDetailsResponseDeserializer;
 impl GetServiceLastAccessedDetailsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4202,9 +4282,10 @@ pub struct GetServiceLastAccessedDetailsWithEntitiesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetServiceLastAccessedDetailsWithEntitiesResponseDeserializer;
 impl GetServiceLastAccessedDetailsWithEntitiesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4285,9 +4366,10 @@ pub struct GetServiceLinkedRoleDeletionStatusResponse {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct GetServiceLinkedRoleDeletionStatusResponseDeserializer;
 impl GetServiceLinkedRoleDeletionStatusResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4348,9 +4430,10 @@ pub struct GetUserPolicyResponse {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct GetUserPolicyResponseDeserializer;
 impl GetUserPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4404,9 +4487,10 @@ pub struct GetUserResponse {
     pub user: User,
 }
 
+#[allow(dead_code)]
 struct GetUserResponseDeserializer;
 impl GetUserResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4438,9 +4522,10 @@ pub struct Group {
     pub path: String,
 }
 
+#[allow(dead_code)]
 struct GroupDeserializer;
 impl GroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Group, XmlParseError> {
         deserialize_elements::<_, Group, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -4484,9 +4569,10 @@ pub struct GroupDetail {
     pub path: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GroupDetailDeserializer;
 impl GroupDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4528,9 +4614,10 @@ impl GroupDetailDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GroupDetailListTypeDeserializer;
 impl GroupDetailListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4545,9 +4632,10 @@ impl GroupDetailListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GroupListTypeDeserializer;
 impl GroupListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4562,9 +4650,10 @@ impl GroupListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GroupNameListTypeDeserializer;
 impl GroupNameListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4579,9 +4668,10 @@ impl GroupNameListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GroupNameTypeDeserializer;
 impl GroupNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4590,9 +4680,10 @@ impl GroupNameTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IdTypeDeserializer;
 impl IdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4619,9 +4710,10 @@ pub struct InstanceProfile {
     pub roles: Vec<Role>,
 }
 
+#[allow(dead_code)]
 struct InstanceProfileDeserializer;
 impl InstanceProfileDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4657,9 +4749,10 @@ impl InstanceProfileDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InstanceProfileListTypeDeserializer;
 impl InstanceProfileListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4674,9 +4767,10 @@ impl InstanceProfileListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct InstanceProfileNameTypeDeserializer;
 impl InstanceProfileNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4685,9 +4779,10 @@ impl InstanceProfileNameTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IntegerTypeDeserializer;
 impl IntegerTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4696,9 +4791,10 @@ impl IntegerTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct JobIDTypeDeserializer;
 impl JobIDTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4707,9 +4803,10 @@ impl JobIDTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct JobStatusTypeDeserializer;
 impl JobStatusTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4718,9 +4815,10 @@ impl JobStatusTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LineNumberDeserializer;
 impl LineNumberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4773,9 +4871,10 @@ pub struct ListAccessKeysResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListAccessKeysResponseDeserializer;
 impl ListAccessKeysResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4844,9 +4943,10 @@ pub struct ListAccountAliasesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListAccountAliasesResponseDeserializer;
 impl ListAccountAliasesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4926,9 +5026,10 @@ pub struct ListAttachedGroupPoliciesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListAttachedGroupPoliciesResponseDeserializer;
 impl ListAttachedGroupPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5009,9 +5110,10 @@ pub struct ListAttachedRolePoliciesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListAttachedRolePoliciesResponseDeserializer;
 impl ListAttachedRolePoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5092,9 +5194,10 @@ pub struct ListAttachedUserPoliciesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListAttachedUserPoliciesResponseDeserializer;
 impl ListAttachedUserPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5189,9 +5292,10 @@ pub struct ListEntitiesForPolicyResponse {
     pub policy_users: Option<Vec<PolicyUser>>,
 }
 
+#[allow(dead_code)]
 struct ListEntitiesForPolicyResponseDeserializer;
 impl ListEntitiesForPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5274,9 +5378,10 @@ pub struct ListGroupPoliciesResponse {
     pub policy_names: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct ListGroupPoliciesResponseDeserializer;
 impl ListGroupPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5351,9 +5456,10 @@ pub struct ListGroupsForUserResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListGroupsForUserResponseDeserializer;
 impl ListGroupsForUserResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5427,9 +5533,10 @@ pub struct ListGroupsResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListGroupsResponseDeserializer;
 impl ListGroupsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5497,9 +5604,10 @@ pub struct ListInstanceProfilesForRoleResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListInstanceProfilesForRoleResponseDeserializer;
 impl ListInstanceProfilesForRoleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5577,9 +5685,10 @@ pub struct ListInstanceProfilesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListInstanceProfilesResponseDeserializer;
 impl ListInstanceProfilesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5657,9 +5766,10 @@ pub struct ListMFADevicesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListMFADevicesResponseDeserializer;
 impl ListMFADevicesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5711,9 +5821,10 @@ pub struct ListOpenIDConnectProvidersResponse {
     pub open_id_connect_provider_list: Option<Vec<OpenIDConnectProviderListEntry>>,
 }
 
+#[allow(dead_code)]
 struct ListOpenIDConnectProvidersResponseDeserializer;
 impl ListOpenIDConnectProvidersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5748,9 +5859,10 @@ pub struct ListPoliciesGrantingServiceAccessEntry {
     pub service_namespace: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListPoliciesGrantingServiceAccessEntryDeserializer;
 impl ListPoliciesGrantingServiceAccessEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5824,9 +5936,10 @@ pub struct ListPoliciesGrantingServiceAccessResponse {
     pub policies_granting_service_access: Vec<ListPoliciesGrantingServiceAccessEntry>,
 }
 
+#[allow(dead_code)]
 struct ListPoliciesGrantingServiceAccessResponseDeserializer;
 impl ListPoliciesGrantingServiceAccessResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5914,9 +6027,10 @@ pub struct ListPoliciesResponse {
     pub policies: Option<Vec<Policy>>,
 }
 
+#[allow(dead_code)]
 struct ListPoliciesResponseDeserializer;
 impl ListPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5943,9 +6057,10 @@ impl ListPoliciesResponseDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ListPolicyGrantingServiceAccessResponseListTypeDeserializer;
 impl ListPolicyGrantingServiceAccessResponseListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6006,9 +6121,10 @@ pub struct ListPolicyVersionsResponse {
     pub versions: Option<Vec<PolicyVersion>>,
 }
 
+#[allow(dead_code)]
 struct ListPolicyVersionsResponseDeserializer;
 impl ListPolicyVersionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6083,9 +6199,10 @@ pub struct ListRolePoliciesResponse {
     pub policy_names: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct ListRolePoliciesResponseDeserializer;
 impl ListRolePoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6159,9 +6276,10 @@ pub struct ListRoleTagsResponse {
     pub tags: Vec<Tag>,
 }
 
+#[allow(dead_code)]
 struct ListRoleTagsResponseDeserializer;
 impl ListRoleTagsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6231,9 +6349,10 @@ pub struct ListRolesResponse {
     pub roles: Vec<Role>,
 }
 
+#[allow(dead_code)]
 struct ListRolesResponseDeserializer;
 impl ListRolesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6282,9 +6401,10 @@ pub struct ListSAMLProvidersResponse {
     pub saml_provider_list: Option<Vec<SAMLProviderListEntry>>,
 }
 
+#[allow(dead_code)]
 struct ListSAMLProvidersResponseDeserializer;
 impl ListSAMLProvidersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6353,9 +6473,10 @@ pub struct ListSSHPublicKeysResponse {
     pub ssh_public_keys: Option<Vec<SSHPublicKeyMetadata>>,
 }
 
+#[allow(dead_code)]
 struct ListSSHPublicKeysResponseDeserializer;
 impl ListSSHPublicKeysResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6430,9 +6551,10 @@ pub struct ListServerCertificatesResponse {
     pub server_certificate_metadata_list: Vec<ServerCertificateMetadata>,
 }
 
+#[allow(dead_code)]
 struct ListServerCertificatesResponseDeserializer;
 impl ListServerCertificatesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6500,9 +6622,10 @@ pub struct ListServiceSpecificCredentialsResponse {
     pub service_specific_credentials: Option<Vec<ServiceSpecificCredentialMetadata>>,
 }
 
+#[allow(dead_code)]
 struct ListServiceSpecificCredentialsResponseDeserializer;
 impl ListServiceSpecificCredentialsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6571,9 +6694,10 @@ pub struct ListSigningCertificatesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListSigningCertificatesResponseDeserializer;
 impl ListSigningCertificatesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6648,9 +6772,10 @@ pub struct ListUserPoliciesResponse {
     pub policy_names: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct ListUserPoliciesResponseDeserializer;
 impl ListUserPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6724,9 +6849,10 @@ pub struct ListUserTagsResponse {
     pub tags: Vec<Tag>,
 }
 
+#[allow(dead_code)]
 struct ListUserTagsResponseDeserializer;
 impl ListUserTagsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6796,9 +6922,10 @@ pub struct ListUsersResponse {
     pub users: Vec<User>,
 }
 
+#[allow(dead_code)]
 struct ListUsersResponseDeserializer;
 impl ListUsersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6868,9 +6995,10 @@ pub struct ListVirtualMFADevicesResponse {
     pub virtual_mfa_devices: Vec<VirtualMFADevice>,
 }
 
+#[allow(dead_code)]
 struct ListVirtualMFADevicesResponseDeserializer;
 impl ListVirtualMFADevicesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6916,9 +7044,10 @@ pub struct LoginProfile {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct LoginProfileDeserializer;
 impl LoginProfileDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6955,9 +7084,10 @@ pub struct MFADevice {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct MFADeviceDeserializer;
 impl MFADeviceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7009,9 +7139,10 @@ pub struct ManagedPolicyDetail {
     pub update_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ManagedPolicyDetailDeserializer;
 impl ManagedPolicyDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7082,9 +7213,10 @@ impl ManagedPolicyDetailDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ManagedPolicyDetailListTypeDeserializer;
 impl ManagedPolicyDetailListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7101,9 +7233,10 @@ impl ManagedPolicyDetailListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MarkerTypeDeserializer;
 impl MarkerTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7112,9 +7245,10 @@ impl MarkerTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaxPasswordAgeTypeDeserializer;
 impl MaxPasswordAgeTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -7123,9 +7257,10 @@ impl MaxPasswordAgeTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MfaDeviceListTypeDeserializer;
 impl MfaDeviceListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7140,9 +7275,10 @@ impl MfaDeviceListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MinimumPasswordLengthTypeDeserializer;
 impl MinimumPasswordLengthTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -7158,9 +7294,10 @@ pub struct OpenIDConnectProviderListEntry {
     pub arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OpenIDConnectProviderListEntryDeserializer;
 impl OpenIDConnectProviderListEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7180,9 +7317,10 @@ impl OpenIDConnectProviderListEntryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct OpenIDConnectProviderListTypeDeserializer;
 impl OpenIDConnectProviderListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7199,9 +7337,10 @@ impl OpenIDConnectProviderListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OpenIDConnectProviderUrlTypeDeserializer;
 impl OpenIDConnectProviderUrlTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7218,9 +7357,10 @@ pub struct OrganizationsDecisionDetail {
     pub allowed_by_organizations: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct OrganizationsDecisionDetailDeserializer;
 impl OrganizationsDecisionDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7243,9 +7383,10 @@ impl OrganizationsDecisionDetailDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct OrganizationsEntityPathTypeDeserializer;
 impl OrganizationsEntityPathTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7280,9 +7421,10 @@ pub struct PasswordPolicy {
     pub require_uppercase_characters: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct PasswordPolicyDeserializer;
 impl PasswordPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7356,9 +7498,10 @@ impl PasswordPolicyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PasswordReusePreventionTypeDeserializer;
 impl PasswordReusePreventionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -7367,9 +7510,10 @@ impl PasswordReusePreventionTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PathTypeDeserializer;
 impl PathTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7378,9 +7522,10 @@ impl PathTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PermissionsBoundaryAttachmentTypeDeserializer;
 impl PermissionsBoundaryAttachmentTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7397,9 +7542,10 @@ pub struct PermissionsBoundaryDecisionDetail {
     pub allowed_by_permissions_boundary: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct PermissionsBoundaryDecisionDetailDeserializer;
 impl PermissionsBoundaryDecisionDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7450,9 +7596,10 @@ pub struct Policy {
     pub update_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyDeserializer;
 impl PolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Policy, XmlParseError> {
         deserialize_elements::<_, Policy, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7512,9 +7659,10 @@ impl PolicyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyDescriptionTypeDeserializer;
 impl PolicyDescriptionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7533,9 +7681,10 @@ pub struct PolicyDetail {
     pub policy_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyDetailDeserializer;
 impl PolicyDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7560,9 +7709,10 @@ impl PolicyDetailDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyDetailListTypeDeserializer;
 impl PolicyDetailListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7577,9 +7727,10 @@ impl PolicyDetailListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyDocumentTypeDeserializer;
 impl PolicyDocumentTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = rusoto_core::signature::decode_uri(&characters(stack)?);
@@ -7588,9 +7739,10 @@ impl PolicyDocumentTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyDocumentVersionListTypeDeserializer;
 impl PolicyDocumentVersionListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7605,9 +7757,10 @@ impl PolicyDocumentVersionListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyEvaluationDecisionTypeDeserializer;
 impl PolicyEvaluationDecisionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7631,9 +7784,10 @@ pub struct PolicyGrantingServiceAccess {
     pub policy_type: String,
 }
 
+#[allow(dead_code)]
 struct PolicyGrantingServiceAccessDeserializer;
 impl PolicyGrantingServiceAccessDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7673,9 +7827,10 @@ impl PolicyGrantingServiceAccessDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PolicyGrantingServiceAccessListTypeDeserializer;
 impl PolicyGrantingServiceAccessListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7702,9 +7857,10 @@ pub struct PolicyGroup {
     pub group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyGroupDeserializer;
 impl PolicyGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7724,9 +7880,10 @@ impl PolicyGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyGroupListTypeDeserializer;
 impl PolicyGroupListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7741,9 +7898,10 @@ impl PolicyGroupListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyIdentifierTypeDeserializer;
 impl PolicyIdentifierTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7752,9 +7910,10 @@ impl PolicyIdentifierTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyListTypeDeserializer;
 impl PolicyListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7769,9 +7928,10 @@ impl PolicyListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyNameListTypeDeserializer;
 impl PolicyNameListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7786,9 +7946,10 @@ impl PolicyNameListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyNameTypeDeserializer;
 impl PolicyNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7797,9 +7958,10 @@ impl PolicyNameTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyOwnerEntityTypeDeserializer;
 impl PolicyOwnerEntityTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7808,9 +7970,10 @@ impl PolicyOwnerEntityTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyPathTypeDeserializer;
 impl PolicyPathTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7829,9 +7992,10 @@ pub struct PolicyRole {
     pub role_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyRoleDeserializer;
 impl PolicyRoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7850,9 +8014,10 @@ impl PolicyRoleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyRoleListTypeDeserializer;
 impl PolicyRoleListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7867,9 +8032,10 @@ impl PolicyRoleListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicySourceTypeDeserializer;
 impl PolicySourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7878,9 +8044,10 @@ impl PolicySourceTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyTypeDeserializer;
 impl PolicyTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7899,9 +8066,10 @@ pub struct PolicyUser {
     pub user_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyUserDeserializer;
 impl PolicyUserDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7920,9 +8088,10 @@ impl PolicyUserDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyUserListTypeDeserializer;
 impl PolicyUserListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7951,9 +8120,10 @@ pub struct PolicyVersion {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PolicyVersionDeserializer;
 impl PolicyVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7986,9 +8156,10 @@ impl PolicyVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PolicyVersionIdTypeDeserializer;
 impl PolicyVersionIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8007,9 +8178,10 @@ pub struct Position {
     pub line: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct PositionDeserializer;
 impl PositionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8028,9 +8200,10 @@ impl PositionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PublicKeyFingerprintTypeDeserializer;
 impl PublicKeyFingerprintTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8039,9 +8212,10 @@ impl PublicKeyFingerprintTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PublicKeyIdTypeDeserializer;
 impl PublicKeyIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8050,9 +8224,10 @@ impl PublicKeyIdTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PublicKeyMaterialTypeDeserializer;
 impl PublicKeyMaterialTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8200,9 +8375,10 @@ impl PutUserPolicyRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReasonTypeDeserializer;
 impl ReasonTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8211,9 +8387,10 @@ impl ReasonTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RegionNameTypeDeserializer;
 impl RegionNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8301,9 +8478,10 @@ impl RemoveUserFromGroupRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReportContentTypeDeserializer;
 impl ReportContentTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8315,9 +8493,10 @@ impl ReportContentTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReportFormatTypeDeserializer;
 impl ReportFormatTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8326,9 +8505,10 @@ impl ReportFormatTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReportStateDescriptionTypeDeserializer;
 impl ReportStateDescriptionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8337,9 +8517,10 @@ impl ReportStateDescriptionTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReportStateTypeDeserializer;
 impl ReportStateTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8383,9 +8564,10 @@ pub struct ResetServiceSpecificCredentialResponse {
     pub service_specific_credential: Option<ServiceSpecificCredential>,
 }
 
+#[allow(dead_code)]
 struct ResetServiceSpecificCredentialResponseDeserializer;
 impl ResetServiceSpecificCredentialResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8421,9 +8603,10 @@ impl ResourceNameListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceNameTypeDeserializer;
 impl ResourceNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8450,9 +8633,10 @@ pub struct ResourceSpecificResult {
     pub permissions_boundary_decision_detail: Option<PermissionsBoundaryDecisionDetail>,
 }
 
+#[allow(dead_code)]
 struct ResourceSpecificResultDeserializer;
 impl ResourceSpecificResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8503,9 +8687,10 @@ impl ResourceSpecificResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ResourceSpecificResultListTypeDeserializer;
 impl ResourceSpecificResultListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8522,9 +8707,10 @@ impl ResourceSpecificResultListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ResponseMarkerTypeDeserializer;
 impl ResponseMarkerTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8596,9 +8782,10 @@ pub struct Role {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct RoleDeserializer;
 impl RoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Role, XmlParseError> {
         deserialize_elements::<_, Role, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -8661,9 +8848,10 @@ impl RoleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RoleDescriptionTypeDeserializer;
 impl RoleDescriptionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8701,9 +8889,10 @@ pub struct RoleDetail {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct RoleDetailDeserializer;
 impl RoleDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8777,9 +8966,10 @@ impl RoleDetailDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RoleDetailListTypeDeserializer;
 impl RoleDetailListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8804,9 +8994,10 @@ pub struct RoleLastUsed {
     pub region: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RoleLastUsedDeserializer;
 impl RoleLastUsedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8826,9 +9017,10 @@ impl RoleLastUsedDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RoleListTypeDeserializer;
 impl RoleListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8843,9 +9035,10 @@ impl RoleListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RoleMaxSessionDurationTypeDeserializer;
 impl RoleMaxSessionDurationTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8854,9 +9047,10 @@ impl RoleMaxSessionDurationTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RoleNameTypeDeserializer;
 impl RoleNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8865,9 +9059,10 @@ impl RoleNameTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RoleUsageListTypeDeserializer;
 impl RoleUsageListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8892,9 +9087,10 @@ pub struct RoleUsageType {
     pub resources: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct RoleUsageTypeDeserializer;
 impl RoleUsageTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8915,9 +9111,10 @@ impl RoleUsageTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SAMLMetadataDocumentTypeDeserializer;
 impl SAMLMetadataDocumentTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8938,9 +9135,10 @@ pub struct SAMLProviderListEntry {
     pub valid_until: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SAMLProviderListEntryDeserializer;
 impl SAMLProviderListEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8962,9 +9160,10 @@ impl SAMLProviderListEntryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SAMLProviderListTypeDeserializer;
 impl SAMLProviderListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8999,9 +9198,10 @@ pub struct SSHPublicKey {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct SSHPublicKeyDeserializer;
 impl SSHPublicKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9035,9 +9235,10 @@ impl SSHPublicKeyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SSHPublicKeyListTypeDeserializer;
 impl SSHPublicKeyListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9068,9 +9269,10 @@ pub struct SSHPublicKeyMetadata {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct SSHPublicKeyMetadataDeserializer;
 impl SSHPublicKeyMetadataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9096,9 +9298,10 @@ impl SSHPublicKeyMetadataDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SerialNumberTypeDeserializer;
 impl SerialNumberTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9119,9 +9322,10 @@ pub struct ServerCertificate {
     pub server_certificate_metadata: ServerCertificateMetadata,
 }
 
+#[allow(dead_code)]
 struct ServerCertificateDeserializer;
 impl ServerCertificateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9169,9 +9373,10 @@ pub struct ServerCertificateMetadata {
     pub upload_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ServerCertificateMetadataDeserializer;
 impl ServerCertificateMetadataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9213,9 +9418,10 @@ impl ServerCertificateMetadataDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ServerCertificateMetadataListTypeDeserializer;
 impl ServerCertificateMetadataListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9232,9 +9438,10 @@ impl ServerCertificateMetadataListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ServerCertificateNameTypeDeserializer;
 impl ServerCertificateNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9259,9 +9466,10 @@ pub struct ServiceLastAccessed {
     pub total_authenticated_entities: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ServiceLastAccessedDeserializer;
 impl ServiceLastAccessedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9300,9 +9508,10 @@ impl ServiceLastAccessedDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ServiceNameDeserializer;
 impl ServiceNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9311,9 +9520,10 @@ impl ServiceNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ServiceNameTypeDeserializer;
 impl ServiceNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9334,9 +9544,10 @@ impl ServiceNamespaceListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ServiceNamespaceTypeDeserializer;
 impl ServiceNamespaceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9345,9 +9556,10 @@ impl ServiceNamespaceTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ServicePasswordDeserializer;
 impl ServicePasswordDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9376,9 +9588,10 @@ pub struct ServiceSpecificCredential {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct ServiceSpecificCredentialDeserializer;
 impl ServiceSpecificCredentialDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9423,9 +9636,10 @@ impl ServiceSpecificCredentialDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ServiceSpecificCredentialIdDeserializer;
 impl ServiceSpecificCredentialIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9452,9 +9666,10 @@ pub struct ServiceSpecificCredentialMetadata {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct ServiceSpecificCredentialMetadataDeserializer;
 impl ServiceSpecificCredentialMetadataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9495,9 +9710,10 @@ impl ServiceSpecificCredentialMetadataDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ServiceSpecificCredentialsListTypeDeserializer;
 impl ServiceSpecificCredentialsListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9514,9 +9730,10 @@ impl ServiceSpecificCredentialsListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ServiceUserNameDeserializer;
 impl ServiceUserNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9525,9 +9742,10 @@ impl ServiceUserNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ServicesLastAccessedDeserializer;
 impl ServicesLastAccessedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9606,9 +9824,10 @@ pub struct SigningCertificate {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct SigningCertificateDeserializer;
 impl SigningCertificateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9741,9 +9960,10 @@ pub struct SimulatePolicyResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SimulatePolicyResponseDeserializer;
 impl SimulatePolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9897,9 +10117,10 @@ pub struct Statement {
     pub start_position: Option<Position>,
 }
 
+#[allow(dead_code)]
 struct StatementDeserializer;
 impl StatementDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9932,9 +10153,10 @@ impl StatementDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StatementListTypeDeserializer;
 impl StatementListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9949,9 +10171,10 @@ impl StatementListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StatusTypeDeserializer;
 impl StatusTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9960,9 +10183,10 @@ impl StatusTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StringTypeDeserializer;
 impl StringTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9971,9 +10195,10 @@ impl StringTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SummaryKeyTypeDeserializer;
 impl SummaryKeyTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9982,9 +10207,10 @@ impl SummaryKeyTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SummaryMapTypeDeserializer;
 impl SummaryMapTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10005,9 +10231,10 @@ impl SummaryMapTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SummaryValueTypeDeserializer;
 impl SummaryValueTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -10027,9 +10254,10 @@ pub struct Tag {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -10071,9 +10299,10 @@ impl TagKeyListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyTypeDeserializer;
 impl TagKeyTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10082,9 +10311,10 @@ impl TagKeyTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TagListTypeDeserializer;
 impl TagListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10157,9 +10387,10 @@ impl TagUserRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagValueTypeDeserializer;
 impl TagValueTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10168,9 +10399,10 @@ impl TagValueTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ThumbprintListTypeDeserializer;
 impl ThumbprintListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10197,9 +10429,10 @@ impl ThumbprintListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ThumbprintTypeDeserializer;
 impl ThumbprintTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10520,9 +10753,10 @@ pub struct UpdateRoleDescriptionResponse {
     pub role: Option<Role>,
 }
 
+#[allow(dead_code)]
 struct UpdateRoleDescriptionResponseDeserializer;
 impl UpdateRoleDescriptionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10576,9 +10810,10 @@ impl UpdateRoleRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct UpdateRoleResponse {}
 
+#[allow(dead_code)]
 struct UpdateRoleResponseDeserializer;
 impl UpdateRoleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10629,9 +10864,10 @@ pub struct UpdateSAMLProviderResponse {
     pub saml_provider_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateSAMLProviderResponseDeserializer;
 impl UpdateSAMLProviderResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10843,9 +11079,10 @@ pub struct UploadSSHPublicKeyResponse {
     pub ssh_public_key: Option<SSHPublicKey>,
 }
 
+#[allow(dead_code)]
 struct UploadSSHPublicKeyResponseDeserializer;
 impl UploadSSHPublicKeyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10918,9 +11155,10 @@ pub struct UploadServerCertificateResponse {
     pub server_certificate_metadata: Option<ServerCertificateMetadata>,
 }
 
+#[allow(dead_code)]
 struct UploadServerCertificateResponseDeserializer;
 impl UploadServerCertificateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10980,9 +11218,10 @@ pub struct UploadSigningCertificateResponse {
     pub certificate: SigningCertificate,
 }
 
+#[allow(dead_code)]
 struct UploadSigningCertificateResponseDeserializer;
 impl UploadSigningCertificateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11025,9 +11264,10 @@ pub struct User {
     pub user_name: String,
 }
 
+#[allow(dead_code)]
 struct UserDeserializer;
 impl UserDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<User, XmlParseError> {
         deserialize_elements::<_, User, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -11095,9 +11335,10 @@ pub struct UserDetail {
     pub user_policy_list: Option<Vec<PolicyDetail>>,
 }
 
+#[allow(dead_code)]
 struct UserDetailDeserializer;
 impl UserDetailDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11155,9 +11396,10 @@ impl UserDetailDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct UserDetailListTypeDeserializer;
 impl UserDetailListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11172,9 +11414,10 @@ impl UserDetailListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct UserListTypeDeserializer;
 impl UserListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11189,9 +11432,10 @@ impl UserListTypeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct UserNameTypeDeserializer;
 impl UserNameTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -11216,9 +11460,10 @@ pub struct VirtualMFADevice {
     pub user: Option<User>,
 }
 
+#[allow(dead_code)]
 struct VirtualMFADeviceDeserializer;
 impl VirtualMFADeviceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11251,9 +11496,10 @@ impl VirtualMFADeviceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct VirtualMFADeviceListTypeDeserializer;
 impl VirtualMFADeviceListTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -1683,9 +1683,8 @@ impl ImportExport for ImportExportClient {
             return Err(CancelJobError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CancelJobOutput::default();
         } else {
@@ -1734,9 +1733,8 @@ impl ImportExport for ImportExportClient {
             return Err(CreateJobError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateJobOutput::default();
         } else {
@@ -1785,9 +1783,8 @@ impl ImportExport for ImportExportClient {
             return Err(GetShippingLabelError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetShippingLabelOutput::default();
         } else {
@@ -1839,9 +1836,8 @@ impl ImportExport for ImportExportClient {
             return Err(GetStatusError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetStatusOutput::default();
         } else {
@@ -1886,9 +1882,8 @@ impl ImportExport for ImportExportClient {
             return Err(ListJobsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListJobsOutput::default();
         } else {
@@ -1937,9 +1932,8 @@ impl ImportExport for ImportExportClient {
             return Err(UpdateJobError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateJobOutput::default();
         } else {

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -44,9 +44,10 @@ pub struct Artifact {
     pub url: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ArtifactDeserializer;
 impl ArtifactDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -66,9 +67,10 @@ impl ArtifactDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ArtifactListDeserializer;
 impl ArtifactListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -114,9 +116,10 @@ pub struct CancelJobOutput {
     pub success: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct CancelJobOutputDeserializer;
 impl CancelJobOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -132,9 +135,10 @@ impl CancelJobOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CarrierDeserializer;
 impl CarrierDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -187,9 +191,10 @@ pub struct CreateJobOutput {
     pub warning_message: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateJobOutputDeserializer;
 impl CreateJobOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -229,9 +234,10 @@ impl CreateJobOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CreationDateDeserializer;
 impl CreationDateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -240,9 +246,10 @@ impl CreationDateDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CurrentManifestDeserializer;
 impl CurrentManifestDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -251,9 +258,10 @@ impl CurrentManifestDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DescriptionDeserializer;
 impl DescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -262,9 +270,10 @@ impl DescriptionDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ErrorCountDeserializer;
 impl ErrorCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -273,9 +282,10 @@ impl ErrorCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct GenericStringDeserializer;
 impl GenericStringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -354,9 +364,10 @@ pub struct GetShippingLabelOutput {
     pub warning: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetShippingLabelOutputDeserializer;
 impl GetShippingLabelOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -424,9 +435,10 @@ pub struct GetStatusOutput {
     pub tracking_number: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetStatusOutputDeserializer;
 impl GetStatusOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -514,9 +526,10 @@ impl GetStatusOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IsCanceledDeserializer;
 impl IsCanceledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -525,9 +538,10 @@ impl IsCanceledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IsTruncatedDeserializer;
 impl IsTruncatedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -546,9 +560,10 @@ pub struct Job {
     pub job_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct JobDeserializer;
 impl JobDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Job, XmlParseError> {
         deserialize_elements::<_, Job, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -574,9 +589,10 @@ impl JobDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct JobIdDeserializer;
 impl JobIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -597,9 +613,10 @@ impl JobIdListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct JobTypeDeserializer;
 impl JobTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -608,9 +625,10 @@ impl JobTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct JobsListDeserializer;
 impl JobsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -663,9 +681,10 @@ pub struct ListJobsOutput {
     pub jobs: Option<Vec<Job>>,
 }
 
+#[allow(dead_code)]
 struct ListJobsOutputDeserializer;
 impl ListJobsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -687,9 +706,10 @@ impl ListJobsOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LocationCodeDeserializer;
 impl LocationCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -698,9 +718,10 @@ impl LocationCodeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LocationMessageDeserializer;
 impl LocationMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -709,9 +730,10 @@ impl LocationMessageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LogBucketDeserializer;
 impl LogBucketDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -720,9 +742,10 @@ impl LogBucketDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LogKeyDeserializer;
 impl LogKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -731,9 +754,10 @@ impl LogKeyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ProgressCodeDeserializer;
 impl ProgressCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -742,9 +766,10 @@ impl ProgressCodeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ProgressMessageDeserializer;
 impl ProgressMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -753,9 +778,10 @@ impl ProgressMessageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SignatureDeserializer;
 impl SignatureDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -764,9 +790,10 @@ impl SignatureDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SignatureFileContentsDeserializer;
 impl SignatureFileContentsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -775,9 +802,10 @@ impl SignatureFileContentsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SuccessDeserializer;
 impl SuccessDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -786,9 +814,10 @@ impl SuccessDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TrackingNumberDeserializer;
 impl TrackingNumberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -797,9 +826,10 @@ impl TrackingNumberDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct URLDeserializer;
 impl URLDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -847,9 +877,10 @@ pub struct UpdateJobOutput {
     pub warning_message: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UpdateJobOutputDeserializer;
 impl UpdateJobOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -876,9 +907,10 @@ impl UpdateJobOutputDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct WarningMessageDeserializer;
 impl WarningMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -97,9 +97,10 @@ pub struct AddSourceIdentifierToSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct AddSourceIdentifierToSubscriptionResultDeserializer;
 impl AddSourceIdentifierToSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -145,9 +146,10 @@ impl AddTagsToResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ApplyMethodDeserializer;
 impl ApplyMethodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -191,9 +193,10 @@ pub struct ApplyPendingMaintenanceActionResult {
     pub resource_pending_maintenance_actions: Option<ResourcePendingMaintenanceActions>,
 }
 
+#[allow(dead_code)]
 struct ApplyPendingMaintenanceActionResultDeserializer;
 impl ApplyPendingMaintenanceActionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -217,9 +220,10 @@ impl ApplyPendingMaintenanceActionResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AttributeValueListDeserializer;
 impl AttributeValueListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -254,9 +258,10 @@ pub struct AvailabilityZone {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AvailabilityZoneDeserializer;
 impl AvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -272,9 +277,10 @@ impl AvailabilityZoneDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZoneListDeserializer;
 impl AvailabilityZoneListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -292,9 +298,10 @@ impl AvailabilityZoneListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZonesDeserializer;
 impl AvailabilityZonesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -321,9 +328,10 @@ impl AvailabilityZonesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -332,9 +340,10 @@ impl BooleanDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanOptionalDeserializer;
 impl BooleanOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -353,9 +362,10 @@ pub struct CharacterSet {
     pub character_set_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CharacterSetDeserializer;
 impl CharacterSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -460,9 +470,10 @@ pub struct CopyDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CopyDBClusterParameterGroupResultDeserializer;
 impl CopyDBClusterParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -541,9 +552,10 @@ pub struct CopyDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CopyDBClusterSnapshotResultDeserializer;
 impl CopyDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -612,9 +624,10 @@ pub struct CopyDBParameterGroupResult {
     pub db_parameter_group: Option<DBParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CopyDBParameterGroupResultDeserializer;
 impl CopyDBParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -846,9 +859,10 @@ pub struct CreateDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterParameterGroupResultDeserializer;
 impl CreateDBClusterParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -878,9 +892,10 @@ pub struct CreateDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterResultDeserializer;
 impl CreateDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -936,9 +951,10 @@ pub struct CreateDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterSnapshotResultDeserializer;
 impl CreateDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1237,9 +1253,10 @@ pub struct CreateDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct CreateDBInstanceResultDeserializer;
 impl CreateDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1299,9 +1316,10 @@ pub struct CreateDBParameterGroupResult {
     pub db_parameter_group: Option<DBParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBParameterGroupResultDeserializer;
 impl CreateDBParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1371,9 +1389,10 @@ pub struct CreateDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBSubnetGroupResultDeserializer;
 impl CreateDBSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1461,9 +1480,10 @@ pub struct CreateEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct CreateEventSubscriptionResultDeserializer;
 impl CreateEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1566,9 +1586,10 @@ pub struct DBCluster {
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterDeserializer;
 impl DBClusterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1767,9 +1788,10 @@ impl DBClusterDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterListDeserializer;
 impl DBClusterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1798,9 +1820,10 @@ pub struct DBClusterMember {
     pub promotion_tier: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DBClusterMemberDeserializer;
 impl DBClusterMemberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1835,9 +1858,10 @@ impl DBClusterMemberDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterMemberListDeserializer;
 impl DBClusterMemberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1864,9 +1888,10 @@ pub struct DBClusterMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterMessageDeserializer;
 impl DBClusterMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1887,9 +1912,10 @@ impl DBClusterMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterOptionGroupMembershipsDeserializer;
 impl DBClusterOptionGroupMembershipsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1917,9 +1943,10 @@ pub struct DBClusterOptionGroupStatus {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterOptionGroupStatusDeserializer;
 impl DBClusterOptionGroupStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1959,9 +1986,10 @@ pub struct DBClusterParameterGroup {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupDeserializer;
 impl DBClusterParameterGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2008,9 +2036,10 @@ pub struct DBClusterParameterGroupDetails {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupDetailsDeserializer;
 impl DBClusterParameterGroupDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2035,9 +2064,10 @@ impl DBClusterParameterGroupDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterParameterGroupListDeserializer;
 impl DBClusterParameterGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2062,9 +2092,10 @@ pub struct DBClusterParameterGroupNameMessage {
     pub db_cluster_parameter_group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupNameMessageDeserializer;
 impl DBClusterParameterGroupNameMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2095,9 +2126,10 @@ pub struct DBClusterParameterGroupsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupsMessageDeserializer;
 impl DBClusterParameterGroupsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2135,9 +2167,10 @@ pub struct DBClusterRole {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterRoleDeserializer;
 impl DBClusterRoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2156,9 +2189,10 @@ impl DBClusterRoleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterRolesDeserializer;
 impl DBClusterRolesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2222,9 +2256,10 @@ pub struct DBClusterSnapshot {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotDeserializer;
 impl DBClusterSnapshotDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2336,9 +2371,10 @@ pub struct DBClusterSnapshotAttribute {
     pub attribute_values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributeDeserializer;
 impl DBClusterSnapshotAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2364,9 +2400,10 @@ impl DBClusterSnapshotAttributeDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributeListDeserializer;
 impl DBClusterSnapshotAttributeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2394,9 +2431,10 @@ pub struct DBClusterSnapshotAttributesResult {
     pub db_cluster_snapshot_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributesResultDeserializer;
 impl DBClusterSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2427,9 +2465,10 @@ impl DBClusterSnapshotAttributesResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterSnapshotListDeserializer;
 impl DBClusterSnapshotListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2456,9 +2495,10 @@ pub struct DBClusterSnapshotMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotMessageDeserializer;
 impl DBClusterSnapshotMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2516,9 +2556,10 @@ pub struct DBEngineVersion {
     pub valid_upgrade_target: Option<Vec<UpgradeTarget>>,
 }
 
+#[allow(dead_code)]
 struct DBEngineVersionDeserializer;
 impl DBEngineVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2604,9 +2645,10 @@ impl DBEngineVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBEngineVersionListDeserializer;
 impl DBEngineVersionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2633,9 +2675,10 @@ pub struct DBEngineVersionMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBEngineVersionMessageDeserializer;
 impl DBEngineVersionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2766,9 +2809,10 @@ pub struct DBInstance {
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceDeserializer;
 impl DBInstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3059,9 +3103,10 @@ impl DBInstanceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBInstanceListDeserializer;
 impl DBInstanceListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3085,9 +3130,10 @@ pub struct DBInstanceMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceMessageDeserializer;
 impl DBInstanceMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3122,9 +3168,10 @@ pub struct DBInstanceStatusInfo {
     pub status_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceStatusInfoDeserializer;
 impl DBInstanceStatusInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3149,9 +3196,10 @@ impl DBInstanceStatusInfoDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBInstanceStatusInfoListDeserializer;
 impl DBInstanceStatusInfoListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3183,9 +3231,10 @@ pub struct DBParameterGroup {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupDeserializer;
 impl DBParameterGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3228,9 +3277,10 @@ pub struct DBParameterGroupDetails {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupDetailsDeserializer;
 impl DBParameterGroupDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3255,9 +3305,10 @@ impl DBParameterGroupDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBParameterGroupListDeserializer;
 impl DBParameterGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3282,9 +3333,10 @@ pub struct DBParameterGroupNameMessage {
     pub db_parameter_group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupNameMessageDeserializer;
 impl DBParameterGroupNameMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3317,9 +3369,10 @@ pub struct DBParameterGroupStatus {
     pub parameter_apply_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupStatusDeserializer;
 impl DBParameterGroupStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3344,9 +3397,10 @@ impl DBParameterGroupStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBParameterGroupStatusListDeserializer;
 impl DBParameterGroupStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3373,9 +3427,10 @@ pub struct DBParameterGroupsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupsMessageDeserializer;
 impl DBParameterGroupsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3413,9 +3468,10 @@ pub struct DBSecurityGroupMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSecurityGroupMembershipDeserializer;
 impl DBSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3441,9 +3497,10 @@ impl DBSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBSecurityGroupMembershipListDeserializer;
 impl DBSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3491,9 +3548,10 @@ pub struct DBSubnetGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSubnetGroupDeserializer;
 impl DBSubnetGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3541,9 +3599,10 @@ pub struct DBSubnetGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSubnetGroupMessageDeserializer;
 impl DBSubnetGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3564,9 +3623,10 @@ impl DBSubnetGroupMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBSubnetGroupsDeserializer;
 impl DBSubnetGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3649,9 +3709,10 @@ pub struct DeleteDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBClusterResultDeserializer;
 impl DeleteDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3696,9 +3757,10 @@ pub struct DeleteDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBClusterSnapshotResultDeserializer;
 impl DeleteDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3763,9 +3825,10 @@ pub struct DeleteDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBInstanceResultDeserializer;
 impl DeleteDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3857,9 +3920,10 @@ pub struct DeleteEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct DeleteEventSubscriptionResultDeserializer;
 impl DeleteEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4006,9 +4070,10 @@ pub struct DescribeDBClusterSnapshotAttributesResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBClusterSnapshotAttributesResultDeserializer;
 impl DescribeDBClusterSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4446,9 +4511,10 @@ pub struct DescribeEngineDefaultClusterParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
 
+#[allow(dead_code)]
 struct DescribeEngineDefaultClusterParametersResultDeserializer;
 impl DescribeEngineDefaultClusterParametersResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4519,9 +4585,10 @@ pub struct DescribeEngineDefaultParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
 
+#[allow(dead_code)]
 struct DescribeEngineDefaultParametersResultDeserializer;
 impl DescribeEngineDefaultParametersResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4819,9 +4886,10 @@ pub struct DescribeValidDBInstanceModificationsResult {
     pub valid_db_instance_modifications_message: Option<ValidDBInstanceModificationsMessage>,
 }
 
+#[allow(dead_code)]
 struct DescribeValidDBInstanceModificationsResultDeserializer;
 impl DescribeValidDBInstanceModificationsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4860,9 +4928,10 @@ pub struct DomainMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DomainMembershipDeserializer;
 impl DomainMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4888,9 +4957,10 @@ impl DomainMembershipDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DomainMembershipListDeserializer;
 impl DomainMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4908,9 +4978,10 @@ impl DomainMembershipListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DoubleDeserializer;
 impl DoubleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4919,9 +4990,10 @@ impl DoubleDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DoubleOptionalDeserializer;
 impl DoubleOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4940,9 +5012,10 @@ pub struct DoubleRange {
     pub to: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct DoubleRangeDeserializer;
 impl DoubleRangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4961,9 +5034,10 @@ impl DoubleRangeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DoubleRangeListDeserializer;
 impl DoubleRangeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4990,9 +5064,10 @@ pub struct Endpoint {
     pub port: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct EndpointDeserializer;
 impl EndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5027,9 +5102,10 @@ pub struct EngineDefaults {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct EngineDefaultsDeserializer;
 impl EngineDefaultsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5074,9 +5150,10 @@ pub struct Event {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventDeserializer;
 impl EventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Event, XmlParseError> {
         deserialize_elements::<_, Event, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5108,9 +5185,10 @@ impl EventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesListDeserializer;
 impl EventCategoriesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5147,9 +5225,10 @@ pub struct EventCategoriesMap {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMapDeserializer;
 impl EventCategoriesMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5170,9 +5249,10 @@ impl EventCategoriesMapDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesMapListDeserializer;
 impl EventCategoriesMapListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5197,9 +5277,10 @@ pub struct EventCategoriesMessage {
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMessageDeserializer;
 impl EventCategoriesMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5220,9 +5301,10 @@ impl EventCategoriesMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventListDeserializer;
 impl EventListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5263,9 +5345,10 @@ pub struct EventSubscription {
     pub subscription_creation_time: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventSubscriptionDeserializer;
 impl EventSubscriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5323,9 +5406,10 @@ impl EventSubscriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventSubscriptionsListDeserializer;
 impl EventSubscriptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5352,9 +5436,10 @@ pub struct EventSubscriptionsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventSubscriptionsMessageDeserializer;
 impl EventSubscriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5391,9 +5476,10 @@ pub struct EventsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventsMessageDeserializer;
 impl EventsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5453,9 +5539,10 @@ pub struct FailoverDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct FailoverDBClusterResultDeserializer;
 impl FailoverDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5526,9 +5613,10 @@ impl FilterValueListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5537,9 +5625,10 @@ impl IntegerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IntegerOptionalDeserializer;
 impl IntegerOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5589,9 +5678,10 @@ impl ListTagsForResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LogTypeListDeserializer;
 impl LogTypeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5773,9 +5863,10 @@ pub struct ModifyDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBClusterResultDeserializer;
 impl ModifyDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5844,9 +5935,10 @@ pub struct ModifyDBClusterSnapshotAttributeResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBClusterSnapshotAttributeResultDeserializer;
 impl ModifyDBClusterSnapshotAttributeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6123,9 +6215,10 @@ pub struct ModifyDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBInstanceResultDeserializer;
 impl ModifyDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6216,9 +6309,10 @@ pub struct ModifyDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBSubnetGroupResultDeserializer;
 impl ModifyDBSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6294,9 +6388,10 @@ pub struct ModifyEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct ModifyEventSubscriptionResultDeserializer;
 impl ModifyEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6329,9 +6424,10 @@ pub struct OptionGroupMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OptionGroupMembershipDeserializer;
 impl OptionGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6351,9 +6447,10 @@ impl OptionGroupMembershipDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionGroupMembershipListDeserializer;
 impl OptionGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6417,9 +6514,10 @@ pub struct OrderableDBInstanceOption {
     pub vpc: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionDeserializer;
 impl OrderableDBInstanceOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6543,9 +6641,10 @@ impl OrderableDBInstanceOptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionsListDeserializer;
 impl OrderableDBInstanceOptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6572,9 +6671,10 @@ pub struct OrderableDBInstanceOptionsMessage {
     pub orderable_db_instance_options: Option<Vec<OrderableDBInstanceOption>>,
 }
 
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionsMessageDeserializer;
 impl OrderableDBInstanceOptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6629,9 +6729,10 @@ pub struct Parameter {
     pub source: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ParameterDeserializer;
 impl ParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6728,9 +6829,10 @@ impl ParameterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ParametersListDeserializer;
 impl ParametersListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6767,9 +6869,10 @@ pub struct PendingCloudwatchLogsExports {
     pub log_types_to_enable: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct PendingCloudwatchLogsExportsDeserializer;
 impl PendingCloudwatchLogsExportsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6814,9 +6917,10 @@ pub struct PendingMaintenanceAction {
     pub opt_in_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PendingMaintenanceActionDeserializer;
 impl PendingMaintenanceActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6858,9 +6962,10 @@ impl PendingMaintenanceActionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PendingMaintenanceActionDetailsDeserializer;
 impl PendingMaintenanceActionDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6878,9 +6983,10 @@ impl PendingMaintenanceActionDetailsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PendingMaintenanceActionsDeserializer;
 impl PendingMaintenanceActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6907,9 +7013,10 @@ pub struct PendingMaintenanceActionsMessage {
     pub pending_maintenance_actions: Option<Vec<ResourcePendingMaintenanceActions>>,
 }
 
+#[allow(dead_code)]
 struct PendingMaintenanceActionsMessageDeserializer;
 impl PendingMaintenanceActionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6971,9 +7078,10 @@ pub struct PendingModifiedValues {
     pub storage_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PendingModifiedValuesDeserializer;
 impl PendingModifiedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7081,9 +7189,10 @@ pub struct PromoteReadReplicaDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct PromoteReadReplicaDBClusterResultDeserializer;
 impl PromoteReadReplicaDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7116,9 +7225,10 @@ pub struct Range {
     pub to: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct RangeDeserializer;
 impl RangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Range, XmlParseError> {
         deserialize_elements::<_, Range, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7137,9 +7247,10 @@ impl RangeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RangeListDeserializer;
 impl RangeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7154,9 +7265,10 @@ impl RangeListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReadReplicaDBClusterIdentifierListDeserializer;
 impl ReadReplicaDBClusterIdentifierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7174,9 +7286,10 @@ impl ReadReplicaDBClusterIdentifierListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReadReplicaDBInstanceIdentifierListDeserializer;
 impl ReadReplicaDBInstanceIdentifierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7194,9 +7307,10 @@ impl ReadReplicaDBInstanceIdentifierListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReadReplicaIdentifierListDeserializer;
 impl ReadReplicaIdentifierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7248,9 +7362,10 @@ pub struct RebootDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct RebootDBInstanceResultDeserializer;
 impl RebootDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7332,9 +7447,10 @@ pub struct RemoveSourceIdentifierFromSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct RemoveSourceIdentifierFromSubscriptionResultDeserializer;
 impl RemoveSourceIdentifierFromSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7464,9 +7580,10 @@ pub struct ResourcePendingMaintenanceActions {
     pub resource_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ResourcePendingMaintenanceActionsDeserializer;
 impl ResourcePendingMaintenanceActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7618,9 +7735,10 @@ pub struct RestoreDBClusterFromSnapshotResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBClusterFromSnapshotResultDeserializer;
 impl RestoreDBClusterFromSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7758,9 +7876,10 @@ pub struct RestoreDBClusterToPointInTimeResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBClusterToPointInTimeResultDeserializer;
 impl RestoreDBClusterToPointInTimeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7781,9 +7900,10 @@ impl RestoreDBClusterToPointInTimeResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SourceIdsListDeserializer;
 impl SourceIdsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7810,9 +7930,10 @@ impl SourceIdsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7821,9 +7942,10 @@ impl SourceTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7844,9 +7966,10 @@ pub struct Subnet {
     pub subnet_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SubnetDeserializer;
 impl SubnetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Subnet, XmlParseError> {
         deserialize_elements::<_, Subnet, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7882,9 +8005,10 @@ impl SubnetIdentifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SubnetListDeserializer;
 impl SubnetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7899,9 +8023,10 @@ impl SubnetListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SupportedCharacterSetsListDeserializer;
 impl SupportedCharacterSetsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7919,9 +8044,10 @@ impl SupportedCharacterSetsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SupportedTimezonesListDeserializer;
 impl SupportedTimezonesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7936,9 +8062,10 @@ impl SupportedTimezonesListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TStampDeserializer;
 impl TStampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7958,9 +8085,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7995,9 +8123,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8031,9 +8160,10 @@ pub struct TagListMessage {
     pub tag_list: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct TagListMessageDeserializer;
 impl TagListMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8059,9 +8189,10 @@ pub struct Timezone {
     pub timezone_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TimezoneDeserializer;
 impl TimezoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8094,9 +8225,10 @@ pub struct UpgradeTarget {
     pub is_major_version_upgrade: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct UpgradeTargetDeserializer;
 impl UpgradeTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8137,9 +8269,10 @@ pub struct ValidDBInstanceModificationsMessage {
     pub storage: Option<Vec<ValidStorageOptions>>,
 }
 
+#[allow(dead_code)]
 struct ValidDBInstanceModificationsMessageDeserializer;
 impl ValidDBInstanceModificationsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8175,9 +8308,10 @@ pub struct ValidStorageOptions {
     pub storage_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ValidStorageOptionsDeserializer;
 impl ValidStorageOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8208,9 +8342,10 @@ impl ValidStorageOptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValidStorageOptionsListDeserializer;
 impl ValidStorageOptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8228,9 +8363,10 @@ impl ValidStorageOptionsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValidUpgradeTargetListDeserializer;
 impl ValidUpgradeTargetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8270,9 +8406,10 @@ pub struct VpcSecurityGroupMembership {
     pub vpc_security_group_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipDeserializer;
 impl VpcSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8298,9 +8435,10 @@ impl VpcSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipListDeserializer;
 impl VpcSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -13268,9 +13268,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AddSourceIdentifierToSubscriptionResult::default();
         } else {
@@ -13346,9 +13345,8 @@ impl Neptune for NeptuneClient {
             return Err(ApplyPendingMaintenanceActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplyPendingMaintenanceActionResult::default();
         } else {
@@ -13396,9 +13394,8 @@ impl Neptune for NeptuneClient {
             return Err(CopyDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBClusterParameterGroupResult::default();
         } else {
@@ -13445,9 +13442,8 @@ impl Neptune for NeptuneClient {
             return Err(CopyDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBClusterSnapshotResult::default();
         } else {
@@ -13494,9 +13490,8 @@ impl Neptune for NeptuneClient {
             return Err(CopyDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBParameterGroupResult::default();
         } else {
@@ -13543,9 +13538,8 @@ impl Neptune for NeptuneClient {
             return Err(CreateDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterResult::default();
         } else {
@@ -13593,9 +13587,8 @@ impl Neptune for NeptuneClient {
             return Err(CreateDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterParameterGroupResult::default();
         } else {
@@ -13642,9 +13635,8 @@ impl Neptune for NeptuneClient {
             return Err(CreateDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterSnapshotResult::default();
         } else {
@@ -13691,9 +13683,8 @@ impl Neptune for NeptuneClient {
             return Err(CreateDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBInstanceResult::default();
         } else {
@@ -13740,9 +13731,8 @@ impl Neptune for NeptuneClient {
             return Err(CreateDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBParameterGroupResult::default();
         } else {
@@ -13789,9 +13779,8 @@ impl Neptune for NeptuneClient {
             return Err(CreateDBSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBSubnetGroupResult::default();
         } else {
@@ -13838,9 +13827,8 @@ impl Neptune for NeptuneClient {
             return Err(CreateEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateEventSubscriptionResult::default();
         } else {
@@ -13887,9 +13875,8 @@ impl Neptune for NeptuneClient {
             return Err(DeleteDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBClusterResult::default();
         } else {
@@ -13964,9 +13951,8 @@ impl Neptune for NeptuneClient {
             return Err(DeleteDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBClusterSnapshotResult::default();
         } else {
@@ -14013,9 +13999,8 @@ impl Neptune for NeptuneClient {
             return Err(DeleteDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBInstanceResult::default();
         } else {
@@ -14118,9 +14103,8 @@ impl Neptune for NeptuneClient {
             return Err(DeleteEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteEventSubscriptionResult::default();
         } else {
@@ -14170,9 +14154,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupsMessage::default();
         } else {
@@ -14219,9 +14202,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBClusterParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupDetails::default();
         } else {
@@ -14273,9 +14255,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBClusterSnapshotAttributesResult::default();
         } else {
@@ -14322,9 +14303,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBClusterSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterSnapshotMessage::default();
         } else {
@@ -14371,9 +14351,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBClustersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterMessage::default();
         } else {
@@ -14418,9 +14397,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBEngineVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBEngineVersionMessage::default();
         } else {
@@ -14467,9 +14445,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBInstanceMessage::default();
         } else {
@@ -14516,9 +14493,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBParameterGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupsMessage::default();
         } else {
@@ -14565,9 +14541,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupDetails::default();
         } else {
@@ -14614,9 +14589,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeDBSubnetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBSubnetGroupMessage::default();
         } else {
@@ -14668,9 +14642,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEngineDefaultClusterParametersResult::default();
         } else {
@@ -14722,9 +14695,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEngineDefaultParametersResult::default();
         } else {
@@ -14771,9 +14743,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeEventCategoriesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventCategoriesMessage::default();
         } else {
@@ -14820,9 +14791,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeEventSubscriptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventSubscriptionsMessage::default();
         } else {
@@ -14869,9 +14839,8 @@ impl Neptune for NeptuneClient {
             return Err(DescribeEventsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventsMessage::default();
         } else {
@@ -14920,9 +14889,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = OrderableDBInstanceOptionsMessage::default();
         } else {
@@ -14972,9 +14940,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PendingMaintenanceActionsMessage::default();
         } else {
@@ -15026,9 +14993,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeValidDBInstanceModificationsResult::default();
         } else {
@@ -15075,9 +15041,8 @@ impl Neptune for NeptuneClient {
             return Err(FailoverDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = FailoverDBClusterResult::default();
         } else {
@@ -15124,9 +15089,8 @@ impl Neptune for NeptuneClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TagListMessage::default();
         } else {
@@ -15171,9 +15135,8 @@ impl Neptune for NeptuneClient {
             return Err(ModifyDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBClusterResult::default();
         } else {
@@ -15221,9 +15184,8 @@ impl Neptune for NeptuneClient {
             return Err(ModifyDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupNameMessage::default();
         } else {
@@ -15275,9 +15237,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBClusterSnapshotAttributeResult::default();
         } else {
@@ -15324,9 +15285,8 @@ impl Neptune for NeptuneClient {
             return Err(ModifyDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBInstanceResult::default();
         } else {
@@ -15373,9 +15333,8 @@ impl Neptune for NeptuneClient {
             return Err(ModifyDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupNameMessage::default();
         } else {
@@ -15422,9 +15381,8 @@ impl Neptune for NeptuneClient {
             return Err(ModifyDBSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBSubnetGroupResult::default();
         } else {
@@ -15471,9 +15429,8 @@ impl Neptune for NeptuneClient {
             return Err(ModifyEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyEventSubscriptionResult::default();
         } else {
@@ -15521,9 +15478,8 @@ impl Neptune for NeptuneClient {
             return Err(PromoteReadReplicaDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PromoteReadReplicaDBClusterResult::default();
         } else {
@@ -15570,9 +15526,8 @@ impl Neptune for NeptuneClient {
             return Err(RebootDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RebootDBInstanceResult::default();
         } else {
@@ -15652,9 +15607,8 @@ impl Neptune for NeptuneClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RemoveSourceIdentifierFromSubscriptionResult::default();
         } else {
@@ -15730,9 +15684,8 @@ impl Neptune for NeptuneClient {
             return Err(ResetDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupNameMessage::default();
         } else {
@@ -15779,9 +15732,8 @@ impl Neptune for NeptuneClient {
             return Err(ResetDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupNameMessage::default();
         } else {
@@ -15829,9 +15781,8 @@ impl Neptune for NeptuneClient {
             return Err(RestoreDBClusterFromSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBClusterFromSnapshotResult::default();
         } else {
@@ -15879,9 +15830,8 @@ impl Neptune for NeptuneClient {
             return Err(RestoreDBClusterToPointInTimeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBClusterToPointInTimeResult::default();
         } else {

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -44,9 +44,10 @@ pub struct AccountAttributesMessage {
     pub account_quotas: Option<Vec<AccountQuota>>,
 }
 
+#[allow(dead_code)]
 struct AccountAttributesMessageDeserializer;
 impl AccountAttributesMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -80,9 +81,10 @@ pub struct AccountQuota {
     pub used: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct AccountQuotaDeserializer;
 impl AccountQuotaDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -105,9 +107,10 @@ impl AccountQuotaDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccountQuotaListDeserializer;
 impl AccountQuotaListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -125,9 +128,10 @@ impl AccountQuotaListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ActivityStreamModeDeserializer;
 impl ActivityStreamModeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -136,9 +140,10 @@ impl ActivityStreamModeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ActivityStreamStatusDeserializer;
 impl ActivityStreamStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -243,9 +248,10 @@ pub struct AddSourceIdentifierToSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct AddSourceIdentifierToSubscriptionResultDeserializer;
 impl AddSourceIdentifierToSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -292,9 +298,10 @@ impl AddTagsToResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ApplyMethodDeserializer;
 impl ApplyMethodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -339,9 +346,10 @@ pub struct ApplyPendingMaintenanceActionResult {
     pub resource_pending_maintenance_actions: Option<ResourcePendingMaintenanceActions>,
 }
 
+#[allow(dead_code)]
 struct ApplyPendingMaintenanceActionResultDeserializer;
 impl ApplyPendingMaintenanceActionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -365,9 +373,10 @@ impl ApplyPendingMaintenanceActionResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AttributeValueListDeserializer;
 impl AttributeValueListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -394,9 +403,10 @@ impl AttributeValueListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AuthSchemeDeserializer;
 impl AuthSchemeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -461,9 +471,10 @@ pub struct AuthorizeDBSecurityGroupIngressResult {
     pub db_security_group: Option<DBSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct AuthorizeDBSecurityGroupIngressResultDeserializer;
 impl AuthorizeDBSecurityGroupIngressResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -494,9 +505,10 @@ pub struct AvailabilityZone {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AvailabilityZoneDeserializer;
 impl AvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -512,9 +524,10 @@ impl AvailabilityZoneDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZoneListDeserializer;
 impl AvailabilityZoneListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -532,9 +545,10 @@ impl AvailabilityZoneListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZonesDeserializer;
 impl AvailabilityZonesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -573,9 +587,10 @@ pub struct AvailableProcessorFeature {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AvailableProcessorFeatureDeserializer;
 impl AvailableProcessorFeatureDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -603,9 +618,10 @@ impl AvailableProcessorFeatureDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AvailableProcessorFeatureListDeserializer;
 impl AvailableProcessorFeatureListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -663,9 +679,10 @@ impl BacktrackDBClusterMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -674,9 +691,10 @@ impl BooleanDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanOptionalDeserializer;
 impl BooleanOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -730,9 +748,10 @@ pub struct Certificate {
     pub valid_till: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CertificateDeserializer;
 impl CertificateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -780,9 +799,10 @@ impl CertificateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CertificateListDeserializer;
 impl CertificateListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -807,9 +827,10 @@ pub struct CertificateMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CertificateMessageDeserializer;
 impl CertificateMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -840,9 +861,10 @@ pub struct CharacterSet {
     pub character_set_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CharacterSetDeserializer;
 impl CharacterSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -973,9 +995,10 @@ pub struct ConnectionPoolConfigurationInfo {
     pub session_pinning_filters: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ConnectionPoolConfigurationInfoDeserializer;
 impl ConnectionPoolConfigurationInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1063,9 +1086,10 @@ pub struct CopyDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CopyDBClusterParameterGroupResultDeserializer;
 impl CopyDBClusterParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1144,9 +1168,10 @@ pub struct CopyDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CopyDBClusterSnapshotResultDeserializer;
 impl CopyDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1215,9 +1240,10 @@ pub struct CopyDBParameterGroupResult {
     pub db_parameter_group: Option<DBParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CopyDBParameterGroupResultDeserializer;
 impl CopyDBParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1300,9 +1326,10 @@ pub struct CopyDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CopyDBSnapshotResultDeserializer;
 impl CopyDBSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1365,9 +1392,10 @@ pub struct CopyOptionGroupResult {
     pub option_group: Option<OptionGroup>,
 }
 
+#[allow(dead_code)]
 struct CopyOptionGroupResultDeserializer;
 impl CopyOptionGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1432,9 +1460,10 @@ pub struct CreateCustomAvailabilityZoneResult {
     pub custom_availability_zone: Option<CustomAvailabilityZone>,
 }
 
+#[allow(dead_code)]
 struct CreateCustomAvailabilityZoneResultDeserializer;
 impl CreateCustomAvailabilityZoneResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1761,9 +1790,10 @@ pub struct CreateDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterParameterGroupResultDeserializer;
 impl CreateDBClusterParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1793,9 +1823,10 @@ pub struct CreateDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterResultDeserializer;
 impl CreateDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1852,9 +1883,10 @@ pub struct CreateDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CreateDBClusterSnapshotResultDeserializer;
 impl CreateDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2384,9 +2416,10 @@ pub struct CreateDBInstanceReadReplicaResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct CreateDBInstanceReadReplicaResultDeserializer;
 impl CreateDBInstanceReadReplicaResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2413,9 +2446,10 @@ pub struct CreateDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct CreateDBInstanceResultDeserializer;
 impl CreateDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2476,9 +2510,10 @@ pub struct CreateDBParameterGroupResult {
     pub db_parameter_group: Option<DBParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBParameterGroupResultDeserializer;
 impl CreateDBParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2577,9 +2612,10 @@ pub struct CreateDBProxyResponse {
     pub db_proxy: Option<DBProxy>,
 }
 
+#[allow(dead_code)]
 struct CreateDBProxyResponseDeserializer;
 impl CreateDBProxyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2636,9 +2672,10 @@ pub struct CreateDBSecurityGroupResult {
     pub db_security_group: Option<DBSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBSecurityGroupResultDeserializer;
 impl CreateDBSecurityGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2701,9 +2738,10 @@ pub struct CreateDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
 
+#[allow(dead_code)]
 struct CreateDBSnapshotResultDeserializer;
 impl CreateDBSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2768,9 +2806,10 @@ pub struct CreateDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateDBSubnetGroupResultDeserializer;
 impl CreateDBSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2858,9 +2897,10 @@ pub struct CreateEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct CreateEventSubscriptionResultDeserializer;
 impl CreateEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2947,9 +2987,10 @@ pub struct CreateGlobalClusterResult {
     pub global_cluster: Option<GlobalCluster>,
 }
 
+#[allow(dead_code)]
 struct CreateGlobalClusterResultDeserializer;
 impl CreateGlobalClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3022,9 +3063,10 @@ pub struct CreateOptionGroupResult {
     pub option_group: Option<OptionGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateOptionGroupResultDeserializer;
 impl CreateOptionGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3059,9 +3101,10 @@ pub struct CustomAvailabilityZone {
     pub vpn_details: Option<VpnDetails>,
 }
 
+#[allow(dead_code)]
 struct CustomAvailabilityZoneDeserializer;
 impl CustomAvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3096,9 +3139,10 @@ impl CustomAvailabilityZoneDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CustomAvailabilityZoneListDeserializer;
 impl CustomAvailabilityZoneListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3125,9 +3169,10 @@ pub struct CustomAvailabilityZoneMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CustomAvailabilityZoneMessageDeserializer;
 impl CustomAvailabilityZoneMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3262,9 +3307,10 @@ pub struct DBCluster {
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterDeserializer;
 impl DBClusterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3562,9 +3608,10 @@ pub struct DBClusterBacktrack {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterBacktrackDeserializer;
 impl DBClusterBacktrackDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3605,9 +3652,10 @@ impl DBClusterBacktrackDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterBacktrackListDeserializer;
 impl DBClusterBacktrackListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3635,9 +3683,10 @@ pub struct DBClusterBacktrackMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterBacktrackMessageDeserializer;
 impl DBClusterBacktrackMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3680,9 +3729,10 @@ pub struct DBClusterCapacityInfo {
     pub timeout_action: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterCapacityInfoDeserializer;
 impl DBClusterCapacityInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3749,9 +3799,10 @@ pub struct DBClusterEndpoint {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterEndpointDeserializer;
 impl DBClusterEndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3815,9 +3866,10 @@ impl DBClusterEndpointDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterEndpointListDeserializer;
 impl DBClusterEndpointListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3844,9 +3896,10 @@ pub struct DBClusterEndpointMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterEndpointMessageDeserializer;
 impl DBClusterEndpointMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3874,9 +3927,10 @@ impl DBClusterEndpointMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterListDeserializer;
 impl DBClusterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3905,9 +3959,10 @@ pub struct DBClusterMember {
     pub promotion_tier: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DBClusterMemberDeserializer;
 impl DBClusterMemberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3942,9 +3997,10 @@ impl DBClusterMemberDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterMemberListDeserializer;
 impl DBClusterMemberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3972,9 +4028,10 @@ pub struct DBClusterMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterMessageDeserializer;
 impl DBClusterMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3995,9 +4052,10 @@ impl DBClusterMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterOptionGroupMembershipsDeserializer;
 impl DBClusterOptionGroupMembershipsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4025,9 +4083,10 @@ pub struct DBClusterOptionGroupStatus {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterOptionGroupStatusDeserializer;
 impl DBClusterOptionGroupStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4067,9 +4126,10 @@ pub struct DBClusterParameterGroup {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupDeserializer;
 impl DBClusterParameterGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4117,9 +4177,10 @@ pub struct DBClusterParameterGroupDetails {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupDetailsDeserializer;
 impl DBClusterParameterGroupDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4144,9 +4205,10 @@ impl DBClusterParameterGroupDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterParameterGroupListDeserializer;
 impl DBClusterParameterGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4172,9 +4234,10 @@ pub struct DBClusterParameterGroupNameMessage {
     pub db_cluster_parameter_group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupNameMessageDeserializer;
 impl DBClusterParameterGroupNameMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4206,9 +4269,10 @@ pub struct DBClusterParameterGroupsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterParameterGroupsMessageDeserializer;
 impl DBClusterParameterGroupsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4248,9 +4312,10 @@ pub struct DBClusterRole {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterRoleDeserializer;
 impl DBClusterRoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4272,9 +4337,10 @@ impl DBClusterRoleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBClusterRolesDeserializer;
 impl DBClusterRolesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4338,9 +4404,10 @@ pub struct DBClusterSnapshot {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotDeserializer;
 impl DBClusterSnapshotDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4452,9 +4519,10 @@ pub struct DBClusterSnapshotAttribute {
     pub attribute_values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributeDeserializer;
 impl DBClusterSnapshotAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4480,9 +4548,10 @@ impl DBClusterSnapshotAttributeDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributeListDeserializer;
 impl DBClusterSnapshotAttributeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4510,9 +4579,10 @@ pub struct DBClusterSnapshotAttributesResult {
     pub db_cluster_snapshot_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotAttributesResultDeserializer;
 impl DBClusterSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4543,9 +4613,10 @@ impl DBClusterSnapshotAttributesResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBClusterSnapshotListDeserializer;
 impl DBClusterSnapshotListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4573,9 +4644,10 @@ pub struct DBClusterSnapshotMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBClusterSnapshotMessageDeserializer;
 impl DBClusterSnapshotMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4639,9 +4711,10 @@ pub struct DBEngineVersion {
     pub valid_upgrade_target: Option<Vec<UpgradeTarget>>,
 }
 
+#[allow(dead_code)]
 struct DBEngineVersionDeserializer;
 impl DBEngineVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4740,9 +4813,10 @@ impl DBEngineVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBEngineVersionListDeserializer;
 impl DBEngineVersionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4770,9 +4844,10 @@ pub struct DBEngineVersionMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBEngineVersionMessageDeserializer;
 impl DBEngineVersionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4915,9 +4990,10 @@ pub struct DBInstance {
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceDeserializer;
 impl DBInstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5295,9 +5371,10 @@ pub struct DBInstanceAutomatedBackup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceAutomatedBackupDeserializer;
 impl DBInstanceAutomatedBackupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5406,9 +5483,10 @@ impl DBInstanceAutomatedBackupDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBInstanceAutomatedBackupListDeserializer;
 impl DBInstanceAutomatedBackupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5436,9 +5514,10 @@ pub struct DBInstanceAutomatedBackupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceAutomatedBackupMessageDeserializer;
 impl DBInstanceAutomatedBackupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5466,9 +5545,10 @@ impl DBInstanceAutomatedBackupMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBInstanceListDeserializer;
 impl DBInstanceListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5493,9 +5573,10 @@ pub struct DBInstanceMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceMessageDeserializer;
 impl DBInstanceMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5528,9 +5609,10 @@ pub struct DBInstanceRole {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceRoleDeserializer;
 impl DBInstanceRoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5552,9 +5634,10 @@ impl DBInstanceRoleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBInstanceRolesDeserializer;
 impl DBInstanceRolesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5586,9 +5669,10 @@ pub struct DBInstanceStatusInfo {
     pub status_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBInstanceStatusInfoDeserializer;
 impl DBInstanceStatusInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5613,9 +5697,10 @@ impl DBInstanceStatusInfoDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBInstanceStatusInfoListDeserializer;
 impl DBInstanceStatusInfoListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5647,9 +5732,10 @@ pub struct DBParameterGroup {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupDeserializer;
 impl DBParameterGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5693,9 +5779,10 @@ pub struct DBParameterGroupDetails {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupDetailsDeserializer;
 impl DBParameterGroupDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5720,9 +5807,10 @@ impl DBParameterGroupDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBParameterGroupListDeserializer;
 impl DBParameterGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5748,9 +5836,10 @@ pub struct DBParameterGroupNameMessage {
     pub db_parameter_group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupNameMessageDeserializer;
 impl DBParameterGroupNameMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5783,9 +5872,10 @@ pub struct DBParameterGroupStatus {
     pub parameter_apply_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupStatusDeserializer;
 impl DBParameterGroupStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5810,9 +5900,10 @@ impl DBParameterGroupStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBParameterGroupStatusListDeserializer;
 impl DBParameterGroupStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5840,9 +5931,10 @@ pub struct DBParameterGroupsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBParameterGroupsMessageDeserializer;
 impl DBParameterGroupsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5904,9 +5996,10 @@ pub struct DBProxy {
     pub vpc_subnet_ids: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DBProxyDeserializer;
 impl DBProxyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5973,9 +6066,10 @@ impl DBProxyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBProxyListDeserializer;
 impl DBProxyListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5990,9 +6084,10 @@ impl DBProxyListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBProxyStatusDeserializer;
 impl DBProxyStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6019,9 +6114,10 @@ pub struct DBProxyTarget {
     pub type_: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBProxyTargetDeserializer;
 impl DBProxyTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6076,9 +6172,10 @@ pub struct DBProxyTargetGroup {
     pub updated_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBProxyTargetGroupDeserializer;
 impl DBProxyTargetGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6142,9 +6239,10 @@ pub struct DBSecurityGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSecurityGroupDeserializer;
 impl DBSecurityGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6201,9 +6299,10 @@ pub struct DBSecurityGroupMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSecurityGroupMembershipDeserializer;
 impl DBSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6229,9 +6328,10 @@ impl DBSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBSecurityGroupMembershipListDeserializer;
 impl DBSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6259,9 +6359,10 @@ pub struct DBSecurityGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSecurityGroupMessageDeserializer;
 impl DBSecurityGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6294,9 +6395,10 @@ impl DBSecurityGroupNameListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DBSecurityGroupsDeserializer;
 impl DBSecurityGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6376,9 +6478,10 @@ pub struct DBSnapshot {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSnapshotDeserializer;
 impl DBSnapshotDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6518,9 +6621,10 @@ pub struct DBSnapshotAttribute {
     pub attribute_values: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct DBSnapshotAttributeDeserializer;
 impl DBSnapshotAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6542,9 +6646,10 @@ impl DBSnapshotAttributeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBSnapshotAttributeListDeserializer;
 impl DBSnapshotAttributeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6572,9 +6677,10 @@ pub struct DBSnapshotAttributesResult {
     pub db_snapshot_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSnapshotAttributesResultDeserializer;
 impl DBSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6605,9 +6711,10 @@ impl DBSnapshotAttributesResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DBSnapshotListDeserializer;
 impl DBSnapshotListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6632,9 +6739,10 @@ pub struct DBSnapshotMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSnapshotMessageDeserializer;
 impl DBSnapshotMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6673,9 +6781,10 @@ pub struct DBSubnetGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSubnetGroupDeserializer;
 impl DBSubnetGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6724,9 +6833,10 @@ pub struct DBSubnetGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DBSubnetGroupMessageDeserializer;
 impl DBSubnetGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6747,9 +6857,10 @@ impl DBSubnetGroupMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DBSubnetGroupsDeserializer;
 impl DBSubnetGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6796,9 +6907,10 @@ pub struct DeleteCustomAvailabilityZoneResult {
     pub custom_availability_zone: Option<CustomAvailabilityZone>,
 }
 
+#[allow(dead_code)]
 struct DeleteCustomAvailabilityZoneResultDeserializer;
 impl DeleteCustomAvailabilityZoneResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6912,9 +7024,10 @@ pub struct DeleteDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBClusterResultDeserializer;
 impl DeleteDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6960,9 +7073,10 @@ pub struct DeleteDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBClusterSnapshotResultDeserializer;
 impl DeleteDBClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7015,9 +7129,10 @@ pub struct DeleteDBInstanceAutomatedBackupResult {
     pub db_instance_automated_backup: Option<DBInstanceAutomatedBackup>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBInstanceAutomatedBackupResultDeserializer;
 impl DeleteDBInstanceAutomatedBackupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7092,9 +7207,10 @@ pub struct DeleteDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBInstanceResultDeserializer;
 impl DeleteDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7162,9 +7278,10 @@ pub struct DeleteDBProxyResponse {
     pub db_proxy: Option<DBProxy>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBProxyResponseDeserializer;
 impl DeleteDBProxyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7234,9 +7351,10 @@ pub struct DeleteDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
 
+#[allow(dead_code)]
 struct DeleteDBSnapshotResultDeserializer;
 impl DeleteDBSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7307,9 +7425,10 @@ pub struct DeleteEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct DeleteEventSubscriptionResultDeserializer;
 impl DeleteEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7361,9 +7480,10 @@ pub struct DeleteGlobalClusterResult {
     pub global_cluster: Option<GlobalCluster>,
 }
 
+#[allow(dead_code)]
 struct DeleteGlobalClusterResultDeserializer;
 impl DeleteGlobalClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7480,9 +7600,10 @@ impl DeregisterDBProxyTargetsRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeregisterDBProxyTargetsResponse {}
 
+#[allow(dead_code)]
 struct DeregisterDBProxyTargetsResponseDeserializer;
 impl DeregisterDBProxyTargetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7831,9 +7952,10 @@ pub struct DescribeDBClusterSnapshotAttributesResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBClusterSnapshotAttributesResultDeserializer;
 impl DescribeDBClusterSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8162,9 +8284,10 @@ pub struct DescribeDBLogFilesDetails {
     pub size: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBLogFilesDetailsDeserializer;
 impl DescribeDBLogFilesDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8192,9 +8315,10 @@ impl DescribeDBLogFilesDetailsDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DescribeDBLogFilesListDeserializer;
 impl DescribeDBLogFilesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8280,9 +8404,10 @@ pub struct DescribeDBLogFilesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBLogFilesResponseDeserializer;
 impl DescribeDBLogFilesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8452,9 +8577,10 @@ pub struct DescribeDBProxiesResponse {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBProxiesResponseDeserializer;
 impl DescribeDBProxiesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8532,9 +8658,10 @@ pub struct DescribeDBProxyTargetGroupsResponse {
     pub target_groups: Option<Vec<DBProxyTargetGroup>>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBProxyTargetGroupsResponseDeserializer;
 impl DescribeDBProxyTargetGroupsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8612,9 +8739,10 @@ pub struct DescribeDBProxyTargetsResponse {
     pub targets: Option<Vec<DBProxyTarget>>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBProxyTargetsResponseDeserializer;
 impl DescribeDBProxyTargetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8714,9 +8842,10 @@ pub struct DescribeDBSnapshotAttributesResult {
     pub db_snapshot_attributes_result: Option<DBSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct DescribeDBSnapshotAttributesResultDeserializer;
 impl DescribeDBSnapshotAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8908,9 +9037,10 @@ pub struct DescribeEngineDefaultClusterParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
 
+#[allow(dead_code)]
 struct DescribeEngineDefaultClusterParametersResultDeserializer;
 impl DescribeEngineDefaultClusterParametersResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8982,9 +9112,10 @@ pub struct DescribeEngineDefaultParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
 
+#[allow(dead_code)]
 struct DescribeEngineDefaultParametersResultDeserializer;
 impl DescribeEngineDefaultParametersResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9721,9 +9852,10 @@ pub struct DescribeValidDBInstanceModificationsResult {
     pub valid_db_instance_modifications_message: Option<ValidDBInstanceModificationsMessage>,
 }
 
+#[allow(dead_code)]
 struct DescribeValidDBInstanceModificationsResultDeserializer;
 impl DescribeValidDBInstanceModificationsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9762,9 +9894,10 @@ pub struct DomainMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DomainMembershipDeserializer;
 impl DomainMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9790,9 +9923,10 @@ impl DomainMembershipDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DomainMembershipListDeserializer;
 impl DomainMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9810,9 +9944,10 @@ impl DomainMembershipListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DoubleDeserializer;
 impl DoubleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -9821,9 +9956,10 @@ impl DoubleDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DoubleOptionalDeserializer;
 impl DoubleOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -9842,9 +9978,10 @@ pub struct DoubleRange {
     pub to: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct DoubleRangeDeserializer;
 impl DoubleRangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9863,9 +10000,10 @@ impl DoubleRangeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DoubleRangeListDeserializer;
 impl DoubleRangeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9892,9 +10030,10 @@ pub struct DownloadDBLogFilePortionDetails {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DownloadDBLogFilePortionDetailsDeserializer;
 impl DownloadDBLogFilePortionDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9975,9 +10114,10 @@ pub struct EC2SecurityGroup {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EC2SecurityGroupDeserializer;
 impl EC2SecurityGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10011,9 +10151,10 @@ impl EC2SecurityGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EC2SecurityGroupListDeserializer;
 impl EC2SecurityGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10043,9 +10184,10 @@ pub struct Endpoint {
     pub port: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct EndpointDeserializer;
 impl EndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10080,9 +10222,10 @@ pub struct EngineDefaults {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct EngineDefaultsDeserializer;
 impl EngineDefaultsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10109,9 +10252,10 @@ impl EngineDefaultsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EngineModeListDeserializer;
 impl EngineModeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10156,9 +10300,10 @@ pub struct Event {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventDeserializer;
 impl EventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Event, XmlParseError> {
         deserialize_elements::<_, Event, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -10190,9 +10335,10 @@ impl EventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesListDeserializer;
 impl EventCategoriesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10229,9 +10375,10 @@ pub struct EventCategoriesMap {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMapDeserializer;
 impl EventCategoriesMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10252,9 +10399,10 @@ impl EventCategoriesMapDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesMapListDeserializer;
 impl EventCategoriesMapListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10280,9 +10428,10 @@ pub struct EventCategoriesMessage {
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMessageDeserializer;
 impl EventCategoriesMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10303,9 +10452,10 @@ impl EventCategoriesMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventListDeserializer;
 impl EventListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10346,9 +10496,10 @@ pub struct EventSubscription {
     pub subscription_creation_time: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventSubscriptionDeserializer;
 impl EventSubscriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10406,9 +10557,10 @@ impl EventSubscriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventSubscriptionsListDeserializer;
 impl EventSubscriptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10436,9 +10588,10 @@ pub struct EventSubscriptionsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventSubscriptionsMessageDeserializer;
 impl EventSubscriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10476,9 +10629,10 @@ pub struct EventsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventsMessageDeserializer;
 impl EventsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10535,9 +10689,10 @@ pub struct ExportTask {
     pub warning_message: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ExportTaskDeserializer;
 impl ExportTaskDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10609,9 +10764,10 @@ impl ExportTaskDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ExportTasksListDeserializer;
 impl ExportTasksListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10635,9 +10791,10 @@ pub struct ExportTasksMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ExportTasksMessageDeserializer;
 impl ExportTasksMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10696,9 +10853,10 @@ pub struct FailoverDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct FailoverDBClusterResultDeserializer;
 impl FailoverDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10719,9 +10877,10 @@ impl FailoverDBClusterResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct FeatureNameListDeserializer;
 impl FeatureNameListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10812,9 +10971,10 @@ pub struct GlobalCluster {
     pub storage_encrypted: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct GlobalClusterDeserializer;
 impl GlobalClusterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10877,9 +11037,10 @@ impl GlobalClusterDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GlobalClusterListDeserializer;
 impl GlobalClusterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10909,9 +11070,10 @@ pub struct GlobalClusterMember {
     pub readers: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct GlobalClusterMemberDeserializer;
 impl GlobalClusterMemberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10936,9 +11098,10 @@ impl GlobalClusterMemberDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GlobalClusterMemberListDeserializer;
 impl GlobalClusterMemberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10965,9 +11128,10 @@ pub struct GlobalClustersMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GlobalClustersMessageDeserializer;
 impl GlobalClustersMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10988,9 +11152,10 @@ impl GlobalClustersMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IAMAuthModeDeserializer;
 impl IAMAuthModeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -11009,9 +11174,10 @@ pub struct IPRange {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct IPRangeDeserializer;
 impl IPRangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11030,9 +11196,10 @@ impl IPRangeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IPRangeListDeserializer;
 impl IPRangeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11113,9 +11280,10 @@ pub struct InstallationMedia {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstallationMediaDeserializer;
 impl InstallationMediaDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11177,9 +11345,10 @@ pub struct InstallationMediaFailureCause {
     pub message: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstallationMediaFailureCauseDeserializer;
 impl InstallationMediaFailureCauseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11199,9 +11368,10 @@ impl InstallationMediaFailureCauseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct InstallationMediaListDeserializer;
 impl InstallationMediaListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11228,9 +11398,10 @@ pub struct InstallationMediaMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InstallationMediaMessageDeserializer;
 impl InstallationMediaMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11258,9 +11429,10 @@ impl InstallationMediaMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -11269,9 +11441,10 @@ impl IntegerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IntegerOptionalDeserializer;
 impl IntegerOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -11322,9 +11495,10 @@ impl ListTagsForResourceMessageSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LogTypeListDeserializer;
 impl LogTypeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11351,9 +11525,10 @@ impl LogTypeListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LongDeserializer;
 impl LongDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -11362,9 +11537,10 @@ impl LongDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LongOptionalDeserializer;
 impl LongOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -11383,9 +11559,10 @@ pub struct MinimumEngineVersionPerAllowedValue {
     pub minimum_engine_version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MinimumEngineVersionPerAllowedValueDeserializer;
 impl MinimumEngineVersionPerAllowedValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11412,9 +11589,10 @@ impl MinimumEngineVersionPerAllowedValueDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct MinimumEngineVersionPerAllowedValueListDeserializer;
 impl MinimumEngineVersionPerAllowedValueListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11473,9 +11651,10 @@ pub struct ModifyCertificatesResult {
     pub certificate: Option<Certificate>,
 }
 
+#[allow(dead_code)]
 struct ModifyCertificatesResultDeserializer;
 impl ModifyCertificatesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11780,9 +11959,10 @@ pub struct ModifyDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBClusterResultDeserializer;
 impl ModifyDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11852,9 +12032,10 @@ pub struct ModifyDBClusterSnapshotAttributeResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBClusterSnapshotAttributeResultDeserializer;
 impl ModifyDBClusterSnapshotAttributeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12177,9 +12358,10 @@ pub struct ModifyDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBInstanceResultDeserializer;
 impl ModifyDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12297,9 +12479,10 @@ pub struct ModifyDBProxyResponse {
     pub db_proxy: Option<DBProxy>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBProxyResponseDeserializer;
 impl ModifyDBProxyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12362,9 +12545,10 @@ pub struct ModifyDBProxyTargetGroupResponse {
     pub db_proxy_target_group: Option<DBProxyTargetGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBProxyTargetGroupResponseDeserializer;
 impl ModifyDBProxyTargetGroupResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12442,9 +12626,10 @@ pub struct ModifyDBSnapshotAttributeResult {
     pub db_snapshot_attributes_result: Option<DBSnapshotAttributesResult>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBSnapshotAttributeResultDeserializer;
 impl ModifyDBSnapshotAttributeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12507,9 +12692,10 @@ pub struct ModifyDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBSnapshotResultDeserializer;
 impl ModifyDBSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12571,9 +12757,10 @@ pub struct ModifyDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyDBSubnetGroupResultDeserializer;
 impl ModifyDBSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12650,9 +12837,10 @@ pub struct ModifyEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct ModifyEventSubscriptionResultDeserializer;
 impl ModifyEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12719,9 +12907,10 @@ pub struct ModifyGlobalClusterResult {
     pub global_cluster: Option<GlobalCluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyGlobalClusterResultDeserializer;
 impl ModifyGlobalClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12797,9 +12986,10 @@ pub struct ModifyOptionGroupResult {
     pub option_group: Option<OptionGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyOptionGroupResultDeserializer;
 impl ModifyOptionGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12844,9 +13034,10 @@ pub struct RDSOption {
     pub vpc_security_group_memberships: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct RDSOptionDeserializer;
 impl RDSOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12994,9 +13185,10 @@ pub struct OptionGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OptionGroupDeserializer;
 impl OptionGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13057,9 +13249,10 @@ pub struct OptionGroupMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OptionGroupMembershipDeserializer;
 impl OptionGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13079,9 +13272,10 @@ impl OptionGroupMembershipDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionGroupMembershipListDeserializer;
 impl OptionGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13137,9 +13331,10 @@ pub struct OptionGroupOption {
     pub vpc_only: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct OptionGroupOptionDeserializer;
 impl OptionGroupOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13258,9 +13453,10 @@ pub struct OptionGroupOptionSetting {
     pub setting_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OptionGroupOptionSettingDeserializer;
 impl OptionGroupOptionSettingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13316,9 +13512,10 @@ impl OptionGroupOptionSettingDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct OptionGroupOptionSettingsListDeserializer;
 impl OptionGroupOptionSettingsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13336,9 +13533,10 @@ impl OptionGroupOptionSettingsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionGroupOptionVersionsListDeserializer;
 impl OptionGroupOptionVersionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13356,9 +13554,10 @@ impl OptionGroupOptionVersionsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionGroupOptionsListDeserializer;
 impl OptionGroupOptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13385,9 +13584,10 @@ pub struct OptionGroupOptionsMessage {
     pub option_group_options: Option<Vec<OptionGroupOption>>,
 }
 
+#[allow(dead_code)]
 struct OptionGroupOptionsMessageDeserializer;
 impl OptionGroupOptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13425,9 +13625,10 @@ pub struct OptionGroups {
     pub option_groups_list: Option<Vec<OptionGroup>>,
 }
 
+#[allow(dead_code)]
 struct OptionGroupsDeserializer;
 impl OptionGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13448,9 +13649,10 @@ impl OptionGroupsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionGroupsListDeserializer;
 impl OptionGroupsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13502,9 +13704,10 @@ pub struct OptionSetting {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OptionSettingDeserializer;
 impl OptionSettingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13588,9 +13791,10 @@ impl OptionSettingSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OptionSettingConfigurationListDeserializer;
 impl OptionSettingConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13630,9 +13834,10 @@ pub struct OptionVersion {
     pub version: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OptionVersionDeserializer;
 impl OptionVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13651,9 +13856,10 @@ impl OptionVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionsConflictsWithDeserializer;
 impl OptionsConflictsWithDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13671,9 +13877,10 @@ impl OptionsConflictsWithDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionsDependedOnDeserializer;
 impl OptionsDependedOnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13688,9 +13895,10 @@ impl OptionsDependedOnDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OptionsListDeserializer;
 impl OptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13759,9 +13967,10 @@ pub struct OrderableDBInstanceOption {
     pub vpc: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionDeserializer;
 impl OrderableDBInstanceOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13912,9 +14121,10 @@ impl OrderableDBInstanceOptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionsListDeserializer;
 impl OrderableDBInstanceOptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13942,9 +14152,10 @@ pub struct OrderableDBInstanceOptionsMessage {
     pub orderable_db_instance_options: Option<Vec<OrderableDBInstanceOption>>,
 }
 
+#[allow(dead_code)]
 struct OrderableDBInstanceOptionsMessageDeserializer;
 impl OrderableDBInstanceOptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14001,9 +14212,10 @@ pub struct Parameter {
     pub supported_engine_modes: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ParameterDeserializer;
 impl ParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14112,9 +14324,10 @@ impl ParameterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ParametersListDeserializer;
 impl ParametersListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14151,9 +14364,10 @@ pub struct PendingCloudwatchLogsExports {
     pub log_types_to_enable: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct PendingCloudwatchLogsExportsDeserializer;
 impl PendingCloudwatchLogsExportsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14198,9 +14412,10 @@ pub struct PendingMaintenanceAction {
     pub opt_in_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PendingMaintenanceActionDeserializer;
 impl PendingMaintenanceActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14242,9 +14457,10 @@ impl PendingMaintenanceActionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct PendingMaintenanceActionDetailsDeserializer;
 impl PendingMaintenanceActionDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14262,9 +14478,10 @@ impl PendingMaintenanceActionDetailsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PendingMaintenanceActionsDeserializer;
 impl PendingMaintenanceActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14292,9 +14509,10 @@ pub struct PendingMaintenanceActionsMessage {
     pub pending_maintenance_actions: Option<Vec<ResourcePendingMaintenanceActions>>,
 }
 
+#[allow(dead_code)]
 struct PendingMaintenanceActionsMessageDeserializer;
 impl PendingMaintenanceActionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14357,9 +14575,10 @@ pub struct PendingModifiedValues {
     pub storage_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PendingModifiedValuesDeserializer;
 impl PendingModifiedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14454,9 +14673,10 @@ pub struct ProcessorFeature {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ProcessorFeatureDeserializer;
 impl ProcessorFeatureDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14494,9 +14714,10 @@ impl ProcessorFeatureSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ProcessorFeatureListDeserializer;
 impl ProcessorFeatureListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14556,9 +14777,10 @@ pub struct PromoteReadReplicaDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct PromoteReadReplicaDBClusterResultDeserializer;
 impl PromoteReadReplicaDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14625,9 +14847,10 @@ pub struct PromoteReadReplicaResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct PromoteReadReplicaResultDeserializer;
 impl PromoteReadReplicaResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14699,9 +14922,10 @@ pub struct PurchaseReservedDBInstancesOfferingResult {
     pub reserved_db_instance: Option<ReservedDBInstance>,
 }
 
+#[allow(dead_code)]
 struct PurchaseReservedDBInstancesOfferingResultDeserializer;
 impl PurchaseReservedDBInstancesOfferingResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14737,9 +14961,10 @@ pub struct Range {
     pub to: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct RangeDeserializer;
 impl RangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Range, XmlParseError> {
         deserialize_elements::<_, Range, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -14758,9 +14983,10 @@ impl RangeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RangeListDeserializer;
 impl RangeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14775,9 +15001,10 @@ impl RangeListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReadReplicaDBClusterIdentifierListDeserializer;
 impl ReadReplicaDBClusterIdentifierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14795,9 +15022,10 @@ impl ReadReplicaDBClusterIdentifierListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReadReplicaDBInstanceIdentifierListDeserializer;
 impl ReadReplicaDBInstanceIdentifierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14815,9 +15043,10 @@ impl ReadReplicaDBInstanceIdentifierListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReadReplicaIdentifierListDeserializer;
 impl ReadReplicaIdentifierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14835,9 +15064,10 @@ impl ReadReplicaIdentifierListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReadersArnListDeserializer;
 impl ReadersArnListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14887,9 +15117,10 @@ pub struct RebootDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct RebootDBInstanceResultDeserializer;
 impl RebootDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14916,9 +15147,10 @@ pub struct RecurringCharge {
     pub recurring_charge_frequency: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RecurringChargeDeserializer;
 impl RecurringChargeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14943,9 +15175,10 @@ impl RecurringChargeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RecurringChargeListDeserializer;
 impl RecurringChargeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15013,9 +15246,10 @@ pub struct RegisterDBProxyTargetsResponse {
     pub db_proxy_targets: Option<Vec<DBProxyTarget>>,
 }
 
+#[allow(dead_code)]
 struct RegisterDBProxyTargetsResponseDeserializer;
 impl RegisterDBProxyTargetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15076,9 +15310,10 @@ pub struct RemoveFromGlobalClusterResult {
     pub global_cluster: Option<GlobalCluster>,
 }
 
+#[allow(dead_code)]
 struct RemoveFromGlobalClusterResultDeserializer;
 impl RemoveFromGlobalClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15201,9 +15436,10 @@ pub struct RemoveSourceIdentifierFromSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct RemoveSourceIdentifierFromSubscriptionResultDeserializer;
 impl RemoveSourceIdentifierFromSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15288,9 +15524,10 @@ pub struct ReservedDBInstance {
     pub usage_price: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct ReservedDBInstanceDeserializer;
 impl ReservedDBInstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15369,9 +15606,10 @@ impl ReservedDBInstanceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReservedDBInstanceListDeserializer;
 impl ReservedDBInstanceListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15399,9 +15637,10 @@ pub struct ReservedDBInstanceMessage {
     pub reserved_db_instances: Option<Vec<ReservedDBInstance>>,
 }
 
+#[allow(dead_code)]
 struct ReservedDBInstanceMessageDeserializer;
 impl ReservedDBInstanceMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15455,9 +15694,10 @@ pub struct ReservedDBInstancesOffering {
     pub usage_price: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct ReservedDBInstancesOfferingDeserializer;
 impl ReservedDBInstancesOfferingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15521,9 +15761,10 @@ impl ReservedDBInstancesOfferingDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ReservedDBInstancesOfferingListDeserializer;
 impl ReservedDBInstancesOfferingListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15551,9 +15792,10 @@ pub struct ReservedDBInstancesOfferingMessage {
     pub reserved_db_instances_offerings: Option<Vec<ReservedDBInstancesOffering>>,
 }
 
+#[allow(dead_code)]
 struct ReservedDBInstancesOfferingMessageDeserializer;
 impl ReservedDBInstancesOfferingMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15667,9 +15909,10 @@ pub struct ResourcePendingMaintenanceActions {
     pub resource_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ResourcePendingMaintenanceActionsDeserializer;
 impl ResourcePendingMaintenanceActionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15896,9 +16139,10 @@ pub struct RestoreDBClusterFromS3Result {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBClusterFromS3ResultDeserializer;
 impl RestoreDBClusterFromS3ResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -16065,9 +16309,10 @@ pub struct RestoreDBClusterFromSnapshotResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBClusterFromSnapshotResultDeserializer;
 impl RestoreDBClusterFromSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -16215,9 +16460,10 @@ pub struct RestoreDBClusterToPointInTimeResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBClusterToPointInTimeResultDeserializer;
 impl RestoreDBClusterToPointInTimeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -16430,9 +16676,10 @@ pub struct RestoreDBInstanceFromDBSnapshotResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBInstanceFromDBSnapshotResultDeserializer;
 impl RestoreDBInstanceFromDBSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -16738,9 +16985,10 @@ pub struct RestoreDBInstanceFromS3Result {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBInstanceFromS3ResultDeserializer;
 impl RestoreDBInstanceFromS3ResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -16976,9 +17224,10 @@ pub struct RestoreDBInstanceToPointInTimeResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct RestoreDBInstanceToPointInTimeResultDeserializer;
 impl RestoreDBInstanceToPointInTimeResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17009,9 +17258,10 @@ pub struct RestoreWindow {
     pub latest_time: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RestoreWindowDeserializer;
 impl RestoreWindowDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17087,9 +17337,10 @@ pub struct RevokeDBSecurityGroupIngressResult {
     pub db_security_group: Option<DBSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct RevokeDBSecurityGroupIngressResultDeserializer;
 impl RevokeDBSecurityGroupIngressResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17174,9 +17425,10 @@ pub struct ScalingConfigurationInfo {
     pub timeout_action: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ScalingConfigurationInfoDeserializer;
 impl ScalingConfigurationInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17222,9 +17474,10 @@ impl ScalingConfigurationInfoDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SourceIdsListDeserializer;
 impl SourceIdsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17263,9 +17516,10 @@ pub struct SourceRegion {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SourceRegionDeserializer;
 impl SourceRegionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17287,9 +17541,10 @@ impl SourceRegionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SourceRegionListDeserializer;
 impl SourceRegionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17317,9 +17572,10 @@ pub struct SourceRegionMessage {
     pub source_regions: Option<Vec<SourceRegion>>,
 }
 
+#[allow(dead_code)]
 struct SourceRegionMessageDeserializer;
 impl SourceRegionMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17340,9 +17596,10 @@ impl SourceRegionMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -17397,9 +17654,10 @@ pub struct StartActivityStreamResponse {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StartActivityStreamResponseDeserializer;
 impl StartActivityStreamResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17465,9 +17723,10 @@ pub struct StartDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct StartDBClusterResultDeserializer;
 impl StartDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17512,9 +17771,10 @@ pub struct StartDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct StartDBInstanceResultDeserializer;
 impl StartDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17619,9 +17879,10 @@ pub struct StopActivityStreamResponse {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StopActivityStreamResponseDeserializer;
 impl StopActivityStreamResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17679,9 +17940,10 @@ pub struct StopDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
 
+#[allow(dead_code)]
 struct StopDBClusterResultDeserializer;
 impl StopDBClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17734,9 +17996,10 @@ pub struct StopDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
 
+#[allow(dead_code)]
 struct StopDBInstanceResultDeserializer;
 impl StopDBInstanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17753,9 +18016,10 @@ impl StopDBInstanceResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -17764,9 +18028,10 @@ impl StringDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StringListDeserializer;
 impl StringListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17793,9 +18058,10 @@ impl StringListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StringSensitiveDeserializer;
 impl StringSensitiveDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -17815,9 +18081,10 @@ pub struct Subnet {
     pub subnet_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SubnetDeserializer;
 impl SubnetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Subnet, XmlParseError> {
         deserialize_elements::<_, Subnet, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -17853,9 +18120,10 @@ impl SubnetIdentifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SubnetListDeserializer;
 impl SubnetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17870,9 +18138,10 @@ impl SubnetListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SupportedCharacterSetsListDeserializer;
 impl SupportedCharacterSetsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17890,9 +18159,10 @@ impl SupportedCharacterSetsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SupportedTimezonesListDeserializer;
 impl SupportedTimezonesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -17907,9 +18177,10 @@ impl SupportedTimezonesListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TStampDeserializer;
 impl TStampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -17929,9 +18200,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -17966,9 +18238,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18003,9 +18276,10 @@ pub struct TagListMessage {
     pub tag_list: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct TagListMessageDeserializer;
 impl TagListMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18023,9 +18297,10 @@ impl TagListMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TargetGroupListDeserializer;
 impl TargetGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18042,9 +18317,10 @@ impl TargetGroupListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TargetListDeserializer;
 impl TargetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18059,9 +18335,10 @@ impl TargetListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TargetTypeDeserializer;
 impl TargetTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -18078,9 +18355,10 @@ pub struct Timezone {
     pub timezone_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TimezoneDeserializer;
 impl TimezoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18113,9 +18391,10 @@ pub struct UpgradeTarget {
     pub is_major_version_upgrade: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct UpgradeTargetDeserializer;
 impl UpgradeTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18207,9 +18486,10 @@ pub struct UserAuthConfigInfo {
     pub user_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UserAuthConfigInfoDeserializer;
 impl UserAuthConfigInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18238,9 +18518,10 @@ impl UserAuthConfigInfoDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct UserAuthConfigInfoListDeserializer;
 impl UserAuthConfigInfoListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18279,9 +18560,10 @@ pub struct ValidDBInstanceModificationsMessage {
     pub valid_processor_features: Option<Vec<AvailableProcessorFeature>>,
 }
 
+#[allow(dead_code)]
 struct ValidDBInstanceModificationsMessageDeserializer;
 impl ValidDBInstanceModificationsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18327,9 +18609,10 @@ pub struct ValidStorageOptions {
     pub supports_storage_autoscaling: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct ValidStorageOptionsDeserializer;
 impl ValidStorageOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18366,9 +18649,10 @@ impl ValidStorageOptionsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValidStorageOptionsListDeserializer;
 impl ValidStorageOptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18386,9 +18670,10 @@ impl ValidStorageOptionsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ValidUpgradeTargetListDeserializer;
 impl ValidUpgradeTargetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18428,9 +18713,10 @@ pub struct VpcSecurityGroupMembership {
     pub vpc_security_group_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipDeserializer;
 impl VpcSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18456,9 +18742,10 @@ impl VpcSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipListDeserializer;
 impl VpcSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -18494,9 +18781,10 @@ pub struct VpnDetails {
     pub vpn_tunnel_originator_ip: Option<String>,
 }
 
+#[allow(dead_code)]
 struct VpnDetailsDeserializer;
 impl VpnDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -29753,9 +29753,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AddSourceIdentifierToSubscriptionResult::default();
         } else {
@@ -29831,9 +29830,8 @@ impl Rds for RdsClient {
             return Err(ApplyPendingMaintenanceActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ApplyPendingMaintenanceActionResult::default();
         } else {
@@ -29885,9 +29883,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AuthorizeDBSecurityGroupIngressResult::default();
         } else {
@@ -29934,9 +29931,8 @@ impl Rds for RdsClient {
             return Err(BacktrackDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterBacktrack::default();
         } else {
@@ -29983,9 +29979,8 @@ impl Rds for RdsClient {
             return Err(CancelExportTaskError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ExportTask::default();
         } else {
@@ -30030,9 +30025,8 @@ impl Rds for RdsClient {
             return Err(CopyDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBClusterParameterGroupResult::default();
         } else {
@@ -30079,9 +30073,8 @@ impl Rds for RdsClient {
             return Err(CopyDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBClusterSnapshotResult::default();
         } else {
@@ -30128,9 +30121,8 @@ impl Rds for RdsClient {
             return Err(CopyDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBParameterGroupResult::default();
         } else {
@@ -30177,9 +30169,8 @@ impl Rds for RdsClient {
             return Err(CopyDBSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyDBSnapshotResult::default();
         } else {
@@ -30224,9 +30215,8 @@ impl Rds for RdsClient {
             return Err(CopyOptionGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyOptionGroupResult::default();
         } else {
@@ -30274,9 +30264,8 @@ impl Rds for RdsClient {
             return Err(CreateCustomAvailabilityZoneError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateCustomAvailabilityZoneResult::default();
         } else {
@@ -30323,9 +30312,8 @@ impl Rds for RdsClient {
             return Err(CreateDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterResult::default();
         } else {
@@ -30372,9 +30360,8 @@ impl Rds for RdsClient {
             return Err(CreateDBClusterEndpointError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterEndpoint::default();
         } else {
@@ -30422,9 +30409,8 @@ impl Rds for RdsClient {
             return Err(CreateDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterParameterGroupResult::default();
         } else {
@@ -30471,9 +30457,8 @@ impl Rds for RdsClient {
             return Err(CreateDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBClusterSnapshotResult::default();
         } else {
@@ -30520,9 +30505,8 @@ impl Rds for RdsClient {
             return Err(CreateDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBInstanceResult::default();
         } else {
@@ -30570,9 +30554,8 @@ impl Rds for RdsClient {
             return Err(CreateDBInstanceReadReplicaError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBInstanceReadReplicaResult::default();
         } else {
@@ -30619,9 +30602,8 @@ impl Rds for RdsClient {
             return Err(CreateDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBParameterGroupResult::default();
         } else {
@@ -30668,9 +30650,8 @@ impl Rds for RdsClient {
             return Err(CreateDBProxyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBProxyResponse::default();
         } else {
@@ -30715,9 +30696,8 @@ impl Rds for RdsClient {
             return Err(CreateDBSecurityGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBSecurityGroupResult::default();
         } else {
@@ -30764,9 +30744,8 @@ impl Rds for RdsClient {
             return Err(CreateDBSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBSnapshotResult::default();
         } else {
@@ -30813,9 +30792,8 @@ impl Rds for RdsClient {
             return Err(CreateDBSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateDBSubnetGroupResult::default();
         } else {
@@ -30862,9 +30840,8 @@ impl Rds for RdsClient {
             return Err(CreateEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateEventSubscriptionResult::default();
         } else {
@@ -30911,9 +30888,8 @@ impl Rds for RdsClient {
             return Err(CreateGlobalClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateGlobalClusterResult::default();
         } else {
@@ -30960,9 +30936,8 @@ impl Rds for RdsClient {
             return Err(CreateOptionGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateOptionGroupResult::default();
         } else {
@@ -31010,9 +30985,8 @@ impl Rds for RdsClient {
             return Err(DeleteCustomAvailabilityZoneError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteCustomAvailabilityZoneResult::default();
         } else {
@@ -31059,9 +31033,8 @@ impl Rds for RdsClient {
             return Err(DeleteDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBClusterResult::default();
         } else {
@@ -31108,9 +31081,8 @@ impl Rds for RdsClient {
             return Err(DeleteDBClusterEndpointError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterEndpoint::default();
         } else {
@@ -31185,9 +31157,8 @@ impl Rds for RdsClient {
             return Err(DeleteDBClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBClusterSnapshotResult::default();
         } else {
@@ -31234,9 +31205,8 @@ impl Rds for RdsClient {
             return Err(DeleteDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBInstanceResult::default();
         } else {
@@ -31288,9 +31258,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBInstanceAutomatedBackupResult::default();
         } else {
@@ -31365,9 +31334,8 @@ impl Rds for RdsClient {
             return Err(DeleteDBProxyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBProxyResponse::default();
         } else {
@@ -31440,9 +31408,8 @@ impl Rds for RdsClient {
             return Err(DeleteDBSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteDBSnapshotResult::default();
         } else {
@@ -31517,9 +31484,8 @@ impl Rds for RdsClient {
             return Err(DeleteEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteEventSubscriptionResult::default();
         } else {
@@ -31566,9 +31532,8 @@ impl Rds for RdsClient {
             return Err(DeleteGlobalClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteGlobalClusterResult::default();
         } else {
@@ -31615,9 +31580,8 @@ impl Rds for RdsClient {
             return Err(DeleteInstallationMediaError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = InstallationMedia::default();
         } else {
@@ -31692,9 +31656,7 @@ impl Rds for RdsClient {
             return Err(DeregisterDBProxyTargetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeregisterDBProxyTargetsResponse::default();
         // parse non-payload
         Ok(result)
@@ -31724,9 +31686,8 @@ impl Rds for RdsClient {
             return Err(DescribeAccountAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AccountAttributesMessage::default();
         } else {
@@ -31773,9 +31734,8 @@ impl Rds for RdsClient {
             return Err(DescribeCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CertificateMessage::default();
         } else {
@@ -31825,9 +31785,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CustomAvailabilityZoneMessage::default();
         } else {
@@ -31874,9 +31833,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBClusterBacktracksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterBacktrackMessage::default();
         } else {
@@ -31923,9 +31881,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBClusterEndpointsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterEndpointMessage::default();
         } else {
@@ -31975,9 +31932,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupsMessage::default();
         } else {
@@ -32024,9 +31980,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBClusterParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupDetails::default();
         } else {
@@ -32078,9 +32033,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBClusterSnapshotAttributesResult::default();
         } else {
@@ -32127,9 +32081,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBClusterSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterSnapshotMessage::default();
         } else {
@@ -32176,9 +32129,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBClustersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterMessage::default();
         } else {
@@ -32223,9 +32175,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBEngineVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBEngineVersionMessage::default();
         } else {
@@ -32277,9 +32228,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBInstanceAutomatedBackupMessage::default();
         } else {
@@ -32326,9 +32276,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBInstanceMessage::default();
         } else {
@@ -32375,9 +32324,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBLogFilesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBLogFilesResponse::default();
         } else {
@@ -32424,9 +32372,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBParameterGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupsMessage::default();
         } else {
@@ -32473,9 +32420,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupDetails::default();
         } else {
@@ -32522,9 +32468,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBProxiesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBProxiesResponse::default();
         } else {
@@ -32572,9 +32517,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBProxyTargetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBProxyTargetGroupsResponse::default();
         } else {
@@ -32621,9 +32565,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBProxyTargetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBProxyTargetsResponse::default();
         } else {
@@ -32670,9 +32613,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBSecurityGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBSecurityGroupMessage::default();
         } else {
@@ -32720,9 +32662,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBSnapshotAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDBSnapshotAttributesResult::default();
         } else {
@@ -32769,9 +32710,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBSnapshotMessage::default();
         } else {
@@ -32818,9 +32758,8 @@ impl Rds for RdsClient {
             return Err(DescribeDBSubnetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBSubnetGroupMessage::default();
         } else {
@@ -32872,9 +32811,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEngineDefaultClusterParametersResult::default();
         } else {
@@ -32926,9 +32864,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeEngineDefaultParametersResult::default();
         } else {
@@ -32975,9 +32912,8 @@ impl Rds for RdsClient {
             return Err(DescribeEventCategoriesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventCategoriesMessage::default();
         } else {
@@ -33024,9 +32960,8 @@ impl Rds for RdsClient {
             return Err(DescribeEventSubscriptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventSubscriptionsMessage::default();
         } else {
@@ -33073,9 +33008,8 @@ impl Rds for RdsClient {
             return Err(DescribeEventsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventsMessage::default();
         } else {
@@ -33119,9 +33053,8 @@ impl Rds for RdsClient {
             return Err(DescribeExportTasksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ExportTasksMessage::default();
         } else {
@@ -33168,9 +33101,8 @@ impl Rds for RdsClient {
             return Err(DescribeGlobalClustersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GlobalClustersMessage::default();
         } else {
@@ -33217,9 +33149,8 @@ impl Rds for RdsClient {
             return Err(DescribeInstallationMediaError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = InstallationMediaMessage::default();
         } else {
@@ -33266,9 +33197,8 @@ impl Rds for RdsClient {
             return Err(DescribeOptionGroupOptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = OptionGroupOptionsMessage::default();
         } else {
@@ -33315,9 +33245,8 @@ impl Rds for RdsClient {
             return Err(DescribeOptionGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = OptionGroups::default();
         } else {
@@ -33367,9 +33296,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = OrderableDBInstanceOptionsMessage::default();
         } else {
@@ -33419,9 +33347,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PendingMaintenanceActionsMessage::default();
         } else {
@@ -33468,9 +33395,8 @@ impl Rds for RdsClient {
             return Err(DescribeReservedDBInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReservedDBInstanceMessage::default();
         } else {
@@ -33522,9 +33448,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReservedDBInstancesOfferingMessage::default();
         } else {
@@ -33571,9 +33496,8 @@ impl Rds for RdsClient {
             return Err(DescribeSourceRegionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SourceRegionMessage::default();
         } else {
@@ -33625,9 +33549,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeValidDBInstanceModificationsResult::default();
         } else {
@@ -33674,9 +33597,8 @@ impl Rds for RdsClient {
             return Err(DownloadDBLogFilePortionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DownloadDBLogFilePortionDetails::default();
         } else {
@@ -33723,9 +33645,8 @@ impl Rds for RdsClient {
             return Err(FailoverDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = FailoverDBClusterResult::default();
         } else {
@@ -33772,9 +33693,8 @@ impl Rds for RdsClient {
             return Err(ImportInstallationMediaError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = InstallationMedia::default();
         } else {
@@ -33821,9 +33741,8 @@ impl Rds for RdsClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TagListMessage::default();
         } else {
@@ -33868,9 +33787,8 @@ impl Rds for RdsClient {
             return Err(ModifyCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyCertificatesResult::default();
         } else {
@@ -33917,9 +33835,8 @@ impl Rds for RdsClient {
             return Err(ModifyCurrentDBClusterCapacityError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterCapacityInfo::default();
         } else {
@@ -33966,9 +33883,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBClusterResult::default();
         } else {
@@ -34015,9 +33931,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBClusterEndpointError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterEndpoint::default();
         } else {
@@ -34065,9 +33980,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupNameMessage::default();
         } else {
@@ -34119,9 +34033,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBClusterSnapshotAttributeResult::default();
         } else {
@@ -34168,9 +34081,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBInstanceResult::default();
         } else {
@@ -34217,9 +34129,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupNameMessage::default();
         } else {
@@ -34266,9 +34177,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBProxyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBProxyResponse::default();
         } else {
@@ -34313,9 +34223,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBProxyTargetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBProxyTargetGroupResponse::default();
         } else {
@@ -34362,9 +34271,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBSnapshotResult::default();
         } else {
@@ -34411,9 +34319,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBSnapshotAttributeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBSnapshotAttributeResult::default();
         } else {
@@ -34460,9 +34367,8 @@ impl Rds for RdsClient {
             return Err(ModifyDBSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyDBSubnetGroupResult::default();
         } else {
@@ -34509,9 +34415,8 @@ impl Rds for RdsClient {
             return Err(ModifyEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyEventSubscriptionResult::default();
         } else {
@@ -34558,9 +34463,8 @@ impl Rds for RdsClient {
             return Err(ModifyGlobalClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyGlobalClusterResult::default();
         } else {
@@ -34607,9 +34511,8 @@ impl Rds for RdsClient {
             return Err(ModifyOptionGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyOptionGroupResult::default();
         } else {
@@ -34656,9 +34559,8 @@ impl Rds for RdsClient {
             return Err(PromoteReadReplicaError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PromoteReadReplicaResult::default();
         } else {
@@ -34706,9 +34608,8 @@ impl Rds for RdsClient {
             return Err(PromoteReadReplicaDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PromoteReadReplicaDBClusterResult::default();
         } else {
@@ -34760,9 +34661,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PurchaseReservedDBInstancesOfferingResult::default();
         } else {
@@ -34809,9 +34709,8 @@ impl Rds for RdsClient {
             return Err(RebootDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RebootDBInstanceResult::default();
         } else {
@@ -34858,9 +34757,8 @@ impl Rds for RdsClient {
             return Err(RegisterDBProxyTargetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RegisterDBProxyTargetsResponse::default();
         } else {
@@ -34907,9 +34805,8 @@ impl Rds for RdsClient {
             return Err(RemoveFromGlobalClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RemoveFromGlobalClusterResult::default();
         } else {
@@ -35017,9 +34914,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RemoveSourceIdentifierFromSubscriptionResult::default();
         } else {
@@ -35095,9 +34991,8 @@ impl Rds for RdsClient {
             return Err(ResetDBClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBClusterParameterGroupNameMessage::default();
         } else {
@@ -35144,9 +35039,8 @@ impl Rds for RdsClient {
             return Err(ResetDBParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DBParameterGroupNameMessage::default();
         } else {
@@ -35193,9 +35087,8 @@ impl Rds for RdsClient {
             return Err(RestoreDBClusterFromS3Error::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBClusterFromS3Result::default();
         } else {
@@ -35243,9 +35136,8 @@ impl Rds for RdsClient {
             return Err(RestoreDBClusterFromSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBClusterFromSnapshotResult::default();
         } else {
@@ -35293,9 +35185,8 @@ impl Rds for RdsClient {
             return Err(RestoreDBClusterToPointInTimeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBClusterToPointInTimeResult::default();
         } else {
@@ -35347,9 +35238,8 @@ impl Rds for RdsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBInstanceFromDBSnapshotResult::default();
         } else {
@@ -35396,9 +35286,8 @@ impl Rds for RdsClient {
             return Err(RestoreDBInstanceFromS3Error::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBInstanceFromS3Result::default();
         } else {
@@ -35448,9 +35337,8 @@ impl Rds for RdsClient {
             return Err(RestoreDBInstanceToPointInTimeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreDBInstanceToPointInTimeResult::default();
         } else {
@@ -35498,9 +35386,8 @@ impl Rds for RdsClient {
             return Err(RevokeDBSecurityGroupIngressError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RevokeDBSecurityGroupIngressResult::default();
         } else {
@@ -35547,9 +35434,8 @@ impl Rds for RdsClient {
             return Err(StartActivityStreamError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StartActivityStreamResponse::default();
         } else {
@@ -35596,9 +35482,8 @@ impl Rds for RdsClient {
             return Err(StartDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StartDBClusterResult::default();
         } else {
@@ -35643,9 +35528,8 @@ impl Rds for RdsClient {
             return Err(StartDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StartDBInstanceResult::default();
         } else {
@@ -35692,9 +35576,8 @@ impl Rds for RdsClient {
             return Err(StartExportTaskError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ExportTask::default();
         } else {
@@ -35738,9 +35621,8 @@ impl Rds for RdsClient {
             return Err(StopActivityStreamError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StopActivityStreamResponse::default();
         } else {
@@ -35787,9 +35669,8 @@ impl Rds for RdsClient {
             return Err(StopDBClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StopDBClusterResult::default();
         } else {
@@ -35834,9 +35715,8 @@ impl Rds for RdsClient {
             return Err(StopDBInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = StopDBInstanceResult::default();
         } else {

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -72,9 +72,10 @@ pub struct AcceptReservedNodeExchangeOutputMessage {
     pub exchanged_reserved_node: Option<ReservedNode>,
 }
 
+#[allow(dead_code)]
 struct AcceptReservedNodeExchangeOutputMessageDeserializer;
 impl AcceptReservedNodeExchangeOutputMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -107,9 +108,10 @@ pub struct AccountAttribute {
     pub attribute_values: Option<Vec<AttributeValueTarget>>,
 }
 
+#[allow(dead_code)]
 struct AccountAttributeDeserializer;
 impl AccountAttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -138,9 +140,10 @@ pub struct AccountAttributeList {
     pub account_attributes: Option<Vec<AccountAttribute>>,
 }
 
+#[allow(dead_code)]
 struct AccountAttributeListDeserializer;
 impl AccountAttributeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -168,9 +171,10 @@ pub struct AccountWithRestoreAccess {
     pub account_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AccountWithRestoreAccessDeserializer;
 impl AccountWithRestoreAccessDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -194,9 +198,10 @@ impl AccountWithRestoreAccessDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AccountsWithRestoreAccessListDeserializer;
 impl AccountsWithRestoreAccessListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -214,9 +219,10 @@ impl AccountsWithRestoreAccessListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AssociatedClusterListDeserializer;
 impl AssociatedClusterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -234,9 +240,10 @@ impl AssociatedClusterListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AttributeListDeserializer;
 impl AttributeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -266,9 +273,10 @@ impl AttributeNameListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AttributeValueListDeserializer;
 impl AttributeValueListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -294,9 +302,10 @@ pub struct AttributeValueTarget {
     pub attribute_value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AttributeValueTargetDeserializer;
 impl AttributeValueTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -368,9 +377,10 @@ pub struct AuthorizeClusterSecurityGroupIngressResult {
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct AuthorizeClusterSecurityGroupIngressResultDeserializer;
 impl AuthorizeClusterSecurityGroupIngressResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -438,9 +448,10 @@ pub struct AuthorizeSnapshotAccessResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct AuthorizeSnapshotAccessResultDeserializer;
 impl AuthorizeSnapshotAccessResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -470,9 +481,10 @@ pub struct AvailabilityZone {
     pub supported_platforms: Option<Vec<SupportedPlatform>>,
 }
 
+#[allow(dead_code)]
 struct AvailabilityZoneDeserializer;
 impl AvailabilityZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -496,9 +508,10 @@ impl AvailabilityZoneDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AvailabilityZoneListDeserializer;
 impl AvailabilityZoneListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -549,9 +562,10 @@ pub struct BatchDeleteClusterSnapshotsResult {
     pub resources: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct BatchDeleteClusterSnapshotsResultDeserializer;
 impl BatchDeleteClusterSnapshotsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -626,9 +640,10 @@ pub struct BatchModifyClusterSnapshotsOutputMessage {
     pub resources: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct BatchModifyClusterSnapshotsOutputMessageDeserializer;
 impl BatchModifyClusterSnapshotsOutputMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -655,9 +670,10 @@ impl BatchModifyClusterSnapshotsOutputMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct BatchSnapshotOperationErrorListDeserializer;
 impl BatchSnapshotOperationErrorListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -675,9 +691,10 @@ impl BatchSnapshotOperationErrorListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BatchSnapshotOperationErrorsDeserializer;
 impl BatchSnapshotOperationErrorsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -695,9 +712,10 @@ impl BatchSnapshotOperationErrorsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -706,9 +724,10 @@ impl BooleanDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanOptionalDeserializer;
 impl BooleanOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -838,9 +857,10 @@ pub struct Cluster {
     pub vpc_security_groups: Option<Vec<VpcSecurityGroupMembership>>,
 }
 
+#[allow(dead_code)]
 struct ClusterDeserializer;
 impl ClusterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1105,9 +1125,10 @@ pub struct ClusterAssociatedToSchedule {
     pub schedule_association_state: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterAssociatedToScheduleDeserializer;
 impl ClusterAssociatedToScheduleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1147,9 +1168,10 @@ pub struct ClusterCredentials {
     pub expiration: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterCredentialsDeserializer;
 impl ClusterCredentialsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1188,9 +1210,10 @@ pub struct ClusterDbRevision {
     pub revision_targets: Option<Vec<RevisionTarget>>,
 }
 
+#[allow(dead_code)]
 struct ClusterDbRevisionDeserializer;
 impl ClusterDbRevisionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1224,9 +1247,10 @@ impl ClusterDbRevisionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ClusterDbRevisionsListDeserializer;
 impl ClusterDbRevisionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1253,9 +1277,10 @@ pub struct ClusterDbRevisionsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterDbRevisionsMessageDeserializer;
 impl ClusterDbRevisionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1293,9 +1318,10 @@ pub struct ClusterIamRole {
     pub iam_role_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterIamRoleDeserializer;
 impl ClusterIamRoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1314,9 +1340,10 @@ impl ClusterIamRoleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ClusterIamRoleListDeserializer;
 impl ClusterIamRoleListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1334,9 +1361,10 @@ impl ClusterIamRoleListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ClusterListDeserializer;
 impl ClusterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1363,9 +1391,10 @@ pub struct ClusterNode {
     pub public_ip_address: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterNodeDeserializer;
 impl ClusterNodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1389,9 +1418,10 @@ impl ClusterNodeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ClusterNodesListDeserializer;
 impl ClusterNodesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1420,9 +1450,10 @@ pub struct ClusterParameterGroup {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct ClusterParameterGroupDeserializer;
 impl ClusterParameterGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1465,9 +1496,10 @@ pub struct ClusterParameterGroupDetails {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct ClusterParameterGroupDetailsDeserializer;
 impl ClusterParameterGroupDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1502,9 +1534,10 @@ pub struct ClusterParameterGroupNameMessage {
     pub parameter_group_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterParameterGroupNameMessageDeserializer;
 impl ClusterParameterGroupNameMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1545,9 +1578,10 @@ pub struct ClusterParameterGroupStatus {
     pub parameter_group_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterParameterGroupStatusDeserializer;
 impl ClusterParameterGroupStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1584,9 +1618,10 @@ impl ClusterParameterGroupStatusDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ClusterParameterGroupStatusListDeserializer;
 impl ClusterParameterGroupStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1614,9 +1649,10 @@ pub struct ClusterParameterGroupsMessage {
     pub parameter_groups: Option<Vec<ClusterParameterGroup>>,
 }
 
+#[allow(dead_code)]
 struct ClusterParameterGroupsMessageDeserializer;
 impl ClusterParameterGroupsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1653,9 +1689,10 @@ pub struct ClusterParameterStatus {
     pub parameter_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterParameterStatusDeserializer;
 impl ClusterParameterStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1684,9 +1721,10 @@ impl ClusterParameterStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ClusterParameterStatusListDeserializer;
 impl ClusterParameterStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1719,9 +1757,10 @@ pub struct ClusterSecurityGroup {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct ClusterSecurityGroupDeserializer;
 impl ClusterSecurityGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1768,9 +1807,10 @@ pub struct ClusterSecurityGroupMembership {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterSecurityGroupMembershipDeserializer;
 impl ClusterSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1796,9 +1836,10 @@ impl ClusterSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ClusterSecurityGroupMembershipListDeserializer;
 impl ClusterSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1826,9 +1867,10 @@ pub struct ClusterSecurityGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterSecurityGroupMessageDeserializer;
 impl ClusterSecurityGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1868,9 +1910,10 @@ impl ClusterSecurityGroupNameListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ClusterSecurityGroupsDeserializer;
 impl ClusterSecurityGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1902,9 +1945,10 @@ pub struct ClusterSnapshotCopyStatus {
     pub snapshot_copy_grant_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterSnapshotCopyStatusDeserializer;
 impl ClusterSnapshotCopyStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1960,9 +2004,10 @@ pub struct ClusterSubnetGroup {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterSubnetGroupDeserializer;
 impl ClusterSubnetGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2011,9 +2056,10 @@ pub struct ClusterSubnetGroupMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterSubnetGroupMessageDeserializer;
 impl ClusterSubnetGroupMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2041,9 +2087,10 @@ impl ClusterSubnetGroupMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ClusterSubnetGroupsDeserializer;
 impl ClusterSubnetGroupsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2073,9 +2120,10 @@ pub struct ClusterVersion {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterVersionDeserializer;
 impl ClusterVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2101,9 +2149,10 @@ impl ClusterVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ClusterVersionListDeserializer;
 impl ClusterVersionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2131,9 +2180,10 @@ pub struct ClusterVersionsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClusterVersionsMessageDeserializer;
 impl ClusterVersionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2164,9 +2214,10 @@ pub struct ClustersMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ClustersMessageDeserializer;
 impl ClustersMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2239,9 +2290,10 @@ pub struct CopyClusterSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct CopyClusterSnapshotResultDeserializer;
 impl CopyClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2516,9 +2568,10 @@ pub struct CreateClusterParameterGroupResult {
     pub cluster_parameter_group: Option<ClusterParameterGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateClusterParameterGroupResultDeserializer;
 impl CreateClusterParameterGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2548,9 +2601,10 @@ pub struct CreateClusterResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct CreateClusterResultDeserializer;
 impl CreateClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2604,9 +2658,10 @@ pub struct CreateClusterSecurityGroupResult {
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateClusterSecurityGroupResultDeserializer;
 impl CreateClusterSecurityGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2679,9 +2734,10 @@ pub struct CreateClusterSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct CreateClusterSnapshotResultDeserializer;
 impl CreateClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2746,9 +2802,10 @@ pub struct CreateClusterSubnetGroupResult {
     pub cluster_subnet_group: Option<ClusterSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct CreateClusterSubnetGroupResultDeserializer;
 impl CreateClusterSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2843,9 +2900,10 @@ pub struct CreateEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct CreateEventSubscriptionResultDeserializer;
 impl CreateEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2903,9 +2961,10 @@ pub struct CreateHsmClientCertificateResult {
     pub hsm_client_certificate: Option<HsmClientCertificate>,
 }
 
+#[allow(dead_code)]
 struct CreateHsmClientCertificateResultDeserializer;
 impl CreateHsmClientCertificateResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2991,9 +3050,10 @@ pub struct CreateHsmConfigurationResult {
     pub hsm_configuration: Option<HsmConfiguration>,
 }
 
+#[allow(dead_code)]
 struct CreateHsmConfigurationResultDeserializer;
 impl CreateHsmConfigurationResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3115,9 +3175,10 @@ pub struct CreateSnapshotCopyGrantResult {
     pub snapshot_copy_grant: Option<SnapshotCopyGrant>,
 }
 
+#[allow(dead_code)]
 struct CreateSnapshotCopyGrantResultDeserializer;
 impl CreateSnapshotCopyGrantResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3227,9 +3288,10 @@ pub struct CustomerStorageMessage {
     pub total_provisioned_storage_in_mega_bytes: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct CustomerStorageMessageDeserializer;
 impl CustomerStorageMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3273,9 +3335,10 @@ pub struct DataTransferProgress {
     pub total_data_in_mega_bytes: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DataTransferProgressDeserializer;
 impl DataTransferProgressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3347,9 +3410,10 @@ pub struct DefaultClusterParameters {
     pub parameters: Option<Vec<Parameter>>,
 }
 
+#[allow(dead_code)]
 struct DefaultClusterParametersDeserializer;
 impl DefaultClusterParametersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3392,9 +3456,10 @@ pub struct DeferredMaintenanceWindow {
     pub defer_maintenance_start_time: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeferredMaintenanceWindowDeserializer;
 impl DeferredMaintenanceWindowDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3429,9 +3494,10 @@ impl DeferredMaintenanceWindowDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DeferredMaintenanceWindowsListDeserializer;
 impl DeferredMaintenanceWindowsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3527,9 +3593,10 @@ pub struct DeleteClusterResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct DeleteClusterResultDeserializer;
 impl DeleteClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3618,9 +3685,10 @@ pub struct DeleteClusterSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct DeleteClusterSnapshotResultDeserializer;
 impl DeleteClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4343,9 +4411,10 @@ pub struct DescribeDefaultClusterParametersResult {
     pub default_cluster_parameters: Option<DefaultClusterParameters>,
 }
 
+#[allow(dead_code)]
 struct DescribeDefaultClusterParametersResultDeserializer;
 impl DescribeDefaultClusterParametersResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4995,9 +5064,10 @@ pub struct DescribeSnapshotSchedulesOutputMessage {
     pub snapshot_schedules: Option<Vec<SnapshotSchedule>>,
 }
 
+#[allow(dead_code)]
 struct DescribeSnapshotSchedulesOutputMessageDeserializer;
 impl DescribeSnapshotSchedulesOutputMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5176,9 +5246,10 @@ pub struct DisableSnapshotCopyResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct DisableSnapshotCopyResultDeserializer;
 impl DisableSnapshotCopyResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5198,9 +5269,10 @@ impl DisableSnapshotCopyResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DoubleDeserializer;
 impl DoubleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5209,9 +5281,10 @@ impl DoubleDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DoubleOptionalDeserializer;
 impl DoubleOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5234,9 +5307,10 @@ pub struct EC2SecurityGroup {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct EC2SecurityGroupDeserializer;
 impl EC2SecurityGroupDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5269,9 +5343,10 @@ impl EC2SecurityGroupDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EC2SecurityGroupListDeserializer;
 impl EC2SecurityGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5299,9 +5374,10 @@ pub struct ElasticIpStatus {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ElasticIpStatusDeserializer;
 impl ElasticIpStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5320,9 +5396,10 @@ impl ElasticIpStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EligibleTracksToUpdateListDeserializer;
 impl EligibleTracksToUpdateListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5429,9 +5506,10 @@ pub struct EnableSnapshotCopyResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct EnableSnapshotCopyResultDeserializer;
 impl EnableSnapshotCopyResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5461,9 +5539,10 @@ pub struct Endpoint {
     pub port: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct EndpointDeserializer;
 impl EndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5502,9 +5581,10 @@ pub struct Event {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventDeserializer;
 impl EventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Event, XmlParseError> {
         deserialize_elements::<_, Event, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5539,9 +5619,10 @@ impl EventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesListDeserializer;
 impl EventCategoriesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5578,9 +5659,10 @@ pub struct EventCategoriesMap {
     pub source_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMapDeserializer;
 impl EventCategoriesMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5601,9 +5683,10 @@ impl EventCategoriesMapDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventCategoriesMapListDeserializer;
 impl EventCategoriesMapListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5629,9 +5712,10 @@ pub struct EventCategoriesMessage {
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
 }
 
+#[allow(dead_code)]
 struct EventCategoriesMessageDeserializer;
 impl EventCategoriesMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5666,9 +5750,10 @@ pub struct EventInfoMap {
     pub severity: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventInfoMapDeserializer;
 impl EventInfoMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5696,9 +5781,10 @@ impl EventInfoMapDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventInfoMapListDeserializer;
 impl EventInfoMapListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5716,9 +5802,10 @@ impl EventInfoMapListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventListDeserializer;
 impl EventListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5761,9 +5848,10 @@ pub struct EventSubscription {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct EventSubscriptionDeserializer;
 impl EventSubscriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5823,9 +5911,10 @@ impl EventSubscriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventSubscriptionsListDeserializer;
 impl EventSubscriptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5853,9 +5942,10 @@ pub struct EventSubscriptionsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventSubscriptionsMessageDeserializer;
 impl EventSubscriptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5893,9 +5983,10 @@ pub struct EventsMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EventsMessageDeserializer;
 impl EventsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6014,9 +6105,10 @@ pub struct GetReservedNodeExchangeOfferingsOutputMessage {
     pub reserved_node_offerings: Option<Vec<ReservedNodeOffering>>,
 }
 
+#[allow(dead_code)]
 struct GetReservedNodeExchangeOfferingsOutputMessageDeserializer;
 impl GetReservedNodeExchangeOfferingsOutputMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6056,9 +6148,10 @@ pub struct HsmClientCertificate {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct HsmClientCertificateDeserializer;
 impl HsmClientCertificateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6088,9 +6181,10 @@ impl HsmClientCertificateDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HsmClientCertificateListDeserializer;
 impl HsmClientCertificateListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6118,9 +6212,10 @@ pub struct HsmClientCertificateMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct HsmClientCertificateMessageDeserializer;
 impl HsmClientCertificateMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6164,9 +6259,10 @@ pub struct HsmConfiguration {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct HsmConfigurationDeserializer;
 impl HsmConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6201,9 +6297,10 @@ impl HsmConfigurationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HsmConfigurationListDeserializer;
 impl HsmConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6231,9 +6328,10 @@ pub struct HsmConfigurationMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct HsmConfigurationMessageDeserializer;
 impl HsmConfigurationMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6273,9 +6371,10 @@ pub struct HsmStatus {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct HsmStatusDeserializer;
 impl HsmStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6315,9 +6414,10 @@ pub struct IPRange {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct IPRangeDeserializer;
 impl IPRangeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6341,9 +6441,10 @@ impl IPRangeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IPRangeListDeserializer;
 impl IPRangeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6370,9 +6471,10 @@ impl IamRoleArnListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ImportTablesCompletedDeserializer;
 impl ImportTablesCompletedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6387,9 +6489,10 @@ impl ImportTablesCompletedDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ImportTablesInProgressDeserializer;
 impl ImportTablesInProgressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6404,9 +6507,10 @@ impl ImportTablesInProgressDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ImportTablesNotStartedDeserializer;
 impl ImportTablesNotStartedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6421,9 +6525,10 @@ impl ImportTablesNotStartedDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6432,9 +6537,10 @@ impl IntegerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IntegerOptionalDeserializer;
 impl IntegerOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6461,9 +6567,10 @@ pub struct LoggingStatus {
     pub s3_key_prefix: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LoggingStatusDeserializer;
 impl LoggingStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6503,9 +6610,10 @@ impl LoggingStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LongDeserializer;
 impl LongDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6514,9 +6622,10 @@ impl LongDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct LongOptionalDeserializer;
 impl LongOptionalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6537,9 +6646,10 @@ pub struct MaintenanceTrack {
     pub update_targets: Option<Vec<UpdateTarget>>,
 }
 
+#[allow(dead_code)]
 struct MaintenanceTrackDeserializer;
 impl MaintenanceTrackDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6570,9 +6680,10 @@ impl MaintenanceTrackDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ModeDeserializer;
 impl ModeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6616,9 +6727,10 @@ pub struct ModifyClusterDbRevisionResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyClusterDbRevisionResultDeserializer;
 impl ModifyClusterDbRevisionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6686,9 +6798,10 @@ pub struct ModifyClusterIamRolesResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyClusterIamRolesResultDeserializer;
 impl ModifyClusterIamRolesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6774,9 +6887,10 @@ pub struct ModifyClusterMaintenanceResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyClusterMaintenanceResultDeserializer;
 impl ModifyClusterMaintenanceResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6997,9 +7111,10 @@ pub struct ModifyClusterResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct ModifyClusterResultDeserializer;
 impl ModifyClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7057,9 +7172,10 @@ pub struct ModifyClusterSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct ModifyClusterSnapshotResultDeserializer;
 impl ModifyClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7157,9 +7273,10 @@ pub struct ModifyClusterSubnetGroupResult {
     pub cluster_subnet_group: Option<ClusterSubnetGroup>,
 }
 
+#[allow(dead_code)]
 struct ModifyClusterSubnetGroupResultDeserializer;
 impl ModifyClusterSubnetGroupResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7251,9 +7368,10 @@ pub struct ModifyEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
 
+#[allow(dead_code)]
 struct ModifyEventSubscriptionResultDeserializer;
 impl ModifyEventSubscriptionResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7382,9 +7500,10 @@ pub struct ModifySnapshotCopyRetentionPeriodResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct ModifySnapshotCopyRetentionPeriodResultDeserializer;
 impl ModifySnapshotCopyRetentionPeriodResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7448,9 +7567,10 @@ pub struct NodeConfigurationOption {
     pub number_of_nodes: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct NodeConfigurationOptionDeserializer;
 impl NodeConfigurationOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7484,9 +7604,10 @@ impl NodeConfigurationOptionDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct NodeConfigurationOptionListDeserializer;
 impl NodeConfigurationOptionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7561,9 +7682,10 @@ pub struct NodeConfigurationOptionsMessage {
     pub node_configuration_option_list: Option<Vec<NodeConfigurationOption>>,
 }
 
+#[allow(dead_code)]
 struct NodeConfigurationOptionsMessageDeserializer;
 impl NodeConfigurationOptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7605,9 +7727,10 @@ pub struct OrderableClusterOption {
     pub node_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OrderableClusterOptionDeserializer;
 impl OrderableClusterOptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7635,9 +7758,10 @@ impl OrderableClusterOptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct OrderableClusterOptionsListDeserializer;
 impl OrderableClusterOptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7665,9 +7789,10 @@ pub struct OrderableClusterOptionsMessage {
     pub orderable_cluster_options: Option<Vec<OrderableClusterOption>>,
 }
 
+#[allow(dead_code)]
 struct OrderableClusterOptionsMessageDeserializer;
 impl OrderableClusterOptionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7720,9 +7845,10 @@ pub struct Parameter {
     pub source: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ParameterDeserializer;
 impl ParameterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7815,9 +7941,10 @@ impl ParameterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ParameterApplyTypeDeserializer;
 impl ParameterApplyTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7826,9 +7953,10 @@ impl ParameterApplyTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ParameterGroupListDeserializer;
 impl ParameterGroupListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7846,9 +7974,10 @@ impl ParameterGroupListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ParametersListDeserializer;
 impl ParametersListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7875,9 +8004,10 @@ impl ParametersListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PendingActionsListDeserializer;
 impl PendingActionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7920,9 +8050,10 @@ pub struct PendingModifiedValues {
     pub publicly_accessible: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct PendingModifiedValuesDeserializer;
 impl PendingModifiedValuesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8025,9 +8156,10 @@ pub struct PurchaseReservedNodeOfferingResult {
     pub reserved_node: Option<ReservedNode>,
 }
 
+#[allow(dead_code)]
 struct PurchaseReservedNodeOfferingResultDeserializer;
 impl PurchaseReservedNodeOfferingResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8080,9 +8212,10 @@ pub struct RebootClusterResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct RebootClusterResultDeserializer;
 impl RebootClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8108,9 +8241,10 @@ pub struct RecurringCharge {
     pub recurring_charge_frequency: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RecurringChargeDeserializer;
 impl RecurringChargeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8135,9 +8269,10 @@ impl RecurringChargeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RecurringChargeListDeserializer;
 impl RecurringChargeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8187,9 +8322,10 @@ pub struct ReservedNode {
     pub usage_price: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct ReservedNodeDeserializer;
 impl ReservedNodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8253,9 +8389,10 @@ impl ReservedNodeDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReservedNodeListDeserializer;
 impl ReservedNodeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8297,9 +8434,10 @@ pub struct ReservedNodeOffering {
     pub usage_price: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct ReservedNodeOfferingDeserializer;
 impl ReservedNodeOfferingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8350,9 +8488,10 @@ impl ReservedNodeOfferingDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReservedNodeOfferingListDeserializer;
 impl ReservedNodeOfferingListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8370,9 +8509,10 @@ impl ReservedNodeOfferingListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReservedNodeOfferingTypeDeserializer;
 impl ReservedNodeOfferingTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8391,9 +8531,10 @@ pub struct ReservedNodeOfferingsMessage {
     pub reserved_node_offerings: Option<Vec<ReservedNodeOffering>>,
 }
 
+#[allow(dead_code)]
 struct ReservedNodeOfferingsMessageDeserializer;
 impl ReservedNodeOfferingsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8431,9 +8572,10 @@ pub struct ReservedNodesMessage {
     pub reserved_nodes: Option<Vec<ReservedNode>>,
 }
 
+#[allow(dead_code)]
 struct ReservedNodesMessageDeserializer;
 impl ReservedNodesMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8508,9 +8650,10 @@ pub struct ResizeClusterMessage {
     pub number_of_nodes: i64,
 }
 
+#[allow(dead_code)]
 struct ResizeClusterMessageDeserializer;
 impl ResizeClusterMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8575,9 +8718,10 @@ pub struct ResizeClusterResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct ResizeClusterResultDeserializer;
 impl ResizeClusterResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8603,9 +8747,10 @@ pub struct ResizeInfo {
     pub resize_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ResizeInfoDeserializer;
 impl ResizeInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8665,9 +8810,10 @@ pub struct ResizeProgressMessage {
     pub total_resize_data_in_mega_bytes: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ResizeProgressMessageDeserializer;
 impl ResizeProgressMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8771,9 +8917,10 @@ impl ResizeProgressMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RestorableNodeTypeListDeserializer;
 impl RestorableNodeTypeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8989,9 +9136,10 @@ pub struct RestoreFromClusterSnapshotResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct RestoreFromClusterSnapshotResultDeserializer;
 impl RestoreFromClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9029,9 +9177,10 @@ pub struct RestoreStatus {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RestoreStatusDeserializer;
 impl RestoreStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9144,9 +9293,10 @@ pub struct RestoreTableFromClusterSnapshotResult {
     pub table_restore_status: Option<TableRestoreStatus>,
 }
 
+#[allow(dead_code)]
 struct RestoreTableFromClusterSnapshotResultDeserializer;
 impl RestoreTableFromClusterSnapshotResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9182,9 +9332,10 @@ pub struct RevisionTarget {
     pub description: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RevisionTargetDeserializer;
 impl RevisionTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9210,9 +9361,10 @@ impl RevisionTargetDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RevisionTargetsListDeserializer;
 impl RevisionTargetsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9281,9 +9433,10 @@ pub struct RevokeClusterSecurityGroupIngressResult {
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
 
+#[allow(dead_code)]
 struct RevokeClusterSecurityGroupIngressResultDeserializer;
 impl RevokeClusterSecurityGroupIngressResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9351,9 +9504,10 @@ pub struct RevokeSnapshotAccessResult {
     pub snapshot: Option<Snapshot>,
 }
 
+#[allow(dead_code)]
 struct RevokeSnapshotAccessResultDeserializer;
 impl RevokeSnapshotAccessResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9403,9 +9557,10 @@ pub struct RotateEncryptionKeyResult {
     pub cluster: Option<Cluster>,
 }
 
+#[allow(dead_code)]
 struct RotateEncryptionKeyResultDeserializer;
 impl RotateEncryptionKeyResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9425,9 +9580,10 @@ impl RotateEncryptionKeyResultDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ScheduleDefinitionListDeserializer;
 impl ScheduleDefinitionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9457,9 +9613,10 @@ impl ScheduleDefinitionListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ScheduleStateDeserializer;
 impl ScheduleStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9492,9 +9649,10 @@ pub struct ScheduledAction {
     pub target_action: Option<ScheduledActionType>,
 }
 
+#[allow(dead_code)]
 struct ScheduledActionDeserializer;
 impl ScheduledActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9582,9 +9740,10 @@ impl ScheduledActionFilterListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ScheduledActionListDeserializer;
 impl ScheduledActionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9602,9 +9761,10 @@ impl ScheduledActionListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ScheduledActionStateDeserializer;
 impl ScheduledActionStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9613,9 +9773,10 @@ impl ScheduledActionStateDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ScheduledActionTimeListDeserializer;
 impl ScheduledActionTimeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9642,9 +9803,10 @@ pub struct ScheduledActionType {
     pub resize_cluster: Option<ResizeClusterMessage>,
 }
 
+#[allow(dead_code)]
 struct ScheduledActionTypeDeserializer;
 impl ScheduledActionTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9692,9 +9854,10 @@ pub struct ScheduledActionsMessage {
     pub scheduled_actions: Option<Vec<ScheduledAction>>,
 }
 
+#[allow(dead_code)]
 struct ScheduledActionsMessageDeserializer;
 impl ScheduledActionsMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9722,9 +9885,10 @@ impl ScheduledActionsMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ScheduledSnapshotTimeListDeserializer;
 impl ScheduledSnapshotTimeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9739,9 +9903,10 @@ impl ScheduledSnapshotTimeListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SensitiveStringDeserializer;
 impl SensitiveStringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9822,9 +9987,10 @@ pub struct Snapshot {
     pub vpc_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SnapshotDeserializer;
 impl SnapshotDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10013,9 +10179,10 @@ pub struct SnapshotCopyGrant {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct SnapshotCopyGrantDeserializer;
 impl SnapshotCopyGrantDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10042,9 +10209,10 @@ impl SnapshotCopyGrantDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SnapshotCopyGrantListDeserializer;
 impl SnapshotCopyGrantListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10072,9 +10240,10 @@ pub struct SnapshotCopyGrantMessage {
     pub snapshot_copy_grants: Option<Vec<SnapshotCopyGrant>>,
 }
 
+#[allow(dead_code)]
 struct SnapshotCopyGrantMessageDeserializer;
 impl SnapshotCopyGrantMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10116,9 +10285,10 @@ pub struct SnapshotErrorMessage {
     pub snapshot_identifier: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SnapshotErrorMessageDeserializer;
 impl SnapshotErrorMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10150,9 +10320,10 @@ impl SnapshotErrorMessageDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SnapshotIdentifierListDeserializer;
 impl SnapshotIdentifierListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10179,9 +10350,10 @@ impl SnapshotIdentifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SnapshotListDeserializer;
 impl SnapshotListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10206,9 +10378,10 @@ pub struct SnapshotMessage {
     pub snapshots: Option<Vec<Snapshot>>,
 }
 
+#[allow(dead_code)]
 struct SnapshotMessageDeserializer;
 impl SnapshotMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10249,9 +10422,10 @@ pub struct SnapshotSchedule {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct SnapshotScheduleDeserializer;
 impl SnapshotScheduleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10311,9 +10485,10 @@ impl SnapshotScheduleDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SnapshotScheduleListDeserializer;
 impl SnapshotScheduleListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10368,9 +10543,10 @@ impl SnapshotSortingEntityListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SourceIdsListDeserializer;
 impl SourceIdsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10397,9 +10573,10 @@ impl SourceIdsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SourceTypeDeserializer;
 impl SourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10408,9 +10585,10 @@ impl SourceTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10431,9 +10609,10 @@ pub struct Subnet {
     pub subnet_status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SubnetDeserializer;
 impl SubnetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Subnet, XmlParseError> {
         deserialize_elements::<_, Subnet, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -10469,9 +10648,10 @@ impl SubnetIdentifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SubnetListDeserializer;
 impl SubnetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10494,9 +10674,10 @@ pub struct SupportedOperation {
     pub operation_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SupportedOperationDeserializer;
 impl SupportedOperationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10513,9 +10694,10 @@ impl SupportedOperationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SupportedOperationListDeserializer;
 impl SupportedOperationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10541,9 +10723,10 @@ pub struct SupportedPlatform {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SupportedPlatformDeserializer;
 impl SupportedPlatformDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10559,9 +10742,10 @@ impl SupportedPlatformDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SupportedPlatformsListDeserializer;
 impl SupportedPlatformsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10579,9 +10763,10 @@ impl SupportedPlatformsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TStampDeserializer;
 impl TStampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10624,9 +10809,10 @@ pub struct TableRestoreStatus {
     pub total_data_in_mega_bytes: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct TableRestoreStatusDeserializer;
 impl TableRestoreStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10706,9 +10892,10 @@ impl TableRestoreStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TableRestoreStatusListDeserializer;
 impl TableRestoreStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10736,9 +10923,10 @@ pub struct TableRestoreStatusMessage {
     pub table_restore_status_details: Option<Vec<TableRestoreStatus>>,
 }
 
+#[allow(dead_code)]
 struct TableRestoreStatusMessageDeserializer;
 impl TableRestoreStatusMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10766,9 +10954,10 @@ impl TableRestoreStatusMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct TableRestoreStatusTypeDeserializer;
 impl TableRestoreStatusTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10788,9 +10977,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -10836,9 +11026,10 @@ impl TagKeyListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10888,9 +11079,10 @@ pub struct TaggedResource {
     pub tag: Option<Tag>,
 }
 
+#[allow(dead_code)]
 struct TaggedResourceDeserializer;
 impl TaggedResourceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10914,9 +11106,10 @@ impl TaggedResourceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TaggedResourceListDeserializer;
 impl TaggedResourceListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10944,9 +11137,10 @@ pub struct TaggedResourceListMessage {
     pub tagged_resources: Option<Vec<TaggedResource>>,
 }
 
+#[allow(dead_code)]
 struct TaggedResourceListMessageDeserializer;
 impl TaggedResourceListMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10971,9 +11165,10 @@ impl TaggedResourceListMessageDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct TrackListDeserializer;
 impl TrackListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11000,9 +11195,10 @@ pub struct TrackListMessage {
     pub marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TrackListMessageDeserializer;
 impl TrackListMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11035,9 +11231,10 @@ pub struct UpdateTarget {
     pub supported_operations: Option<Vec<SupportedOperation>>,
 }
 
+#[allow(dead_code)]
 struct UpdateTargetDeserializer;
 impl UpdateTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11101,9 +11298,10 @@ pub struct VpcSecurityGroupMembership {
     pub vpc_security_group_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipDeserializer;
 impl VpcSecurityGroupMembershipDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11129,9 +11327,10 @@ impl VpcSecurityGroupMembershipDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct VpcSecurityGroupMembershipListDeserializer;
 impl VpcSecurityGroupMembershipListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -18517,9 +18517,8 @@ impl Redshift for RedshiftClient {
             return Err(AcceptReservedNodeExchangeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AcceptReservedNodeExchangeOutputMessage::default();
         } else {
@@ -18571,9 +18570,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AuthorizeClusterSecurityGroupIngressResult::default();
         } else {
@@ -18620,9 +18618,8 @@ impl Redshift for RedshiftClient {
             return Err(AuthorizeSnapshotAccessError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AuthorizeSnapshotAccessResult::default();
         } else {
@@ -18670,9 +18667,8 @@ impl Redshift for RedshiftClient {
             return Err(BatchDeleteClusterSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = BatchDeleteClusterSnapshotsResult::default();
         } else {
@@ -18722,9 +18718,8 @@ impl Redshift for RedshiftClient {
             return Err(BatchModifyClusterSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = BatchModifyClusterSnapshotsOutputMessage::default();
         } else {
@@ -18771,9 +18766,8 @@ impl Redshift for RedshiftClient {
             return Err(CancelResizeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ResizeProgressMessage::default();
         } else {
@@ -18818,9 +18812,8 @@ impl Redshift for RedshiftClient {
             return Err(CopyClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyClusterSnapshotResult::default();
         } else {
@@ -18867,9 +18860,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateClusterResult::default();
         } else {
@@ -18915,9 +18907,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateClusterParameterGroupResult::default();
         } else {
@@ -18965,9 +18956,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateClusterSecurityGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateClusterSecurityGroupResult::default();
         } else {
@@ -19014,9 +19004,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateClusterSnapshotResult::default();
         } else {
@@ -19063,9 +19052,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateClusterSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateClusterSubnetGroupResult::default();
         } else {
@@ -19112,9 +19100,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateEventSubscriptionResult::default();
         } else {
@@ -19162,9 +19149,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateHsmClientCertificateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateHsmClientCertificateResult::default();
         } else {
@@ -19211,9 +19197,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateHsmConfigurationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateHsmConfigurationResult::default();
         } else {
@@ -19260,9 +19245,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateScheduledActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ScheduledAction::default();
         } else {
@@ -19309,9 +19293,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateSnapshotCopyGrantError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateSnapshotCopyGrantResult::default();
         } else {
@@ -19358,9 +19341,8 @@ impl Redshift for RedshiftClient {
             return Err(CreateSnapshotScheduleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SnapshotSchedule::default();
         } else {
@@ -19435,9 +19417,8 @@ impl Redshift for RedshiftClient {
             return Err(DeleteClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteClusterResult::default();
         } else {
@@ -19538,9 +19519,8 @@ impl Redshift for RedshiftClient {
             return Err(DeleteClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteClusterSnapshotResult::default();
         } else {
@@ -19811,9 +19791,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeAccountAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AccountAttributeList::default();
         } else {
@@ -19860,9 +19839,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterDbRevisionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterDbRevisionsMessage::default();
         } else {
@@ -19910,9 +19888,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterParameterGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterParameterGroupsMessage::default();
         } else {
@@ -19959,9 +19936,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterParametersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterParameterGroupDetails::default();
         } else {
@@ -20008,9 +19984,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterSecurityGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterSecurityGroupMessage::default();
         } else {
@@ -20057,9 +20032,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterSnapshotsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SnapshotMessage::default();
         } else {
@@ -20106,9 +20080,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterSubnetGroupsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterSubnetGroupMessage::default();
         } else {
@@ -20155,9 +20128,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterTracksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TrackListMessage::default();
         } else {
@@ -20204,9 +20176,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClusterVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterVersionsMessage::default();
         } else {
@@ -20253,9 +20224,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeClustersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClustersMessage::default();
         } else {
@@ -20305,9 +20275,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeDefaultClusterParametersResult::default();
         } else {
@@ -20354,9 +20323,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeEventCategoriesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventCategoriesMessage::default();
         } else {
@@ -20403,9 +20371,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeEventSubscriptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventSubscriptionsMessage::default();
         } else {
@@ -20452,9 +20419,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeEventsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EventsMessage::default();
         } else {
@@ -20498,9 +20464,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeHsmClientCertificatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = HsmClientCertificateMessage::default();
         } else {
@@ -20547,9 +20512,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeHsmConfigurationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = HsmConfigurationMessage::default();
         } else {
@@ -20596,9 +20560,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeLoggingStatusError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = LoggingStatus::default();
         } else {
@@ -20646,9 +20609,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = NodeConfigurationOptionsMessage::default();
         } else {
@@ -20698,9 +20660,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = OrderableClusterOptionsMessage::default();
         } else {
@@ -20747,9 +20708,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeReservedNodeOfferingsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReservedNodeOfferingsMessage::default();
         } else {
@@ -20796,9 +20756,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeReservedNodesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReservedNodesMessage::default();
         } else {
@@ -20845,9 +20804,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeResizeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ResizeProgressMessage::default();
         } else {
@@ -20892,9 +20850,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeScheduledActionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ScheduledActionsMessage::default();
         } else {
@@ -20941,9 +20898,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeSnapshotCopyGrantsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SnapshotCopyGrantMessage::default();
         } else {
@@ -20991,9 +20947,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeSnapshotSchedulesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeSnapshotSchedulesOutputMessage::default();
         } else {
@@ -21039,9 +20994,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeStorageError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CustomerStorageMessage::default();
         } else {
@@ -21088,9 +21042,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeTableRestoreStatusError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TableRestoreStatusMessage::default();
         } else {
@@ -21137,9 +21090,8 @@ impl Redshift for RedshiftClient {
             return Err(DescribeTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TaggedResourceListMessage::default();
         } else {
@@ -21186,9 +21138,8 @@ impl Redshift for RedshiftClient {
             return Err(DisableLoggingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = LoggingStatus::default();
         } else {
@@ -21232,9 +21183,8 @@ impl Redshift for RedshiftClient {
             return Err(DisableSnapshotCopyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DisableSnapshotCopyResult::default();
         } else {
@@ -21281,9 +21231,8 @@ impl Redshift for RedshiftClient {
             return Err(EnableLoggingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = LoggingStatus::default();
         } else {
@@ -21327,9 +21276,8 @@ impl Redshift for RedshiftClient {
             return Err(EnableSnapshotCopyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = EnableSnapshotCopyResult::default();
         } else {
@@ -21376,9 +21324,8 @@ impl Redshift for RedshiftClient {
             return Err(GetClusterCredentialsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterCredentials::default();
         } else {
@@ -21430,9 +21377,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetReservedNodeExchangeOfferingsOutputMessage::default();
         } else {
@@ -21479,9 +21425,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyClusterResult::default();
         } else {
@@ -21526,9 +21471,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyClusterDbRevisionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyClusterDbRevisionResult::default();
         } else {
@@ -21575,9 +21519,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyClusterIamRolesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyClusterIamRolesResult::default();
         } else {
@@ -21624,9 +21567,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyClusterMaintenanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyClusterMaintenanceResult::default();
         } else {
@@ -21674,9 +21616,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterParameterGroupNameMessage::default();
         } else {
@@ -21723,9 +21664,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyClusterSnapshotResult::default();
         } else {
@@ -21800,9 +21740,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyClusterSubnetGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyClusterSubnetGroupResult::default();
         } else {
@@ -21849,9 +21788,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyEventSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifyEventSubscriptionResult::default();
         } else {
@@ -21898,9 +21836,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifyScheduledActionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ScheduledAction::default();
         } else {
@@ -21952,9 +21889,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ModifySnapshotCopyRetentionPeriodResult::default();
         } else {
@@ -22001,9 +21937,8 @@ impl Redshift for RedshiftClient {
             return Err(ModifySnapshotScheduleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SnapshotSchedule::default();
         } else {
@@ -22051,9 +21986,8 @@ impl Redshift for RedshiftClient {
             return Err(PurchaseReservedNodeOfferingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PurchaseReservedNodeOfferingResult::default();
         } else {
@@ -22100,9 +22034,8 @@ impl Redshift for RedshiftClient {
             return Err(RebootClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RebootClusterResult::default();
         } else {
@@ -22148,9 +22081,8 @@ impl Redshift for RedshiftClient {
             return Err(ResetClusterParameterGroupError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ClusterParameterGroupNameMessage::default();
         } else {
@@ -22197,9 +22129,8 @@ impl Redshift for RedshiftClient {
             return Err(ResizeClusterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ResizeClusterResult::default();
         } else {
@@ -22245,9 +22176,8 @@ impl Redshift for RedshiftClient {
             return Err(RestoreFromClusterSnapshotError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreFromClusterSnapshotResult::default();
         } else {
@@ -22299,9 +22229,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RestoreTableFromClusterSnapshotResult::default();
         } else {
@@ -22353,9 +22282,8 @@ impl Redshift for RedshiftClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RevokeClusterSecurityGroupIngressResult::default();
         } else {
@@ -22402,9 +22330,8 @@ impl Redshift for RedshiftClient {
             return Err(RevokeSnapshotAccessError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RevokeSnapshotAccessResult::default();
         } else {
@@ -22451,9 +22378,8 @@ impl Redshift for RedshiftClient {
             return Err(RotateEncryptionKeyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = RotateEncryptionKeyResult::default();
         } else {

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -12222,9 +12222,8 @@ impl Route53 for Route53Client {
             return Err(AssociateVPCWithHostedZoneError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AssociateVPCWithHostedZoneResponse::default();
         } else {
@@ -12280,9 +12279,8 @@ impl Route53 for Route53Client {
             return Err(ChangeResourceRecordSetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ChangeResourceRecordSetsResponse::default();
         } else {
@@ -12338,9 +12336,7 @@ impl Route53 for Route53Client {
             return Err(ChangeTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = ChangeTagsForResourceResponse::default();
         // parse non-payload
         Ok(result)
@@ -12375,9 +12371,8 @@ impl Route53 for Route53Client {
             return Err(CreateHealthCheckError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateHealthCheckResponse::default();
         } else {
@@ -12425,9 +12420,8 @@ impl Route53 for Route53Client {
             return Err(CreateHostedZoneError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateHostedZoneResponse::default();
         } else {
@@ -12475,9 +12469,8 @@ impl Route53 for Route53Client {
             return Err(CreateQueryLoggingConfigError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateQueryLoggingConfigResponse::default();
         } else {
@@ -12528,9 +12521,8 @@ impl Route53 for Route53Client {
             return Err(CreateReusableDelegationSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateReusableDelegationSetResponse::default();
         } else {
@@ -12580,9 +12572,8 @@ impl Route53 for Route53Client {
             return Err(CreateTrafficPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateTrafficPolicyResponse::default();
         } else {
@@ -12631,9 +12622,8 @@ impl Route53 for Route53Client {
             return Err(CreateTrafficPolicyInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateTrafficPolicyInstanceResponse::default();
         } else {
@@ -12687,9 +12677,8 @@ impl Route53 for Route53Client {
             return Err(CreateTrafficPolicyVersionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateTrafficPolicyVersionResponse::default();
         } else {
@@ -12750,9 +12739,8 @@ impl Route53 for Route53Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateVPCAssociationAuthorizationResponse::default();
         } else {
@@ -12798,9 +12786,7 @@ impl Route53 for Route53Client {
             return Err(DeleteHealthCheckError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteHealthCheckResponse::default();
         // parse non-payload
         Ok(result)
@@ -12829,9 +12815,8 @@ impl Route53 for Route53Client {
             return Err(DeleteHostedZoneError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteHostedZoneResponse::default();
         } else {
@@ -12872,9 +12857,7 @@ impl Route53 for Route53Client {
             return Err(DeleteQueryLoggingConfigError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteQueryLoggingConfigResponse::default();
         // parse non-payload
         Ok(result)
@@ -12904,9 +12887,7 @@ impl Route53 for Route53Client {
             return Err(DeleteReusableDelegationSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteReusableDelegationSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -12939,9 +12920,7 @@ impl Route53 for Route53Client {
             return Err(DeleteTrafficPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteTrafficPolicyResponse::default();
         // parse non-payload
         Ok(result)
@@ -12971,9 +12950,7 @@ impl Route53 for Route53Client {
             return Err(DeleteTrafficPolicyInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteTrafficPolicyInstanceResponse::default();
         // parse non-payload
         Ok(result)
@@ -13019,9 +12996,7 @@ impl Route53 for Route53Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteVPCAssociationAuthorizationResponse::default();
         // parse non-payload
         Ok(result)
@@ -13065,9 +13040,8 @@ impl Route53 for Route53Client {
             return Err(DisassociateVPCFromHostedZoneError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DisassociateVPCFromHostedZoneResponse::default();
         } else {
@@ -13110,9 +13084,8 @@ impl Route53 for Route53Client {
             return Err(GetAccountLimitError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAccountLimitResponse::default();
         } else {
@@ -13153,9 +13126,8 @@ impl Route53 for Route53Client {
             return Err(GetChangeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetChangeResponse::default();
         } else {
@@ -13192,9 +13164,8 @@ impl Route53 for Route53Client {
             return Err(GetCheckerIpRangesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetCheckerIpRangesResponse::default();
         } else {
@@ -13244,9 +13215,8 @@ impl Route53 for Route53Client {
             return Err(GetGeoLocationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetGeoLocationResponse::default();
         } else {
@@ -13289,9 +13259,8 @@ impl Route53 for Route53Client {
             return Err(GetHealthCheckError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetHealthCheckResponse::default();
         } else {
@@ -13328,9 +13297,8 @@ impl Route53 for Route53Client {
             return Err(GetHealthCheckCountError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetHealthCheckCountResponse::default();
         } else {
@@ -13379,9 +13347,8 @@ impl Route53 for Route53Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetHealthCheckLastFailureReasonResponse::default();
         } else {
@@ -13427,9 +13394,8 @@ impl Route53 for Route53Client {
             return Err(GetHealthCheckStatusError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetHealthCheckStatusResponse::default();
         } else {
@@ -13472,9 +13438,8 @@ impl Route53 for Route53Client {
             return Err(GetHostedZoneError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetHostedZoneResponse::default();
         } else {
@@ -13511,9 +13476,8 @@ impl Route53 for Route53Client {
             return Err(GetHostedZoneCountError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetHostedZoneCountResponse::default();
         } else {
@@ -13551,9 +13515,8 @@ impl Route53 for Route53Client {
             return Err(GetHostedZoneLimitError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetHostedZoneLimitResponse::default();
         } else {
@@ -13594,9 +13557,8 @@ impl Route53 for Route53Client {
             return Err(GetQueryLoggingConfigError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetQueryLoggingConfigResponse::default();
         } else {
@@ -13639,9 +13601,8 @@ impl Route53 for Route53Client {
             return Err(GetReusableDelegationSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetReusableDelegationSetResponse::default();
         } else {
@@ -13684,9 +13645,8 @@ impl Route53 for Route53Client {
             return Err(GetReusableDelegationSetLimitError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetReusableDelegationSetLimitResponse::default();
         } else {
@@ -13733,9 +13693,8 @@ impl Route53 for Route53Client {
             return Err(GetTrafficPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetTrafficPolicyResponse::default();
         } else {
@@ -13776,9 +13735,8 @@ impl Route53 for Route53Client {
             return Err(GetTrafficPolicyInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetTrafficPolicyInstanceResponse::default();
         } else {
@@ -13821,9 +13779,8 @@ impl Route53 for Route53Client {
             return Err(GetTrafficPolicyInstanceCountError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetTrafficPolicyInstanceCountResponse::default();
         } else {
@@ -13878,9 +13835,8 @@ impl Route53 for Route53Client {
             return Err(ListGeoLocationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListGeoLocationsResponse::default();
         } else {
@@ -13927,9 +13883,8 @@ impl Route53 for Route53Client {
             return Err(ListHealthChecksError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListHealthChecksResponse::default();
         } else {
@@ -13979,9 +13934,8 @@ impl Route53 for Route53Client {
             return Err(ListHostedZonesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListHostedZonesResponse::default();
         } else {
@@ -14031,9 +13985,8 @@ impl Route53 for Route53Client {
             return Err(ListHostedZonesByNameError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListHostedZonesByNameResponse::default();
         } else {
@@ -14085,9 +14038,8 @@ impl Route53 for Route53Client {
             return Err(ListQueryLoggingConfigsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListQueryLoggingConfigsResponse::default();
         } else {
@@ -14148,9 +14100,8 @@ impl Route53 for Route53Client {
             return Err(ListResourceRecordSetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListResourceRecordSetsResponse::default();
         } else {
@@ -14200,9 +14151,8 @@ impl Route53 for Route53Client {
             return Err(ListReusableDelegationSetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListReusableDelegationSetsResponse::default();
         } else {
@@ -14249,9 +14199,8 @@ impl Route53 for Route53Client {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTagsForResourceResponse::default();
         } else {
@@ -14304,9 +14253,8 @@ impl Route53 for Route53Client {
             return Err(ListTagsForResourcesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTagsForResourcesResponse::default();
         } else {
@@ -14355,9 +14303,8 @@ impl Route53 for Route53Client {
             return Err(ListTrafficPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTrafficPoliciesResponse::default();
         } else {
@@ -14411,9 +14358,8 @@ impl Route53 for Route53Client {
             return Err(ListTrafficPolicyInstancesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTrafficPolicyInstancesResponse::default();
         } else {
@@ -14471,9 +14417,8 @@ impl Route53 for Route53Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTrafficPolicyInstancesByHostedZoneResponse::default();
         } else {
@@ -14535,9 +14480,8 @@ impl Route53 for Route53Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTrafficPolicyInstancesByPolicyResponse::default();
         } else {
@@ -14590,9 +14534,8 @@ impl Route53 for Route53Client {
             return Err(ListTrafficPolicyVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTrafficPolicyVersionsResponse::default();
         } else {
@@ -14652,9 +14595,8 @@ impl Route53 for Route53Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListVPCAssociationAuthorizationsResponse::default();
         } else {
@@ -14709,9 +14651,8 @@ impl Route53 for Route53Client {
             return Err(TestDNSAnswerError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TestDNSAnswerResponse::default();
         } else {
@@ -14763,9 +14704,8 @@ impl Route53 for Route53Client {
             return Err(UpdateHealthCheckError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateHealthCheckResponse::default();
         } else {
@@ -14815,9 +14755,8 @@ impl Route53 for Route53Client {
             return Err(UpdateHostedZoneCommentError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateHostedZoneCommentResponse::default();
         } else {
@@ -14874,9 +14813,8 @@ impl Route53 for Route53Client {
             return Err(UpdateTrafficPolicyCommentError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateTrafficPolicyCommentResponse::default();
         } else {
@@ -14929,9 +14867,8 @@ impl Route53 for Route53Client {
             return Err(UpdateTrafficPolicyInstanceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UpdateTrafficPolicyInstanceResponse::default();
         } else {

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -48,9 +48,10 @@ pub struct AccountLimit {
     pub value: i64,
 }
 
+#[allow(dead_code)]
 struct AccountLimitDeserializer;
 impl AccountLimitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -69,9 +70,10 @@ impl AccountLimitDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AccountLimitTypeDeserializer;
 impl AccountLimitTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -112,9 +114,10 @@ pub struct AlarmIdentifier {
     pub region: String,
 }
 
+#[allow(dead_code)]
 struct AlarmIdentifierDeserializer;
 impl AlarmIdentifierDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -162,9 +165,10 @@ impl AlarmIdentifierSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AlarmNameDeserializer;
 impl AlarmNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -194,9 +198,10 @@ impl AlarmNameSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AliasHealthEnabledDeserializer;
 impl AliasHealthEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -239,9 +244,10 @@ pub struct AliasTarget {
     pub hosted_zone_id: String,
 }
 
+#[allow(dead_code)]
 struct AliasTargetDeserializer;
 impl AliasTargetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -360,9 +366,10 @@ pub struct AssociateVPCWithHostedZoneResponse {
     pub change_info: ChangeInfo,
 }
 
+#[allow(dead_code)]
 struct AssociateVPCWithHostedZoneResponseDeserializer;
 impl AssociateVPCWithHostedZoneResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -488,9 +495,10 @@ pub struct ChangeInfo {
     pub submitted_at: String,
 }
 
+#[allow(dead_code)]
 struct ChangeInfoDeserializer;
 impl ChangeInfoDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -552,9 +560,10 @@ pub struct ChangeResourceRecordSetsResponse {
     pub change_info: ChangeInfo,
 }
 
+#[allow(dead_code)]
 struct ChangeResourceRecordSetsResponseDeserializer;
 impl ChangeResourceRecordSetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -574,9 +583,10 @@ impl ChangeResourceRecordSetsResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ChangeStatusDeserializer;
 impl ChangeStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -626,9 +636,10 @@ impl ChangeTagsForResourceRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct ChangeTagsForResourceResponse {}
 
+#[allow(dead_code)]
 struct ChangeTagsForResourceResponseDeserializer;
 impl ChangeTagsForResourceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -663,9 +674,10 @@ impl ChangesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CheckerIpRangesDeserializer;
 impl CheckerIpRangesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -680,9 +692,10 @@ impl CheckerIpRangesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ChildHealthCheckListDeserializer;
 impl ChildHealthCheckListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -743,9 +756,10 @@ pub struct CloudWatchAlarmConfiguration {
     pub threshold: f64,
 }
 
+#[allow(dead_code)]
 struct CloudWatchAlarmConfigurationDeserializer;
 impl CloudWatchAlarmConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -792,9 +806,10 @@ impl CloudWatchAlarmConfigurationDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CloudWatchLogsLogGroupArnDeserializer;
 impl CloudWatchLogsLogGroupArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -824,9 +839,10 @@ impl CloudWatchLogsLogGroupArnSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CloudWatchRegionDeserializer;
 impl CloudWatchRegionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -856,9 +872,10 @@ impl CloudWatchRegionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ComparisonOperatorDeserializer;
 impl ComparisonOperatorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -913,9 +930,10 @@ pub struct CreateHealthCheckResponse {
     pub location: String,
 }
 
+#[allow(dead_code)]
 struct CreateHealthCheckResponseDeserializer;
 impl CreateHealthCheckResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -995,9 +1013,10 @@ pub struct CreateHostedZoneResponse {
     pub vpc: Option<VPC>,
 }
 
+#[allow(dead_code)]
 struct CreateHostedZoneResponseDeserializer;
 impl CreateHostedZoneResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1067,9 +1086,10 @@ pub struct CreateQueryLoggingConfigResponse {
     pub query_logging_config: QueryLoggingConfig,
 }
 
+#[allow(dead_code)]
 struct CreateQueryLoggingConfigResponseDeserializer;
 impl CreateQueryLoggingConfigResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1130,9 +1150,10 @@ pub struct CreateReusableDelegationSetResponse {
     pub location: String,
 }
 
+#[allow(dead_code)]
 struct CreateReusableDelegationSetResponseDeserializer;
 impl CreateReusableDelegationSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1208,9 +1229,10 @@ pub struct CreateTrafficPolicyInstanceResponse {
     pub traffic_policy_instance: TrafficPolicyInstance,
 }
 
+#[allow(dead_code)]
 struct CreateTrafficPolicyInstanceResponseDeserializer;
 impl CreateTrafficPolicyInstanceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1277,9 +1299,10 @@ pub struct CreateTrafficPolicyResponse {
     pub traffic_policy: TrafficPolicy,
 }
 
+#[allow(dead_code)]
 struct CreateTrafficPolicyResponseDeserializer;
 impl CreateTrafficPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1342,9 +1365,10 @@ pub struct CreateTrafficPolicyVersionResponse {
     pub traffic_policy: TrafficPolicy,
 }
 
+#[allow(dead_code)]
 struct CreateTrafficPolicyVersionResponseDeserializer;
 impl CreateTrafficPolicyVersionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1402,9 +1426,10 @@ pub struct CreateVPCAssociationAuthorizationResponse {
     pub vpc: VPC,
 }
 
+#[allow(dead_code)]
 struct CreateVPCAssociationAuthorizationResponseDeserializer;
 impl CreateVPCAssociationAuthorizationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1428,9 +1453,10 @@ impl CreateVPCAssociationAuthorizationResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DNSNameDeserializer;
 impl DNSNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1460,9 +1486,10 @@ impl DNSNameSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DNSRCodeDeserializer;
 impl DNSRCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1483,9 +1510,10 @@ pub struct DelegationSet {
     pub name_servers: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct DelegationSetDeserializer;
 impl DelegationSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1512,9 +1540,10 @@ impl DelegationSetDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DelegationSetNameServersDeserializer;
 impl DelegationSetNameServersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1529,9 +1558,10 @@ impl DelegationSetNameServersDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DelegationSetsDeserializer;
 impl DelegationSetsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1562,9 +1592,10 @@ pub struct DeleteHealthCheckRequest {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteHealthCheckResponse {}
 
+#[allow(dead_code)]
 struct DeleteHealthCheckResponseDeserializer;
 impl DeleteHealthCheckResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1594,9 +1625,10 @@ pub struct DeleteHostedZoneResponse {
     pub change_info: ChangeInfo,
 }
 
+#[allow(dead_code)]
 struct DeleteHostedZoneResponseDeserializer;
 impl DeleteHostedZoneResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1627,9 +1659,10 @@ pub struct DeleteQueryLoggingConfigRequest {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteQueryLoggingConfigResponse {}
 
+#[allow(dead_code)]
 struct DeleteQueryLoggingConfigResponseDeserializer;
 impl DeleteQueryLoggingConfigResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1656,9 +1689,10 @@ pub struct DeleteReusableDelegationSetRequest {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteReusableDelegationSetResponse {}
 
+#[allow(dead_code)]
 struct DeleteReusableDelegationSetResponseDeserializer;
 impl DeleteReusableDelegationSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1685,9 +1719,10 @@ pub struct DeleteTrafficPolicyInstanceRequest {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteTrafficPolicyInstanceResponse {}
 
+#[allow(dead_code)]
 struct DeleteTrafficPolicyInstanceResponseDeserializer;
 impl DeleteTrafficPolicyInstanceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1716,9 +1751,10 @@ pub struct DeleteTrafficPolicyRequest {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteTrafficPolicyResponse {}
 
+#[allow(dead_code)]
 struct DeleteTrafficPolicyResponseDeserializer;
 impl DeleteTrafficPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1764,9 +1800,10 @@ impl DeleteVPCAssociationAuthorizationRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteVPCAssociationAuthorizationResponse {}
 
+#[allow(dead_code)]
 struct DeleteVPCAssociationAuthorizationResponseDeserializer;
 impl DeleteVPCAssociationAuthorizationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1790,9 +1827,10 @@ pub struct Dimension {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct DimensionDeserializer;
 impl DimensionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1811,9 +1849,10 @@ impl DimensionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DimensionFieldDeserializer;
 impl DimensionFieldDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1822,9 +1861,10 @@ impl DimensionFieldDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DimensionListDeserializer;
 impl DimensionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1839,9 +1879,10 @@ impl DimensionListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DisabledDeserializer;
 impl DisabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1931,9 +1972,10 @@ pub struct DisassociateVPCFromHostedZoneResponse {
     pub change_info: ChangeInfo,
 }
 
+#[allow(dead_code)]
 struct DisassociateVPCFromHostedZoneResponseDeserializer;
 impl DisassociateVPCFromHostedZoneResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1953,9 +1995,10 @@ impl DisassociateVPCFromHostedZoneResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct EnableSNIDeserializer;
 impl EnableSNIDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1985,9 +2028,10 @@ impl EnableSNISerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EvaluationPeriodsDeserializer;
 impl EvaluationPeriodsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1996,9 +2040,10 @@ impl EvaluationPeriodsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FailureThresholdDeserializer;
 impl FailureThresholdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2028,9 +2073,10 @@ impl FailureThresholdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FullyQualifiedDomainNameDeserializer;
 impl FullyQualifiedDomainNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2073,9 +2119,10 @@ pub struct GeoLocation {
     pub subdivision_code: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GeoLocationDeserializer;
 impl GeoLocationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2148,9 +2195,10 @@ impl GeoLocationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct GeoLocationContinentCodeDeserializer;
 impl GeoLocationContinentCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2180,9 +2228,10 @@ impl GeoLocationContinentCodeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct GeoLocationContinentNameDeserializer;
 impl GeoLocationContinentNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2191,9 +2240,10 @@ impl GeoLocationContinentNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct GeoLocationCountryCodeDeserializer;
 impl GeoLocationCountryCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2223,9 +2273,10 @@ impl GeoLocationCountryCodeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct GeoLocationCountryNameDeserializer;
 impl GeoLocationCountryNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2252,9 +2303,10 @@ pub struct GeoLocationDetails {
     pub subdivision_name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GeoLocationDetailsDeserializer;
 impl GeoLocationDetailsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2305,9 +2357,10 @@ impl GeoLocationDetailsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GeoLocationDetailsListDeserializer;
 impl GeoLocationDetailsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2325,9 +2378,10 @@ impl GeoLocationDetailsListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct GeoLocationSubdivisionCodeDeserializer;
 impl GeoLocationSubdivisionCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2357,9 +2411,10 @@ impl GeoLocationSubdivisionCodeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct GeoLocationSubdivisionNameDeserializer;
 impl GeoLocationSubdivisionNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2386,9 +2441,10 @@ pub struct GetAccountLimitResponse {
     pub limit: AccountLimit,
 }
 
+#[allow(dead_code)]
 struct GetAccountLimitResponseDeserializer;
 impl GetAccountLimitResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2427,9 +2483,10 @@ pub struct GetChangeResponse {
     pub change_info: ChangeInfo,
 }
 
+#[allow(dead_code)]
 struct GetChangeResponseDeserializer;
 impl GetChangeResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2458,9 +2515,10 @@ pub struct GetCheckerIpRangesResponse {
     pub checker_ip_ranges: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct GetCheckerIpRangesResponseDeserializer;
 impl GetCheckerIpRangesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2504,9 +2562,10 @@ pub struct GetGeoLocationResponse {
     pub geo_location_details: GeoLocationDetails,
 }
 
+#[allow(dead_code)]
 struct GetGeoLocationResponseDeserializer;
 impl GetGeoLocationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2536,9 +2595,10 @@ pub struct GetHealthCheckCountResponse {
     pub health_check_count: i64,
 }
 
+#[allow(dead_code)]
 struct GetHealthCheckCountResponseDeserializer;
 impl GetHealthCheckCountResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2575,9 +2635,10 @@ pub struct GetHealthCheckLastFailureReasonResponse {
     pub health_check_observations: Vec<HealthCheckObservation>,
 }
 
+#[allow(dead_code)]
 struct GetHealthCheckLastFailureReasonResponseDeserializer;
 impl GetHealthCheckLastFailureReasonResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2618,9 +2679,10 @@ pub struct GetHealthCheckResponse {
     pub health_check: HealthCheck,
 }
 
+#[allow(dead_code)]
 struct GetHealthCheckResponseDeserializer;
 impl GetHealthCheckResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2652,9 +2714,10 @@ pub struct GetHealthCheckStatusResponse {
     pub health_check_observations: Vec<HealthCheckObservation>,
 }
 
+#[allow(dead_code)]
 struct GetHealthCheckStatusResponseDeserializer;
 impl GetHealthCheckStatusResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2692,9 +2755,10 @@ pub struct GetHostedZoneCountResponse {
     pub hosted_zone_count: i64,
 }
 
+#[allow(dead_code)]
 struct GetHostedZoneCountResponseDeserializer;
 impl GetHostedZoneCountResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2735,9 +2799,10 @@ pub struct GetHostedZoneLimitResponse {
     pub limit: HostedZoneLimit,
 }
 
+#[allow(dead_code)]
 struct GetHostedZoneLimitResponseDeserializer;
 impl GetHostedZoneLimitResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2780,9 +2845,10 @@ pub struct GetHostedZoneResponse {
     pub vp_cs: Option<Vec<VPC>>,
 }
 
+#[allow(dead_code)]
 struct GetHostedZoneResponseDeserializer;
 impl GetHostedZoneResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2823,9 +2889,10 @@ pub struct GetQueryLoggingConfigResponse {
     pub query_logging_config: QueryLoggingConfig,
 }
 
+#[allow(dead_code)]
 struct GetQueryLoggingConfigResponseDeserializer;
 impl GetQueryLoggingConfigResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2868,9 +2935,10 @@ pub struct GetReusableDelegationSetLimitResponse {
     pub limit: ReusableDelegationSetLimit,
 }
 
+#[allow(dead_code)]
 struct GetReusableDelegationSetLimitResponseDeserializer;
 impl GetReusableDelegationSetLimitResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2910,9 +2978,10 @@ pub struct GetReusableDelegationSetResponse {
     pub delegation_set: DelegationSet,
 }
 
+#[allow(dead_code)]
 struct GetReusableDelegationSetResponseDeserializer;
 impl GetReusableDelegationSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2946,9 +3015,10 @@ pub struct GetTrafficPolicyInstanceCountResponse {
     pub traffic_policy_instance_count: i64,
 }
 
+#[allow(dead_code)]
 struct GetTrafficPolicyInstanceCountResponseDeserializer;
 impl GetTrafficPolicyInstanceCountResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2988,9 +3058,10 @@ pub struct GetTrafficPolicyInstanceResponse {
     pub traffic_policy_instance: TrafficPolicyInstance,
 }
 
+#[allow(dead_code)]
 struct GetTrafficPolicyInstanceResponseDeserializer;
 impl GetTrafficPolicyInstanceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3032,9 +3103,10 @@ pub struct GetTrafficPolicyResponse {
     pub traffic_policy: TrafficPolicy,
 }
 
+#[allow(dead_code)]
 struct GetTrafficPolicyResponseDeserializer;
 impl GetTrafficPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3073,9 +3145,10 @@ pub struct HealthCheck {
     pub linked_service: Option<LinkedService>,
 }
 
+#[allow(dead_code)]
 struct HealthCheckDeserializer;
 impl HealthCheckDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3157,9 +3230,10 @@ pub struct HealthCheckConfig {
     pub type_: String,
 }
 
+#[allow(dead_code)]
 struct HealthCheckConfigDeserializer;
 impl HealthCheckConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3396,9 +3470,10 @@ impl HealthCheckConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthCheckCountDeserializer;
 impl HealthCheckCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3407,9 +3482,10 @@ impl HealthCheckCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HealthCheckIdDeserializer;
 impl HealthCheckIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3439,9 +3515,10 @@ impl HealthCheckIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthCheckNonceDeserializer;
 impl HealthCheckNonceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3483,9 +3560,10 @@ pub struct HealthCheckObservation {
     pub status_report: Option<StatusReport>,
 }
 
+#[allow(dead_code)]
 struct HealthCheckObservationDeserializer;
 impl HealthCheckObservationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3510,9 +3588,10 @@ impl HealthCheckObservationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HealthCheckObservationsDeserializer;
 impl HealthCheckObservationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3530,9 +3609,10 @@ impl HealthCheckObservationsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HealthCheckRegionDeserializer;
 impl HealthCheckRegionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3562,9 +3642,10 @@ impl HealthCheckRegionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthCheckRegionListDeserializer;
 impl HealthCheckRegionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3600,9 +3681,10 @@ impl HealthCheckRegionListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthCheckTypeDeserializer;
 impl HealthCheckTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3632,9 +3714,10 @@ impl HealthCheckTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthCheckVersionDeserializer;
 impl HealthCheckVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3664,9 +3747,10 @@ impl HealthCheckVersionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HealthChecksDeserializer;
 impl HealthChecksDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3681,9 +3765,10 @@ impl HealthChecksDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HealthThresholdDeserializer;
 impl HealthThresholdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3731,9 +3816,10 @@ pub struct HostedZone {
     pub resource_record_set_count: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct HostedZoneDeserializer;
 impl HostedZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3783,9 +3869,10 @@ pub struct HostedZoneConfig {
     pub private_zone: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct HostedZoneConfigDeserializer;
 impl HostedZoneConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3842,9 +3929,10 @@ impl HostedZoneConfigSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HostedZoneCountDeserializer;
 impl HostedZoneCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3863,9 +3951,10 @@ pub struct HostedZoneLimit {
     pub value: i64,
 }
 
+#[allow(dead_code)]
 struct HostedZoneLimitDeserializer;
 impl HostedZoneLimitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3884,9 +3973,10 @@ impl HostedZoneLimitDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HostedZoneLimitTypeDeserializer;
 impl HostedZoneLimitTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3916,9 +4006,10 @@ impl HostedZoneLimitTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HostedZoneRRSetCountDeserializer;
 impl HostedZoneRRSetCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3927,9 +4018,10 @@ impl HostedZoneRRSetCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HostedZonesDeserializer;
 impl HostedZonesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3944,9 +4036,10 @@ impl HostedZonesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IPAddressDeserializer;
 impl IPAddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3976,9 +4069,10 @@ impl IPAddressSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IPAddressCidrDeserializer;
 impl IPAddressCidrDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3987,9 +4081,10 @@ impl IPAddressCidrDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct InsufficientDataHealthStatusDeserializer;
 impl InsufficientDataHealthStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4019,9 +4114,10 @@ impl InsufficientDataHealthStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InvertedDeserializer;
 impl InvertedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4051,9 +4147,10 @@ impl InvertedSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IsPrivateZoneDeserializer;
 impl IsPrivateZoneDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4083,9 +4180,10 @@ impl IsPrivateZoneSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LimitValueDeserializer;
 impl LimitValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4104,9 +4202,10 @@ pub struct LinkedService {
     pub service_principal: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LinkedServiceDeserializer;
 impl LinkedServiceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4163,9 +4262,10 @@ pub struct ListGeoLocationsResponse {
     pub next_subdivision_code: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListGeoLocationsResponseDeserializer;
 impl ListGeoLocationsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4244,9 +4344,10 @@ pub struct ListHealthChecksResponse {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListHealthChecksResponseDeserializer;
 impl ListHealthChecksResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4316,9 +4417,10 @@ pub struct ListHostedZonesByNameResponse {
     pub next_hosted_zone_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListHostedZonesByNameResponseDeserializer;
 impl ListHostedZonesByNameResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4390,9 +4492,10 @@ pub struct ListHostedZonesResponse {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListHostedZonesResponseDeserializer;
 impl ListHostedZonesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4447,9 +4550,10 @@ pub struct ListQueryLoggingConfigsResponse {
     pub query_logging_configs: Vec<QueryLoggingConfig>,
 }
 
+#[allow(dead_code)]
 struct ListQueryLoggingConfigsResponseDeserializer;
 impl ListQueryLoggingConfigsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4514,9 +4618,10 @@ pub struct ListResourceRecordSetsResponse {
     pub resource_record_sets: Vec<ResourceRecordSet>,
 }
 
+#[allow(dead_code)]
 struct ListResourceRecordSetsResponseDeserializer;
 impl ListResourceRecordSetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4589,9 +4694,10 @@ pub struct ListReusableDelegationSetsResponse {
     pub next_marker: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListReusableDelegationSetsResponseDeserializer;
 impl ListReusableDelegationSetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4647,9 +4753,10 @@ pub struct ListTagsForResourceResponse {
     pub resource_tag_set: ResourceTagSet,
 }
 
+#[allow(dead_code)]
 struct ListTagsForResourceResponseDeserializer;
 impl ListTagsForResourceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4705,9 +4812,10 @@ pub struct ListTagsForResourcesResponse {
     pub resource_tag_sets: Vec<ResourceTagSet>,
 }
 
+#[allow(dead_code)]
 struct ListTagsForResourcesResponseDeserializer;
 impl ListTagsForResourcesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4755,9 +4863,10 @@ pub struct ListTrafficPoliciesResponse {
     pub traffic_policy_summaries: Vec<TrafficPolicySummary>,
 }
 
+#[allow(dead_code)]
 struct ListTrafficPoliciesResponseDeserializer;
 impl ListTrafficPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4825,9 +4934,10 @@ pub struct ListTrafficPolicyInstancesByHostedZoneResponse {
     pub traffic_policy_instances: Vec<TrafficPolicyInstance>,
 }
 
+#[allow(dead_code)]
 struct ListTrafficPolicyInstancesByHostedZoneResponseDeserializer;
 impl ListTrafficPolicyInstancesByHostedZoneResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4909,9 +5019,10 @@ pub struct ListTrafficPolicyInstancesByPolicyResponse {
     pub traffic_policy_instances: Vec<TrafficPolicyInstance>,
 }
 
+#[allow(dead_code)]
 struct ListTrafficPolicyInstancesByPolicyResponseDeserializer;
 impl ListTrafficPolicyInstancesByPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4995,9 +5106,10 @@ pub struct ListTrafficPolicyInstancesResponse {
     pub traffic_policy_instances: Vec<TrafficPolicyInstance>,
 }
 
+#[allow(dead_code)]
 struct ListTrafficPolicyInstancesResponseDeserializer;
 impl ListTrafficPolicyInstancesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5075,9 +5187,10 @@ pub struct ListTrafficPolicyVersionsResponse {
     pub traffic_policy_version_marker: String,
 }
 
+#[allow(dead_code)]
 struct ListTrafficPolicyVersionsResponseDeserializer;
 impl ListTrafficPolicyVersionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5139,9 +5252,10 @@ pub struct ListVPCAssociationAuthorizationsResponse {
     pub vp_cs: Vec<VPC>,
 }
 
+#[allow(dead_code)]
 struct ListVPCAssociationAuthorizationsResponseDeserializer;
 impl ListVPCAssociationAuthorizationsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5193,9 +5307,10 @@ impl MaxResultsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MeasureLatencyDeserializer;
 impl MeasureLatencyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5225,9 +5340,10 @@ impl MeasureLatencySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MessageDeserializer;
 impl MessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5236,9 +5352,10 @@ impl MessageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MetricNameDeserializer;
 impl MetricNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5247,9 +5364,10 @@ impl MetricNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NameserverDeserializer;
 impl NameserverDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5258,9 +5376,10 @@ impl NameserverDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NamespaceDeserializer;
 impl NamespaceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5269,9 +5388,10 @@ impl NamespaceDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NonceDeserializer;
 impl NonceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5301,9 +5421,10 @@ impl NonceSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PageMarkerDeserializer;
 impl PageMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5333,9 +5454,10 @@ impl PageMarkerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PageMaxItemsDeserializer;
 impl PageMaxItemsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5365,9 +5487,10 @@ impl PageMaxItemsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PageTruncatedDeserializer;
 impl PageTruncatedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5376,9 +5499,10 @@ impl PageTruncatedDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PaginationTokenDeserializer;
 impl PaginationTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5408,9 +5532,10 @@ impl PaginationTokenSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PeriodDeserializer;
 impl PeriodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5419,9 +5544,10 @@ impl PeriodDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PortDeserializer;
 impl PortDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5463,9 +5589,10 @@ pub struct QueryLoggingConfig {
     pub id: String,
 }
 
+#[allow(dead_code)]
 struct QueryLoggingConfigDeserializer;
 impl QueryLoggingConfigDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5492,9 +5619,10 @@ impl QueryLoggingConfigDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct QueryLoggingConfigIdDeserializer;
 impl QueryLoggingConfigIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5524,9 +5652,10 @@ impl QueryLoggingConfigIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct QueryLoggingConfigsDeserializer;
 impl QueryLoggingConfigsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5544,9 +5673,10 @@ impl QueryLoggingConfigsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RDataDeserializer;
 impl RDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5576,9 +5706,10 @@ impl RDataSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RRTypeDeserializer;
 impl RRTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5608,9 +5739,10 @@ impl RRTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RecordDataDeserializer;
 impl RecordDataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5628,9 +5760,10 @@ impl RecordDataDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RecordDataEntryDeserializer;
 impl RecordDataEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5639,9 +5772,10 @@ impl RecordDataEntryDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct RequestIntervalDeserializer;
 impl RequestIntervalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5711,9 +5845,10 @@ impl ResettableElementNameListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceDescriptionDeserializer;
 impl ResourceDescriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5743,9 +5878,10 @@ impl ResourceDescriptionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceIdDeserializer;
 impl ResourceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5775,9 +5911,10 @@ impl ResourceIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourcePathDeserializer;
 impl ResourcePathDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5816,9 +5953,10 @@ pub struct ResourceRecord {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct ResourceRecordDeserializer;
 impl ResourceRecordDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5890,9 +6028,10 @@ pub struct ResourceRecordSet {
     pub weight: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ResourceRecordSetDeserializer;
 impl ResourceRecordSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6073,9 +6212,10 @@ impl ResourceRecordSetSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceRecordSetFailoverDeserializer;
 impl ResourceRecordSetFailoverDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6105,9 +6245,10 @@ impl ResourceRecordSetFailoverSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceRecordSetIdentifierDeserializer;
 impl ResourceRecordSetIdentifierDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6137,9 +6278,10 @@ impl ResourceRecordSetIdentifierSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceRecordSetMultiValueAnswerDeserializer;
 impl ResourceRecordSetMultiValueAnswerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6169,9 +6311,10 @@ impl ResourceRecordSetMultiValueAnswerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceRecordSetRegionDeserializer;
 impl ResourceRecordSetRegionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6201,9 +6344,10 @@ impl ResourceRecordSetRegionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceRecordSetWeightDeserializer;
 impl ResourceRecordSetWeightDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6233,9 +6377,10 @@ impl ResourceRecordSetWeightSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ResourceRecordSetsDeserializer;
 impl ResourceRecordSetsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6253,9 +6398,10 @@ impl ResourceRecordSetsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ResourceRecordsDeserializer;
 impl ResourceRecordsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6306,9 +6452,10 @@ pub struct ResourceTagSet {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct ResourceTagSetDeserializer;
 impl ResourceTagSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6336,9 +6483,10 @@ impl ResourceTagSetDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ResourceTagSetListDeserializer;
 impl ResourceTagSetListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6366,9 +6514,10 @@ pub struct ReusableDelegationSetLimit {
     pub value: i64,
 }
 
+#[allow(dead_code)]
 struct ReusableDelegationSetLimitDeserializer;
 impl ReusableDelegationSetLimitDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6392,9 +6541,10 @@ impl ReusableDelegationSetLimitDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ReusableDelegationSetLimitTypeDeserializer;
 impl ReusableDelegationSetLimitTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6424,9 +6574,10 @@ impl ReusableDelegationSetLimitTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SearchStringDeserializer;
 impl SearchStringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6456,9 +6607,10 @@ impl SearchStringSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ServicePrincipalDeserializer;
 impl ServicePrincipalDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6467,9 +6619,10 @@ impl ServicePrincipalDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StatisticDeserializer;
 impl StatisticDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6478,9 +6631,10 @@ impl StatisticDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StatusDeserializer;
 impl StatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6499,9 +6653,10 @@ pub struct StatusReport {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StatusReportDeserializer;
 impl StatusReportDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6542,9 +6697,10 @@ impl SubnetMaskSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TTLDeserializer;
 impl TTLDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6585,9 +6741,10 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -6636,9 +6793,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6688,9 +6846,10 @@ impl TagKeyListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6726,9 +6885,10 @@ impl TagListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagResourceIdDeserializer;
 impl TagResourceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6778,9 +6938,10 @@ impl TagResourceIdListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagResourceTypeDeserializer;
 impl TagResourceTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6810,9 +6971,10 @@ impl TagResourceTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6878,9 +7040,10 @@ pub struct TestDNSAnswerResponse {
     pub response_code: String,
 }
 
+#[allow(dead_code)]
 struct TestDNSAnswerResponseDeserializer;
 impl TestDNSAnswerResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6912,9 +7075,10 @@ impl TestDNSAnswerResponseDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ThresholdDeserializer;
 impl ThresholdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6923,9 +7087,10 @@ impl ThresholdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TimeStampDeserializer;
 impl TimeStampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6934,9 +7099,10 @@ impl TimeStampDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TrafficPoliciesDeserializer;
 impl TrafficPoliciesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6972,9 +7138,10 @@ pub struct TrafficPolicy {
     pub version: i64,
 }
 
+#[allow(dead_code)]
 struct TrafficPolicyDeserializer;
 impl TrafficPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7008,9 +7175,10 @@ impl TrafficPolicyDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TrafficPolicyCommentDeserializer;
 impl TrafficPolicyCommentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7040,9 +7208,10 @@ impl TrafficPolicyCommentSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TrafficPolicyDocumentDeserializer;
 impl TrafficPolicyDocumentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7072,9 +7241,10 @@ impl TrafficPolicyDocumentSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TrafficPolicyIdDeserializer;
 impl TrafficPolicyIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7128,9 +7298,10 @@ pub struct TrafficPolicyInstance {
     pub traffic_policy_version: i64,
 }
 
+#[allow(dead_code)]
 struct TrafficPolicyInstanceDeserializer;
 impl TrafficPolicyInstanceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7177,9 +7348,10 @@ impl TrafficPolicyInstanceDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TrafficPolicyInstanceCountDeserializer;
 impl TrafficPolicyInstanceCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -7188,9 +7360,10 @@ impl TrafficPolicyInstanceCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TrafficPolicyInstanceIdDeserializer;
 impl TrafficPolicyInstanceIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7220,9 +7393,10 @@ impl TrafficPolicyInstanceIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TrafficPolicyInstanceStateDeserializer;
 impl TrafficPolicyInstanceStateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7231,9 +7405,10 @@ impl TrafficPolicyInstanceStateDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TrafficPolicyInstancesDeserializer;
 impl TrafficPolicyInstancesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7251,9 +7426,10 @@ impl TrafficPolicyInstancesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TrafficPolicyNameDeserializer;
 impl TrafficPolicyNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7283,9 +7459,10 @@ impl TrafficPolicyNameSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TrafficPolicySummariesDeserializer;
 impl TrafficPolicySummariesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7319,9 +7496,10 @@ pub struct TrafficPolicySummary {
     pub type_: String,
 }
 
+#[allow(dead_code)]
 struct TrafficPolicySummaryDeserializer;
 impl TrafficPolicySummaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7351,9 +7529,10 @@ impl TrafficPolicySummaryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TrafficPolicyVersionDeserializer;
 impl TrafficPolicyVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -7383,9 +7562,10 @@ impl TrafficPolicyVersionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TrafficPolicyVersionMarkerDeserializer;
 impl TrafficPolicyVersionMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7415,9 +7595,10 @@ impl TrafficPolicyVersionMarkerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TransportProtocolDeserializer;
 impl TransportProtocolDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7546,9 +7727,10 @@ pub struct UpdateHealthCheckResponse {
     pub health_check: HealthCheck,
 }
 
+#[allow(dead_code)]
 struct UpdateHealthCheckResponseDeserializer;
 impl UpdateHealthCheckResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7606,9 +7788,10 @@ pub struct UpdateHostedZoneCommentResponse {
     pub hosted_zone: HostedZone,
 }
 
+#[allow(dead_code)]
 struct UpdateHostedZoneCommentResponseDeserializer;
 impl UpdateHostedZoneCommentResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7665,9 +7848,10 @@ pub struct UpdateTrafficPolicyCommentResponse {
     pub traffic_policy: TrafficPolicy,
 }
 
+#[allow(dead_code)]
 struct UpdateTrafficPolicyCommentResponseDeserializer;
 impl UpdateTrafficPolicyCommentResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7737,9 +7921,10 @@ pub struct UpdateTrafficPolicyInstanceResponse {
     pub traffic_policy_instance: TrafficPolicyInstance,
 }
 
+#[allow(dead_code)]
 struct UpdateTrafficPolicyInstanceResponseDeserializer;
 impl UpdateTrafficPolicyInstanceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7763,9 +7948,10 @@ impl UpdateTrafficPolicyInstanceResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct UsageCountDeserializer;
 impl UsageCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -7784,9 +7970,10 @@ pub struct VPC {
     pub vpc_region: Option<String>,
 }
 
+#[allow(dead_code)]
 struct VPCDeserializer;
 impl VPCDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<VPC, XmlParseError> {
         deserialize_elements::<_, VPC, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -7835,9 +8022,10 @@ impl VPCSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct VPCIdDeserializer;
 impl VPCIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7867,9 +8055,10 @@ impl VPCIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct VPCRegionDeserializer;
 impl VPCRegionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7899,9 +8088,10 @@ impl VPCRegionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct VPCsDeserializer;
 impl VPCsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -19756,9 +19756,7 @@ impl S3 for S3Client {
             return Err(AbortMultipartUploadError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = AbortMultipartUploadOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
@@ -19805,9 +19803,8 @@ impl S3 for S3Client {
             return Err(CompleteMultipartUploadError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CompleteMultipartUploadOutput::default();
         } else {
@@ -20059,9 +20056,8 @@ impl S3 for S3Client {
             return Err(CopyObjectError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CopyObjectOutput::default();
         } else {
@@ -20187,9 +20183,7 @@ impl S3 for S3Client {
             return Err(CreateBucketError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = CreateBucketOutput::default();
         if let Some(location) = response.headers.get("Location") {
             let value = location.to_owned();
@@ -20351,9 +20345,8 @@ impl S3 for S3Client {
             return Err(CreateMultipartUploadError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateMultipartUploadOutput::default();
         } else {
@@ -20766,9 +20759,7 @@ impl S3 for S3Client {
             return Err(DeleteObjectError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteObjectOutput::default();
         if let Some(delete_marker) = response.headers.get("x-amz-delete-marker") {
             let value = delete_marker.to_owned();
@@ -20812,9 +20803,7 @@ impl S3 for S3Client {
             return Err(DeleteObjectTaggingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = DeleteObjectTaggingOutput::default();
         if let Some(version_id) = response.headers.get("x-amz-version-id") {
             let value = version_id.to_owned();
@@ -20865,9 +20854,8 @@ impl S3 for S3Client {
             return Err(DeleteObjectsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteObjectsOutput::default();
         } else {
@@ -20944,9 +20932,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketAccelerateConfigurationOutput::default();
         } else {
@@ -20990,9 +20977,8 @@ impl S3 for S3Client {
             return Err(GetBucketAclError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketAclOutput::default();
         } else {
@@ -21039,9 +21025,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketAnalyticsConfigurationOutput::default();
         } else {
@@ -21085,9 +21070,8 @@ impl S3 for S3Client {
             return Err(GetBucketCorsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketCorsOutput::default();
         } else {
@@ -21128,9 +21112,8 @@ impl S3 for S3Client {
             return Err(GetBucketEncryptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketEncryptionOutput::default();
         } else {
@@ -21178,9 +21161,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketInventoryConfigurationOutput::default();
         } else {
@@ -21224,9 +21206,8 @@ impl S3 for S3Client {
             return Err(GetBucketLifecycleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketLifecycleOutput::default();
         } else {
@@ -21273,9 +21254,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketLifecycleConfigurationOutput::default();
         } else {
@@ -21319,9 +21299,8 @@ impl S3 for S3Client {
             return Err(GetBucketLocationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketLocationOutput::default();
         } else {
@@ -21363,9 +21342,8 @@ impl S3 for S3Client {
             return Err(GetBucketLoggingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketLoggingOutput::default();
         } else {
@@ -21408,9 +21386,8 @@ impl S3 for S3Client {
             return Err(GetBucketMetricsConfigurationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketMetricsConfigurationOutput::default();
         } else {
@@ -21454,9 +21431,8 @@ impl S3 for S3Client {
             return Err(GetBucketNotificationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = NotificationConfigurationDeprecated::default();
         } else {
@@ -21503,9 +21479,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = NotificationConfiguration::default();
         } else {
@@ -21578,9 +21553,8 @@ impl S3 for S3Client {
             return Err(GetBucketPolicyStatusError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketPolicyStatusOutput::default();
         } else {
@@ -21622,9 +21596,8 @@ impl S3 for S3Client {
             return Err(GetBucketReplicationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketReplicationOutput::default();
         } else {
@@ -21666,9 +21639,8 @@ impl S3 for S3Client {
             return Err(GetBucketRequestPaymentError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketRequestPaymentOutput::default();
         } else {
@@ -21712,9 +21684,8 @@ impl S3 for S3Client {
             return Err(GetBucketTaggingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketTaggingOutput::default();
         } else {
@@ -21755,9 +21726,8 @@ impl S3 for S3Client {
             return Err(GetBucketVersioningError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketVersioningOutput::default();
         } else {
@@ -21799,9 +21769,8 @@ impl S3 for S3Client {
             return Err(GetBucketWebsiteError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetBucketWebsiteOutput::default();
         } else {
@@ -22085,9 +22054,8 @@ impl S3 for S3Client {
             return Err(GetObjectAclError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetObjectAclOutput::default();
         } else {
@@ -22137,9 +22105,8 @@ impl S3 for S3Client {
             return Err(GetObjectLegalHoldError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetObjectLegalHoldOutput::default();
         } else {
@@ -22182,9 +22149,8 @@ impl S3 for S3Client {
             return Err(GetObjectLockConfigurationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetObjectLockConfigurationOutput::default();
         } else {
@@ -22234,9 +22200,8 @@ impl S3 for S3Client {
             return Err(GetObjectRetentionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetObjectRetentionOutput::default();
         } else {
@@ -22281,9 +22246,8 @@ impl S3 for S3Client {
             return Err(GetObjectTaggingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetObjectTaggingOutput::default();
         } else {
@@ -22363,9 +22327,8 @@ impl S3 for S3Client {
             return Err(GetPublicAccessBlockError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetPublicAccessBlockOutput::default();
         } else {
@@ -22480,9 +22443,7 @@ impl S3 for S3Client {
             return Err(HeadObjectError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = HeadObjectOutput::default();
         if let Some(accept_ranges) = response.headers.get("accept-ranges") {
             let value = accept_ranges.to_owned();
@@ -22652,9 +22613,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListBucketAnalyticsConfigurationsOutput::default();
         } else {
@@ -22706,9 +22666,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListBucketInventoryConfigurationsOutput::default();
         } else {
@@ -22760,9 +22719,8 @@ impl S3 for S3Client {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListBucketMetricsConfigurationsOutput::default();
         } else {
@@ -22799,9 +22757,8 @@ impl S3 for S3Client {
             return Err(ListBucketsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListBucketsOutput::default();
         } else {
@@ -22860,9 +22817,8 @@ impl S3 for S3Client {
             return Err(ListMultipartUploadsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListMultipartUploadsOutput::default();
         } else {
@@ -22922,9 +22878,8 @@ impl S3 for S3Client {
             return Err(ListObjectVersionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListObjectVersionsOutput::default();
         } else {
@@ -22983,9 +22938,8 @@ impl S3 for S3Client {
             return Err(ListObjectsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListObjectsOutput::default();
         } else {
@@ -23050,9 +23004,8 @@ impl S3 for S3Client {
             return Err(ListObjectsV2Error::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListObjectsV2Output::default();
         } else {
@@ -23102,9 +23055,8 @@ impl S3 for S3Client {
             return Err(ListPartsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPartsOutput::default();
         } else {
@@ -24020,9 +23972,7 @@ impl S3 for S3Client {
             return Err(PutObjectError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = PutObjectOutput::default();
         if let Some(e_tag) = response.headers.get("ETag") {
             let value = e_tag.to_owned();
@@ -24143,9 +24093,7 @@ impl S3 for S3Client {
             return Err(PutObjectAclError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = PutObjectAclOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
@@ -24199,9 +24147,7 @@ impl S3 for S3Client {
             return Err(PutObjectLegalHoldError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = PutObjectLegalHoldOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
@@ -24257,9 +24203,7 @@ impl S3 for S3Client {
             return Err(PutObjectLockConfigurationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = PutObjectLockConfigurationOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
@@ -24320,9 +24264,7 @@ impl S3 for S3Client {
             return Err(PutObjectRetentionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = PutObjectRetentionOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
@@ -24364,9 +24306,7 @@ impl S3 for S3Client {
             return Err(PutObjectTaggingError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = PutObjectTaggingOutput::default();
         if let Some(version_id) = response.headers.get("x-amz-version-id") {
             let value = version_id.to_owned();
@@ -24454,9 +24394,7 @@ impl S3 for S3Client {
             return Err(RestoreObjectError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = RestoreObjectOutput::default();
         if let Some(request_charged) = response.headers.get("x-amz-request-charged") {
             let value = request_charged.to_owned();
@@ -24522,9 +24460,8 @@ impl S3 for S3Client {
             return Err(SelectObjectContentError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SelectObjectContentOutput::default();
         } else {
@@ -24602,9 +24539,7 @@ impl S3 for S3Client {
             return Err(UploadPartError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
         result = UploadPartOutput::default();
         if let Some(e_tag) = response.headers.get("ETag") {
             let value = e_tag.to_owned();
@@ -24748,9 +24683,8 @@ impl S3 for S3Client {
             return Err(UploadPartCopyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let mut result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = UploadPartCopyOutput::default();
         } else {

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -47,9 +47,10 @@ pub struct AbortIncompleteMultipartUpload {
     pub days_after_initiation: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct AbortIncompleteMultipartUploadDeserializer;
 impl AbortIncompleteMultipartUploadDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -104,9 +105,10 @@ pub struct AbortMultipartUploadOutput {
     pub request_charged: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AbortMultipartUploadOutputDeserializer;
 impl AbortMultipartUploadOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -205,9 +207,10 @@ pub struct AccessControlTranslation {
     pub owner: String,
 }
 
+#[allow(dead_code)]
 struct AccessControlTranslationDeserializer;
 impl AccessControlTranslationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -250,9 +253,10 @@ impl AccessControlTranslationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AccountIdDeserializer;
 impl AccountIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -302,9 +306,10 @@ impl AllowQuotedRecordDelimiterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedHeaderDeserializer;
 impl AllowedHeaderDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -334,9 +339,10 @@ impl AllowedHeaderSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedHeadersDeserializer;
 impl AllowedHeadersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -380,9 +386,10 @@ impl AllowedHeadersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedMethodDeserializer;
 impl AllowedMethodDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -412,9 +419,10 @@ impl AllowedMethodSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedMethodsDeserializer;
 impl AllowedMethodsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -458,9 +466,10 @@ impl AllowedMethodsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedOriginDeserializer;
 impl AllowedOriginDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -490,9 +499,10 @@ impl AllowedOriginSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AllowedOriginsDeserializer;
 impl AllowedOriginsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -547,9 +557,10 @@ pub struct AnalyticsAndOperator {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct AnalyticsAndOperatorDeserializer;
 impl AnalyticsAndOperatorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -611,9 +622,10 @@ pub struct AnalyticsConfiguration {
     pub storage_class_analysis: StorageClassAnalysis,
 }
 
+#[allow(dead_code)]
 struct AnalyticsConfigurationDeserializer;
 impl AnalyticsConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -669,9 +681,10 @@ impl AnalyticsConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AnalyticsConfigurationListDeserializer;
 impl AnalyticsConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -707,9 +720,10 @@ pub struct AnalyticsExportDestination {
     pub s3_bucket_destination: AnalyticsS3BucketDestination,
 }
 
+#[allow(dead_code)]
 struct AnalyticsExportDestinationDeserializer;
 impl AnalyticsExportDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -768,9 +782,10 @@ pub struct AnalyticsFilter {
     pub tag: Option<Tag>,
 }
 
+#[allow(dead_code)]
 struct AnalyticsFilterDeserializer;
 impl AnalyticsFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -823,9 +838,10 @@ impl AnalyticsFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AnalyticsIdDeserializer;
 impl AnalyticsIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -870,9 +886,10 @@ pub struct AnalyticsS3BucketDestination {
     pub prefix: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AnalyticsS3BucketDestinationDeserializer;
 impl AnalyticsS3BucketDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -950,9 +967,10 @@ impl AnalyticsS3BucketDestinationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AnalyticsS3ExportFileFormatDeserializer;
 impl AnalyticsS3ExportFileFormatDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -983,9 +1001,10 @@ impl AnalyticsS3ExportFileFormatSerializer {
 }
 
 pub type StreamingBody = ::rusoto_core::ByteStream;
+#[allow(dead_code)]
 struct BodyDeserializer;
 impl BodyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1028,9 +1047,10 @@ pub struct Bucket {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct BucketDeserializer;
 impl BucketDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Bucket, XmlParseError> {
         deserialize_elements::<_, Bucket, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -1049,9 +1069,10 @@ impl BucketDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BucketAccelerateStatusDeserializer;
 impl BucketAccelerateStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1106,9 +1127,10 @@ impl BucketLifecycleConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BucketLocationConstraintDeserializer;
 impl BucketLocationConstraintDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1164,9 +1186,10 @@ impl BucketLoggingStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BucketLogsPermissionDeserializer;
 impl BucketLogsPermissionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1196,9 +1219,10 @@ impl BucketLogsPermissionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BucketNameDeserializer;
 impl BucketNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1228,9 +1252,10 @@ impl BucketNameSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BucketVersioningStatusDeserializer;
 impl BucketVersioningStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1260,9 +1285,10 @@ impl BucketVersioningStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BucketsDeserializer;
 impl BucketsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1277,9 +1303,10 @@ impl BucketsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BytesProcessedDeserializer;
 impl BytesProcessedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1288,9 +1315,10 @@ impl BytesProcessedDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BytesReturnedDeserializer;
 impl BytesReturnedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1299,9 +1327,10 @@ impl BytesReturnedDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BytesScannedDeserializer;
 impl BytesScannedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -1352,9 +1381,10 @@ pub struct CORSRule {
     pub max_age_seconds: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct CORSRuleDeserializer;
 impl CORSRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1430,9 +1460,10 @@ impl CORSRuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CORSRulesDeserializer;
 impl CORSRulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1642,9 +1673,10 @@ impl CSVOutputSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CloudFunctionDeserializer;
 impl CloudFunctionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1688,9 +1720,10 @@ pub struct CloudFunctionConfiguration {
     pub invocation_role: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CloudFunctionConfigurationDeserializer;
 impl CloudFunctionConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1772,9 +1805,10 @@ impl CloudFunctionConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CloudFunctionInvocationRoleDeserializer;
 impl CloudFunctionInvocationRoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1804,9 +1838,10 @@ impl CloudFunctionInvocationRoleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CodeDeserializer;
 impl CodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1844,9 +1879,10 @@ pub struct CommonPrefix {
     pub prefix: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CommonPrefixDeserializer;
 impl CommonPrefixDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1862,9 +1898,10 @@ impl CommonPrefixDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct CommonPrefixListDeserializer;
 impl CommonPrefixListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1911,9 +1948,10 @@ pub struct CompleteMultipartUploadOutput {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CompleteMultipartUploadOutputDeserializer;
 impl CompleteMultipartUploadOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2074,9 +2112,10 @@ pub struct Condition {
     pub key_prefix_equals: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ConditionDeserializer;
 impl ConditionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2142,9 +2181,10 @@ impl ConditionSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct ContinuationEvent {}
 
+#[allow(dead_code)]
 struct ContinuationEventDeserializer;
 impl ContinuationEventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2182,9 +2222,10 @@ pub struct CopyObjectOutput {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CopyObjectOutputDeserializer;
 impl CopyObjectOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2286,9 +2327,10 @@ pub struct CopyObjectResult {
     pub last_modified: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CopyObjectResultDeserializer;
 impl CopyObjectResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2320,9 +2362,10 @@ pub struct CopyPartResult {
     pub last_modified: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CopyPartResultDeserializer;
 impl CopyPartResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2383,9 +2426,10 @@ pub struct CreateBucketOutput {
     pub location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateBucketOutputDeserializer;
 impl CreateBucketOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2448,9 +2492,10 @@ pub struct CreateMultipartUploadOutput {
     pub upload_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateMultipartUploadOutputDeserializer;
 impl CreateMultipartUploadOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2536,9 +2581,10 @@ pub struct CreateMultipartUploadRequest {
     pub website_redirect_location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreationDateDeserializer;
 impl CreationDateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2547,9 +2593,10 @@ impl CreationDateDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DateDeserializer;
 impl DateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2579,9 +2626,10 @@ impl DateSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DaysDeserializer;
 impl DaysDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2611,9 +2659,10 @@ impl DaysSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DaysAfterInitiationDeserializer;
 impl DaysAfterInitiationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2656,9 +2705,10 @@ pub struct DefaultRetention {
     pub years: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DefaultRetentionDeserializer;
 impl DefaultRetentionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2841,9 +2891,10 @@ pub struct DeleteBucketWebsiteRequest {
     pub bucket: String,
 }
 
+#[allow(dead_code)]
 struct DeleteMarkerDeserializer;
 impl DeleteMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2868,9 +2919,10 @@ pub struct DeleteMarkerEntry {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeleteMarkerEntryDeserializer;
 impl DeleteMarkerEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2913,9 +2965,10 @@ pub struct DeleteMarkerReplication {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeleteMarkerReplicationDeserializer;
 impl DeleteMarkerReplicationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2962,9 +3015,10 @@ impl DeleteMarkerReplicationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DeleteMarkerReplicationStatusDeserializer;
 impl DeleteMarkerReplicationStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2994,9 +3048,10 @@ impl DeleteMarkerReplicationStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DeleteMarkerVersionIdDeserializer;
 impl DeleteMarkerVersionIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3005,9 +3060,10 @@ impl DeleteMarkerVersionIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DeleteMarkersDeserializer;
 impl DeleteMarkersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3042,9 +3098,10 @@ pub struct DeleteObjectOutput {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeleteObjectOutputDeserializer;
 impl DeleteObjectOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3081,9 +3138,10 @@ pub struct DeleteObjectTaggingOutput {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeleteObjectTaggingOutputDeserializer;
 impl DeleteObjectTaggingOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3118,9 +3176,10 @@ pub struct DeleteObjectsOutput {
     pub request_charged: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeleteObjectsOutputDeserializer;
 impl DeleteObjectsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3178,9 +3237,10 @@ pub struct DeletedObject {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeletedObjectDeserializer;
 impl DeletedObjectDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3215,9 +3275,10 @@ impl DeletedObjectDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DeletedObjectsDeserializer;
 impl DeletedObjectsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3242,9 +3303,10 @@ impl DeletedObjectsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DelimiterDeserializer;
 impl DelimiterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3315,9 +3377,10 @@ pub struct Destination {
     pub storage_class: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DestinationDeserializer;
 impl DestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3424,9 +3487,10 @@ impl DestinationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DisplayNameDeserializer;
 impl DisplayNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3456,9 +3520,10 @@ impl DisplayNameSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ETagDeserializer;
 impl ETagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3488,9 +3553,10 @@ impl ETagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EmailAddressDeserializer;
 impl EmailAddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3540,9 +3606,10 @@ impl EnableRequestProgressSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EncodingTypeDeserializer;
 impl EncodingTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3631,9 +3698,10 @@ pub struct EncryptionConfiguration {
     pub replica_kms_key_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct EncryptionConfigurationDeserializer;
 impl EncryptionConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3706,9 +3774,10 @@ impl EndSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct EndEvent {}
 
+#[allow(dead_code)]
 struct EndEventDeserializer;
 impl EndEventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3736,9 +3805,10 @@ pub struct S3Error {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct S3ErrorDeserializer;
 impl S3ErrorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3775,9 +3845,10 @@ pub struct ErrorDocument {
     pub key: String,
 }
 
+#[allow(dead_code)]
 struct ErrorDocumentDeserializer;
 impl ErrorDocumentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3816,9 +3887,10 @@ impl ErrorDocumentSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ErrorsDeserializer;
 impl ErrorsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3843,9 +3915,10 @@ impl ErrorsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EventDeserializer;
 impl EventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3875,9 +3948,10 @@ impl EventSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EventListDeserializer;
 impl EventListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3930,9 +4004,10 @@ pub struct ExistingObjectReplication {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct ExistingObjectReplicationDeserializer;
 impl ExistingObjectReplicationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3977,9 +4052,10 @@ impl ExistingObjectReplicationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ExistingObjectReplicationStatusDeserializer;
 impl ExistingObjectReplicationStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4009,9 +4085,10 @@ impl ExistingObjectReplicationStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ExpirationStatusDeserializer;
 impl ExpirationStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4041,9 +4118,10 @@ impl ExpirationStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ExpiredObjectDeleteMarkerDeserializer;
 impl ExpiredObjectDeleteMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -4073,9 +4151,10 @@ impl ExpiredObjectDeleteMarkerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ExposeHeaderDeserializer;
 impl ExposeHeaderDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4105,9 +4184,10 @@ impl ExposeHeaderSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ExposeHeadersDeserializer;
 impl ExposeHeadersDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4262,9 +4342,10 @@ pub struct FilterRule {
     pub value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct FilterRuleDeserializer;
 impl FilterRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4316,9 +4397,10 @@ impl FilterRuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FilterRuleListDeserializer;
 impl FilterRuleListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4362,9 +4444,10 @@ impl FilterRuleListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FilterRuleNameDeserializer;
 impl FilterRuleNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4394,9 +4477,10 @@ impl FilterRuleNameSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FilterRuleValueDeserializer;
 impl FilterRuleValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4433,9 +4517,10 @@ pub struct GetBucketAccelerateConfigurationOutput {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetBucketAccelerateConfigurationOutputDeserializer;
 impl GetBucketAccelerateConfigurationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4473,9 +4558,10 @@ pub struct GetBucketAclOutput {
     pub owner: Option<Owner>,
 }
 
+#[allow(dead_code)]
 struct GetBucketAclOutputDeserializer;
 impl GetBucketAclOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4510,9 +4596,10 @@ pub struct GetBucketAnalyticsConfigurationOutput {
     pub analytics_configuration: Option<AnalyticsConfiguration>,
 }
 
+#[allow(dead_code)]
 struct GetBucketAnalyticsConfigurationOutputDeserializer;
 impl GetBucketAnalyticsConfigurationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4542,9 +4629,10 @@ pub struct GetBucketCorsOutput {
     pub cors_rules: Option<Vec<CORSRule>>,
 }
 
+#[allow(dead_code)]
 struct GetBucketCorsOutputDeserializer;
 impl GetBucketCorsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4575,9 +4663,10 @@ pub struct GetBucketEncryptionOutput {
     pub server_side_encryption_configuration: Option<ServerSideEncryptionConfiguration>,
 }
 
+#[allow(dead_code)]
 struct GetBucketEncryptionOutputDeserializer;
 impl GetBucketEncryptionOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4607,9 +4696,10 @@ pub struct GetBucketInventoryConfigurationOutput {
     pub inventory_configuration: Option<InventoryConfiguration>,
 }
 
+#[allow(dead_code)]
 struct GetBucketInventoryConfigurationOutputDeserializer;
 impl GetBucketInventoryConfigurationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4639,9 +4729,10 @@ pub struct GetBucketLifecycleConfigurationOutput {
     pub rules: Option<Vec<LifecycleRule>>,
 }
 
+#[allow(dead_code)]
 struct GetBucketLifecycleConfigurationOutputDeserializer;
 impl GetBucketLifecycleConfigurationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4677,9 +4768,10 @@ pub struct GetBucketLifecycleOutput {
     pub rules: Option<Vec<Rule>>,
 }
 
+#[allow(dead_code)]
 struct GetBucketLifecycleOutputDeserializer;
 impl GetBucketLifecycleOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4715,9 +4807,10 @@ pub struct GetBucketLocationOutput {
     pub location_constraint: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetBucketLocationOutputDeserializer;
 impl GetBucketLocationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4743,9 +4836,10 @@ pub struct GetBucketLoggingOutput {
     pub logging_enabled: Option<LoggingEnabled>,
 }
 
+#[allow(dead_code)]
 struct GetBucketLoggingOutputDeserializer;
 impl GetBucketLoggingOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4778,9 +4872,10 @@ pub struct GetBucketMetricsConfigurationOutput {
     pub metrics_configuration: Option<MetricsConfiguration>,
 }
 
+#[allow(dead_code)]
 struct GetBucketMetricsConfigurationOutputDeserializer;
 impl GetBucketMetricsConfigurationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4830,9 +4925,10 @@ pub struct GetBucketPolicyStatusOutput {
     pub policy_status: Option<PolicyStatus>,
 }
 
+#[allow(dead_code)]
 struct GetBucketPolicyStatusOutputDeserializer;
 impl GetBucketPolicyStatusOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4859,9 +4955,10 @@ pub struct GetBucketReplicationOutput {
     pub replication_configuration: Option<ReplicationConfiguration>,
 }
 
+#[allow(dead_code)]
 struct GetBucketReplicationOutputDeserializer;
 impl GetBucketReplicationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4889,9 +4986,10 @@ pub struct GetBucketRequestPaymentOutput {
     pub payer: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetBucketRequestPaymentOutputDeserializer;
 impl GetBucketRequestPaymentOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4925,9 +5023,10 @@ pub struct GetBucketTaggingOutput {
     pub tag_set: Vec<Tag>,
 }
 
+#[allow(dead_code)]
 struct GetBucketTaggingOutputDeserializer;
 impl GetBucketTaggingOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4960,9 +5059,10 @@ pub struct GetBucketVersioningOutput {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetBucketVersioningOutputDeserializer;
 impl GetBucketVersioningOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5010,9 +5110,10 @@ pub struct GetBucketWebsiteOutput {
     pub routing_rules: Option<Vec<RoutingRule>>,
 }
 
+#[allow(dead_code)]
 struct GetBucketWebsiteOutputDeserializer;
 impl GetBucketWebsiteOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5066,9 +5167,10 @@ pub struct GetObjectAclOutput {
     pub request_charged: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetObjectAclOutputDeserializer;
 impl GetObjectAclOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5108,9 +5210,10 @@ pub struct GetObjectLegalHoldOutput {
     pub legal_hold: Option<ObjectLockLegalHold>,
 }
 
+#[allow(dead_code)]
 struct GetObjectLegalHoldOutputDeserializer;
 impl GetObjectLegalHoldOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5143,9 +5246,10 @@ pub struct GetObjectLockConfigurationOutput {
     pub object_lock_configuration: Option<ObjectLockConfiguration>,
 }
 
+#[allow(dead_code)]
 struct GetObjectLockConfigurationOutputDeserializer;
 impl GetObjectLockConfigurationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5280,9 +5384,10 @@ pub struct GetObjectRetentionOutput {
     pub retention: Option<ObjectLockRetention>,
 }
 
+#[allow(dead_code)]
 struct GetObjectRetentionOutputDeserializer;
 impl GetObjectRetentionOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5317,9 +5422,10 @@ pub struct GetObjectTaggingOutput {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetObjectTaggingOutputDeserializer;
 impl GetObjectTaggingOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5371,9 +5477,10 @@ pub struct GetPublicAccessBlockOutput {
     pub public_access_block_configuration: Option<PublicAccessBlockConfiguration>,
 }
 
+#[allow(dead_code)]
 struct GetPublicAccessBlockOutputDeserializer;
 impl GetPublicAccessBlockOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5437,9 +5544,10 @@ pub struct Grant {
     pub permission: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GrantDeserializer;
 impl GrantDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Grant, XmlParseError> {
         deserialize_elements::<_, Grant, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -5501,9 +5609,10 @@ pub struct Grantee {
     pub uri: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GranteeDeserializer;
 impl GranteeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5590,9 +5699,10 @@ impl GranteeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct GrantsDeserializer;
 impl GrantsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5695,9 +5805,10 @@ pub struct HeadObjectOutput {
     pub website_redirect_location: Option<String>,
 }
 
+#[allow(dead_code)]
 struct HeadObjectOutputDeserializer;
 impl HeadObjectOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5741,9 +5852,10 @@ pub struct HeadObjectRequest {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct HostNameDeserializer;
 impl HostNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5773,9 +5885,10 @@ impl HostNameSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HttpErrorCodeReturnedEqualsDeserializer;
 impl HttpErrorCodeReturnedEqualsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5805,9 +5918,10 @@ impl HttpErrorCodeReturnedEqualsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct HttpRedirectCodeDeserializer;
 impl HttpRedirectCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5837,9 +5951,10 @@ impl HttpRedirectCodeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IDDeserializer;
 impl IDDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5878,9 +5993,10 @@ pub struct IndexDocument {
     pub suffix: String,
 }
 
+#[allow(dead_code)]
 struct IndexDocumentDeserializer;
 impl IndexDocumentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5919,9 +6035,10 @@ impl IndexDocumentSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InitiatedDeserializer;
 impl InitiatedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5940,9 +6057,10 @@ pub struct Initiator {
     pub id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InitiatorDeserializer;
 impl InitiatorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6030,9 +6148,10 @@ pub struct InventoryConfiguration {
     pub schedule: InventorySchedule,
 }
 
+#[allow(dead_code)]
 struct InventoryConfigurationDeserializer;
 impl InventoryConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6118,9 +6237,10 @@ impl InventoryConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InventoryConfigurationListDeserializer;
 impl InventoryConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6156,9 +6276,10 @@ pub struct InventoryDestination {
     pub s3_bucket_destination: InventoryS3BucketDestination,
 }
 
+#[allow(dead_code)]
 struct InventoryDestinationDeserializer;
 impl InventoryDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6211,9 +6332,10 @@ pub struct InventoryEncryption {
     pub sses3: Option<SSES3>,
 }
 
+#[allow(dead_code)]
 struct InventoryEncryptionDeserializer;
 impl InventoryEncryptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6264,9 +6386,10 @@ pub struct InventoryFilter {
     pub prefix: String,
 }
 
+#[allow(dead_code)]
 struct InventoryFilterDeserializer;
 impl InventoryFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6305,9 +6428,10 @@ impl InventoryFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InventoryFormatDeserializer;
 impl InventoryFormatDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6337,9 +6461,10 @@ impl InventoryFormatSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InventoryFrequencyDeserializer;
 impl InventoryFrequencyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6369,9 +6494,10 @@ impl InventoryFrequencySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InventoryIdDeserializer;
 impl InventoryIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6401,9 +6527,10 @@ impl InventoryIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InventoryIncludedObjectVersionsDeserializer;
 impl InventoryIncludedObjectVersionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6433,9 +6560,10 @@ impl InventoryIncludedObjectVersionsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InventoryOptionalFieldDeserializer;
 impl InventoryOptionalFieldDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6465,9 +6593,10 @@ impl InventoryOptionalFieldSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct InventoryOptionalFieldsDeserializer;
 impl InventoryOptionalFieldsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6522,9 +6651,10 @@ pub struct InventoryS3BucketDestination {
     pub prefix: Option<String>,
 }
 
+#[allow(dead_code)]
 struct InventoryS3BucketDestinationDeserializer;
 impl InventoryS3BucketDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6617,9 +6747,10 @@ pub struct InventorySchedule {
     pub frequency: String,
 }
 
+#[allow(dead_code)]
 struct InventoryScheduleDeserializer;
 impl InventoryScheduleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6659,9 +6790,10 @@ impl InventoryScheduleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IsEnabledDeserializer;
 impl IsEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6691,9 +6823,10 @@ impl IsEnabledSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct IsLatestDeserializer;
 impl IsLatestDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6702,9 +6835,10 @@ impl IsLatestDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IsPublicDeserializer;
 impl IsPublicDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6713,9 +6847,10 @@ impl IsPublicDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IsTruncatedDeserializer;
 impl IsTruncatedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6828,9 +6963,10 @@ impl KMSContextSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct KeyCountDeserializer;
 impl KeyCountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -6839,9 +6975,10 @@ impl KeyCountDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct KeyMarkerDeserializer;
 impl KeyMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6871,9 +7008,10 @@ impl KeyMarkerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct KeyPrefixEqualsDeserializer;
 impl KeyPrefixEqualsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6903,9 +7041,10 @@ impl KeyPrefixEqualsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LambdaFunctionArnDeserializer;
 impl LambdaFunctionArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6948,9 +7087,10 @@ pub struct LambdaFunctionConfiguration {
     pub lambda_function_arn: String,
 }
 
+#[allow(dead_code)]
 struct LambdaFunctionConfigurationDeserializer;
 impl LambdaFunctionConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7019,9 +7159,10 @@ impl LambdaFunctionConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LambdaFunctionConfigurationListDeserializer;
 impl LambdaFunctionConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7067,9 +7208,10 @@ impl LambdaFunctionConfigurationListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LastModifiedDeserializer;
 impl LastModifiedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -7116,9 +7258,10 @@ pub struct LifecycleExpiration {
     pub expired_object_delete_marker: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct LifecycleExpirationDeserializer;
 impl LifecycleExpirationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7207,9 +7350,10 @@ pub struct LifecycleRule {
     pub transitions: Option<Vec<Transition>>,
 }
 
+#[allow(dead_code)]
 struct LifecycleRuleDeserializer;
 impl LifecycleRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7338,9 +7482,10 @@ pub struct LifecycleRuleAndOperator {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct LifecycleRuleAndOperatorDeserializer;
 impl LifecycleRuleAndOperatorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7405,9 +7550,10 @@ pub struct LifecycleRuleFilter {
     pub tag: Option<Tag>,
 }
 
+#[allow(dead_code)]
 struct LifecycleRuleFilterDeserializer;
 impl LifecycleRuleFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7462,9 +7608,10 @@ impl LifecycleRuleFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LifecycleRulesDeserializer;
 impl LifecycleRulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7521,9 +7668,10 @@ pub struct ListBucketAnalyticsConfigurationsOutput {
     pub next_continuation_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListBucketAnalyticsConfigurationsOutputDeserializer;
 impl ListBucketAnalyticsConfigurationsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7584,9 +7732,10 @@ pub struct ListBucketInventoryConfigurationsOutput {
     pub next_continuation_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListBucketInventoryConfigurationsOutputDeserializer;
 impl ListBucketInventoryConfigurationsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7647,9 +7796,10 @@ pub struct ListBucketMetricsConfigurationsOutput {
     pub next_continuation_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListBucketMetricsConfigurationsOutputDeserializer;
 impl ListBucketMetricsConfigurationsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7706,9 +7856,10 @@ pub struct ListBucketsOutput {
     pub owner: Option<Owner>,
 }
 
+#[allow(dead_code)]
 struct ListBucketsOutputDeserializer;
 impl ListBucketsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7758,9 +7909,10 @@ pub struct ListMultipartUploadsOutput {
     pub uploads: Option<Vec<MultipartUpload>>,
 }
 
+#[allow(dead_code)]
 struct ListMultipartUploadsOutputDeserializer;
 impl ListMultipartUploadsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7883,9 +8035,10 @@ pub struct ListObjectVersionsOutput {
     pub versions: Option<Vec<ObjectVersion>>,
 }
 
+#[allow(dead_code)]
 struct ListObjectVersionsOutputDeserializer;
 impl ListObjectVersionsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8006,9 +8159,10 @@ pub struct ListObjectsOutput {
     pub prefix: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListObjectsOutputDeserializer;
 impl ListObjectsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8107,9 +8261,10 @@ pub struct ListObjectsV2Output {
     pub start_after: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListObjectsV2OutputDeserializer;
 impl ListObjectsV2OutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8226,9 +8381,10 @@ pub struct ListPartsOutput {
     pub upload_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListPartsOutputDeserializer;
 impl ListPartsOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8305,9 +8461,10 @@ pub struct ListPartsRequest {
     pub upload_id: String,
 }
 
+#[allow(dead_code)]
 struct LocationDeserializer;
 impl LocationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8350,9 +8507,10 @@ pub struct LoggingEnabled {
     pub target_prefix: String,
 }
 
+#[allow(dead_code)]
 struct LoggingEnabledDeserializer;
 impl LoggingEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8430,9 +8588,10 @@ impl MFADeleteSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MFADeleteStatusDeserializer;
 impl MFADeleteStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8441,9 +8600,10 @@ impl MFADeleteStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MarkerDeserializer;
 impl MarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8473,9 +8633,10 @@ impl MarkerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MaxAgeSecondsDeserializer;
 impl MaxAgeSecondsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8505,9 +8666,10 @@ impl MaxAgeSecondsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MaxKeysDeserializer;
 impl MaxKeysDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8537,9 +8699,10 @@ impl MaxKeysSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MaxPartsDeserializer;
 impl MaxPartsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8569,9 +8732,10 @@ impl MaxPartsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MaxUploadsDeserializer;
 impl MaxUploadsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -8601,9 +8765,10 @@ impl MaxUploadsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MessageDeserializer;
 impl MessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -8705,9 +8870,10 @@ pub struct Metrics {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct MetricsDeserializer;
 impl MetricsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8766,9 +8932,10 @@ pub struct MetricsAndOperator {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct MetricsAndOperatorDeserializer;
 impl MetricsAndOperatorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8828,9 +8995,10 @@ pub struct MetricsConfiguration {
     pub id: String,
 }
 
+#[allow(dead_code)]
 struct MetricsConfigurationDeserializer;
 impl MetricsConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8875,9 +9043,10 @@ impl MetricsConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MetricsConfigurationListDeserializer;
 impl MetricsConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8917,9 +9086,10 @@ pub struct MetricsFilter {
     pub tag: Option<Tag>,
 }
 
+#[allow(dead_code)]
 struct MetricsFilterDeserializer;
 impl MetricsFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -8972,9 +9142,10 @@ impl MetricsFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MetricsIdDeserializer;
 impl MetricsIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9004,9 +9175,10 @@ impl MetricsIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MetricsStatusDeserializer;
 impl MetricsStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9036,9 +9208,10 @@ impl MetricsStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MinutesDeserializer;
 impl MinutesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -9086,9 +9259,10 @@ pub struct MultipartUpload {
     pub upload_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MultipartUploadDeserializer;
 impl MultipartUploadDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9124,9 +9298,10 @@ impl MultipartUploadDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MultipartUploadIdDeserializer;
 impl MultipartUploadIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9156,9 +9331,10 @@ impl MultipartUploadIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MultipartUploadListDeserializer;
 impl MultipartUploadListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9183,9 +9359,10 @@ impl MultipartUploadListDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextKeyMarkerDeserializer;
 impl NextKeyMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9194,9 +9371,10 @@ impl NextKeyMarkerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextMarkerDeserializer;
 impl NextMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9205,9 +9383,10 @@ impl NextMarkerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextPartNumberMarkerDeserializer;
 impl NextPartNumberMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -9216,9 +9395,10 @@ impl NextPartNumberMarkerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextTokenDeserializer;
 impl NextTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9227,9 +9407,10 @@ impl NextTokenDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextUploadIdMarkerDeserializer;
 impl NextUploadIdMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9238,9 +9419,10 @@ impl NextUploadIdMarkerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextVersionIdMarkerDeserializer;
 impl NextVersionIdMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9258,9 +9440,10 @@ pub struct NoncurrentVersionExpiration {
     pub noncurrent_days: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct NoncurrentVersionExpirationDeserializer;
 impl NoncurrentVersionExpirationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9317,9 +9500,10 @@ pub struct NoncurrentVersionTransition {
     pub storage_class: Option<String>,
 }
 
+#[allow(dead_code)]
 struct NoncurrentVersionTransitionDeserializer;
 impl NoncurrentVersionTransitionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9379,9 +9563,10 @@ impl NoncurrentVersionTransitionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct NoncurrentVersionTransitionListDeserializer;
 impl NoncurrentVersionTransitionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9440,9 +9625,10 @@ pub struct NotificationConfiguration {
     pub topic_configurations: Option<Vec<TopicConfiguration>>,
 }
 
+#[allow(dead_code)]
 struct NotificationConfigurationDeserializer;
 impl NotificationConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9525,9 +9711,10 @@ pub struct NotificationConfigurationDeprecated {
     pub topic_configuration: Option<TopicConfigurationDeprecated>,
 }
 
+#[allow(dead_code)]
 struct NotificationConfigurationDeprecatedDeserializer;
 impl NotificationConfigurationDeprecatedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9611,9 +9798,10 @@ pub struct NotificationConfigurationFilter {
     pub key: Option<S3KeyFilter>,
 }
 
+#[allow(dead_code)]
 struct NotificationConfigurationFilterDeserializer;
 impl NotificationConfigurationFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9653,9 +9841,10 @@ impl NotificationConfigurationFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct NotificationIdDeserializer;
 impl NotificationIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9703,9 +9892,10 @@ pub struct Object {
     pub storage_class: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ObjectDeserializer;
 impl ObjectDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Object, XmlParseError> {
         deserialize_elements::<_, Object, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -9818,9 +10008,10 @@ impl ObjectIdentifierListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ObjectKeyDeserializer;
 impl ObjectKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9850,9 +10041,10 @@ impl ObjectKeySerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ObjectListDeserializer;
 impl ObjectListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9888,9 +10080,10 @@ pub struct ObjectLockConfiguration {
     pub rule: Option<ObjectLockRule>,
 }
 
+#[allow(dead_code)]
 struct ObjectLockConfigurationDeserializer;
 impl ObjectLockConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -9944,9 +10137,10 @@ impl ObjectLockConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ObjectLockEnabledDeserializer;
 impl ObjectLockEnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -9985,9 +10179,10 @@ pub struct ObjectLockLegalHold {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ObjectLockLegalHoldDeserializer;
 impl ObjectLockLegalHoldDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10030,9 +10225,10 @@ impl ObjectLockLegalHoldSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ObjectLockLegalHoldStatusDeserializer;
 impl ObjectLockLegalHoldStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10073,9 +10269,10 @@ pub struct ObjectLockRetention {
     pub retain_until_date: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ObjectLockRetentionDeserializer;
 impl ObjectLockRetentionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10130,9 +10327,10 @@ impl ObjectLockRetentionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ObjectLockRetentionModeDeserializer;
 impl ObjectLockRetentionModeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10171,9 +10369,10 @@ pub struct ObjectLockRule {
     pub default_retention: Option<DefaultRetention>,
 }
 
+#[allow(dead_code)]
 struct ObjectLockRuleDeserializer;
 impl ObjectLockRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10212,9 +10411,10 @@ impl ObjectLockRuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ObjectStorageClassDeserializer;
 impl ObjectStorageClassDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10245,9 +10445,10 @@ pub struct ObjectVersion {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ObjectVersionDeserializer;
 impl ObjectVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10293,9 +10494,10 @@ impl ObjectVersionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ObjectVersionIdDeserializer;
 impl ObjectVersionIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10325,9 +10527,10 @@ impl ObjectVersionIdSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ObjectVersionListDeserializer;
 impl ObjectVersionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10352,9 +10555,10 @@ impl ObjectVersionListDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ObjectVersionStorageClassDeserializer;
 impl ObjectVersionStorageClassDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10433,9 +10637,10 @@ pub struct Owner {
     pub id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct OwnerDeserializer;
 impl OwnerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Owner, XmlParseError> {
         deserialize_elements::<_, Owner, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -10485,9 +10690,10 @@ impl OwnerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct OwnerOverrideDeserializer;
 impl OwnerOverrideDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10552,9 +10758,10 @@ pub struct Part {
     pub size: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct PartDeserializer;
 impl PartDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Part, XmlParseError> {
         deserialize_elements::<_, Part, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -10580,9 +10787,10 @@ impl PartDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PartNumberDeserializer;
 impl PartNumberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -10612,9 +10820,10 @@ impl PartNumberSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PartNumberMarkerDeserializer;
 impl PartNumberMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -10644,9 +10853,10 @@ impl PartNumberMarkerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PartsDeserializer;
 impl PartsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10671,9 +10881,10 @@ impl PartsDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PayerDeserializer;
 impl PayerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10703,9 +10914,10 @@ impl PayerSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PermissionDeserializer;
 impl PermissionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10743,9 +10955,10 @@ pub struct PolicyStatus {
     pub is_public: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct PolicyStatusDeserializer;
 impl PolicyStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10761,9 +10974,10 @@ impl PolicyStatusDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct PrefixDeserializer;
 impl PrefixDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10793,9 +11007,10 @@ impl PrefixSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct PriorityDeserializer;
 impl PriorityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -10837,9 +11052,10 @@ pub struct Progress {
     pub bytes_scanned: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ProgressDeserializer;
 impl ProgressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10878,9 +11094,10 @@ pub struct ProgressEvent {
     pub details: Option<Progress>,
 }
 
+#[allow(dead_code)]
 struct ProgressEventDeserializer;
 impl ProgressEventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -10896,9 +11113,10 @@ impl ProgressEventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ProtocolDeserializer;
 impl ProtocolDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -10943,9 +11161,10 @@ pub struct PublicAccessBlockConfiguration {
     pub restrict_public_buckets: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct PublicAccessBlockConfigurationDeserializer;
 impl PublicAccessBlockConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11246,9 +11465,10 @@ pub struct PutObjectAclOutput {
     pub request_charged: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PutObjectAclOutputDeserializer;
 impl PutObjectAclOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11296,9 +11516,10 @@ pub struct PutObjectLegalHoldOutput {
     pub request_charged: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PutObjectLegalHoldOutputDeserializer;
 impl PutObjectLegalHoldOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11334,9 +11555,10 @@ pub struct PutObjectLockConfigurationOutput {
     pub request_charged: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PutObjectLockConfigurationOutputDeserializer;
 impl PutObjectLockConfigurationOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11386,9 +11608,10 @@ pub struct PutObjectOutput {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PutObjectOutputDeserializer;
 impl PutObjectOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11471,9 +11694,10 @@ pub struct PutObjectRetentionOutput {
     pub request_charged: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PutObjectRetentionOutputDeserializer;
 impl PutObjectRetentionOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11512,9 +11736,10 @@ pub struct PutObjectTaggingOutput {
     pub version_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PutObjectTaggingOutputDeserializer;
 impl PutObjectTaggingOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11554,9 +11779,10 @@ pub struct PutPublicAccessBlockRequest {
     pub public_access_block_configuration: PublicAccessBlockConfiguration,
 }
 
+#[allow(dead_code)]
 struct QueueArnDeserializer;
 impl QueueArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -11599,9 +11825,10 @@ pub struct QueueConfiguration {
     pub queue_arn: String,
 }
 
+#[allow(dead_code)]
 struct QueueConfigurationDeserializer;
 impl QueueConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11676,9 +11903,10 @@ pub struct QueueConfigurationDeprecated {
     pub queue: Option<String>,
 }
 
+#[allow(dead_code)]
 struct QueueConfigurationDeprecatedDeserializer;
 impl QueueConfigurationDeprecatedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11742,9 +11970,10 @@ impl QueueConfigurationDeprecatedSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct QueueConfigurationListDeserializer;
 impl QueueConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11898,9 +12127,10 @@ pub struct RecordsEvent {
     pub payload: Option<bytes::Bytes>,
 }
 
+#[allow(dead_code)]
 struct RecordsEventDeserializer;
 impl RecordsEventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -11933,9 +12163,10 @@ pub struct Redirect {
     pub replace_key_with: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RedirectDeserializer;
 impl RedirectDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12041,9 +12272,10 @@ pub struct RedirectAllRequestsTo {
     pub protocol: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RedirectAllRequestsToDeserializer;
 impl RedirectAllRequestsToDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12093,9 +12325,10 @@ impl RedirectAllRequestsToSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReplaceKeyPrefixWithDeserializer;
 impl ReplaceKeyPrefixWithDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -12125,9 +12358,10 @@ impl ReplaceKeyPrefixWithSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReplaceKeyWithDeserializer;
 impl ReplaceKeyWithDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -12157,9 +12391,10 @@ impl ReplaceKeyWithSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReplicaKmsKeyIDDeserializer;
 impl ReplicaKmsKeyIDDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -12200,9 +12435,10 @@ pub struct ReplicationConfiguration {
     pub rules: Vec<ReplicationRule>,
 }
 
+#[allow(dead_code)]
 struct ReplicationConfigurationDeserializer;
 impl ReplicationConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12271,9 +12507,10 @@ pub struct ReplicationRule {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct ReplicationRuleDeserializer;
 impl ReplicationRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12399,9 +12636,10 @@ pub struct ReplicationRuleAndOperator {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct ReplicationRuleAndOperatorDeserializer;
 impl ReplicationRuleAndOperatorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12467,9 +12705,10 @@ pub struct ReplicationRuleFilter {
     pub tag: Option<Tag>,
 }
 
+#[allow(dead_code)]
 struct ReplicationRuleFilterDeserializer;
 impl ReplicationRuleFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12524,9 +12763,10 @@ impl ReplicationRuleFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReplicationRuleStatusDeserializer;
 impl ReplicationRuleStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -12556,9 +12796,10 @@ impl ReplicationRuleStatusSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReplicationRulesDeserializer;
 impl ReplicationRulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12613,9 +12854,10 @@ pub struct ReplicationTime {
     pub time: ReplicationTimeValue,
 }
 
+#[allow(dead_code)]
 struct ReplicationTimeDeserializer;
 impl ReplicationTimeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12658,9 +12900,10 @@ impl ReplicationTimeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReplicationTimeStatusDeserializer;
 impl ReplicationTimeStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -12699,9 +12942,10 @@ pub struct ReplicationTimeValue {
     pub minutes: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct ReplicationTimeValueDeserializer;
 impl ReplicationTimeValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -12932,9 +13176,10 @@ pub struct RestoreObjectOutput {
     pub restore_output_path: Option<String>,
 }
 
+#[allow(dead_code)]
 struct RestoreObjectOutputDeserializer;
 impl RestoreObjectOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13058,9 +13303,10 @@ impl RestoreRequestTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RoleDeserializer;
 impl RoleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -13101,9 +13347,10 @@ pub struct RoutingRule {
     pub redirect: Redirect,
 }
 
+#[allow(dead_code)]
 struct RoutingRuleDeserializer;
 impl RoutingRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13143,9 +13390,10 @@ impl RoutingRuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RoutingRulesDeserializer;
 impl RoutingRulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13201,9 +13449,10 @@ pub struct Rule {
     pub transition: Option<Transition>,
 }
 
+#[allow(dead_code)]
 struct RuleDeserializer;
 impl RuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Rule, XmlParseError> {
         deserialize_elements::<_, Rule, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -13317,9 +13566,10 @@ impl RuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RulesDeserializer;
 impl RulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13371,9 +13621,10 @@ pub struct S3KeyFilter {
     pub filter_rules: Option<Vec<FilterRule>>,
 }
 
+#[allow(dead_code)]
 struct S3KeyFilterDeserializer;
 impl S3KeyFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13497,9 +13748,10 @@ pub struct SSEKMS {
     pub key_id: String,
 }
 
+#[allow(dead_code)]
 struct SSEKMSDeserializer;
 impl SSEKMSDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<SSEKMS, XmlParseError> {
         deserialize_elements::<_, SSEKMS, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -13535,9 +13787,10 @@ impl SSEKMSSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SSEKMSKeyIdDeserializer;
 impl SSEKMSKeyIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -13573,9 +13826,10 @@ impl SSEKMSKeyIdSerializer {
 #[cfg_attr(feature = "deserialize_structs", derive(Deserialize))]
 pub struct SSES3 {}
 
+#[allow(dead_code)]
 struct SSES3Deserializer;
 impl SSES3Deserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<SSES3, XmlParseError> {
         start_element(tag_name, stack)?;
 
@@ -13661,9 +13915,10 @@ pub struct SelectObjectContentEventStream {
     pub stats: Option<StatsEvent>,
 }
 
+#[allow(dead_code)]
 struct SelectObjectContentEventStreamDeserializer;
 impl SelectObjectContentEventStreamDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13704,9 +13959,10 @@ pub struct SelectObjectContentOutput {
     pub payload: Option<SelectObjectContentEventStream>,
 }
 
+#[allow(dead_code)]
 struct SelectObjectContentOutputDeserializer;
 impl SelectObjectContentOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13833,9 +14089,10 @@ impl SelectParametersSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ServerSideEncryptionDeserializer;
 impl ServerSideEncryptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -13876,9 +14133,10 @@ pub struct ServerSideEncryptionByDefault {
     pub sse_algorithm: String,
 }
 
+#[allow(dead_code)]
 struct ServerSideEncryptionByDefaultDeserializer;
 impl ServerSideEncryptionByDefaultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13945,9 +14203,10 @@ pub struct ServerSideEncryptionConfiguration {
     pub rules: Vec<ServerSideEncryptionRule>,
 }
 
+#[allow(dead_code)]
 struct ServerSideEncryptionConfigurationDeserializer;
 impl ServerSideEncryptionConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -13997,9 +14256,10 @@ pub struct ServerSideEncryptionRule {
     pub apply_server_side_encryption_by_default: Option<ServerSideEncryptionByDefault>,
 }
 
+#[allow(dead_code)]
 struct ServerSideEncryptionRuleDeserializer;
 impl ServerSideEncryptionRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14047,9 +14307,10 @@ impl ServerSideEncryptionRuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ServerSideEncryptionRulesDeserializer;
 impl ServerSideEncryptionRulesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14095,9 +14356,10 @@ impl ServerSideEncryptionRulesSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SettingDeserializer;
 impl SettingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -14127,9 +14389,10 @@ impl SettingSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SizeDeserializer;
 impl SizeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -14147,9 +14410,10 @@ pub struct SourceSelectionCriteria {
     pub sse_kms_encrypted_objects: Option<SseKmsEncryptedObjects>,
 }
 
+#[allow(dead_code)]
 struct SourceSelectionCriteriaDeserializer;
 impl SourceSelectionCriteriaDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14206,9 +14470,10 @@ pub struct SseKmsEncryptedObjects {
     pub status: String,
 }
 
+#[allow(dead_code)]
 struct SseKmsEncryptedObjectsDeserializer;
 impl SseKmsEncryptedObjectsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14248,9 +14513,10 @@ impl SseKmsEncryptedObjectsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SseKmsEncryptedObjectsStatusDeserializer;
 impl SseKmsEncryptedObjectsStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14300,9 +14566,10 @@ impl StartSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StartAfterDeserializer;
 impl StartAfterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14344,9 +14611,10 @@ pub struct Stats {
     pub bytes_scanned: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct StatsDeserializer;
 impl StatsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Stats, XmlParseError> {
         deserialize_elements::<_, Stats, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -14382,9 +14650,10 @@ pub struct StatsEvent {
     pub details: Option<Stats>,
 }
 
+#[allow(dead_code)]
 struct StatsEventDeserializer;
 impl StatsEventDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14400,9 +14669,10 @@ impl StatsEventDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StorageClassDeserializer;
 impl StorageClassDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14441,9 +14711,10 @@ pub struct StorageClassAnalysis {
     pub data_export: Option<StorageClassAnalysisDataExport>,
 }
 
+#[allow(dead_code)]
 struct StorageClassAnalysisDeserializer;
 impl StorageClassAnalysisDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14494,9 +14765,10 @@ pub struct StorageClassAnalysisDataExport {
     pub output_schema_version: String,
 }
 
+#[allow(dead_code)]
 struct StorageClassAnalysisDataExportDeserializer;
 impl StorageClassAnalysisDataExportDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14554,9 +14826,10 @@ impl StorageClassAnalysisDataExportSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StorageClassAnalysisSchemaVersionDeserializer;
 impl StorageClassAnalysisSchemaVersionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14586,9 +14859,10 @@ impl StorageClassAnalysisSchemaVersionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SuffixDeserializer;
 impl SuffixDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14629,9 +14903,10 @@ pub struct Tag {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -14676,9 +14951,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagSetDeserializer;
 impl TagSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14739,9 +15015,10 @@ impl TaggingSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetBucketDeserializer;
 impl TargetBucketDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14782,9 +15059,10 @@ pub struct TargetGrant {
     pub permission: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TargetGrantDeserializer;
 impl TargetGrantDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14834,9 +15112,10 @@ impl TargetGrantSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetGrantsDeserializer;
 impl TargetGrantsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -14872,9 +15151,10 @@ impl TargetGrantsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TargetPrefixDeserializer;
 impl TargetPrefixDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14924,9 +15204,10 @@ impl TierSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TokenDeserializer;
 impl TokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -14956,9 +15237,10 @@ impl TokenSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TopicArnDeserializer;
 impl TopicArnDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -15001,9 +15283,10 @@ pub struct TopicConfiguration {
     pub topic_arn: String,
 }
 
+#[allow(dead_code)]
 struct TopicConfigurationDeserializer;
 impl TopicConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15078,9 +15361,10 @@ pub struct TopicConfigurationDeprecated {
     pub topic: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TopicConfigurationDeprecatedDeserializer;
 impl TopicConfigurationDeprecatedDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15144,9 +15428,10 @@ impl TopicConfigurationDeprecatedSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TopicConfigurationListDeserializer;
 impl TopicConfigurationListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15205,9 +15490,10 @@ pub struct Transition {
     pub storage_class: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TransitionDeserializer;
 impl TransitionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15273,9 +15559,10 @@ impl TransitionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TransitionListDeserializer;
 impl TransitionListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15319,9 +15606,10 @@ impl TransitionListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TransitionStorageClassDeserializer;
 impl TransitionStorageClassDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -15351,9 +15639,10 @@ impl TransitionStorageClassSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TypeDeserializer;
 impl TypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -15383,9 +15672,10 @@ impl TypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct URIDeserializer;
 impl URIDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -15415,9 +15705,10 @@ impl URISerializer {
     }
 }
 
+#[allow(dead_code)]
 struct UploadIdMarkerDeserializer;
 impl UploadIdMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -15465,9 +15756,10 @@ pub struct UploadPartCopyOutput {
     pub server_side_encryption: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UploadPartCopyOutputDeserializer;
 impl UploadPartCopyOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15535,9 +15827,10 @@ pub struct UploadPartOutput {
     pub server_side_encryption: Option<String>,
 }
 
+#[allow(dead_code)]
 struct UploadPartOutputDeserializer;
 impl UploadPartOutputDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -15596,9 +15889,10 @@ impl UserMetadataSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ValueDeserializer;
 impl ValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -15628,9 +15922,10 @@ impl ValueSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct VersionIdMarkerDeserializer;
 impl VersionIdMarkerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -15748,9 +16043,10 @@ impl WebsiteConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct YearsDeserializer;
 impl YearsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -1859,9 +1859,8 @@ impl SimpleDb for SimpleDbClient {
             return Err(DomainMetadataError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DomainMetadataResult::default();
         } else {
@@ -1906,9 +1905,8 @@ impl SimpleDb for SimpleDbClient {
             return Err(GetAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAttributesResult::default();
         } else {
@@ -1953,9 +1951,8 @@ impl SimpleDb for SimpleDbClient {
             return Err(ListDomainsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListDomainsResult::default();
         } else {
@@ -2024,9 +2021,8 @@ impl SimpleDb for SimpleDbClient {
             return Err(SelectError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SelectResult::default();
         } else {

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -51,9 +51,10 @@ pub struct Attribute {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct AttributeDeserializer;
 impl AttributeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -111,9 +112,10 @@ impl AttributeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AttributeListDeserializer;
 impl AttributeListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -373,9 +375,10 @@ pub struct DomainMetadataResult {
     pub timestamp: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct DomainMetadataResultDeserializer;
 impl DomainMetadataResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -422,9 +425,10 @@ impl DomainMetadataResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DomainNameListDeserializer;
 impl DomainNameListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -493,9 +497,10 @@ pub struct GetAttributesResult {
     pub attributes: Option<Vec<Attribute>>,
 }
 
+#[allow(dead_code)]
 struct GetAttributesResultDeserializer;
 impl GetAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -513,9 +518,10 @@ impl GetAttributesResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IntegerDeserializer;
 impl IntegerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -536,9 +542,10 @@ pub struct Item {
     pub name: String,
 }
 
+#[allow(dead_code)]
 struct ItemDeserializer;
 impl ItemDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Item, XmlParseError> {
         deserialize_elements::<_, Item, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -561,9 +568,10 @@ impl ItemDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ItemListDeserializer;
 impl ItemListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -624,9 +632,10 @@ pub struct ListDomainsResult {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListDomainsResultDeserializer;
 impl ListDomainsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -647,9 +656,10 @@ impl ListDomainsResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct LongDeserializer;
 impl LongDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -818,9 +828,10 @@ pub struct SelectResult {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SelectResultDeserializer;
 impl SelectResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -841,9 +852,10 @@ impl SelectResultDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -47,9 +47,10 @@ pub struct AddHeaderAction {
     pub header_value: String,
 }
 
+#[allow(dead_code)]
 struct AddHeaderActionDeserializer;
 impl AddHeaderActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -83,9 +84,10 @@ impl AddHeaderActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AddressDeserializer;
 impl AddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -94,9 +96,10 @@ impl AddressDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AddressListDeserializer;
 impl AddressListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -123,9 +126,10 @@ impl AddressListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AmazonResourceNameDeserializer;
 impl AmazonResourceNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -134,9 +138,10 @@ impl AmazonResourceNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BehaviorOnMXFailureDeserializer;
 impl BehaviorOnMXFailureDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -190,9 +195,10 @@ pub struct BounceAction {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct BounceActionDeserializer;
 impl BounceActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -251,9 +257,10 @@ impl BounceActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BounceMessageDeserializer;
 impl BounceMessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -262,9 +269,10 @@ impl BounceMessageDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BounceSmtpReplyCodeDeserializer;
 impl BounceSmtpReplyCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -273,9 +281,10 @@ impl BounceSmtpReplyCodeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BounceStatusCodeDeserializer;
 impl BounceStatusCodeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -399,9 +408,10 @@ pub struct BulkEmailDestinationStatus {
     pub status: Option<String>,
 }
 
+#[allow(dead_code)]
 struct BulkEmailDestinationStatusDeserializer;
 impl BulkEmailDestinationStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -429,9 +439,10 @@ impl BulkEmailDestinationStatusDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct BulkEmailDestinationStatusListDeserializer;
 impl BulkEmailDestinationStatusListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -448,9 +459,10 @@ impl BulkEmailDestinationStatusListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BulkEmailStatusDeserializer;
 impl BulkEmailStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -459,9 +471,10 @@ impl BulkEmailStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CidrDeserializer;
 impl CidrDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -502,9 +515,10 @@ impl CloneReceiptRuleSetRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CloneReceiptRuleSetResponse {}
 
+#[allow(dead_code)]
 struct CloneReceiptRuleSetResponseDeserializer;
 impl CloneReceiptRuleSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -527,9 +541,10 @@ pub struct CloudWatchDestination {
     pub dimension_configurations: Vec<CloudWatchDimensionConfiguration>,
 }
 
+#[allow(dead_code)]
 struct CloudWatchDestinationDeserializer;
 impl CloudWatchDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -581,9 +596,10 @@ pub struct CloudWatchDimensionConfiguration {
     pub dimension_value_source: String,
 }
 
+#[allow(dead_code)]
 struct CloudWatchDimensionConfigurationDeserializer;
 impl CloudWatchDimensionConfigurationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -642,9 +658,10 @@ impl CloudWatchDimensionConfigurationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CloudWatchDimensionConfigurationsDeserializer;
 impl CloudWatchDimensionConfigurationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -682,9 +699,10 @@ pub struct ConfigurationSet {
     pub name: String,
 }
 
+#[allow(dead_code)]
 struct ConfigurationSetDeserializer;
 impl ConfigurationSetDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -725,9 +743,10 @@ impl ConfigurationSetAttributeListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ConfigurationSetNameDeserializer;
 impl ConfigurationSetNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -736,9 +755,10 @@ impl ConfigurationSetNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ConfigurationSetsDeserializer;
 impl ConfigurationSetsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -779,9 +799,10 @@ impl ContentSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct CounterDeserializer;
 impl CounterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -830,9 +851,10 @@ impl CreateConfigurationSetEventDestinationRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateConfigurationSetEventDestinationResponse {}
 
+#[allow(dead_code)]
 struct CreateConfigurationSetEventDestinationResponseDeserializer;
 impl CreateConfigurationSetEventDestinationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -876,9 +898,10 @@ impl CreateConfigurationSetRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateConfigurationSetResponse {}
 
+#[allow(dead_code)]
 struct CreateConfigurationSetResponseDeserializer;
 impl CreateConfigurationSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -931,9 +954,10 @@ impl CreateConfigurationSetTrackingOptionsRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateConfigurationSetTrackingOptionsResponse {}
 
+#[allow(dead_code)]
 struct CreateConfigurationSetTrackingOptionsResponseDeserializer;
 impl CreateConfigurationSetTrackingOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1028,9 +1052,10 @@ impl CreateReceiptFilterRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateReceiptFilterResponse {}
 
+#[allow(dead_code)]
 struct CreateReceiptFilterResponseDeserializer;
 impl CreateReceiptFilterResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1078,9 +1103,10 @@ impl CreateReceiptRuleRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateReceiptRuleResponse {}
 
+#[allow(dead_code)]
 struct CreateReceiptRuleResponseDeserializer;
 impl CreateReceiptRuleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1120,9 +1146,10 @@ impl CreateReceiptRuleSetRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateReceiptRuleSetResponse {}
 
+#[allow(dead_code)]
 struct CreateReceiptRuleSetResponseDeserializer;
 impl CreateReceiptRuleSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1161,9 +1188,10 @@ impl CreateTemplateRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct CreateTemplateResponse {}
 
+#[allow(dead_code)]
 struct CreateTemplateResponseDeserializer;
 impl CreateTemplateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1177,9 +1205,10 @@ impl CreateTemplateResponseDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CustomMailFromStatusDeserializer;
 impl CustomMailFromStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1188,9 +1217,10 @@ impl CustomMailFromStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct CustomRedirectDomainDeserializer;
 impl CustomRedirectDomainDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1215,9 +1245,10 @@ pub struct CustomVerificationEmailTemplate {
     pub template_subject: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CustomVerificationEmailTemplateDeserializer;
 impl CustomVerificationEmailTemplateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1264,9 +1295,10 @@ impl CustomVerificationEmailTemplateDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct CustomVerificationEmailTemplatesDeserializer;
 impl CustomVerificationEmailTemplatesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1283,9 +1315,10 @@ impl CustomVerificationEmailTemplatesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DefaultDimensionValueDeserializer;
 impl DefaultDimensionValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1333,9 +1366,10 @@ impl DeleteConfigurationSetEventDestinationRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteConfigurationSetEventDestinationResponse {}
 
+#[allow(dead_code)]
 struct DeleteConfigurationSetEventDestinationResponseDeserializer;
 impl DeleteConfigurationSetEventDestinationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1378,9 +1412,10 @@ impl DeleteConfigurationSetRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteConfigurationSetResponse {}
 
+#[allow(dead_code)]
 struct DeleteConfigurationSetResponseDeserializer;
 impl DeleteConfigurationSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1427,9 +1462,10 @@ impl DeleteConfigurationSetTrackingOptionsRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteConfigurationSetTrackingOptionsResponse {}
 
+#[allow(dead_code)]
 struct DeleteConfigurationSetTrackingOptionsResponseDeserializer;
 impl DeleteConfigurationSetTrackingOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1497,9 +1533,10 @@ impl DeleteIdentityPolicyRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteIdentityPolicyResponse {}
 
+#[allow(dead_code)]
 struct DeleteIdentityPolicyResponseDeserializer;
 impl DeleteIdentityPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1539,9 +1576,10 @@ impl DeleteIdentityRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteIdentityResponse {}
 
+#[allow(dead_code)]
 struct DeleteIdentityResponseDeserializer;
 impl DeleteIdentityResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1581,9 +1619,10 @@ impl DeleteReceiptFilterRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteReceiptFilterResponse {}
 
+#[allow(dead_code)]
 struct DeleteReceiptFilterResponseDeserializer;
 impl DeleteReceiptFilterResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1626,9 +1665,10 @@ impl DeleteReceiptRuleRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteReceiptRuleResponse {}
 
+#[allow(dead_code)]
 struct DeleteReceiptRuleResponseDeserializer;
 impl DeleteReceiptRuleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1668,9 +1708,10 @@ impl DeleteReceiptRuleSetRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteReceiptRuleSetResponse {}
 
+#[allow(dead_code)]
 struct DeleteReceiptRuleSetResponseDeserializer;
 impl DeleteReceiptRuleSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1709,9 +1750,10 @@ impl DeleteTemplateRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct DeleteTemplateResponse {}
 
+#[allow(dead_code)]
 struct DeleteTemplateResponseDeserializer;
 impl DeleteTemplateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1755,9 +1797,10 @@ pub struct DeliveryOptions {
     pub tls_policy: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DeliveryOptionsDeserializer;
 impl DeliveryOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1815,9 +1858,10 @@ pub struct DescribeActiveReceiptRuleSetResponse {
     pub rules: Option<Vec<ReceiptRule>>,
 }
 
+#[allow(dead_code)]
 struct DescribeActiveReceiptRuleSetResponseDeserializer;
 impl DescribeActiveReceiptRuleSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1892,9 +1936,10 @@ pub struct DescribeConfigurationSetResponse {
     pub tracking_options: Option<TrackingOptions>,
 }
 
+#[allow(dead_code)]
 struct DescribeConfigurationSetResponseDeserializer;
 impl DescribeConfigurationSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1972,9 +2017,10 @@ pub struct DescribeReceiptRuleResponse {
     pub rule: Option<ReceiptRule>,
 }
 
+#[allow(dead_code)]
 struct DescribeReceiptRuleResponseDeserializer;
 impl DescribeReceiptRuleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2025,9 +2071,10 @@ pub struct DescribeReceiptRuleSetResponse {
     pub rules: Option<Vec<ReceiptRule>>,
 }
 
+#[allow(dead_code)]
 struct DescribeReceiptRuleSetResponseDeserializer;
 impl DescribeReceiptRuleSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2099,9 +2146,10 @@ impl DestinationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct DimensionNameDeserializer;
 impl DimensionNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2110,9 +2158,10 @@ impl DimensionNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DimensionValueSourceDeserializer;
 impl DimensionValueSourceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2121,9 +2170,10 @@ impl DimensionValueSourceDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct DkimAttributesDeserializer;
 impl DkimAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2144,9 +2194,10 @@ impl DkimAttributesDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EnabledDeserializer;
 impl EnabledDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -2155,9 +2206,10 @@ impl EnabledDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SesErrorDeserializer;
 impl SesErrorDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2185,9 +2237,10 @@ pub struct EventDestination {
     pub sns_destination: Option<SNSDestination>,
 }
 
+#[allow(dead_code)]
 struct EventDestinationDeserializer;
 impl EventDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2276,9 +2329,10 @@ impl EventDestinationSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EventDestinationNameDeserializer;
 impl EventDestinationNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2287,9 +2341,10 @@ impl EventDestinationNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EventDestinationsDeserializer;
 impl EventDestinationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2304,9 +2359,10 @@ impl EventDestinationsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct EventTypeDeserializer;
 impl EventTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2315,9 +2371,10 @@ impl EventTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct EventTypesDeserializer;
 impl EventTypesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2379,9 +2436,10 @@ impl ExtensionFieldListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct FailureRedirectionURLDeserializer;
 impl FailureRedirectionURLDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2390,9 +2448,10 @@ impl FailureRedirectionURLDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FromAddressDeserializer;
 impl FromAddressDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2409,9 +2468,10 @@ pub struct GetAccountSendingEnabledResponse {
     pub enabled: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct GetAccountSendingEnabledResponseDeserializer;
 impl GetAccountSendingEnabledResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2470,9 +2530,10 @@ pub struct GetCustomVerificationEmailTemplateResponse {
     pub template_subject: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetCustomVerificationEmailTemplateResponseDeserializer;
 impl GetCustomVerificationEmailTemplateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2558,9 +2619,10 @@ pub struct GetIdentityDkimAttributesResponse {
     pub dkim_attributes: ::std::collections::HashMap<String, IdentityDkimAttributes>,
 }
 
+#[allow(dead_code)]
 struct GetIdentityDkimAttributesResponseDeserializer;
 impl GetIdentityDkimAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2619,9 +2681,10 @@ pub struct GetIdentityMailFromDomainAttributesResponse {
         ::std::collections::HashMap<String, IdentityMailFromDomainAttributes>,
 }
 
+#[allow(dead_code)]
 struct GetIdentityMailFromDomainAttributesResponseDeserializer;
 impl GetIdentityMailFromDomainAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2679,9 +2742,10 @@ pub struct GetIdentityNotificationAttributesResponse {
         ::std::collections::HashMap<String, IdentityNotificationAttributes>,
 }
 
+#[allow(dead_code)]
 struct GetIdentityNotificationAttributesResponseDeserializer;
 impl GetIdentityNotificationAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2741,9 +2805,10 @@ pub struct GetIdentityPoliciesResponse {
     pub policies: ::std::collections::HashMap<String, String>,
 }
 
+#[allow(dead_code)]
 struct GetIdentityPoliciesResponseDeserializer;
 impl GetIdentityPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2797,9 +2862,10 @@ pub struct GetIdentityVerificationAttributesResponse {
         ::std::collections::HashMap<String, IdentityVerificationAttributes>,
 }
 
+#[allow(dead_code)]
 struct GetIdentityVerificationAttributesResponseDeserializer;
 impl GetIdentityVerificationAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2835,9 +2901,10 @@ pub struct GetSendQuotaResponse {
     pub sent_last_24_hours: Option<f64>,
 }
 
+#[allow(dead_code)]
 struct GetSendQuotaResponseDeserializer;
 impl GetSendQuotaResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2874,9 +2941,10 @@ pub struct GetSendStatisticsResponse {
     pub send_data_points: Option<Vec<SendDataPoint>>,
 }
 
+#[allow(dead_code)]
 struct GetSendStatisticsResponseDeserializer;
 impl GetSendStatisticsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2924,9 +2992,10 @@ pub struct GetTemplateResponse {
     pub template: Option<Template>,
 }
 
+#[allow(dead_code)]
 struct GetTemplateResponseDeserializer;
 impl GetTemplateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2942,9 +3011,10 @@ impl GetTemplateResponseDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct HeaderNameDeserializer;
 impl HeaderNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2953,9 +3023,10 @@ impl HeaderNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HeaderValueDeserializer;
 impl HeaderValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2964,9 +3035,10 @@ impl HeaderValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct HtmlPartDeserializer;
 impl HtmlPartDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2975,9 +3047,10 @@ impl HtmlPartDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct IdentityDeserializer;
 impl IdentityDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2998,9 +3071,10 @@ pub struct IdentityDkimAttributes {
     pub dkim_verification_status: String,
 }
 
+#[allow(dead_code)]
 struct IdentityDkimAttributesDeserializer;
 impl IdentityDkimAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3027,9 +3101,10 @@ impl IdentityDkimAttributesDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct IdentityListDeserializer;
 impl IdentityListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3068,9 +3143,10 @@ pub struct IdentityMailFromDomainAttributes {
     pub mail_from_domain_status: String,
 }
 
+#[allow(dead_code)]
 struct IdentityMailFromDomainAttributesDeserializer;
 impl IdentityMailFromDomainAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3124,9 +3200,10 @@ pub struct IdentityNotificationAttributes {
     pub headers_in_delivery_notifications_enabled: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct IdentityNotificationAttributesDeserializer;
 impl IdentityNotificationAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3190,9 +3267,10 @@ pub struct IdentityVerificationAttributes {
     pub verification_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct IdentityVerificationAttributesDeserializer;
 impl IdentityVerificationAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3221,9 +3299,10 @@ impl IdentityVerificationAttributesDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct InvocationTypeDeserializer;
 impl InvocationTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3243,9 +3322,10 @@ pub struct KinesisFirehoseDestination {
     pub iam_role_arn: String,
 }
 
+#[allow(dead_code)]
 struct KinesisFirehoseDestinationDeserializer;
 impl KinesisFirehoseDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3303,9 +3383,10 @@ pub struct LambdaAction {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct LambdaActionDeserializer;
 impl LambdaActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3353,9 +3434,10 @@ impl LambdaActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct LastFreshStartDeserializer;
 impl LastFreshStartDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3402,9 +3484,10 @@ pub struct ListConfigurationSetsResponse {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListConfigurationSetsResponseDeserializer;
 impl ListConfigurationSetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3472,9 +3555,10 @@ pub struct ListCustomVerificationEmailTemplatesResponse {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListCustomVerificationEmailTemplatesResponseDeserializer;
 impl ListCustomVerificationEmailTemplatesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3546,9 +3630,10 @@ pub struct ListIdentitiesResponse {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListIdentitiesResponseDeserializer;
 impl ListIdentitiesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3597,9 +3682,10 @@ pub struct ListIdentityPoliciesResponse {
     pub policy_names: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct ListIdentityPoliciesResponseDeserializer;
 impl ListIdentityPoliciesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3647,9 +3733,10 @@ pub struct ListReceiptFiltersResponse {
     pub filters: Option<Vec<ReceiptFilter>>,
 }
 
+#[allow(dead_code)]
 struct ListReceiptFiltersResponseDeserializer;
 impl ListReceiptFiltersResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3704,9 +3791,10 @@ pub struct ListReceiptRuleSetsResponse {
     pub rule_sets: Option<Vec<ReceiptRuleSetMetadata>>,
 }
 
+#[allow(dead_code)]
 struct ListReceiptRuleSetsResponseDeserializer;
 impl ListReceiptRuleSetsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3768,9 +3856,10 @@ pub struct ListTemplatesResponse {
     pub templates_metadata: Option<Vec<TemplateMetadata>>,
 }
 
+#[allow(dead_code)]
 struct ListTemplatesResponseDeserializer;
 impl ListTemplatesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3799,9 +3888,10 @@ pub struct ListVerifiedEmailAddressesResponse {
     pub verified_email_addresses: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ListVerifiedEmailAddressesResponseDeserializer;
 impl ListVerifiedEmailAddressesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3823,9 +3913,10 @@ impl ListVerifiedEmailAddressesResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct MailFromDomainAttributesDeserializer;
 impl MailFromDomainAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -3847,9 +3938,10 @@ impl MailFromDomainAttributesDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MailFromDomainNameDeserializer;
 impl MailFromDomainNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3858,9 +3950,10 @@ impl MailFromDomainNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct Max24HourSendDeserializer;
 impl Max24HourSendDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3869,9 +3962,10 @@ impl Max24HourSendDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MaxSendRateDeserializer;
 impl MaxSendRateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -3939,9 +4033,10 @@ impl MessageDsnSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MessageIdDeserializer;
 impl MessageIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3985,9 +4080,10 @@ impl MessageTagListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct NextTokenDeserializer;
 impl NextTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -3996,9 +4092,10 @@ impl NextTokenDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NotificationAttributesDeserializer;
 impl NotificationAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4020,9 +4117,10 @@ impl NotificationAttributesDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NotificationTopicDeserializer;
 impl NotificationTopicDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4031,9 +4129,10 @@ impl NotificationTopicDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyDeserializer;
 impl PolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4042,9 +4141,10 @@ impl PolicyDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyMapDeserializer;
 impl PolicyMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4065,9 +4165,10 @@ impl PolicyMapDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyNameDeserializer;
 impl PolicyNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4076,9 +4177,10 @@ impl PolicyNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PolicyNameListDeserializer;
 impl PolicyNameListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4143,9 +4245,10 @@ impl PutConfigurationSetDeliveryOptionsRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct PutConfigurationSetDeliveryOptionsResponse {}
 
+#[allow(dead_code)]
 struct PutConfigurationSetDeliveryOptionsResponseDeserializer;
 impl PutConfigurationSetDeliveryOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4191,9 +4294,10 @@ impl PutIdentityPolicyRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct PutIdentityPolicyResponse {}
 
+#[allow(dead_code)]
 struct PutIdentityPolicyResponseDeserializer;
 impl PutIdentityPolicyResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4252,9 +4356,10 @@ pub struct ReceiptAction {
     pub workmail_action: Option<WorkmailAction>,
 }
 
+#[allow(dead_code)]
 struct ReceiptActionDeserializer;
 impl ReceiptActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4363,9 +4468,10 @@ impl ReceiptActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReceiptActionsListDeserializer;
 impl ReceiptActionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4403,9 +4509,10 @@ pub struct ReceiptFilter {
     pub name: String,
 }
 
+#[allow(dead_code)]
 struct ReceiptFilterDeserializer;
 impl ReceiptFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4443,9 +4550,10 @@ impl ReceiptFilterSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReceiptFilterListDeserializer;
 impl ReceiptFilterListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4460,9 +4568,10 @@ impl ReceiptFilterListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReceiptFilterNameDeserializer;
 impl ReceiptFilterNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4471,9 +4580,10 @@ impl ReceiptFilterNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReceiptFilterPolicyDeserializer;
 impl ReceiptFilterPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4493,9 +4603,10 @@ pub struct ReceiptIpFilter {
     pub policy: String,
 }
 
+#[allow(dead_code)]
 struct ReceiptIpFilterDeserializer;
 impl ReceiptIpFilterDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4548,9 +4659,10 @@ pub struct ReceiptRule {
     pub tls_policy: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ReceiptRuleDeserializer;
 impl ReceiptRuleDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4623,9 +4735,10 @@ impl ReceiptRuleSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct ReceiptRuleNameDeserializer;
 impl ReceiptRuleNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4656,9 +4769,10 @@ pub struct ReceiptRuleSetMetadata {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ReceiptRuleSetMetadataDeserializer;
 impl ReceiptRuleSetMetadataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4680,9 +4794,10 @@ impl ReceiptRuleSetMetadataDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReceiptRuleSetNameDeserializer;
 impl ReceiptRuleSetNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4691,9 +4806,10 @@ impl ReceiptRuleSetNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ReceiptRuleSetsListsDeserializer;
 impl ReceiptRuleSetsListsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4710,9 +4826,10 @@ impl ReceiptRuleSetsListsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ReceiptRulesListDeserializer;
 impl ReceiptRulesListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4727,9 +4844,10 @@ impl ReceiptRulesListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct RecipientDeserializer;
 impl RecipientDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4791,9 +4909,10 @@ impl RecipientDsnFieldsSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RecipientsListDeserializer;
 impl RecipientsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4820,9 +4939,10 @@ impl RecipientsListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct RenderedTemplateDeserializer;
 impl RenderedTemplateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -4864,9 +4984,10 @@ impl ReorderReceiptRuleSetRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct ReorderReceiptRuleSetResponse {}
 
+#[allow(dead_code)]
 struct ReorderReceiptRuleSetResponseDeserializer;
 impl ReorderReceiptRuleSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4892,9 +5013,10 @@ pub struct ReputationOptions {
     pub sending_enabled: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct ReputationOptionsDeserializer;
 impl ReputationOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4938,9 +5060,10 @@ pub struct S3Action {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct S3ActionDeserializer;
 impl S3ActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -4996,9 +5119,10 @@ impl S3ActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct S3BucketNameDeserializer;
 impl S3BucketNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5007,9 +5131,10 @@ impl S3BucketNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct S3KeyPrefixDeserializer;
 impl S3KeyPrefixDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5029,9 +5154,10 @@ pub struct SNSAction {
     pub topic_arn: String,
 }
 
+#[allow(dead_code)]
 struct SNSActionDeserializer;
 impl SNSActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5069,9 +5195,10 @@ impl SNSActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SNSActionEncodingDeserializer;
 impl SNSActionEncodingDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -5089,9 +5216,10 @@ pub struct SNSDestination {
     pub topic_arn: String,
 }
 
+#[allow(dead_code)]
 struct SNSDestinationDeserializer;
 impl SNSDestinationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5182,9 +5310,10 @@ pub struct SendBounceResponse {
     pub message_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SendBounceResponseDeserializer;
 impl SendBounceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5292,9 +5421,10 @@ pub struct SendBulkTemplatedEmailResponse {
     pub status: Vec<BulkEmailDestinationStatus>,
 }
 
+#[allow(dead_code)]
 struct SendBulkTemplatedEmailResponseDeserializer;
 impl SendBulkTemplatedEmailResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5357,9 +5487,10 @@ pub struct SendCustomVerificationEmailResponse {
     pub message_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SendCustomVerificationEmailResponseDeserializer;
 impl SendCustomVerificationEmailResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5396,9 +5527,10 @@ pub struct SendDataPoint {
     pub timestamp: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SendDataPointDeserializer;
 impl SendDataPointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5427,9 +5559,10 @@ impl SendDataPointDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SendDataPointListDeserializer;
 impl SendDataPointListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5524,9 +5657,10 @@ pub struct SendEmailResponse {
     pub message_id: String,
 }
 
+#[allow(dead_code)]
 struct SendEmailResponseDeserializer;
 impl SendEmailResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5621,9 +5755,10 @@ pub struct SendRawEmailResponse {
     pub message_id: String,
 }
 
+#[allow(dead_code)]
 struct SendRawEmailResponseDeserializer;
 impl SendRawEmailResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5726,9 +5861,10 @@ pub struct SendTemplatedEmailResponse {
     pub message_id: String,
 }
 
+#[allow(dead_code)]
 struct SendTemplatedEmailResponseDeserializer;
 impl SendTemplatedEmailResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5748,9 +5884,10 @@ impl SendTemplatedEmailResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SentLast24HoursDeserializer;
 impl SentLast24HoursDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<f64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = f64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -5787,9 +5924,10 @@ impl SetActiveReceiptRuleSetRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetActiveReceiptRuleSetResponse {}
 
+#[allow(dead_code)]
 struct SetActiveReceiptRuleSetResponseDeserializer;
 impl SetActiveReceiptRuleSetResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5832,9 +5970,10 @@ impl SetIdentityDkimEnabledRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetIdentityDkimEnabledResponse {}
 
+#[allow(dead_code)]
 struct SetIdentityDkimEnabledResponseDeserializer;
 impl SetIdentityDkimEnabledResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5884,9 +6023,10 @@ impl SetIdentityFeedbackForwardingEnabledRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetIdentityFeedbackForwardingEnabledResponse {}
 
+#[allow(dead_code)]
 struct SetIdentityFeedbackForwardingEnabledResponseDeserializer;
 impl SetIdentityFeedbackForwardingEnabledResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5939,9 +6079,10 @@ impl SetIdentityHeadersInNotificationsEnabledRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetIdentityHeadersInNotificationsEnabledResponse {}
 
+#[allow(dead_code)]
 struct SetIdentityHeadersInNotificationsEnabledResponseDeserializer;
 impl SetIdentityHeadersInNotificationsEnabledResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -5994,9 +6135,10 @@ impl SetIdentityMailFromDomainRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetIdentityMailFromDomainResponse {}
 
+#[allow(dead_code)]
 struct SetIdentityMailFromDomainResponseDeserializer;
 impl SetIdentityMailFromDomainResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6047,9 +6189,10 @@ impl SetIdentityNotificationTopicRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetIdentityNotificationTopicResponse {}
 
+#[allow(dead_code)]
 struct SetIdentityNotificationTopicResponseDeserializer;
 impl SetIdentityNotificationTopicResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6097,9 +6240,10 @@ impl SetReceiptRulePositionRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetReceiptRulePositionResponse {}
 
+#[allow(dead_code)]
 struct SetReceiptRulePositionResponseDeserializer;
 impl SetReceiptRulePositionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6124,9 +6268,10 @@ pub struct StopAction {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct StopActionDeserializer;
 impl StopActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6164,9 +6309,10 @@ impl StopActionSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StopScopeDeserializer;
 impl StopScopeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6175,9 +6321,10 @@ impl StopScopeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SubjectDeserializer;
 impl SubjectDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6186,9 +6333,10 @@ impl SubjectDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SubjectPartDeserializer;
 impl SubjectPartDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6197,9 +6345,10 @@ impl SubjectPartDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SuccessRedirectionURLDeserializer;
 impl SuccessRedirectionURLDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6223,9 +6372,10 @@ pub struct Template {
     pub text_part: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TemplateDeserializer;
 impl TemplateDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6275,9 +6425,10 @@ impl TemplateSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TemplateContentDeserializer;
 impl TemplateContentDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6296,9 +6447,10 @@ pub struct TemplateMetadata {
     pub name: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TemplateMetadataDeserializer;
 impl TemplateMetadataDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6320,9 +6472,10 @@ impl TemplateMetadataDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TemplateMetadataListDeserializer;
 impl TemplateMetadataListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6337,9 +6490,10 @@ impl TemplateMetadataListDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TemplateNameDeserializer;
 impl TemplateNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6378,9 +6532,10 @@ pub struct TestRenderTemplateResponse {
     pub rendered_template: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TestRenderTemplateResponseDeserializer;
 impl TestRenderTemplateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6403,9 +6558,10 @@ impl TestRenderTemplateResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct TextPartDeserializer;
 impl TextPartDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6414,9 +6570,10 @@ impl TextPartDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TimestampDeserializer;
 impl TimestampDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6425,9 +6582,10 @@ impl TimestampDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TlsPolicyDeserializer;
 impl TlsPolicyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6445,9 +6603,10 @@ pub struct TrackingOptions {
     pub custom_redirect_domain: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TrackingOptionsDeserializer;
 impl TrackingOptionsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6549,9 +6708,10 @@ impl UpdateConfigurationSetEventDestinationRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct UpdateConfigurationSetEventDestinationResponse {}
 
+#[allow(dead_code)]
 struct UpdateConfigurationSetEventDestinationResponseDeserializer;
 impl UpdateConfigurationSetEventDestinationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6666,9 +6826,10 @@ impl UpdateConfigurationSetTrackingOptionsRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct UpdateConfigurationSetTrackingOptionsResponse {}
 
+#[allow(dead_code)]
 struct UpdateConfigurationSetTrackingOptionsResponseDeserializer;
 impl UpdateConfigurationSetTrackingOptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6767,9 +6928,10 @@ impl UpdateReceiptRuleRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct UpdateReceiptRuleResponse {}
 
+#[allow(dead_code)]
 struct UpdateReceiptRuleResponseDeserializer;
 impl UpdateReceiptRuleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6806,9 +6968,10 @@ impl UpdateTemplateRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct UpdateTemplateResponse {}
 
+#[allow(dead_code)]
 struct UpdateTemplateResponseDeserializer;
 impl UpdateTemplateResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6822,9 +6985,10 @@ impl UpdateTemplateResponseDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VerificationAttributesDeserializer;
 impl VerificationAttributesDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6846,9 +7010,10 @@ impl VerificationAttributesDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VerificationStatusDeserializer;
 impl VerificationStatusDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6857,9 +7022,10 @@ impl VerificationStatusDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VerificationTokenDeserializer;
 impl VerificationTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -6868,9 +7034,10 @@ impl VerificationTokenDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct VerificationTokenListDeserializer;
 impl VerificationTokenListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6914,9 +7081,10 @@ pub struct VerifyDomainDkimResponse {
     pub dkim_tokens: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct VerifyDomainDkimResponseDeserializer;
 impl VerifyDomainDkimResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -6969,9 +7137,10 @@ pub struct VerifyDomainIdentityResponse {
     pub verification_token: String,
 }
 
+#[allow(dead_code)]
 struct VerifyDomainIdentityResponseDeserializer;
 impl VerifyDomainIdentityResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7039,9 +7208,10 @@ impl VerifyEmailIdentityRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct VerifyEmailIdentityResponse {}
 
+#[allow(dead_code)]
 struct VerifyEmailIdentityResponseDeserializer;
 impl VerifyEmailIdentityResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -7066,9 +7236,10 @@ pub struct WorkmailAction {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct WorkmailActionDeserializer;
 impl WorkmailActionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -11252,9 +11252,7 @@ impl Ses for SesClient {
             return Err(CloneReceiptRuleSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CloneReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -11284,9 +11282,7 @@ impl Ses for SesClient {
             return Err(CreateConfigurationSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateConfigurationSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -11321,9 +11317,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateConfigurationSetEventDestinationResponse::default();
         // parse non-payload
         Ok(result)
@@ -11358,9 +11352,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateConfigurationSetTrackingOptionsResponse::default();
         // parse non-payload
         Ok(result)
@@ -11420,9 +11412,7 @@ impl Ses for SesClient {
             return Err(CreateReceiptFilterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateReceiptFilterResponse::default();
         // parse non-payload
         Ok(result)
@@ -11452,9 +11442,7 @@ impl Ses for SesClient {
             return Err(CreateReceiptRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateReceiptRuleResponse::default();
         // parse non-payload
         Ok(result)
@@ -11484,9 +11472,7 @@ impl Ses for SesClient {
             return Err(CreateReceiptRuleSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -11516,9 +11502,7 @@ impl Ses for SesClient {
             return Err(CreateTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = CreateTemplateResponse::default();
         // parse non-payload
         Ok(result)
@@ -11548,9 +11532,7 @@ impl Ses for SesClient {
             return Err(DeleteConfigurationSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteConfigurationSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -11585,9 +11567,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteConfigurationSetEventDestinationResponse::default();
         // parse non-payload
         Ok(result)
@@ -11622,9 +11602,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteConfigurationSetTrackingOptionsResponse::default();
         // parse non-payload
         Ok(result)
@@ -11684,9 +11662,7 @@ impl Ses for SesClient {
             return Err(DeleteIdentityError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteIdentityResponse::default();
         // parse non-payload
         Ok(result)
@@ -11716,9 +11692,7 @@ impl Ses for SesClient {
             return Err(DeleteIdentityPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteIdentityPolicyResponse::default();
         // parse non-payload
         Ok(result)
@@ -11748,9 +11722,7 @@ impl Ses for SesClient {
             return Err(DeleteReceiptFilterError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteReceiptFilterResponse::default();
         // parse non-payload
         Ok(result)
@@ -11780,9 +11752,7 @@ impl Ses for SesClient {
             return Err(DeleteReceiptRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteReceiptRuleResponse::default();
         // parse non-payload
         Ok(result)
@@ -11812,9 +11782,7 @@ impl Ses for SesClient {
             return Err(DeleteReceiptRuleSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -11844,9 +11812,7 @@ impl Ses for SesClient {
             return Err(DeleteTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = DeleteTemplateResponse::default();
         // parse non-payload
         Ok(result)
@@ -11905,9 +11871,8 @@ impl Ses for SesClient {
             return Err(DescribeActiveReceiptRuleSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeActiveReceiptRuleSetResponse::default();
         } else {
@@ -11954,9 +11919,8 @@ impl Ses for SesClient {
             return Err(DescribeConfigurationSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeConfigurationSetResponse::default();
         } else {
@@ -12003,9 +11967,8 @@ impl Ses for SesClient {
             return Err(DescribeReceiptRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeReceiptRuleResponse::default();
         } else {
@@ -12052,9 +12015,8 @@ impl Ses for SesClient {
             return Err(DescribeReceiptRuleSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DescribeReceiptRuleSetResponse::default();
         } else {
@@ -12100,9 +12062,8 @@ impl Ses for SesClient {
             return Err(GetAccountSendingEnabledError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAccountSendingEnabledResponse::default();
         } else {
@@ -12154,9 +12115,8 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetCustomVerificationEmailTemplateResponse::default();
         } else {
@@ -12204,9 +12164,8 @@ impl Ses for SesClient {
             return Err(GetIdentityDkimAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetIdentityDkimAttributesResponse::default();
         } else {
@@ -12258,9 +12217,8 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetIdentityMailFromDomainAttributesResponse::default();
         } else {
@@ -12312,9 +12270,8 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetIdentityNotificationAttributesResponse::default();
         } else {
@@ -12361,9 +12318,8 @@ impl Ses for SesClient {
             return Err(GetIdentityPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetIdentityPoliciesResponse::default();
         } else {
@@ -12415,9 +12371,8 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetIdentityVerificationAttributesResponse::default();
         } else {
@@ -12461,9 +12416,8 @@ impl Ses for SesClient {
             return Err(GetSendQuotaError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetSendQuotaResponse::default();
         } else {
@@ -12507,9 +12461,8 @@ impl Ses for SesClient {
             return Err(GetSendStatisticsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetSendStatisticsResponse::default();
         } else {
@@ -12556,9 +12509,8 @@ impl Ses for SesClient {
             return Err(GetTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetTemplateResponse::default();
         } else {
@@ -12602,9 +12554,8 @@ impl Ses for SesClient {
             return Err(ListConfigurationSetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListConfigurationSetsResponse::default();
         } else {
@@ -12656,9 +12607,8 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListCustomVerificationEmailTemplatesResponse::default();
         } else {
@@ -12705,9 +12655,8 @@ impl Ses for SesClient {
             return Err(ListIdentitiesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListIdentitiesResponse::default();
         } else {
@@ -12754,9 +12703,8 @@ impl Ses for SesClient {
             return Err(ListIdentityPoliciesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListIdentityPoliciesResponse::default();
         } else {
@@ -12803,9 +12751,8 @@ impl Ses for SesClient {
             return Err(ListReceiptFiltersError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListReceiptFiltersResponse::default();
         } else {
@@ -12852,9 +12799,8 @@ impl Ses for SesClient {
             return Err(ListReceiptRuleSetsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListReceiptRuleSetsResponse::default();
         } else {
@@ -12901,9 +12847,8 @@ impl Ses for SesClient {
             return Err(ListTemplatesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTemplatesResponse::default();
         } else {
@@ -12948,9 +12893,8 @@ impl Ses for SesClient {
             return Err(ListVerifiedEmailAddressesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListVerifiedEmailAddressesResponse::default();
         } else {
@@ -13002,9 +12946,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = PutConfigurationSetDeliveryOptionsResponse::default();
         // parse non-payload
         Ok(result)
@@ -13034,9 +12976,7 @@ impl Ses for SesClient {
             return Err(PutIdentityPolicyError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = PutIdentityPolicyResponse::default();
         // parse non-payload
         Ok(result)
@@ -13066,9 +13006,7 @@ impl Ses for SesClient {
             return Err(ReorderReceiptRuleSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = ReorderReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -13098,9 +13036,8 @@ impl Ses for SesClient {
             return Err(SendBounceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendBounceResponse::default();
         } else {
@@ -13144,9 +13081,8 @@ impl Ses for SesClient {
             return Err(SendBulkTemplatedEmailError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendBulkTemplatedEmailResponse::default();
         } else {
@@ -13194,9 +13130,8 @@ impl Ses for SesClient {
             return Err(SendCustomVerificationEmailError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendCustomVerificationEmailResponse::default();
         } else {
@@ -13243,9 +13178,8 @@ impl Ses for SesClient {
             return Err(SendEmailError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendEmailResponse::default();
         } else {
@@ -13289,9 +13223,8 @@ impl Ses for SesClient {
             return Err(SendRawEmailError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendRawEmailResponse::default();
         } else {
@@ -13336,9 +13269,8 @@ impl Ses for SesClient {
             return Err(SendTemplatedEmailError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendTemplatedEmailResponse::default();
         } else {
@@ -13385,9 +13317,7 @@ impl Ses for SesClient {
             return Err(SetActiveReceiptRuleSetError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetActiveReceiptRuleSetResponse::default();
         // parse non-payload
         Ok(result)
@@ -13417,9 +13347,7 @@ impl Ses for SesClient {
             return Err(SetIdentityDkimEnabledError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetIdentityDkimEnabledResponse::default();
         // parse non-payload
         Ok(result)
@@ -13454,9 +13382,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetIdentityFeedbackForwardingEnabledResponse::default();
         // parse non-payload
         Ok(result)
@@ -13493,9 +13419,7 @@ impl Ses for SesClient {
             return Err(SetIdentityHeadersInNotificationsEnabledError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetIdentityHeadersInNotificationsEnabledResponse::default();
         // parse non-payload
         Ok(result)
@@ -13526,9 +13450,7 @@ impl Ses for SesClient {
             return Err(SetIdentityMailFromDomainError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetIdentityMailFromDomainResponse::default();
         // parse non-payload
         Ok(result)
@@ -13559,9 +13481,7 @@ impl Ses for SesClient {
             return Err(SetIdentityNotificationTopicError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetIdentityNotificationTopicResponse::default();
         // parse non-payload
         Ok(result)
@@ -13591,9 +13511,7 @@ impl Ses for SesClient {
             return Err(SetReceiptRulePositionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetReceiptRulePositionResponse::default();
         // parse non-payload
         Ok(result)
@@ -13623,9 +13541,8 @@ impl Ses for SesClient {
             return Err(TestRenderTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = TestRenderTemplateResponse::default();
         } else {
@@ -13705,9 +13622,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = UpdateConfigurationSetEventDestinationResponse::default();
         // parse non-payload
         Ok(result)
@@ -13806,9 +13721,7 @@ impl Ses for SesClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = UpdateConfigurationSetTrackingOptionsResponse::default();
         // parse non-payload
         Ok(result)
@@ -13868,9 +13781,7 @@ impl Ses for SesClient {
             return Err(UpdateReceiptRuleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = UpdateReceiptRuleResponse::default();
         // parse non-payload
         Ok(result)
@@ -13900,9 +13811,7 @@ impl Ses for SesClient {
             return Err(UpdateTemplateError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = UpdateTemplateResponse::default();
         // parse non-payload
         Ok(result)
@@ -13932,9 +13841,8 @@ impl Ses for SesClient {
             return Err(VerifyDomainDkimError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = VerifyDomainDkimResponse::default();
         } else {
@@ -13981,9 +13889,8 @@ impl Ses for SesClient {
             return Err(VerifyDomainIdentityError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = VerifyDomainIdentityResponse::default();
         } else {
@@ -14058,9 +13965,7 @@ impl Ses for SesClient {
             return Err(VerifyEmailIdentityError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = VerifyEmailIdentityResponse::default();
         // parse non-payload
         Ok(result)

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -36,9 +36,10 @@ use std::str::FromStr;
 use xml::reader::ParserConfig;
 use xml::EventReader;
 
+#[allow(dead_code)]
 struct AccountDeserializer;
 impl AccountDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -96,9 +97,10 @@ impl AddPermissionInputSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct AttributeNameDeserializer;
 impl AttributeNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -107,9 +109,10 @@ impl AttributeNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AttributeValueDeserializer;
 impl AttributeValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -118,9 +121,10 @@ impl AttributeValueDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -158,9 +162,10 @@ pub struct CheckIfPhoneNumberIsOptedOutResponse {
     pub is_opted_out: Option<bool>,
 }
 
+#[allow(dead_code)]
 struct CheckIfPhoneNumberIsOptedOutResponseDeserializer;
 impl CheckIfPhoneNumberIsOptedOutResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -221,9 +226,10 @@ pub struct ConfirmSubscriptionResponse {
     pub subscription_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ConfirmSubscriptionResponseDeserializer;
 impl ConfirmSubscriptionResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -254,9 +260,10 @@ pub struct CreateEndpointResponse {
     pub endpoint_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateEndpointResponseDeserializer;
 impl CreateEndpointResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -311,9 +318,10 @@ pub struct CreatePlatformApplicationResponse {
     pub platform_application_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreatePlatformApplicationResponseDeserializer;
 impl CreatePlatformApplicationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -420,9 +428,10 @@ pub struct CreateTopicResponse {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateTopicResponseDeserializer;
 impl CreateTopicResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -515,9 +524,10 @@ impl DeleteTopicInputSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct EndpointDeserializer;
 impl EndpointDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -555,9 +565,10 @@ pub struct GetEndpointAttributesResponse {
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct GetEndpointAttributesResponseDeserializer;
 impl GetEndpointAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -612,9 +623,10 @@ pub struct GetPlatformApplicationAttributesResponse {
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct GetPlatformApplicationAttributesResponseDeserializer;
 impl GetPlatformApplicationAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -672,9 +684,10 @@ pub struct GetSMSAttributesResponse {
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct GetSMSAttributesResponseDeserializer;
 impl GetSMSAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -729,9 +742,10 @@ pub struct GetSubscriptionAttributesResponse {
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct GetSubscriptionAttributesResponseDeserializer;
 impl GetSubscriptionAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -783,9 +797,10 @@ pub struct GetTopicAttributesResponse {
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct GetTopicAttributesResponseDeserializer;
 impl GetTopicAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -847,9 +862,10 @@ pub struct ListEndpointsByPlatformApplicationResponse {
     pub next_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct ListEndpointsByPlatformApplicationResponseDeserializer;
 impl ListEndpointsByPlatformApplicationResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -874,9 +890,10 @@ impl ListEndpointsByPlatformApplicationResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ListOfEndpointsDeserializer;
 impl ListOfEndpointsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -891,9 +908,10 @@ impl ListOfEndpointsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ListOfPlatformApplicationsDeserializer;
 impl ListOfPlatformApplicationsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -943,9 +961,10 @@ pub struct ListPhoneNumbersOptedOutResponse {
     pub phone_numbers: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ListPhoneNumbersOptedOutResponseDeserializer;
 impl ListPhoneNumbersOptedOutResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1003,9 +1022,10 @@ pub struct ListPlatformApplicationsResponse {
     pub platform_applications: Option<Vec<PlatformApplication>>,
 }
 
+#[allow(dead_code)]
 struct ListPlatformApplicationsResponseDeserializer;
 impl ListPlatformApplicationsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1081,9 +1101,10 @@ pub struct ListSubscriptionsByTopicResponse {
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
+#[allow(dead_code)]
 struct ListSubscriptionsByTopicResponseDeserializer;
 impl ListSubscriptionsByTopicResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1142,9 +1163,10 @@ pub struct ListSubscriptionsResponse {
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
+#[allow(dead_code)]
 struct ListSubscriptionsResponseDeserializer;
 impl ListSubscriptionsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1197,9 +1219,10 @@ pub struct ListTagsForResourceResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
+#[allow(dead_code)]
 struct ListTagsForResourceResponseDeserializer;
 impl ListTagsForResourceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1253,9 +1276,10 @@ pub struct ListTopicsResponse {
     pub topics: Option<Vec<Topic>>,
 }
 
+#[allow(dead_code)]
 struct ListTopicsResponseDeserializer;
 impl ListTopicsResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1276,9 +1300,10 @@ impl ListTopicsResponseDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct MapStringToStringDeserializer;
 impl MapStringToStringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1370,9 +1395,10 @@ impl MessageAttributeValueSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MessageIdDeserializer;
 impl MessageIdDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1381,9 +1407,10 @@ impl MessageIdDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NextTokenDeserializer;
 impl NextTokenDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1418,9 +1445,10 @@ impl OptInPhoneNumberInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct OptInPhoneNumberResponse {}
 
+#[allow(dead_code)]
 struct OptInPhoneNumberResponseDeserializer;
 impl OptInPhoneNumberResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1434,9 +1462,10 @@ impl OptInPhoneNumberResponseDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PhoneNumberDeserializer;
 impl PhoneNumberDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1445,9 +1474,10 @@ impl PhoneNumberDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct PhoneNumberListDeserializer;
 impl PhoneNumberListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1472,9 +1502,10 @@ pub struct PlatformApplication {
     pub platform_application_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PlatformApplicationDeserializer;
 impl PlatformApplicationDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1499,9 +1530,10 @@ impl PlatformApplicationDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct ProtocolDeserializer;
 impl ProtocolDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1573,9 +1605,10 @@ pub struct PublishResponse {
     pub message_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct PublishResponseDeserializer;
 impl PublishResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1704,9 +1737,10 @@ impl SetSMSAttributesInputSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct SetSMSAttributesResponse {}
 
+#[allow(dead_code)]
 struct SetSMSAttributesResponseDeserializer;
 impl SetSMSAttributesResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1787,9 +1821,10 @@ impl SetTopicAttributesInputSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1852,9 +1887,10 @@ pub struct SubscribeResponse {
     pub subscription_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SubscribeResponseDeserializer;
 impl SubscribeResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1889,9 +1925,10 @@ pub struct Subscription {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SubscriptionDeserializer;
 impl SubscriptionDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1922,9 +1959,10 @@ impl SubscriptionDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct SubscriptionARNDeserializer;
 impl SubscriptionARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1933,9 +1971,10 @@ impl SubscriptionARNDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SubscriptionAttributesMapDeserializer;
 impl SubscriptionAttributesMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1973,9 +2012,10 @@ impl SubscriptionAttributesMapSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SubscriptionsListDeserializer;
 impl SubscriptionsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2001,9 +2041,10 @@ pub struct Tag {
     pub value: String,
 }
 
+#[allow(dead_code)]
 struct TagDeserializer;
 impl TagDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Tag, XmlParseError> {
         deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -2034,9 +2075,10 @@ impl TagSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2057,9 +2099,10 @@ impl TagKeyListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagListDeserializer;
 impl TagListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2113,9 +2156,10 @@ impl TagResourceRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct TagResourceResponse {}
 
+#[allow(dead_code)]
 struct TagResourceResponseDeserializer;
 impl TagResourceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2129,9 +2173,10 @@ impl TagResourceResponseDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2148,9 +2193,10 @@ pub struct Topic {
     pub topic_arn: Option<String>,
 }
 
+#[allow(dead_code)]
 struct TopicDeserializer;
 impl TopicDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<Topic, XmlParseError> {
         deserialize_elements::<_, Topic, _>(tag_name, stack, |name, stack, obj| {
             match name {
@@ -2163,9 +2209,10 @@ impl TopicDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct TopicARNDeserializer;
 impl TopicARNDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -2174,9 +2221,10 @@ impl TopicARNDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct TopicAttributesMapDeserializer;
 impl TopicAttributesMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2214,9 +2262,10 @@ impl TopicAttributesMapSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TopicsListDeserializer;
 impl TopicsListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2282,9 +2331,10 @@ impl UntagResourceRequestSerializer {
 #[cfg_attr(feature = "serialize_structs", derive(Serialize))]
 pub struct UntagResourceResponse {}
 
+#[allow(dead_code)]
 struct UntagResourceResponseDeserializer;
 impl UntagResourceResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -5184,9 +5184,8 @@ impl Sns for SnsClient {
             return Err(CheckIfPhoneNumberIsOptedOutError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CheckIfPhoneNumberIsOptedOutResponse::default();
         } else {
@@ -5233,9 +5232,8 @@ impl Sns for SnsClient {
             return Err(ConfirmSubscriptionError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ConfirmSubscriptionResponse::default();
         } else {
@@ -5283,9 +5281,8 @@ impl Sns for SnsClient {
             return Err(CreatePlatformApplicationError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreatePlatformApplicationResponse::default();
         } else {
@@ -5332,9 +5329,8 @@ impl Sns for SnsClient {
             return Err(CreatePlatformEndpointError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateEndpointResponse::default();
         } else {
@@ -5381,9 +5377,8 @@ impl Sns for SnsClient {
             return Err(CreateTopicError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateTopicResponse::default();
         } else {
@@ -5511,9 +5506,8 @@ impl Sns for SnsClient {
             return Err(GetEndpointAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetEndpointAttributesResponse::default();
         } else {
@@ -5565,9 +5559,8 @@ impl Sns for SnsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetPlatformApplicationAttributesResponse::default();
         } else {
@@ -5614,9 +5607,8 @@ impl Sns for SnsClient {
             return Err(GetSMSAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetSMSAttributesResponse::default();
         } else {
@@ -5664,9 +5656,8 @@ impl Sns for SnsClient {
             return Err(GetSubscriptionAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetSubscriptionAttributesResponse::default();
         } else {
@@ -5713,9 +5704,8 @@ impl Sns for SnsClient {
             return Err(GetTopicAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetTopicAttributesResponse::default();
         } else {
@@ -5767,9 +5757,8 @@ impl Sns for SnsClient {
             ));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListEndpointsByPlatformApplicationResponse::default();
         } else {
@@ -5816,9 +5805,8 @@ impl Sns for SnsClient {
             return Err(ListPhoneNumbersOptedOutError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPhoneNumbersOptedOutResponse::default();
         } else {
@@ -5865,9 +5853,8 @@ impl Sns for SnsClient {
             return Err(ListPlatformApplicationsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListPlatformApplicationsResponse::default();
         } else {
@@ -5914,9 +5901,8 @@ impl Sns for SnsClient {
             return Err(ListSubscriptionsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListSubscriptionsResponse::default();
         } else {
@@ -5963,9 +5949,8 @@ impl Sns for SnsClient {
             return Err(ListSubscriptionsByTopicError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListSubscriptionsByTopicResponse::default();
         } else {
@@ -6012,9 +5997,8 @@ impl Sns for SnsClient {
             return Err(ListTagsForResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTagsForResourceResponse::default();
         } else {
@@ -6061,9 +6045,8 @@ impl Sns for SnsClient {
             return Err(ListTopicsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListTopicsResponse::default();
         } else {
@@ -6107,9 +6090,7 @@ impl Sns for SnsClient {
             return Err(OptInPhoneNumberError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = OptInPhoneNumberResponse::default();
         // parse non-payload
         Ok(result)
@@ -6139,9 +6120,8 @@ impl Sns for SnsClient {
             return Err(PublishError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = PublishResponse::default();
         } else {
@@ -6271,9 +6251,7 @@ impl Sns for SnsClient {
             return Err(SetSMSAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = SetSMSAttributesResponse::default();
         // parse non-payload
         Ok(result)
@@ -6359,9 +6337,8 @@ impl Sns for SnsClient {
             return Err(SubscribeError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SubscribeResponse::default();
         } else {
@@ -6405,9 +6382,7 @@ impl Sns for SnsClient {
             return Err(TagResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = TagResourceResponse::default();
         // parse non-payload
         Ok(result)
@@ -6465,9 +6440,7 @@ impl Sns for SnsClient {
             return Err(UntagResourceError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
         result = UntagResourceResponse::default();
         // parse non-payload
         Ok(result)

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -3328,9 +3328,8 @@ impl Sqs for SqsClient {
             return Err(ChangeMessageVisibilityBatchError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ChangeMessageVisibilityBatchResult::default();
         } else {
@@ -3377,9 +3376,8 @@ impl Sqs for SqsClient {
             return Err(CreateQueueError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = CreateQueueResult::default();
         } else {
@@ -3451,9 +3449,8 @@ impl Sqs for SqsClient {
             return Err(DeleteMessageBatchError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DeleteMessageBatchResult::default();
         } else {
@@ -3528,9 +3525,8 @@ impl Sqs for SqsClient {
             return Err(GetQueueAttributesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetQueueAttributesResult::default();
         } else {
@@ -3577,9 +3573,8 @@ impl Sqs for SqsClient {
             return Err(GetQueueUrlError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetQueueUrlResult::default();
         } else {
@@ -3624,9 +3619,8 @@ impl Sqs for SqsClient {
             return Err(ListDeadLetterSourceQueuesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListDeadLetterSourceQueuesResult::default();
         } else {
@@ -3673,9 +3667,8 @@ impl Sqs for SqsClient {
             return Err(ListQueueTagsError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListQueueTagsResult::default();
         } else {
@@ -3720,9 +3713,8 @@ impl Sqs for SqsClient {
             return Err(ListQueuesError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ListQueuesResult::default();
         } else {
@@ -3794,9 +3786,8 @@ impl Sqs for SqsClient {
             return Err(ReceiveMessageError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = ReceiveMessageResult::default();
         } else {
@@ -3869,9 +3860,8 @@ impl Sqs for SqsClient {
             return Err(SendMessageError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendMessageResult::default();
         } else {
@@ -3915,9 +3905,8 @@ impl Sqs for SqsClient {
             return Err(SendMessageBatchError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = SendMessageBatchResult::default();
         } else {

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -121,9 +121,10 @@ pub struct BatchResultErrorEntry {
     pub sender_fault: bool,
 }
 
+#[allow(dead_code)]
 struct BatchResultErrorEntryDeserializer;
 impl BatchResultErrorEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -148,9 +149,10 @@ impl BatchResultErrorEntryDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct BatchResultErrorEntryListDeserializer;
 impl BatchResultErrorEntryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -177,9 +179,10 @@ impl BatchResultErrorEntryListDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BinaryDeserializer;
 impl BinaryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -191,9 +194,10 @@ impl BinaryDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct BinaryListDeserializer;
 impl BinaryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -220,9 +224,10 @@ impl BinaryListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct BooleanDeserializer;
 impl BooleanDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<bool, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = bool::from_str(characters(stack)?.as_ref()).unwrap();
@@ -316,9 +321,10 @@ pub struct ChangeMessageVisibilityBatchResult {
     pub successful: Vec<ChangeMessageVisibilityBatchResultEntry>,
 }
 
+#[allow(dead_code)]
 struct ChangeMessageVisibilityBatchResultDeserializer;
 impl ChangeMessageVisibilityBatchResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -358,9 +364,10 @@ pub struct ChangeMessageVisibilityBatchResultEntry {
     pub id: String,
 }
 
+#[allow(dead_code)]
 struct ChangeMessageVisibilityBatchResultEntryDeserializer;
 impl ChangeMessageVisibilityBatchResultEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -380,9 +387,10 @@ impl ChangeMessageVisibilityBatchResultEntryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct ChangeMessageVisibilityBatchResultEntryListDeserializer;
 impl ChangeMessageVisibilityBatchResultEntryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -486,9 +494,10 @@ pub struct CreateQueueResult {
     pub queue_url: Option<String>,
 }
 
+#[allow(dead_code)]
 struct CreateQueueResultDeserializer;
 impl CreateQueueResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -580,9 +589,10 @@ pub struct DeleteMessageBatchResult {
     pub successful: Vec<DeleteMessageBatchResultEntry>,
 }
 
+#[allow(dead_code)]
 struct DeleteMessageBatchResultDeserializer;
 impl DeleteMessageBatchResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -622,9 +632,10 @@ pub struct DeleteMessageBatchResultEntry {
     pub id: String,
 }
 
+#[allow(dead_code)]
 struct DeleteMessageBatchResultEntryDeserializer;
 impl DeleteMessageBatchResultEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -644,9 +655,10 @@ impl DeleteMessageBatchResultEntryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DeleteMessageBatchResultEntryListDeserializer;
 impl DeleteMessageBatchResultEntryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -759,9 +771,10 @@ pub struct GetQueueAttributesResult {
     pub attributes: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct GetQueueAttributesResultDeserializer;
 impl GetQueueAttributesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -821,9 +834,10 @@ pub struct GetQueueUrlResult {
     pub queue_url: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetQueueUrlResultDeserializer;
 impl GetQueueUrlResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -868,9 +882,10 @@ pub struct ListDeadLetterSourceQueuesResult {
     pub queue_urls: Vec<String>,
 }
 
+#[allow(dead_code)]
 struct ListDeadLetterSourceQueuesResultDeserializer;
 impl ListDeadLetterSourceQueuesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -918,9 +933,10 @@ pub struct ListQueueTagsResult {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
+#[allow(dead_code)]
 struct ListQueueTagsResultDeserializer;
 impl ListQueueTagsResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -967,9 +983,10 @@ pub struct ListQueuesResult {
     pub queue_urls: Option<Vec<String>>,
 }
 
+#[allow(dead_code)]
 struct ListQueuesResultDeserializer;
 impl ListQueuesResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1007,9 +1024,10 @@ pub struct Message {
     pub receipt_handle: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MessageDeserializer;
 impl MessageDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1083,9 +1101,10 @@ pub struct MessageAttributeValue {
     pub string_value: Option<String>,
 }
 
+#[allow(dead_code)]
 struct MessageAttributeValueDeserializer;
 impl MessageAttributeValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1154,9 +1173,10 @@ impl MessageAttributeValueSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MessageBodyAttributeMapDeserializer;
 impl MessageBodyAttributeMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1215,9 +1235,10 @@ impl MessageBodySystemAttributeMapSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct MessageListDeserializer;
 impl MessageListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1242,9 +1263,10 @@ impl MessageListDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MessageSystemAttributeMapDeserializer;
 impl MessageSystemAttributeMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1262,9 +1284,10 @@ impl MessageSystemAttributeMapDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct MessageSystemAttributeNameDeserializer;
 impl MessageSystemAttributeNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1346,9 +1369,10 @@ impl PurgeQueueRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct QueueAttributeMapDeserializer;
 impl QueueAttributeMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1383,9 +1407,10 @@ impl QueueAttributeMapSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct QueueAttributeNameDeserializer;
 impl QueueAttributeNameDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1394,9 +1419,10 @@ impl QueueAttributeNameDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct QueueUrlListDeserializer;
 impl QueueUrlListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1494,9 +1520,10 @@ pub struct ReceiveMessageResult {
     pub messages: Option<Vec<Message>>,
 }
 
+#[allow(dead_code)]
 struct ReceiveMessageResultDeserializer;
 impl ReceiveMessageResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1648,9 +1675,10 @@ pub struct SendMessageBatchResult {
     pub successful: Vec<SendMessageBatchResultEntry>,
 }
 
+#[allow(dead_code)]
 struct SendMessageBatchResultDeserializer;
 impl SendMessageBatchResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1696,9 +1724,10 @@ pub struct SendMessageBatchResultEntry {
     pub sequence_number: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SendMessageBatchResultEntryDeserializer;
 impl SendMessageBatchResultEntryDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1740,9 +1769,10 @@ impl SendMessageBatchResultEntryDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct SendMessageBatchResultEntryListDeserializer;
 impl SendMessageBatchResultEntryListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1846,9 +1876,10 @@ pub struct SendMessageResult {
     pub sequence_number: Option<String>,
 }
 
+#[allow(dead_code)]
 struct SendMessageResultDeserializer;
 impl SendMessageResultDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1912,9 +1943,10 @@ impl SetQueueAttributesRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct StringDeserializer;
 impl StringDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1923,9 +1955,10 @@ impl StringDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct StringListDeserializer;
 impl StringListDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -1952,9 +1985,10 @@ impl StringListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagKeyDeserializer;
 impl TagKeyDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1975,9 +2009,10 @@ impl TagKeyListSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagMapDeserializer;
 impl TagMapDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -2035,9 +2070,10 @@ impl TagQueueRequestSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TagValueDeserializer;
 impl TagValueDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -1708,9 +1708,8 @@ impl Sts for StsClient {
             return Err(AssumeRoleError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AssumeRoleResponse::default();
         } else {
@@ -1754,9 +1753,8 @@ impl Sts for StsClient {
             return Err(AssumeRoleWithSAMLError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AssumeRoleWithSAMLResponse::default();
         } else {
@@ -1804,9 +1802,8 @@ impl Sts for StsClient {
             return Err(AssumeRoleWithWebIdentityError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = AssumeRoleWithWebIdentityResponse::default();
         } else {
@@ -1854,9 +1851,8 @@ impl Sts for StsClient {
             return Err(DecodeAuthorizationMessageError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = DecodeAuthorizationMessageResponse::default();
         } else {
@@ -1903,9 +1899,8 @@ impl Sts for StsClient {
             return Err(GetAccessKeyInfoError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetAccessKeyInfoResponse::default();
         } else {
@@ -1952,9 +1947,8 @@ impl Sts for StsClient {
             return Err(GetCallerIdentityError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetCallerIdentityResponse::default();
         } else {
@@ -2001,9 +1995,8 @@ impl Sts for StsClient {
             return Err(GetFederationTokenError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetFederationTokenResponse::default();
         } else {
@@ -2050,9 +2043,8 @@ impl Sts for StsClient {
             return Err(GetSessionTokenError::from_response(response));
         }
 
-        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         let result;
-
+        let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
         if xml_response.body.is_empty() {
             result = GetSessionTokenResponse::default();
         } else {

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -36,9 +36,10 @@ use std::str::FromStr;
 use xml::reader::ParserConfig;
 use xml::EventReader;
 
+#[allow(dead_code)]
 struct AccessKeyIdTypeDeserializer;
 impl AccessKeyIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -47,9 +48,10 @@ impl AccessKeyIdTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccessKeySecretTypeDeserializer;
 impl AccessKeySecretTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -58,9 +60,10 @@ impl AccessKeySecretTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct AccountTypeDeserializer;
 impl AccountTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -69,9 +72,10 @@ impl AccountTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct ArnTypeDeserializer;
 impl ArnTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -166,9 +170,10 @@ pub struct AssumeRoleResponse {
     pub packed_policy_size: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct AssumeRoleResponseDeserializer;
 impl AssumeRoleResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -267,9 +272,10 @@ pub struct AssumeRoleWithSAMLResponse {
     pub subject_type: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AssumeRoleWithSAMLResponseDeserializer;
 impl AssumeRoleWithSAMLResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -396,9 +402,10 @@ pub struct AssumeRoleWithWebIdentityResponse {
     pub subject_from_web_identity_token: Option<String>,
 }
 
+#[allow(dead_code)]
 struct AssumeRoleWithWebIdentityResponseDeserializer;
 impl AssumeRoleWithWebIdentityResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -445,9 +452,10 @@ impl AssumeRoleWithWebIdentityResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct AssumedRoleIdTypeDeserializer;
 impl AssumedRoleIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -466,9 +474,10 @@ pub struct AssumedRoleUser {
     pub assumed_role_id: String,
 }
 
+#[allow(dead_code)]
 struct AssumedRoleUserDeserializer;
 impl AssumedRoleUserDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -488,9 +497,10 @@ impl AssumedRoleUserDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct AudienceDeserializer;
 impl AudienceDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -513,9 +523,10 @@ pub struct Credentials {
     pub session_token: String,
 }
 
+#[allow(dead_code)]
 struct CredentialsDeserializer;
 impl CredentialsDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -542,9 +553,10 @@ impl CredentialsDeserializer {
         })
     }
 }
+#[allow(dead_code)]
 struct DateTypeDeserializer;
 impl DateTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -584,9 +596,10 @@ pub struct DecodeAuthorizationMessageResponse {
     pub decoded_message: Option<String>,
 }
 
+#[allow(dead_code)]
 struct DecodeAuthorizationMessageResponseDeserializer;
 impl DecodeAuthorizationMessageResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -609,9 +622,10 @@ impl DecodeAuthorizationMessageResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct DecodedMessageTypeDeserializer;
 impl DecodedMessageTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -620,9 +634,10 @@ impl DecodedMessageTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct FederatedIdTypeDeserializer;
 impl FederatedIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -641,9 +656,10 @@ pub struct FederatedUser {
     pub federated_user_id: String,
 }
 
+#[allow(dead_code)]
 struct FederatedUserDeserializer;
 impl FederatedUserDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -690,9 +706,10 @@ pub struct GetAccessKeyInfoResponse {
     pub account: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetAccessKeyInfoResponseDeserializer;
 impl GetAccessKeyInfoResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -739,9 +756,10 @@ pub struct GetCallerIdentityResponse {
     pub user_id: Option<String>,
 }
 
+#[allow(dead_code)]
 struct GetCallerIdentityResponseDeserializer;
 impl GetCallerIdentityResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -823,9 +841,10 @@ pub struct GetFederationTokenResponse {
     pub packed_policy_size: Option<i64>,
 }
 
+#[allow(dead_code)]
 struct GetFederationTokenResponseDeserializer;
 impl GetFederationTokenResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -899,9 +918,10 @@ pub struct GetSessionTokenResponse {
     pub credentials: Option<Credentials>,
 }
 
+#[allow(dead_code)]
 struct GetSessionTokenResponseDeserializer;
 impl GetSessionTokenResponseDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(
         tag_name: &str,
         stack: &mut T,
@@ -922,9 +942,10 @@ impl GetSessionTokenResponseDeserializer {
         )
     }
 }
+#[allow(dead_code)]
 struct IssuerDeserializer;
 impl IssuerDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -933,9 +954,10 @@ impl IssuerDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NameQualifierDeserializer;
 impl NameQualifierDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -944,9 +966,10 @@ impl NameQualifierDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct NonNegativeIntegerTypeDeserializer;
 impl NonNegativeIntegerTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<i64, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = i64::from_str(characters(stack)?.as_ref()).unwrap();
@@ -990,9 +1013,10 @@ impl PolicyDescriptorTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct SubjectDeserializer;
 impl SubjectDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1001,9 +1025,10 @@ impl SubjectDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct SubjectTypeDeserializer;
 impl SubjectTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1058,9 +1083,10 @@ impl TagListTypeSerializer {
     }
 }
 
+#[allow(dead_code)]
 struct TokenTypeDeserializer;
 impl TokenTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1069,9 +1095,10 @@ impl TokenTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct UserIdTypeDeserializer;
 impl UserIdTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;
@@ -1080,9 +1107,10 @@ impl UserIdTypeDeserializer {
         Ok(obj)
     }
 }
+#[allow(dead_code)]
 struct WebIdentitySubjectTypeDeserializer;
 impl WebIdentitySubjectTypeDeserializer {
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_variables)]
     fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
         let obj = characters(stack)?;

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -6,9 +6,10 @@ use crate::Service;
 
 pub fn generate_deserializer(name: &str, ty: &str, shape: &Shape, service: &Service<'_>) -> String {
     format!(
-        "struct {name}Deserializer;
+        "#[allow(dead_code)]
+            struct {name}Deserializer;
             impl {name}Deserializer {{
-                #[allow(unused_variables)]
+                #[allow(dead_code, unused_variables)]
                 fn deserialize<T: Peek + Next>(tag_name: &str, stack: &mut T)
                 -> Result<{ty}, XmlParseError> {{
                     {deserializer_body}

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -181,7 +181,8 @@ fn xml_body_parser(
             ),
         };
         format!(
-        "if xml_response.body.is_empty() {{
+        "let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
+        if xml_response.body.is_empty() {{
             result = {output_shape}::default();
         }} else {{
             let reader = EventReader::new_with_config(
@@ -204,9 +205,7 @@ fn xml_body_parser(
     };
 
     format!(
-        "let xml_response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
-        {let_result}
-
+        "{let_result}
         {xml_deserialize}
         {parse_non_payload} // parse non-payload
         Ok(result)",


### PR DESCRIPTION
This sorta duct tapes over the dead code warnings caused in #1728 -- as mentioned there and in the commit messages here, it's difficult to know when to remove these deserializers since they're sometimes used elsewhere.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

n/a