### PR TITLE
Fix Content-Encoding applying in Client

### DIFF
--- a/rusoto/core/src/client.rs
+++ b/rusoto/core/src/client.rs
@@ -150,6 +150,7 @@ where
     P: ProvideAwsCredentials + Send + Sync + 'static,
     D: DispatchSignedRequest + Send + Sync + 'static,
 {
+    client.content_encoding.encode(&mut request);
     if let Some(provider) = client.credentials_provider {
         let credentials = if let Some(to) = timeout {
             time::timeout(to, provider.credentials())


### PR DESCRIPTION
Gzip was introduced in https://github.com/rusoto/rusoto/pull/1615 but later on moving to tokio@0.2 (https://github.com/rusoto/rusoto/pull/1667) `encode` call was removed.

Do I need add entry to changelog about this change?