### PR TITLE
Simple example of rusoto usage for s3.

### DIFF
--- a/examples/s3/.gitignore
+++ b/examples/s3/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/examples/s3/Cargo.toml
+++ b/examples/s3/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [workspace]
 
 [dependencies]
-rusoto_core = "0.45"
-rusoto_s3 = { version = "0.45", features = ["serialize_structs"] }
+rusoto_core = { path = "../../rusoto/core" }
+rusoto_s3 = { path = "../../rusoto/services/s3/", features = ["serialize_structs"] }
 structopt = "0.3"
 
 # note: current implementation requires this version of the tokio runtime.

--- a/examples/s3/Cargo.toml
+++ b/examples/s3/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "s3"
+version = "0.1.0"
+authors = ["andy-thomason <andy@andythomason.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+
+[dependencies]
+rusoto_core = "0.45"
+rusoto_s3 = { version = "0.45", features = ["serialize_structs"] }
+structopt = "0.3"
+
+# note: current implementation requires this version of the tokio runtime.
+tokio = { version = "0.2", features = ["full"] }
+serde_json = "1.0"

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -1,0 +1,82 @@
+//!
+//! This is a very basic example of using the s3 API of rusoto.
+//!
+//! There are several existing crates demonstrating behaviour such as
+//! multipart uploads and range fetches.
+
+use rusoto_core::Region;
+use rusoto_s3::{GetObjectRequest, S3Client, S3};
+use structopt::StructOpt;
+use tokio::prelude::*;
+
+#[derive(StructOpt)]
+enum Command {
+    ListBuckets,
+    GetObject {
+        #[structopt(long)]
+        bucket: String,
+        #[structopt(long)]
+        key: String,
+    },
+}
+
+#[derive(StructOpt)]
+#[structopt(about = "a tiny subset of aws s3api")]
+struct S3Api {
+    #[structopt(long)]
+    region: Region,
+
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+type AnyError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Rough equivalent to aws s3api list-buckets
+async fn aws_s3api_list_buckets(s3: &S3Client) -> Result<(), AnyError> {
+    let response = s3.list_buckets().await?;
+    serde_json::to_writer_pretty(std::io::stdout(), &response)?;
+    Ok(())
+}
+
+/// Rough equivalent to aws s3api get-object
+async fn aws_s3api_get_object(s3: &S3Client, bucket: String, key: String) -> Result<(), AnyError> {
+    let request = GetObjectRequest {
+        bucket,
+        key,
+        ..GetObjectRequest::default()
+    };
+    let response = s3.get_object(request).await?;
+
+    // Get an AsyncRead object from the body.
+    let mut body = response.body.unwrap().into_async_read();
+
+    // Use AsyncReadExt to read to the end.
+    // Note: This is suboptimal for large transfers.
+    let mut buf = Vec::new();
+    body.read_to_end(&mut buf).await?;
+
+    println!("body={}", std::str::from_utf8(buf.as_ref()).unwrap());
+    Ok(())
+}
+
+// Example command lines:
+//
+// cargo run -- --region eu-west-2 list-buckets
+// cargo run -- --region eu-west-2 get-object --bucket my-bucket --key my-file
+
+#[tokio::main]
+async fn main() {
+    let opt = S3Api::from_args();
+    Region::from(opt.region);
+    let s3 = S3Client::new(Region::default());
+    if let Err(err) = match opt.command {
+        Command::ListBuckets => aws_s3api_list_buckets(&s3).await,
+        Command::GetObject {
+            bucket,
+            key,
+        } => aws_s3api_get_object(&s3, bucket, key).await,
+    } {
+        println!("error={}", err);
+    }
+}

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -68,8 +68,7 @@ async fn aws_s3api_get_object(s3: &S3Client, bucket: String, key: String) -> Res
 #[tokio::main]
 async fn main() {
     let opt = S3Api::from_args();
-    Region::from(opt.region);
-    let s3 = S3Client::new(Region::default());
+    let s3 = S3Client::new(Region::from(opt.region));
     if let Err(err) = match opt.command {
         Command::ListBuckets => aws_s3api_list_buckets(&s3).await,
         Command::GetObject {


### PR DESCRIPTION
### Simple example of rusoto usage for s3.

rusoto is an excellent project, but lacks concrete examples which may lead to lack of adoption.

We should endeavour to create small examples like this to show off its capabilities.

We should be careful to avoid creating examples that may end up charging users
unexpectedly for services.

If you approve this PR, we can start adding more.

Examples might be:

* Get a billing summary for all aws resources being used.
* Build and execute lambdas.
* Submit batch jobs.
* Start a container in ecs.
* Process logs.

I'm sure the node.js sdk would provide templates.




