### PR TITLE
Handle HTTP errors in rusoto_credential::InstanceMetadataProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
 - Remove `Sync` constraint on `ByteStream`-related functions.
+- Fixed `rusoto_credential::InstanceMetadataProvider` HTTP errors handling
+
 ## [0.46.0] - 2021-01-05
 
 - Display `rusoto_core::Client` in docs


### PR DESCRIPTION
Returns the body of the HTTP response in a `Err` when the response status is not 200 instead of ignoring the error and just returning the body.

Note: this has been tested in production code and helped us narrow down the issue we're having.