### PR TITLE
Fix skeptical tests

### DIFF
--- a/AWS-CREDENTIALS.md
+++ b/AWS-CREDENTIALS.md
@@ -69,13 +69,18 @@ This will affect the performance as well as the size of you AWS bill.
 
 - https://docs.rs/rusoto_credential
 - https://crates.io/crates/rusoto_credential
-```
+
+```rust,no_run
+use rusoto_core::Region;
+use rusoto_sts::{StsClient, StsAssumeRoleSessionCredentialsProvider};
+let sts = StsClient::new(Region::EuWest1);
+
 let provider = StsAssumeRoleSessionCredentialsProvider::new(
-        sts,
-        "arn:aws:iam::something:role/something".to_owned(),
-        "default".to_owned(),
-        None, None, None, None
-    );
+    sts,
+    "arn:aws:iam::something:role/something".to_owned(),
+    "default".to_owned(),
+    None, None, None, None
+);
 
 let auto_refreshing_provider = rusoto_credential::AutoRefreshingProvider::new(provider);
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,7 +36,7 @@ Rusoto uses [semantic versioning 2.0.0](http://semver.org/).
 
 ### Publishing PR checklist
 
-```
+```text
 Release checklist:
 
 - [ ] run integration tests on this branch

--- a/skeptical/Cargo.toml
+++ b/skeptical/Cargo.toml
@@ -2,20 +2,19 @@
 name = "skeptical"
 version = "0.44.0"
 authors = ["Matthew Mayer <matthewkmayer@gmail.com>"]
-build = "build.rs"
 edition = "2018"
+publish = false
 
 [dependencies]
 rusoto_core = { path = "../rusoto/core" }
+rusoto_credential = { path = "../rusoto/credential" }
 rusoto_dynamodb = { path = "../rusoto/services/dynamodb" }
-rusoto_s3 = { path = "../rusoto/services/s3" }
 rusoto_ec2 = { path = "../rusoto/services/ec2" }
 rusoto_sts = { path = "../rusoto/services/sts" }
+
+doc-comment = "0.3"
 env_logger = "0.5"
 tokio = "0.2"
 
 [build-dependencies]
-skeptic = "0.13"
-
-[dev-dependencies]
-skeptic = "0.13" 
+glob = "0.3"

--- a/skeptical/build.rs
+++ b/skeptical/build.rs
@@ -1,6 +1,25 @@
-use skeptic::markdown_files_of_directory;
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
 
 fn main() {
-  let mdbook_files = markdown_files_of_directory("../");
-  skeptic::generate_doc_tests(&mdbook_files);
+    let mut out =
+        File::create(PathBuf::from(env::var("OUT_DIR").unwrap()).join("doctests.rs")).unwrap();
+    let skeptical = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let botocore = Path::new(&skeptical)
+        .join("..")
+        .join("service_crategen")
+        .join("botocore")
+        .canonicalize()
+        .unwrap();
+    for path in glob::glob(&format!("{}/../**/*.md", skeptical)).unwrap() {
+        let path = path.unwrap().canonicalize().unwrap();
+        if path.starts_with(&botocore) {
+            continue;
+        }
+        let path = path.to_str().unwrap();
+        println!("cargo:rerun-if-changed={}", path);
+        writeln!(out, "doctest!(\"{}\");", path).unwrap();
+    }
 }

--- a/skeptical/src/lib.rs
+++ b/skeptical/src/lib.rs
@@ -1,0 +1,3 @@
+use doc_comment::doctest;
+
+include!(concat!(env!("OUT_DIR"), "/doctests.rs"));

--- a/skeptical/src/main.rs
+++ b/skeptical/src/main.rs
@@ -1,2 +1,0 @@
-// We're just here for the tests.
-fn main() {}

--- a/skeptical/tests/skeptic.rs
+++ b/skeptical/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
Seems like skeptic has been broken on nightly for a while now due to a change in implicit cargo behavior (https://github.com/budziq/rust-skeptic/pull/120) and it's now broken on stable. There doesn't seem to be any maintenace on that crate.

I've replaced skeptic with similar doc-finding logic and doc-comment's [`doctest!`](https://docs.rs/doc-comment/0.3.3/doc_comment/macro.doctest.html). Unfortunately it's harder to find what failed now, but the implementation is extremely simple.

All tests that were previously running are still running.