### PR TITLE
Disable chrono default features

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -21,7 +21,7 @@ azure-devops = { project = "matthewkmayer/Rusoto", pipeline = "rusoto.rusoto", b
 
 [dependencies]
 async-trait = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 dirs = "2.0"
 futures = "0.3"
 hyper = "0.13.1"

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -19,7 +19,7 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
-chrono = "0.4.0"
+chrono = { version = "0.4.0", default-features = false }
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -19,7 +19,7 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
-chrono = "0.4.0"
+chrono = { version = "0.4.0", default-features = false }
 serde_urlencoded = "0.6"
 tempfile = "^3.1.0"
 xml-rs = "0.8"


### PR DESCRIPTION
None of chrono's default features are necessary for rusoto. Disable them
to keep the dependency set smaller. Notably, this eliminates an
unnecessary dependency on the time crate (v0.1).
