### PR TITLE
Disable chrono default features

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -21,7 +21,7 @@ azure-devops = { project = "matthewkmayer/Rusoto", pipeline = "rusoto.rusoto", b
 
 [dependencies]
 async-trait = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 dirs = "2.0"
 futures = "0.3"
 hyper = "0.13.1"

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -19,8 +19,11 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
-chrono = "0.4.0"
 serde_json = "1.0"
+
+[dependencies.chrono]
+version = "0.4.0"
+default-features = false
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -19,10 +19,13 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
-chrono = "0.4.0"
 serde_urlencoded = "0.6"
 tempfile = "^3.1.0"
 xml-rs = "0.8"
+
+[dependencies.chrono]
+version = "0.4.0"
+default-features = false
 
 [dependencies.futures]
 version = "0.3"

--- a/service_crategen/services.json
+++ b/service_crategen/services.json
@@ -250,7 +250,7 @@
     "coreVersion": "0.45.0",
     "protocolVersion": "2014-06-30",
     "customDependencies": {
-      "chrono": "0.4.0"
+      "chrono": { "version": "0.4.0", "default-features": false }
     },
     "baseTypeName": "CognitoIdentity"
   },
@@ -1210,7 +1210,7 @@
     "coreVersion": "0.45.0",
     "protocolVersion": "2011-06-15",
     "customDependencies": {
-      "chrono": "0.4.0",
+      "chrono": { "version": "0.4.0", "default-features": false },
       "tempfile": "^3.1.0"
     },
     "baseTypeName": "Sts"


### PR DESCRIPTION
Many of chrono's default features are necessary for rusoto. Disable them
to keep the dependency set smaller. Notably, this eliminates an
unnecessary dependency on the time crate (v0.1).

Resubmission of #1824 now that Chrono has a separate toggle for the `oldtime` feature.