### PR TITLE
Update hyper-rustls 0.20 -> 0.21

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -32,7 +32,7 @@ crc32fast = "1.2"
 futures = "0.3"
 http = "0.2"
 hyper = "0.13.1"
-hyper-rustls = { version = "0.20", optional = true }
+hyper-rustls = { version = "0.21", optional = true }
 hyper-tls = { version = "0.4", optional = true }
 lazy_static = "1.4"
 log = "0.4"


### PR DESCRIPTION
Hi folks! Thanks for maintaining this library. I'm building a project on top of it, and finding that I wind up with two copies of hyper-rustls. Bringing hyper-rustls up to the latest should help reduce dependencies for users of rusoto.