### PR TITLE
rusoto_signature: upgrade to hmac 0.10

### DIFF
--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -26,7 +26,7 @@ rustc_version = "0.2"
 [dependencies]
 bytes = "0.5"
 futures = "0.3"
-hmac = "0.8"
+hmac = "0.10"
 http = "0.2"
 hyper = "0.13.1"
 log = "0.4.1"


### PR DESCRIPTION
This prevents downstream dependencies from winding up with duplicate versions of the hmac crate.