### PR TITLE
Use RustCrypto's md5 crate to match sha2 provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to `rustc_version` 0.3
 - Replace `time`-related types in `rusoto_signature` with `chrono` types, to
   match `rusoto_credential`
+- Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
+  usage of RustCrypto `sha2` crate
 
 ## [0.46.0] - 2021-01-05
 

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -22,12 +22,13 @@ rustc_version = "0.3"
 [dependencies]
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+digest = "0.9.0"
 futures = "0.3"
 hmac = "0.10"
 http = "0.2"
 hyper = { version = "0.14", features = ["stream"] }
 log = "0.4.1"
-md5 = "0.7"
+md-5 = "0.9"
 base64 = "0.13"
 hex = "0.4"
 serde = "1"

--- a/rusoto/signature/src/signature.rs
+++ b/rusoto/signature/src/signature.rs
@@ -20,15 +20,16 @@ use std::time::Duration;
 use base64;
 use bytes::Bytes;
 use chrono::{DateTime, Utc, NaiveDate};
+use digest::Digest;
 use hex;
 use hmac::{Hmac, Mac, NewMac};
 use http::header::{HeaderMap, HeaderName, HeaderValue};
 use http::{Method, Request};
 use hyper::Body;
 use log::{debug, log_enabled, Level::Debug};
-use md5;
+use md5::Md5;
 use percent_encoding::{percent_decode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 
 use crate::credential::AwsCredentials;
 use crate::region::Region;
@@ -157,7 +158,7 @@ impl SignedRequest {
             return;
         }
         if let Some(SignedRequestPayload::Buffer(ref payload)) = self.payload {
-            let digest = md5::compute(payload);
+            let digest = Md5::digest(payload);
             self.add_header("Content-MD5", &base64::encode(&*digest));
         }
     }


### PR DESCRIPTION
Since we use RustCrypto's SHA-2 implementation, we might as well use
RustCrypto's MD5 implementation, despite its somewhat more awkward name
("md-5" vs. "md5").

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
