### PR TITLE
Replace pin-project with pin-project-lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Display `rusoto_core::Client` in docs
 - Swap the unmaintained `dirs` crate for its replacement `dirs-next`
-- Update to `pin-project` 1.0
+- Swap `pin-project` for the lighter weight `pin-project-lite`
 - Update to `base64` 0.13
 - Update to `hmac` 0.10
 - Update to `hyper-rustls` 0.21.

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -34,7 +34,6 @@ lazy_static = "1.4"
 log = "0.4"
 md5 = "0.7"
 percent-encoding = "2.1"
-pin-project = "1.0"
 base64 = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -21,7 +21,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 dirs-next = "2.0.0"
 futures = "0.3"
 hyper = "0.13.1"
-pin-project = "1.0"
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -32,8 +32,8 @@ hex = "0.4"
 serde = "1"
 sha2 = "0.9"
 time = "0.2.11"
-pin-project = "1.0"
 percent-encoding = "2"
+pin-project-lite = "0.2"
 tokio = { version = "0.2", features = ["macros"] }
 
 [dependencies.rusoto_credential]

--- a/rusoto/signature/src/stream.rs
+++ b/rusoto/signature/src/stream.rs
@@ -5,15 +5,16 @@ use std::task::{Context, Poll};
 
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{future, stream, Stream, StreamExt};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::io::AsyncRead;
 
-/// Stream of bytes.
-#[pin_project]
-pub struct ByteStream {
-    size_hint: Option<usize>,
-    #[pin]
-    inner: Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync + 'static>>,
+pin_project! {
+    /// Stream of bytes.
+    pub struct ByteStream {
+        size_hint: Option<usize>,
+        #[pin]
+        inner: Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync + 'static>>,
+    }
 }
 
 impl ByteStream {
@@ -79,11 +80,12 @@ impl Stream for ByteStream {
     }
 }
 
-#[pin_project]
-struct ImplAsyncRead {
-    buffer: BytesMut,
-    #[pin]
-    stream: futures::stream::Fuse<Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync>>>,
+pin_project! {
+    struct ImplAsyncRead {
+        buffer: BytesMut,
+        #[pin]
+        stream: futures::stream::Fuse<Pin<Box<dyn Stream<Item = Result<Bytes, io::Error>> + Send + Sync>>>,
+    }
 }
 
 impl ImplAsyncRead {
@@ -119,10 +121,11 @@ impl AsyncRead for ImplAsyncRead {
     }
 }
 
-#[pin_project]
-struct ImplBlockingRead {
-    #[pin]
-    inner: ImplAsyncRead,
+pin_project! {
+    struct ImplBlockingRead {
+        #[pin]
+        inner: ImplAsyncRead,
+    }
 }
 
 impl ImplBlockingRead {


### PR DESCRIPTION
This replaces `pin-project` with `pin-project-lite`, which is preferable to pin-project since it's lighter weight.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Replace `pin-project` with `pin-project-lite`