### PR TITLE
Added new_with_size to ByteStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Omit generating XML-deseralization code for actions without a response body
 - Fix OffsetDateTime::now() deprecation warning
 - Add `region_from_profile()` function to ProfileProvider
+- Added `new_with_size()` function to ByteStream
 
 ## [0.43.0] - 2020-03-15
 


### PR DESCRIPTION
S3's PutObject doesn't work if there isn't a content-length, for
ByteStream's that length comes from size_hint, previously this was set
to None in the case of an unsized stream, which then made it unusable
for PutObject. Since there are many cases where this would be useful for
putting to S3, this commit adds a new_with_size constructor that takes a
size_hint.

Fixes Issue #1752 
