### PR TITLE
Update from dirs to dirs-next

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -22,7 +22,7 @@ azure-devops = { project = "matthewkmayer/Rusoto", pipeline = "rusoto.rusoto", b
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-dirs = "2.0"
+dirs-next = "1.0"
 futures = "0.3"
 hyper = "0.13.1"
 pin-project = "0.4"

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -22,7 +22,7 @@ azure-devops = { project = "matthewkmayer/Rusoto", pipeline = "rusoto.rusoto", b
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-dirs-next = "1.0"
+dirs-next = "2.0"
 futures = "0.3"
 hyper = "0.13.1"
 pin-project = "0.4"

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -7,7 +7,7 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use dirs::home_dir;
+use dirs_next::home_dir;
 use regex::Regex;
 use serde::Deserialize;
 use tokio::process::Command;


### PR DESCRIPTION
dirs is unmaintained now, see RUSTSEC-2020-0053:
https://github.com/RustSec/advisory-db/blob/master/crates/dirs/RUSTSEC-2020-0053.md
