### PR TITLE
Add ability to specify IAM role ARN in credentials provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
 - Remove `Sync` constraint on `ByteStream`-related functions.
+- Add `set_role_arn` to `rusoto_credential::InstanceMetadataProvider`
 ## [0.46.0] - 2021-01-05
 
 - Display `rusoto_core::Client` in docs

--- a/rusoto/credential/src/request.rs
+++ b/rusoto/credential/src/request.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use hyper::client::HttpConnector;
-use hyper::{Body, Client as HyperClient, Request, StatusCode, Uri};
+use hyper::{Body, Client as HyperClient, Request, Uri};
 use tokio::time;
 
 /// Http client for use in a credentials provider.
@@ -38,7 +38,6 @@ impl HttpClient {
                 let mut resp = try_resp.map_err(|err| {
                     IoError::new(ErrorKind::Other, format!("Response failed: {}", err))
                 })?;
-
                 let body = resp.body_mut();
                 let mut text = vec![];
                 while let Some(chunk) = body.next().await {
@@ -47,20 +46,8 @@ impl HttpClient {
                     })?;
                     text.extend(chunk.to_vec());
                 }
-                let text = String::from_utf8(text)
-                    .map_err(|_| IoError::new(ErrorKind::InvalidData, "Non UTF-8 Data returned"))?;
-
-                match resp.status() {
-                    StatusCode::OK => Ok(text),
-                    _ => Err(IoError::new(
-                        ErrorKind::Other,
-                        format!(
-                            "Request failed with HTTP status {}: {}",
-                            resp.status(),
-                            text
-                        ),
-                    )),
-                }
+                String::from_utf8(text)
+                    .map_err(|_| IoError::new(ErrorKind::InvalidData, "Non UTF-8 Data returned"))
             }
         }
     }


### PR DESCRIPTION
In some cases (for example when using [kube2iam](https://github.com/jtblin/kube2iam) in Kubernetes), you know the IAM role ARN you need to request the metadata API for, which means you can avoid requesting `/latest/meta-data/iam/security-credentials` before getting the credentials.