### PR TITLE
Tests for serialize features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,25 @@ jobs:
     - name: Generate crates
       run: make generate
 
+  struct_serialize_feature_test:
+    name: Serialize Struct Feature
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up Rust
+      uses: hecrj/setup-rust-action@v1
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Run Checks
+      run: make serialize_structs_limited_test
+
   skeptic:
     name: Skeptic tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,11 @@ bench_s3: ## run S3 benchmarks
 .PHONY: credential_integration_test
 credential_integration_test: ## Run credentials integration tests
 	(cd rusoto/credential_service_mock && ./run-and-test.sh )
+
+.PHONY: serialize_structs_limited_test
+serialize_structs_limited_test:
+	(cd rusoto/services && ./test-select-features.sh)
+
+.PHONY: serialize_structs_full_test
+serialize_structs_full_test:
+	(cd rusoto/services && ./test-features.sh)


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Add tests to the Github test suite for the serialize and deserialize features

In PR #1639 I added a couple of features to the generated crates to allow the structs in the crate to optionally derive `serialize` and/or `deserialize`. Unfortunately, these are rather easy to accidentally break without noticing if somebody is modifying the code generation code, so I also added a script to run `cargo check` on all of the crates with all of the features. This is rather time-consuming to run, so I added another script that runs `cargo check` on a sample of 5 crates, one implementing each of the interface types currently used. This runs in an acceptable timeframe, and would be a good thing to run in the unit test suite.

At the time, I found the test setup rather confusing and was unable to determine how to add the tests before I had to move to other projects. Checking back now, the Github Actions setup is much more straightforward, and I was able to add a test step to run these tests. I ran them locally and in my fork, and they pass, so I am opening this PR to merge these tests into the codebase.