### PR TITLE
`xml::util::characters` should treat CData sections as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 (Please put changes here)
+- CDATA sections are now treated like strings
 
 ## [0.44.0] - 2020-06-01
 

--- a/rusoto/core/src/proto/xml/util.rs
+++ b/rusoto/core/src/proto/xml/util.rs
@@ -91,10 +91,12 @@ pub fn characters<T: Peek + Next>(stack: &mut T) -> Result<String, XmlParseError
             return Ok("".to_string());
         }
     }
-    if let Some(Ok(XmlEvent::Characters(data))) = stack.next() {
-        Ok(data)
-    } else {
-        Err(XmlParseError::new("Expected characters"))
+    match stack.next() {
+        Some(Ok(XmlEvent::Characters(data))) |
+        Some(Ok(XmlEvent::CData(data))) => {
+            Ok(data)
+        },
+        _ => Err(XmlParseError::new("Expected characters")),
     }
 }
 


### PR DESCRIPTION
Currently if a plain string is wrapped in `<![CDATA[]]>`, rusoto will
throw an `Expected characters` error, when it should be handling CDATA
like any other string

Closes #1777 
