### PR TITLE
fix: Unhide rusoto_core::Client in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (Please put changes here)
 
+- Display `rusoto_core::Client` in docs
+
 ## [0.45.0] - 2020-07-22
 
 - Add event-stream protocol support (currently only for JSON APIs, used in `subscribe_to_shard` call in Kinesis)

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -36,7 +36,6 @@ pub mod request;
 #[doc(hidden)]
 pub mod signature;
 
-#[doc(hidden)]
 pub use crate::client::Client;
 #[doc(hidden)]
 pub mod encoding;


### PR DESCRIPTION
Looking at git blame for the hidden line it seems to have been for
`ClientInner` and I think `Client` shouldn't be hidden(?