### PR TITLE
mock: Replace unsound unsafe code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (Please put changes here)
 
 - Display `rusoto_core::Client` in docs
+- Fix unsoundness in `rusoto_mock::MultipleMockRequestDispatcher`
 - Swap the unmaintained `dirs` crate for its replacement `dirs-next`
 - Swap `pin-project` for the lighter weight `pin-project-lite`
 - Update to `base64` 0.13


### PR DESCRIPTION
The previous code was unsound and triggered UB by potentially creating
multiple &mut references to a value. It was also a potential data race
since clients require dispatchers to be Sync.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
- Fix unsoundness in `rusoto_mock::MultipleMockRequestDispatcher`