### PR TITLE
Specify minimum required version of time with now_utc function

### DIFF
--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -35,7 +35,7 @@ base64 = "0.12"
 hex = "0.4"
 serde = "1"
 sha2 = "0.8.0"
-time = "0.2"
+time = "0.2.11"
 pin-project = "0.4"
 percent-encoding = "2"
 tokio = { version = "0.2", features = ["macros"] }


### PR DESCRIPTION
I guess I've had an old version of `time` lying around on my machine and compilation failed with it because it didn't have `OffsetDateTime::now_utc()` yet.
So here is a fix specifying the first version of `time` I've found where this function appeared.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
 - Fix `time` dependency required version.