### PR TITLE
deps: update to tokio v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swap `pin-project` for the lighter weight `pin-project-lite`
 - Update to `base64` 0.13
 - Update to `hmac` 0.10
-- Update to `hyper-rustls` 0.21.
+- Update to `hyper-rustls` 0.22
+- Update to `hyper-tls` 0.5
+- Update to `tokio` 1.0
+- Update to `bytes` 1.0
+- Update to `hyper` 0.14
 - Disable `chrono`'s `oldtime` feature
 - Remove dependency on `regex`
 - Update to botocore 1.19.42

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -652,14 +652,14 @@ path = "../rusoto/services/ram"
 [dev-dependencies]
 async-trait = "0.1.31"
 env_logger = "0.7"
-bytes = "0.5"
+bytes = "1.0"
 futures = "0.3"
 log = "0.4"
 rand = "0.7"
 time = "0.2"
-reqwest = { version = "0.10", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"] }
 http = "0.2"
-tokio = { version = "0.2", features = ["time", "rt-core", "fs"] }
+tokio = { version = "1.0", features = ["time", "rt-multi-thread", "fs"] }
 chrono = "0.4.10"
 
 [features]

--- a/integration_tests/tests/cognitoidentity.rs
+++ b/integration_tests/tests/cognitoidentity.rs
@@ -6,23 +6,23 @@ extern crate rusoto_core;
 extern crate time;
 
 use rusoto_cognito_identity::{
-    SetIdentityPoolRolesInput, 
-    CognitoIdentity, 
-    CognitoIdentityClient, 
-    ListIdentitiesInput, 
-    ListIdentityPoolsInput, 
-    GetOpenIdTokenForDeveloperIdentityInput, 
-    CreateIdentityPoolInput, 
-    DeleteIdentityPoolInput, 
+    SetIdentityPoolRolesInput,
+    CognitoIdentity,
+    CognitoIdentityClient,
+    ListIdentitiesInput,
+    ListIdentityPoolsInput,
+    GetOpenIdTokenForDeveloperIdentityInput,
+    CreateIdentityPoolInput,
+    DeleteIdentityPoolInput,
     CognitoProvider
 };
 
 use rusoto_iam::{
-    Iam, 
-    IamClient, 
-    CreateRoleRequest, 
-    PutRolePolicyRequest, 
-    DeleteRoleRequest, 
+    Iam,
+    IamClient,
+    CreateRoleRequest,
+    PutRolePolicyRequest,
+    DeleteRoleRequest,
     DeleteRolePolicyRequest
 };
 
@@ -32,7 +32,7 @@ use rusoto_credential::ProvideAwsCredentials;
 use time::OffsetDateTime;
 use std::collections::HashMap;
 use std::time::Duration;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 use chrono::offset::Utc;
 
 #[tokio::test]
@@ -98,7 +98,7 @@ async fn should_work_with_credential_provider() {
           }}
         ]
       }}", identity_pool.identity_pool_id).replace("'", "\"");
