### PR TITLE
Fix incorrect type definition for rusoto_batch::JobDetail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 (Please put changes here)
+- Fix incorrect type definition for `rusoto_batch::JobDetail`
 
 ## [0.44.0] - 2020-06-01
 

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -812,7 +812,7 @@ pub struct JobDetail {
     pub retry_strategy: Option<RetryStrategy>,
     /// <p>The Unix timestamp (in seconds and milliseconds) for when the job was started (when the job transitioned from the <code>STARTING</code> state to the <code>RUNNING</code> state).</p>
     #[serde(rename = "startedAt")]
-    pub started_at: i64,
+    pub started_at: Option<i64>,
     /// <p><p>The current status for the job.</p> <note> <p>If your jobs do not progress to <code>STARTING</code>, see <a href="https://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html#job_stuck_in_runnable">Jobs Stuck in RUNNABLE Status</a> in the troubleshooting section of the <i>AWS Batch User Guide</i>.</p> </note></p>
     #[serde(rename = "status")]
     pub status: String,

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -614,6 +614,10 @@ fn generate_struct_fields<P: GenerateProtocol>(
             // See https://github.com/rusoto/rusoto/issues/1419 for more information
             if service.name() == "CodePipeline" && shape_name == "ActionRevision" && name == "revision_change_id" || name == "created" {
                 lines.push(format!("pub {}: Option<{}>,", name, rs_type))
+            // In the official documentation the field startedAt is required but responses lack for the field on certain situations.
+            // See https://github.com/rusoto/rusoto/issues/1736 and https://github.com/boto/botocore/issues/2030 for more information.
+            } else if service.name() == "AWS Batch" && shape_name == "JobDetail" && name == "started_at" {
+                lines.push(format!("pub {}: Option<{}>,", name, rs_type))
             // In pratice, Lex can return null values for slots that are not filled. The documentation
             // does not mention that the slot values themselves can be null.
             } else if service.name() == "Amazon Lex Runtime Service"  && shape_name == "PostTextResponse" && name == "slots"{


### PR DESCRIPTION
Fixes #1736 

In the official documentation the field `startedAt` is required but responses lack for the field on certain situations. This PR fixes inconsistency by making the field `Option` as an workaround until the issue is fixed in botocore (https://github.com/boto/botocore/issues/2030).