### PR TITLE
v0.42.0: Pin rusoto_mock's floating dependency on rusoto_core to 0.42.0

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -33,7 +33,7 @@ optional = true
 version = "0.0"
 
 [dependencies.rusoto_core]
-version = "> 0.25.0"
+version = "0.42.0"
 path = "../rusoto/core"
 default_features = false
 


### PR DESCRIPTION
I have tests for components using `rusoto_sqs { version = "0.42.0" }` (synchronous support) using `rusoto_mock`, however `rusoto_mock` has a floating dependency on `rusoto_core >= 0.25.0`... and, unfortunately, v0.42.0 is no longer compatible with newer versions (`>= 0.43.0`) of Rusoto, so any projects using 0.42.0 today will run into lots of compiler errors if they try to mock using the mocking crate for their same version.
This PR changes the rusoto_mock dependency to be pinned onto 0.42.0. 