-      
+
     let input_create_role = CreateRoleRequest {
         assume_role_policy_document: policy,
         role_name: role_name,
@@ -131,7 +131,7 @@ async fn should_work_with_credential_provider() {
     };
 
     client_iam.put_role_policy(role_policy_input).await.unwrap();
-    
+
     // Assigning the role to the identity pool
     let mut roles = HashMap::new();
     roles.insert("authenticated".to_string(), role.arn.clone());
@@ -143,7 +143,7 @@ async fn should_work_with_credential_provider() {
     };
     client_cognito.set_identity_pool_roles(roles_input).await.unwrap();
 
-    
+
     // Registering a user whose credentials will be tested
     let login = "login";
     let mut logins = HashMap::new();
@@ -157,7 +157,7 @@ async fn should_work_with_credential_provider() {
     let response = client_cognito.get_open_id_token_for_developer_identity(register_input).await.unwrap();
 
     // It can take time for IAM role to be ready for use
-    delay_for(Duration::from_secs(10)).await;
+    sleep(Duration::from_secs(10)).await;
 
     // The test itself
     let provider = CognitoProvider::builder()

--- a/integration_tests/tests/elastictranscoder.rs
+++ b/integration_tests/tests/elastictranscoder.rs
@@ -217,7 +217,7 @@ async fn delete_preset() {
     let preset = response.preset.unwrap();
     let id = preset.id.unwrap();
 
-    tokio::time::delay_for(std::time::Duration::from_secs(2)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     let request = DeletePresetRequest { id: id.clone() };
     let response = client.delete_preset(request).await;

--- a/integration_tests/tests/kinesis.rs
+++ b/integration_tests/tests/kinesis.rs
@@ -13,7 +13,7 @@ use futures::FutureExt;
 use futures::stream::StreamExt;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-use tokio::time::{delay_for, timeout};
+use tokio::time::{sleep, timeout};
 
 use rusoto_core::Region;
 use rusoto_kinesis::{Kinesis, KinesisClient, ListStreamsInput};
@@ -115,7 +115,7 @@ async fn should_listen_for_shard_events() {
 
             if steam_desc_result.stream_description.stream_status == "CREATING" {
                 println!("Stream {} still initializing, waiting...", stream.name);
-                delay_for(std::time::Duration::from_secs(2)).await;
+                sleep(std::time::Duration::from_secs(2)).await;
                 continue;
             } else {
                 break
@@ -132,7 +132,7 @@ async fn should_listen_for_shard_events() {
             .unwrap();
         }
 
-        tokio::time::delay_for(Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
 
         let consumer_result = client
             .register_stream_consumer(rusoto_kinesis::RegisterStreamConsumerInput {
@@ -152,7 +152,7 @@ async fn should_listen_for_shard_events() {
 
             if consumer_desc_result.consumer_description.consumer_status == "CREATING" {
                 println!("Consumer for stream {} still initializing, waiting...", stream.name);
-                delay_for(std::time::Duration::from_secs(2)).await;
+                sleep(std::time::Duration::from_secs(2)).await;
                 continue;
             } else {
                 break

--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -95,7 +95,7 @@ impl TestS3Client {
             .create_bucket(create_bucket_req)
             .await
             .expect("Failed to create test bucket");
-        tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     }
 
     async fn create_test_bucket_with_acl(&self, name: String, acl: Option<String>) {

--- a/integration_tests/tests/xray.rs
+++ b/integration_tests/tests/xray.rs
@@ -14,7 +14,7 @@ use time::OffsetDateTime;
 async fn should_get_service_graph() {
     let client = XRayClient::new(Region::UsEast1);
 
-    let time = (OffsetDateTime::now_utc().timestamp() - 30) as f64; // 30 seconds in the past
+    let time = (OffsetDateTime::now_utc().unix_timestamp() - 30) as f64; // 30 seconds in the past
     println!("{:?}", time);
 
     let request = GetServiceGraphRequest {

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -23,19 +23,19 @@ rustc_version = "0.2"
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 crc32fast = "1.2"
 futures = "0.3"
 http = "0.2"
-hyper = "0.13.1"
-hyper-rustls = { version = "0.21", optional = true }
-hyper-tls = { version = "0.4", optional = true }
+hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
+hyper-rustls = { version = "0.22", optional = true }
+hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = "1.4"
 log = "0.4"
 base64 = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["tcp", "time", "rt-core", "fs"] }
+tokio = { version = "1.0", features = ["time", "io-util"] }
 xml-rs = "0.8"
 flate2 = { version = "1.0", optional = true }
 
@@ -48,7 +48,7 @@ path = "../signature"
 version = "0.45.0"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros"] }
 env_logger = "0.7"
 rand = "0.7"
 serde_json = "1.0.1"

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -224,7 +224,7 @@ impl HttpClient {
         let connector = HttpsConnector::new();
 
         #[cfg(feature = "rustls")]
-        let connector = HttpsConnector::new();
+        let connector = HttpsConnector::with_native_roots();
 
         Ok(Self::from_connector(connector))
     }
@@ -235,7 +235,7 @@ impl HttpClient {
         let connector = HttpsConnector::new();
 
         #[cfg(feature = "rustls")]
-        let connector = HttpsConnector::new();
+        let connector = HttpsConnector::with_native_roots();
 
         Ok(Self::from_connector_with_config(connector, config))
     }

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -20,11 +20,11 @@ async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 dirs-next = "2.0.0"
 futures = "0.3"
-hyper = "0.13.1"
+hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shlex = "0.1"
-tokio = { version = "0.2", features = ["macros", "process"] }
+tokio = { version = "1.0", features = ["process", "sync", "time"] }
 zeroize = "1"
 
 [dev-dependencies]
@@ -32,6 +32,7 @@ lazy_static = "1.4"
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
 tempfile = "3.1.0"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
 nightly-testing = []

--- a/rusoto/credential_service_mock/Cargo.toml
+++ b/rusoto/credential_service_mock/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Matthew Mayer <matthewkmayer@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros"] }
-warp = "0.2"
+hyper = { version = "0.14", features = ["http1", "server", "tcp"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/rusoto/credential_service_mock/src/main.rs
+++ b/rusoto/credential_service_mock/src/main.rs
@@ -1,12 +1,23 @@
-use warp::{self, path, Filter};
+use std::convert::Infallible;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use hyper::service;
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
 
 #[tokio::main]
 async fn main() {
-    let instance_profile_role =
-        path!("latest" / "meta-data" / "iam" / "security-credentials").map(|| "testrole");
-    let instance_profile_creds =
-        path!("latest" / "meta-data" / "iam" / "security-credentials" / "testrole").map(|| {
-            r#"{
+    let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+    Server::bind(&listen_addr)
+        .serve(service::make_service_fn(|_conn| async {
+            Ok::<_, Infallible>(service::service_fn(|req| async {
+                Ok::<_, Infallible>(handle(req).await)
+            }))
+        }))
+        .await
+        .unwrap();
+}
+
+const ROLE_JSON: &str = r#"{
   "Code" : "Success",
   "LastUpdated" : "2015-08-04T00:09:23Z",
   "Type" : "AWS-HMAC",
@@ -14,12 +25,19 @@ async fn main() {
   "SecretAccessKey" : "Secret_access_key_value",
   "Token" : "AAAAA",
   "Expiration" : "2015-08-04T06:32:37Z"
-}"#
-        });
+}"#;
 
-    let routes = warp::get()
-        .and(instance_profile_creds)
-        .or(instance_profile_role);
-
-    warp::serve(routes).run(([127, 0, 0, 1], 8080)).await;
+async fn handle(req: Request<Body>) -> Response<Body> {
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/latest/meta-data/iam/security-credentials/") => {
+            Response::new(Body::from("testrole"))
+        }
+        (&Method::GET, "/latest/meta-data/iam/security-credentials/testrole") => {
+            Response::new(Body::from(ROLE_JSON))
+        }
+        _ => Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from("unsupported"))
+            .unwrap(),
+    }
 }

--- a/rusoto/services/accessanalyzer/Cargo.toml
+++ b/rusoto/services/accessanalyzer/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 
@@ -31,7 +31,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/appconfig/Cargo.toml
+++ b/rusoto/services/appconfig/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/application-insights/Cargo.toml
+++ b/rusoto/services/application-insights/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/appmesh/Cargo.toml
+++ b/rusoto/services/appmesh/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/backup/Cargo.toml
+++ b/rusoto/services/backup/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 xml-rs = "0.8"
 
 [dependencies.futures]
@@ -38,7 +38,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 
@@ -31,7 +31,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codeguru-reviewer/Cargo.toml
+++ b/rusoto/services/codeguru-reviewer/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codeguruprofiler/Cargo.toml
+++ b/rusoto/services/codeguruprofiler/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codestar-connections/Cargo.toml
+++ b/rusoto/services/codestar-connections/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codestar-notifications/Cargo.toml
+++ b/rusoto/services/codestar-notifications/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.chrono]
@@ -38,7 +38,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/compute-optimizer/Cargo.toml
+++ b/rusoto/services/compute-optimizer/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/connectparticipant/Cargo.toml
+++ b/rusoto/services/connectparticipant/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/dataexchange/Cargo.toml
+++ b/rusoto/services/dataexchange/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/datasync/Cargo.toml
+++ b/rusoto/services/datasync/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/detective/Cargo.toml
+++ b/rusoto/services/detective/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/dlm/Cargo.toml
+++ b/rusoto/services/dlm/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ebs/Cargo.toml
+++ b/rusoto/services/ebs/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ec2-instance-connect/Cargo.toml
+++ b/rusoto/services/ec2-instance-connect/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/elastic-inference/Cargo.toml
+++ b/rusoto/services/elastic-inference/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/es/Cargo.toml
+++ b/rusoto/services/es/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/forecast/Cargo.toml
+++ b/rusoto/services/forecast/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/forecastquery/Cargo.toml
+++ b/rusoto/services/forecastquery/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/frauddetector/Cargo.toml
+++ b/rusoto/services/frauddetector/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/globalaccelerator/Cargo.toml
+++ b/rusoto/services/globalaccelerator/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/groundstation/Cargo.toml
+++ b/rusoto/services/groundstation/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/imagebuilder/Cargo.toml
+++ b/rusoto/services/imagebuilder/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 
@@ -31,7 +31,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iotevents-data/Cargo.toml
+++ b/rusoto/services/iotevents-data/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iotevents/Cargo.toml
+++ b/rusoto/services/iotevents/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iotsecuretunneling/Cargo.toml
+++ b/rusoto/services/iotsecuretunneling/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/iotthingsgraph/Cargo.toml
+++ b/rusoto/services/iotthingsgraph/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kendra/Cargo.toml
+++ b/rusoto/services/kendra/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kinesis-video-signaling/Cargo.toml
+++ b/rusoto/services/kinesis-video-signaling/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kinesisanalyticsv2/Cargo.toml
+++ b/rusoto/services/kinesisanalyticsv2/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/lakeformation/Cargo.toml
+++ b/rusoto/services/lakeformation/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -35,7 +35,7 @@ features = ["derive"]
 
 [dev-dependencies]
 chrono = "0.4"
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/managedblockchain/Cargo.toml
+++ b/rusoto/services/managedblockchain/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/marketplace-catalog/Cargo.toml
+++ b/rusoto/services/marketplace-catalog/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mediaconnect/Cargo.toml
+++ b/rusoto/services/mediaconnect/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mediapackage-vod/Cargo.toml
+++ b/rusoto/services/mediapackage-vod/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/migrationhub-config/Cargo.toml
+++ b/rusoto/services/migrationhub-config/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 
@@ -31,7 +31,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/networkmanager/Cargo.toml
+++ b/rusoto/services/networkmanager/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/outposts/Cargo.toml
+++ b/rusoto/services/outposts/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/personalize-events/Cargo.toml
+++ b/rusoto/services/personalize-events/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/personalize-runtime/Cargo.toml
+++ b/rusoto/services/personalize-runtime/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/personalize/Cargo.toml
+++ b/rusoto/services/personalize/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/pinpoint-email/Cargo.toml
+++ b/rusoto/services/pinpoint-email/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/pinpoint-sms-voice/Cargo.toml
+++ b/rusoto/services/pinpoint-sms-voice/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/qldb-session/Cargo.toml
+++ b/rusoto/services/qldb-session/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/qldb/Cargo.toml
+++ b/rusoto/services/qldb/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/quicksight/Cargo.toml
+++ b/rusoto/services/quicksight/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/robomaker/Cargo.toml
+++ b/rusoto/services/robomaker/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 xml-rs = "0.8"
 
 [dependencies.futures]
@@ -38,7 +38,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/route53resolver/Cargo.toml
+++ b/rusoto/services/route53resolver/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 xml-rs = "0.8"
 
 [dependencies.futures]
@@ -38,7 +38,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 
@@ -31,7 +31,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/savingsplans/Cargo.toml
+++ b/rusoto/services/savingsplans/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/schemas/Cargo.toml
+++ b/rusoto/services/schemas/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/securityhub/Cargo.toml
+++ b/rusoto/services/securityhub/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/service-quotas/Cargo.toml
+++ b/rusoto/services/service-quotas/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sesv2/Cargo.toml
+++ b/rusoto/services/sesv2/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/signer/Cargo.toml
+++ b/rusoto/services/signer/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sms-voice/Cargo.toml
+++ b/rusoto/services/sms-voice/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -39,7 +39,7 @@ version = "1.0.2"
 optional = true
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sso-oidc/Cargo.toml
+++ b/rusoto/services/sso-oidc/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sso/Cargo.toml
+++ b/rusoto/services/sso/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 
@@ -31,7 +31,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_urlencoded = "0.6"
 xml-rs = "0.8"
 
@@ -44,7 +44,7 @@ optional = true
 
 [dev-dependencies]
 tempfile = "^3.1.0"
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/textract/Cargo.toml
+++ b/rusoto/services/textract/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/transfer/Cargo.toml
+++ b/rusoto/services/transfer/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/workmailmessageflow/Cargo.toml
+++ b/rusoto/services/workmailmessageflow/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 
@@ -31,7 +31,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde_json = "1.0"
 
 [dependencies.futures]
@@ -34,7 +34,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5"
+bytes = "1.0"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0"
@@ -32,7 +32,7 @@ path = "../../core"
 default-features = false
 
 [dev-dependencies]
-tokio = "0.2"
+tokio = "1.0"
 
 [dev-dependencies.rusoto_mock]
 version = "0.45.0"

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -20,11 +20,11 @@ edition = "2018"
 rustc_version = "0.2"
 
 [dependencies]
-bytes = "0.5"
+bytes = "1.0"
 futures = "0.3"
 hmac = "0.10"
 http = "0.2"
-hyper = "0.13.1"
+hyper = { version = "0.14", features = ["stream"] }
 log = "0.4.1"
 md5 = "0.7"
 base64 = "0.13"
@@ -34,7 +34,7 @@ sha2 = "0.9"
 time = "0.2.11"
 percent-encoding = "2"
 pin-project-lite = "0.2"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [dependencies.rusoto_credential]
 version = "0.45.0"
@@ -43,6 +43,7 @@ path = "../credential"
 [dev-dependencies]
 serde_json = "1"
 serde_test = "1"
+tokio = { version = "1.0", features = ["io-util"] }
 
 [package.metadata.docs.rs]
 targets = []

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -124,7 +124,7 @@ impl<'b> Service<'b> {
             "async-trait".to_owned(),
             cargo::Dependency::Simple("0.1".into()),
         );
-        dependencies.insert("bytes".to_owned(), cargo::Dependency::Simple("0.5".into()));
+        dependencies.insert("bytes".to_owned(), cargo::Dependency::Simple("1.0".into()));
         dependencies.insert(
             "futures".to_owned(),
             cargo::Dependency::Extended {
@@ -256,7 +256,7 @@ impl<'b> Service<'b> {
 
         dev_dependencies.insert(
             "tokio".to_owned(),
-            cargo::Dependency::Simple("0.2".to_owned()),
+            cargo::Dependency::Simple("1.0".to_owned()),
         );
 
         if let Some(ref custom_dev_dependencies) = self.config.custom_dev_dependencies {

--- a/skeptical/Cargo.toml
+++ b/skeptical/Cargo.toml
@@ -14,7 +14,7 @@ rusoto_sts = { path = "../rusoto/services/sts" }
 
 doc-comment = "0.3"
 env_logger = "0.5"
-tokio = "0.2"
+tokio = "1.0"
 
 [build-dependencies]
 glob = "0.3"


### PR DESCRIPTION
Just a draft for the moment. Waiting on:

  * [x] hyper-tls (https://github.com/hyperium/hyper-tls/pull/79)
  * [x] hyper-rustls (https://github.com/ctz/hyper-rustls/issues/138)
  * [x] reqwest (https://github.com/seanmonstar/reqwest/pull/1076)
  * [ ] ~warp (https://github.com/seanmonstar/warp/pull/753)~ credential service mock rewritten to use hyper directly, rather than warp