### PR TITLE
Add Sync bounds to Read impls

### DIFF
--- a/rusoto/signature/src/stream.rs
+++ b/rusoto/signature/src/stream.rs
@@ -45,12 +45,12 @@ impl ByteStream {
     }
 
     /// Return an implementation of `AsyncRead` that uses async i/o to consume the stream.
-    pub fn into_async_read(self) -> impl AsyncRead + Send {
+    pub fn into_async_read(self) -> impl AsyncRead + Send + Sync {
         ImplAsyncRead::new(self.inner)
     }
 
     /// Return an implementation of `Read` that uses blocking i/o to consume the stream.
-    pub fn into_blocking_read(self) -> impl io::Read + Send {
+    pub fn into_blocking_read(self) -> impl io::Read + Send + Sync {
         ImplBlockingRead::new(self.inner)
     }
 }
@@ -83,11 +83,11 @@ impl Stream for ByteStream {
 struct ImplAsyncRead {
     buffer: BytesMut,
     #[pin]
-    stream: futures::stream::Fuse<Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send>>>,
+    stream: futures::stream::Fuse<Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync>>>,
 }
 
 impl ImplAsyncRead {
-    fn new(stream: Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send>>) -> Self {
+    fn new(stream: Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync>>) -> Self {
         ImplAsyncRead {
             buffer: BytesMut::new(),
             stream: stream.fuse(),


### PR DESCRIPTION
This PR adds the `Sync` bounds to the futures generated by the `ByteStream`. A lot of external crates tend to require `Sync` bounds on `Future` types, so this provides better compatibility with them. The use case that led me here was trying to work with `tokio-tar`, which requires `Sync` on these types. 

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Added `Sync` bounds to `AsyncRead` and `Read` structures.