### PR TITLE
Wake immediately before returning Poll::Pending

### DIFF
--- a/rusoto/core/src/event_stream.rs
+++ b/rusoto/core/src/event_stream.rs
@@ -340,7 +340,10 @@ impl<T: DeserializeEvent + Unpin> futures::Stream for EventStream<T> {
                 projection.buf.extend(byte_chunk);
 
                 let parsed_event = match Self::pop_event(&mut projection.buf) {
-                    Ok(None) => return Poll::Pending,
+                    Ok(None) => {
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    }
                     Ok(Some(item)) => Ok(item),
                     Err(err) => {
                         projection.drop_response_body();


### PR DESCRIPTION
The original code returned Poll::Pending without first receiving
Poll::Pending from a downstream future or telling the task's waker
to wake the future immediately. This results in the future never
being called ever again (as nothing is told to wake it.

The original intent was for this future to be polled immediately
so more data would be read from the earlier part of poll_next().
Therefore, tell the task to wake this future immediately.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
