### PR TITLE
Reduce the amount of llvm IR generated

### DIFF
--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -539,13 +539,13 @@ impl CacheBehaviorSerializer {
             &AllowedMethodsSerializer::serialize(&mut writer, "AllowedMethods", value)?;
         }
         if let Some(ref value) = obj.cache_policy_id {
-            write_characters_element(writer, "CachePolicyId", &value.to_string())?;
+            write_characters_element(writer, "CachePolicyId", &value)?;
         }
         if let Some(ref value) = obj.compress {
             write_characters_element(writer, "Compress", &value.to_string())?;
         }
         if let Some(ref value) = obj.field_level_encryption_id {
-            write_characters_element(writer, "FieldLevelEncryptionId", &value.to_string())?;
+            write_characters_element(writer, "FieldLevelEncryptionId", &value)?;
         }
         if let Some(ref value) = obj.lambda_function_associations {
             &LambdaFunctionAssociationsSerializer::serialize(
@@ -555,27 +555,23 @@ impl CacheBehaviorSerializer {
             )?;
         }
         if let Some(ref value) = obj.origin_request_policy_id {
-            write_characters_element(writer, "OriginRequestPolicyId", &value.to_string())?;
+            write_characters_element(writer, "OriginRequestPolicyId", &value)?;
         }
-        write_characters_element(writer, "PathPattern", &obj.path_pattern.to_string())?;
+        write_characters_element(writer, "PathPattern", &obj.path_pattern)?;
         if let Some(ref value) = obj.realtime_log_config_arn {
-            write_characters_element(writer, "RealtimeLogConfigArn", &value.to_string())?;
+            write_characters_element(writer, "RealtimeLogConfigArn", &value)?;
         }
         if let Some(ref value) = obj.smooth_streaming {
             write_characters_element(writer, "SmoothStreaming", &value.to_string())?;
         }
-        write_characters_element(writer, "TargetOriginId", &obj.target_origin_id.to_string())?;
+        write_characters_element(writer, "TargetOriginId", &obj.target_origin_id)?;
         if let Some(ref value) = obj.trusted_key_groups {
             &TrustedKeyGroupsSerializer::serialize(&mut writer, "TrustedKeyGroups", value)?;
         }
         if let Some(ref value) = obj.trusted_signers {
             &TrustedSignersSerializer::serialize(&mut writer, "TrustedSigners", value)?;
         }
-        write_characters_element(
-            writer,
-            "ViewerProtocolPolicy",
-            &obj.viewer_protocol_policy.to_string(),
-        )?;
+        write_characters_element(writer, "ViewerProtocolPolicy", &obj.viewer_protocol_policy)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -790,7 +786,7 @@ impl CachePolicyConfigSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
         if let Some(ref value) = obj.default_ttl {
             write_characters_element(writer, "DefaultTTL", &value.to_string())?;
@@ -799,7 +795,7 @@ impl CachePolicyConfigSerializer {
             write_characters_element(writer, "MaxTTL", &value.to_string())?;
         }
         write_characters_element(writer, "MinTTL", &obj.min_ttl.to_string())?;
-        write_characters_element(writer, "Name", &obj.name.to_string())?;
+        write_characters_element(writer, "Name", &obj.name)?;
         if let Some(ref value) = obj.parameters_in_cache_key_and_forwarded_to_origin {
             &ParametersInCacheKeyAndForwardedToOriginSerializer::serialize(
                 &mut writer,
@@ -887,7 +883,7 @@ impl CachePolicyCookiesConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "CookieBehavior", &obj.cookie_behavior.to_string())?;
+        write_characters_element(writer, "CookieBehavior", &obj.cookie_behavior)?;
         if let Some(ref value) = obj.cookies {
             &CookieNamesSerializer::serialize(&mut writer, "Cookies", value)?;
         }
@@ -971,7 +967,7 @@ impl CachePolicyHeadersConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "HeaderBehavior", &obj.header_behavior.to_string())?;
+        write_characters_element(writer, "HeaderBehavior", &obj.header_behavior)?;
         if let Some(ref value) = obj.headers {
             &HeadersSerializer::serialize(&mut writer, "Headers", value)?;
         }
@@ -1104,11 +1100,7 @@ impl CachePolicyQueryStringsConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(
-            writer,
-            "QueryStringBehavior",
-            &obj.query_string_behavior.to_string(),
-        )?;
+        write_characters_element(writer, "QueryStringBehavior", &obj.query_string_behavior)?;
         if let Some(ref value) = obj.query_strings {
             &QueryStringNamesSerializer::serialize(&mut writer, "QueryStrings", value)?;
         }
@@ -1344,8 +1336,8 @@ impl CloudFrontOriginAccessIdentityConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "CallerReference", &obj.caller_reference.to_string())?;
-        write_characters_element(writer, "Comment", &obj.comment.to_string())?;
+        write_characters_element(writer, "CallerReference", &obj.caller_reference)?;
+        write_characters_element(writer, "Comment", &obj.comment)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -1551,10 +1543,10 @@ impl ContentTypeProfileSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "ContentType", &obj.content_type.to_string())?;
-        write_characters_element(writer, "Format", &obj.format.to_string())?;
+        write_characters_element(writer, "ContentType", &obj.content_type)?;
+        write_characters_element(writer, "Format", &obj.format)?;
         if let Some(ref value) = obj.profile_id {
-            write_characters_element(writer, "ProfileId", &value.to_string())?;
+            write_characters_element(writer, "ProfileId", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -2422,10 +2414,10 @@ impl CustomErrorResponseSerializer {
         }
         write_characters_element(writer, "ErrorCode", &obj.error_code.to_string())?;
         if let Some(ref value) = obj.response_code {
-            write_characters_element(writer, "ResponseCode", &value.to_string())?;
+            write_characters_element(writer, "ResponseCode", &value)?;
         }
         if let Some(ref value) = obj.response_page_path {
-            write_characters_element(writer, "ResponsePagePath", &value.to_string())?;
+            write_characters_element(writer, "ResponsePagePath", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -2668,11 +2660,7 @@ impl CustomOriginConfigSerializer {
         if let Some(ref value) = obj.origin_keepalive_timeout {
             write_characters_element(writer, "OriginKeepaliveTimeout", &value.to_string())?;
         }
-        write_characters_element(
-            writer,
-            "OriginProtocolPolicy",
-            &obj.origin_protocol_policy.to_string(),
-        )?;
+        write_characters_element(writer, "OriginProtocolPolicy", &obj.origin_protocol_policy)?;
         if let Some(ref value) = obj.origin_read_timeout {
             write_characters_element(writer, "OriginReadTimeout", &value.to_string())?;
         }
@@ -2810,13 +2798,13 @@ impl DefaultCacheBehaviorSerializer {
             &AllowedMethodsSerializer::serialize(&mut writer, "AllowedMethods", value)?;
         }
         if let Some(ref value) = obj.cache_policy_id {
-            write_characters_element(writer, "CachePolicyId", &value.to_string())?;
+            write_characters_element(writer, "CachePolicyId", &value)?;
         }
         if let Some(ref value) = obj.compress {
             write_characters_element(writer, "Compress", &value.to_string())?;
         }
         if let Some(ref value) = obj.field_level_encryption_id {
-            write_characters_element(writer, "FieldLevelEncryptionId", &value.to_string())?;
+            write_characters_element(writer, "FieldLevelEncryptionId", &value)?;
         }
         if let Some(ref value) = obj.lambda_function_associations {
             &LambdaFunctionAssociationsSerializer::serialize(
@@ -2826,26 +2814,22 @@ impl DefaultCacheBehaviorSerializer {
             )?;
         }
         if let Some(ref value) = obj.origin_request_policy_id {
-            write_characters_element(writer, "OriginRequestPolicyId", &value.to_string())?;
+            write_characters_element(writer, "OriginRequestPolicyId", &value)?;
         }
         if let Some(ref value) = obj.realtime_log_config_arn {
-            write_characters_element(writer, "RealtimeLogConfigArn", &value.to_string())?;
+            write_characters_element(writer, "RealtimeLogConfigArn", &value)?;
         }
         if let Some(ref value) = obj.smooth_streaming {
             write_characters_element(writer, "SmoothStreaming", &value.to_string())?;
         }
-        write_characters_element(writer, "TargetOriginId", &obj.target_origin_id.to_string())?;
+        write_characters_element(writer, "TargetOriginId", &obj.target_origin_id)?;
         if let Some(ref value) = obj.trusted_key_groups {
             &TrustedKeyGroupsSerializer::serialize(&mut writer, "TrustedKeyGroups", value)?;
         }
         if let Some(ref value) = obj.trusted_signers {
             &TrustedSignersSerializer::serialize(&mut writer, "TrustedSigners", value)?;
         }
-        write_characters_element(
-            writer,
-            "ViewerProtocolPolicy",
-            &obj.viewer_protocol_policy.to_string(),
-        )?;
+        write_characters_element(writer, "ViewerProtocolPolicy", &obj.viewer_protocol_policy)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -3229,8 +3213,8 @@ impl DistributionConfigSerializer {
         if let Some(ref value) = obj.cache_behaviors {
             &CacheBehaviorsSerializer::serialize(&mut writer, "CacheBehaviors", value)?;
         }
-        write_characters_element(writer, "CallerReference", &obj.caller_reference.to_string())?;
-        write_characters_element(writer, "Comment", &obj.comment.to_string())?;
+        write_characters_element(writer, "CallerReference", &obj.caller_reference)?;
+        write_characters_element(writer, "Comment", &obj.comment)?;
         if let Some(ref value) = obj.custom_error_responses {
             &CustomErrorResponsesSerializer::serialize(&mut writer, "CustomErrorResponses", value)?;
         }
@@ -3240,11 +3224,11 @@ impl DistributionConfigSerializer {
             &obj.default_cache_behavior,
         )?;
         if let Some(ref value) = obj.default_root_object {
-            write_characters_element(writer, "DefaultRootObject", &value.to_string())?;
+            write_characters_element(writer, "DefaultRootObject", &value)?;
         }
         write_characters_element(writer, "Enabled", &obj.enabled.to_string())?;
         if let Some(ref value) = obj.http_version {
-            write_characters_element(writer, "HttpVersion", &value.to_string())?;
+            write_characters_element(writer, "HttpVersion", &value)?;
         }
         if let Some(ref value) = obj.is_ipv6_enabled {
             write_characters_element(writer, "IsIPV6Enabled", &value.to_string())?;
@@ -3257,7 +3241,7 @@ impl DistributionConfigSerializer {
         }
         OriginsSerializer::serialize(&mut writer, "Origins", &obj.origins)?;
         if let Some(ref value) = obj.price_class {
-            write_characters_element(writer, "PriceClass", &value.to_string())?;
+            write_characters_element(writer, "PriceClass", &value)?;
         }
         if let Some(ref value) = obj.restrictions {
             &RestrictionsSerializer::serialize(&mut writer, "Restrictions", value)?;
@@ -3266,7 +3250,7 @@ impl DistributionConfigSerializer {
             &ViewerCertificateSerializer::serialize(&mut writer, "ViewerCertificate", value)?;
         }
         if let Some(ref value) = obj.web_acl_id {
-            write_characters_element(writer, "WebACLId", &value.to_string())?;
+            write_characters_element(writer, "WebACLId", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -3697,8 +3681,8 @@ impl EncryptionEntitySerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         FieldPatternsSerializer::serialize(&mut writer, "FieldPatterns", &obj.field_patterns)?;
-        write_characters_element(writer, "ProviderId", &obj.provider_id.to_string())?;
-        write_characters_element(writer, "PublicKeyId", &obj.public_key_id.to_string())?;
+        write_characters_element(writer, "ProviderId", &obj.provider_id)?;
+        write_characters_element(writer, "PublicKeyId", &obj.public_key_id)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -3797,7 +3781,7 @@ impl EndPointSerializer {
         if let Some(ref value) = obj.kinesis_stream_config {
             &KinesisStreamConfigSerializer::serialize(&mut writer, "KinesisStreamConfig", value)?;
         }
-        write_characters_element(writer, "StreamType", &obj.stream_type.to_string())?;
+        write_characters_element(writer, "StreamType", &obj.stream_type)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -3976,9 +3960,9 @@ impl FieldLevelEncryptionConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "CallerReference", &obj.caller_reference.to_string())?;
+        write_characters_element(writer, "CallerReference", &obj.caller_reference)?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
         if let Some(ref value) = obj.content_type_profile_config {
             &ContentTypeProfileConfigSerializer::serialize(
@@ -4159,16 +4143,16 @@ impl FieldLevelEncryptionProfileConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "CallerReference", &obj.caller_reference.to_string())?;
+        write_characters_element(writer, "CallerReference", &obj.caller_reference)?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
         EncryptionEntitiesSerializer::serialize(
             &mut writer,
             "EncryptionEntities",
             &obj.encryption_entities,
         )?;
-        write_characters_element(writer, "Name", &obj.name.to_string())?;
+        write_characters_element(writer, "Name", &obj.name)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -4610,7 +4594,7 @@ impl GeoRestrictionSerializer {
             &LocationListSerializer::serialize(&mut writer, "Items", value)?;
         }
         write_characters_element(writer, "Quantity", &obj.quantity.to_string())?;
-        write_characters_element(writer, "RestrictionType", &obj.restriction_type.to_string())?;
+        write_characters_element(writer, "RestrictionType", &obj.restriction_type)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -5619,7 +5603,7 @@ impl InvalidationBatchSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "CallerReference", &obj.caller_reference.to_string())?;
+        write_characters_element(writer, "CallerReference", &obj.caller_reference)?;
         PathsSerializer::serialize(&mut writer, "Paths", &obj.paths)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -5879,10 +5863,10 @@ impl KeyGroupConfigSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
         PublicKeyIdListSerializer::serialize(&mut writer, "Items", &obj.items)?;
-        write_characters_element(writer, "Name", &obj.name.to_string())?;
+        write_characters_element(writer, "Name", &obj.name)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -6077,8 +6061,8 @@ impl KinesisStreamConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "RoleARN", &obj.role_arn.to_string())?;
-        write_characters_element(writer, "StreamARN", &obj.stream_arn.to_string())?;
+        write_characters_element(writer, "RoleARN", &obj.role_arn)?;
+        write_characters_element(writer, "StreamARN", &obj.stream_arn)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -6164,15 +6148,11 @@ impl LambdaFunctionAssociationSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "EventType", &obj.event_type.to_string())?;
+        write_characters_element(writer, "EventType", &obj.event_type)?;
         if let Some(ref value) = obj.include_body {
             write_characters_element(writer, "IncludeBody", &value.to_string())?;
         }
-        write_characters_element(
-            writer,
-            "LambdaFunctionARN",
-            &obj.lambda_function_arn.to_string(),
-        )?;
+        write_characters_element(writer, "LambdaFunctionARN", &obj.lambda_function_arn)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -6995,10 +6975,10 @@ impl LoggingConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Bucket", &obj.bucket.to_string())?;
+        write_characters_element(writer, "Bucket", &obj.bucket)?;
         write_characters_element(writer, "Enabled", &obj.enabled.to_string())?;
         write_characters_element(writer, "IncludeCookies", &obj.include_cookies.to_string())?;
-        write_characters_element(writer, "Prefix", &obj.prefix.to_string())?;
+        write_characters_element(writer, "Prefix", &obj.prefix)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -7278,10 +7258,10 @@ impl OriginSerializer {
         if let Some(ref value) = obj.custom_origin_config {
             &CustomOriginConfigSerializer::serialize(&mut writer, "CustomOriginConfig", value)?;
         }
-        write_characters_element(writer, "DomainName", &obj.domain_name.to_string())?;
-        write_characters_element(writer, "Id", &obj.id.to_string())?;
+        write_characters_element(writer, "DomainName", &obj.domain_name)?;
+        write_characters_element(writer, "Id", &obj.id)?;
         if let Some(ref value) = obj.origin_path {
-            write_characters_element(writer, "OriginPath", &value.to_string())?;
+            write_characters_element(writer, "OriginPath", &value)?;
         }
         if let Some(ref value) = obj.origin_shield {
             &OriginShieldSerializer::serialize(&mut writer, "OriginShield", value)?;
@@ -7339,8 +7319,8 @@ impl OriginCustomHeaderSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "HeaderName", &obj.header_name.to_string())?;
-        write_characters_element(writer, "HeaderValue", &obj.header_value.to_string())?;
+        write_characters_element(writer, "HeaderName", &obj.header_name)?;
+        write_characters_element(writer, "HeaderValue", &obj.header_value)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -7446,7 +7426,7 @@ impl OriginGroupSerializer {
             "FailoverCriteria",
             &obj.failover_criteria,
         )?;
-        write_characters_element(writer, "Id", &obj.id.to_string())?;
+        write_characters_element(writer, "Id", &obj.id)?;
         OriginGroupMembersSerializer::serialize(&mut writer, "Members", &obj.members)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -7583,7 +7563,7 @@ impl OriginGroupMemberSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "OriginId", &obj.origin_id.to_string())?;
+        write_characters_element(writer, "OriginId", &obj.origin_id)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -7924,7 +7904,7 @@ impl OriginRequestPolicyConfigSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
         OriginRequestPolicyCookiesConfigSerializer::serialize(
             &mut writer,
@@ -7936,7 +7916,7 @@ impl OriginRequestPolicyConfigSerializer {
             "HeadersConfig",
             &obj.headers_config,
         )?;
-        write_characters_element(writer, "Name", &obj.name.to_string())?;
+        write_characters_element(writer, "Name", &obj.name)?;
         OriginRequestPolicyQueryStringsConfigSerializer::serialize(
             &mut writer,
             "QueryStringsConfig",
@@ -8023,7 +8003,7 @@ impl OriginRequestPolicyCookiesConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "CookieBehavior", &obj.cookie_behavior.to_string())?;
+        write_characters_element(writer, "CookieBehavior", &obj.cookie_behavior)?;
         if let Some(ref value) = obj.cookies {
             &CookieNamesSerializer::serialize(&mut writer, "Cookies", value)?;
         }
@@ -8108,7 +8088,7 @@ impl OriginRequestPolicyHeadersConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "HeaderBehavior", &obj.header_behavior.to_string())?;
+        write_characters_element(writer, "HeaderBehavior", &obj.header_behavior)?;
         if let Some(ref value) = obj.headers {
             &HeadersSerializer::serialize(&mut writer, "Headers", value)?;
         }
@@ -8248,11 +8228,7 @@ impl OriginRequestPolicyQueryStringsConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(
-            writer,
-            "QueryStringBehavior",
-            &obj.query_string_behavior.to_string(),
-        )?;
+        write_characters_element(writer, "QueryStringBehavior", &obj.query_string_behavior)?;
         if let Some(ref value) = obj.query_strings {
             &QueryStringNamesSerializer::serialize(&mut writer, "QueryStrings", value)?;
         }
@@ -8396,7 +8372,7 @@ impl OriginShieldSerializer {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         write_characters_element(writer, "Enabled", &obj.enabled.to_string())?;
         if let Some(ref value) = obj.origin_shield_region {
-            write_characters_element(writer, "OriginShieldRegion", &value.to_string())?;
+            write_characters_element(writer, "OriginShieldRegion", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -8849,12 +8825,12 @@ impl PublicKeyConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "CallerReference", &obj.caller_reference.to_string())?;
+        write_characters_element(writer, "CallerReference", &obj.caller_reference)?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
-        write_characters_element(writer, "EncodedKey", &obj.encoded_key.to_string())?;
-        write_characters_element(writer, "Name", &obj.name.to_string())?;
+        write_characters_element(writer, "EncodedKey", &obj.encoded_key)?;
+        write_characters_element(writer, "Name", &obj.name)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -9056,8 +9032,8 @@ impl QueryArgProfileSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "ProfileId", &obj.profile_id.to_string())?;
-        write_characters_element(writer, "QueryArg", &obj.query_arg.to_string())?;
+        write_characters_element(writer, "ProfileId", &obj.profile_id)?;
+        write_characters_element(writer, "QueryArg", &obj.query_arg)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -9497,7 +9473,7 @@ impl RealtimeMetricsSubscriptionConfigSerializer {
         write_characters_element(
             writer,
             "RealtimeMetricsSubscriptionStatus",
-            &obj.realtime_metrics_subscription_status.to_string(),
+            &obj.realtime_metrics_subscription_status,
         )?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -9636,12 +9612,8 @@ impl S3OriginSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "DomainName", &obj.domain_name.to_string())?;
-        write_characters_element(
-            writer,
-            "OriginAccessIdentity",
-            &obj.origin_access_identity.to_string(),
-        )?;
+        write_characters_element(writer, "DomainName", &obj.domain_name)?;
+        write_characters_element(writer, "OriginAccessIdentity", &obj.origin_access_identity)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -9688,11 +9660,7 @@ impl S3OriginConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(
-            writer,
-            "OriginAccessIdentity",
-            &obj.origin_access_identity.to_string(),
-        )?;
+        write_characters_element(writer, "OriginAccessIdentity", &obj.origin_access_identity)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -10080,14 +10048,14 @@ impl StreamingDistributionConfigSerializer {
         if let Some(ref value) = obj.aliases {
             &AliasesSerializer::serialize(&mut writer, "Aliases", value)?;
         }
-        write_characters_element(writer, "CallerReference", &obj.caller_reference.to_string())?;
-        write_characters_element(writer, "Comment", &obj.comment.to_string())?;
+        write_characters_element(writer, "CallerReference", &obj.caller_reference)?;
+        write_characters_element(writer, "Comment", &obj.comment)?;
         write_characters_element(writer, "Enabled", &obj.enabled.to_string())?;
         if let Some(ref value) = obj.logging {
             &StreamingLoggingConfigSerializer::serialize(&mut writer, "Logging", value)?;
         }
         if let Some(ref value) = obj.price_class {
-            write_characters_element(writer, "PriceClass", &value.to_string())?;
+            write_characters_element(writer, "PriceClass", &value)?;
         }
         S3OriginSerializer::serialize(&mut writer, "S3Origin", &obj.s3_origin)?;
         TrustedSignersSerializer::serialize(&mut writer, "TrustedSigners", &obj.trusted_signers)?;
@@ -10343,9 +10311,9 @@ impl StreamingLoggingConfigSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Bucket", &obj.bucket.to_string())?;
+        write_characters_element(writer, "Bucket", &obj.bucket)?;
         write_characters_element(writer, "Enabled", &obj.enabled.to_string())?;
-        write_characters_element(writer, "Prefix", &obj.prefix.to_string())?;
+        write_characters_element(writer, "Prefix", &obj.prefix)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -10417,9 +10385,9 @@ impl TagSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Key", &obj.key.to_string())?;
+        write_characters_element(writer, "Key", &obj.key)?;
         if let Some(ref value) = obj.value {
-            write_characters_element(writer, "Value", &value.to_string())?;
+            write_characters_element(writer, "Value", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -11284,19 +11252,19 @@ impl ViewerCertificateSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.acm_certificate_arn {
-            write_characters_element(writer, "ACMCertificateArn", &value.to_string())?;
+            write_characters_element(writer, "ACMCertificateArn", &value)?;
         }
         if let Some(ref value) = obj.cloud_front_default_certificate {
             write_characters_element(writer, "CloudFrontDefaultCertificate", &value.to_string())?;
         }
         if let Some(ref value) = obj.iam_certificate_id {
-            write_characters_element(writer, "IAMCertificateId", &value.to_string())?;
+            write_characters_element(writer, "IAMCertificateId", &value)?;
         }
         if let Some(ref value) = obj.minimum_protocol_version {
-            write_characters_element(writer, "MinimumProtocolVersion", &value.to_string())?;
+            write_characters_element(writer, "MinimumProtocolVersion", &value)?;
         }
         if let Some(ref value) = obj.ssl_support_method {
-            write_characters_element(writer, "SSLSupportMethod", &value.to_string())?;
+            write_characters_element(writer, "SSLSupportMethod", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -200,8 +200,8 @@ impl AlarmIdentifierSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Name", &obj.name.to_string())?;
-        write_characters_element(writer, "Region", &obj.region.to_string())?;
+        write_characters_element(writer, "Name", &obj.name)?;
+        write_characters_element(writer, "Region", &obj.region)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -307,13 +307,13 @@ impl AliasTargetSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "DNSName", &obj.dns_name.to_string())?;
+        write_characters_element(writer, "DNSName", &obj.dns_name)?;
         write_characters_element(
             writer,
             "EvaluateTargetHealth",
             &obj.evaluate_target_health.to_string(),
         )?;
-        write_characters_element(writer, "HostedZoneId", &obj.hosted_zone_id.to_string())?;
+        write_characters_element(writer, "HostedZoneId", &obj.hosted_zone_id)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -418,7 +418,7 @@ impl ChangeSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Action", &obj.action.to_string())?;
+        write_characters_element(writer, "Action", &obj.action)?;
         ResourceRecordSetSerializer::serialize(
             &mut writer,
             "ResourceRecordSet",
@@ -467,7 +467,7 @@ impl ChangeBatchSerializer {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         ChangesSerializer::serialize(&mut writer, "Changes", &obj.changes)?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -2335,13 +2335,13 @@ impl GeoLocationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.continent_code {
-            write_characters_element(writer, "ContinentCode", &value.to_string())?;
+            write_characters_element(writer, "ContinentCode", &value)?;
         }
         if let Some(ref value) = obj.country_code {
-            write_characters_element(writer, "CountryCode", &value.to_string())?;
+            write_characters_element(writer, "CountryCode", &value)?;
         }
         if let Some(ref value) = obj.subdivision_code {
-            write_characters_element(writer, "SubdivisionCode", &value.to_string())?;
+            write_characters_element(writer, "SubdivisionCode", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -3514,16 +3514,16 @@ impl HealthCheckConfigSerializer {
             write_characters_element(writer, "FailureThreshold", &value.to_string())?;
         }
         if let Some(ref value) = obj.fully_qualified_domain_name {
-            write_characters_element(writer, "FullyQualifiedDomainName", &value.to_string())?;
+            write_characters_element(writer, "FullyQualifiedDomainName", &value)?;
         }
         if let Some(ref value) = obj.health_threshold {
             write_characters_element(writer, "HealthThreshold", &value.to_string())?;
         }
         if let Some(ref value) = obj.ip_address {
-            write_characters_element(writer, "IPAddress", &value.to_string())?;
+            write_characters_element(writer, "IPAddress", &value)?;
         }
         if let Some(ref value) = obj.insufficient_data_health_status {
-            write_characters_element(writer, "InsufficientDataHealthStatus", &value.to_string())?;
+            write_characters_element(writer, "InsufficientDataHealthStatus", &value)?;
         }
         if let Some(ref value) = obj.inverted {
             write_characters_element(writer, "Inverted", &value.to_string())?;
@@ -3541,12 +3541,12 @@ impl HealthCheckConfigSerializer {
             write_characters_element(writer, "RequestInterval", &value.to_string())?;
         }
         if let Some(ref value) = obj.resource_path {
-            write_characters_element(writer, "ResourcePath", &value.to_string())?;
+            write_characters_element(writer, "ResourcePath", &value)?;
         }
         if let Some(ref value) = obj.search_string {
-            write_characters_element(writer, "SearchString", &value.to_string())?;
+            write_characters_element(writer, "SearchString", &value)?;
         }
-        write_characters_element(writer, "Type", &obj.type_.to_string())?;
+        write_characters_element(writer, "Type", &obj.type_)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -3933,7 +3933,7 @@ impl HostedZoneConfigSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.comment {
-            write_characters_element(writer, "Comment", &value.to_string())?;
+            write_characters_element(writer, "Comment", &value)?;
         }
         if let Some(ref value) = obj.private_zone {
             write_characters_element(writer, "PrivateZone", &value.to_string())?;
@@ -6101,7 +6101,7 @@ impl ResourceRecordSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Value", &obj.value.to_string())?;
+        write_characters_element(writer, "Value", &obj.value)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -6236,34 +6236,34 @@ impl ResourceRecordSetSerializer {
             &AliasTargetSerializer::serialize(&mut writer, "AliasTarget", value)?;
         }
         if let Some(ref value) = obj.failover {
-            write_characters_element(writer, "Failover", &value.to_string())?;
+            write_characters_element(writer, "Failover", &value)?;
         }
         if let Some(ref value) = obj.geo_location {
             &GeoLocationSerializer::serialize(&mut writer, "GeoLocation", value)?;
         }
         if let Some(ref value) = obj.health_check_id {
-            write_characters_element(writer, "HealthCheckId", &value.to_string())?;
+            write_characters_element(writer, "HealthCheckId", &value)?;
         }
         if let Some(ref value) = obj.multi_value_answer {
             write_characters_element(writer, "MultiValueAnswer", &value.to_string())?;
         }
-        write_characters_element(writer, "Name", &obj.name.to_string())?;
+        write_characters_element(writer, "Name", &obj.name)?;
         if let Some(ref value) = obj.region {
-            write_characters_element(writer, "Region", &value.to_string())?;
+            write_characters_element(writer, "Region", &value)?;
         }
         if let Some(ref value) = obj.resource_records {
             &ResourceRecordsSerializer::serialize(&mut writer, "ResourceRecords", value)?;
         }
         if let Some(ref value) = obj.set_identifier {
-            write_characters_element(writer, "SetIdentifier", &value.to_string())?;
+            write_characters_element(writer, "SetIdentifier", &value)?;
         }
         if let Some(ref value) = obj.ttl {
             write_characters_element(writer, "TTL", &value.to_string())?;
         }
         if let Some(ref value) = obj.traffic_policy_instance_id {
-            write_characters_element(writer, "TrafficPolicyInstanceId", &value.to_string())?;
+            write_characters_element(writer, "TrafficPolicyInstanceId", &value)?;
         }
-        write_characters_element(writer, "Type", &obj.type_.to_string())?;
+        write_characters_element(writer, "Type", &obj.type_)?;
         if let Some(ref value) = obj.weight {
             write_characters_element(writer, "Weight", &value.to_string())?;
         }
@@ -6848,10 +6848,10 @@ impl TagSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.key {
-            write_characters_element(writer, "Key", &value.to_string())?;
+            write_characters_element(writer, "Key", &value)?;
         }
         if let Some(ref value) = obj.value {
-            write_characters_element(writer, "Value", &value.to_string())?;
+            write_characters_element(writer, "Value", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -7944,10 +7944,10 @@ impl VPCSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.vpc_id {
-            write_characters_element(writer, "VPCId", &value.to_string())?;
+            write_characters_element(writer, "VPCId", &value)?;
         }
         if let Some(ref value) = obj.vpc_region {
-            write_characters_element(writer, "VPCRegion", &value.to_string())?;
+            write_characters_element(writer, "VPCRegion", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -167,7 +167,7 @@ impl AccelerateConfigurationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.status {
-            write_characters_element(writer, "Status", &value.to_string())?;
+            write_characters_element(writer, "Status", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -250,7 +250,7 @@ impl AccessControlTranslationSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Owner", &obj.owner.to_string())?;
+        write_characters_element(writer, "Owner", &obj.owner)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -556,7 +556,7 @@ impl AnalyticsAndOperatorSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tags {
             &TagSetSerializer::serialize(&mut writer, "Tag", value)?;
@@ -622,7 +622,7 @@ impl AnalyticsConfigurationSerializer {
         if let Some(ref value) = obj.filter {
             &AnalyticsFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
-        write_characters_element(writer, "Id", &obj.id.to_string())?;
+        write_characters_element(writer, "Id", &obj.id)?;
         StorageClassAnalysisSerializer::serialize(
             &mut writer,
             "StorageClassAnalysis",
@@ -775,7 +775,7 @@ impl AnalyticsFilterSerializer {
             &AnalyticsAndOperatorSerializer::serialize(&mut writer, "And", value)?;
         }
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tag {
             &TagSerializer::serialize(&mut writer, "Tag", value)?;
@@ -872,13 +872,13 @@ impl AnalyticsS3BucketDestinationSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Bucket", &obj.bucket.to_string())?;
+        write_characters_element(writer, "Bucket", &obj.bucket)?;
         if let Some(ref value) = obj.bucket_account_id {
-            write_characters_element(writer, "BucketAccountId", &value.to_string())?;
+            write_characters_element(writer, "BucketAccountId", &value)?;
         }
-        write_characters_element(writer, "Format", &obj.format.to_string())?;
+        write_characters_element(writer, "Format", &obj.format)?;
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -1408,22 +1408,22 @@ impl CSVInputSerializer {
             write_characters_element(writer, "AllowQuotedRecordDelimiter", &value.to_string())?;
         }
         if let Some(ref value) = obj.comments {
-            write_characters_element(writer, "Comments", &value.to_string())?;
+            write_characters_element(writer, "Comments", &value)?;
         }
         if let Some(ref value) = obj.field_delimiter {
-            write_characters_element(writer, "FieldDelimiter", &value.to_string())?;
+            write_characters_element(writer, "FieldDelimiter", &value)?;
         }
         if let Some(ref value) = obj.file_header_info {
-            write_characters_element(writer, "FileHeaderInfo", &value.to_string())?;
+            write_characters_element(writer, "FileHeaderInfo", &value)?;
         }
         if let Some(ref value) = obj.quote_character {
-            write_characters_element(writer, "QuoteCharacter", &value.to_string())?;
+            write_characters_element(writer, "QuoteCharacter", &value)?;
         }
         if let Some(ref value) = obj.quote_escape_character {
-            write_characters_element(writer, "QuoteEscapeCharacter", &value.to_string())?;
+            write_characters_element(writer, "QuoteEscapeCharacter", &value)?;
         }
         if let Some(ref value) = obj.record_delimiter {
-            write_characters_element(writer, "RecordDelimiter", &value.to_string())?;
+            write_characters_element(writer, "RecordDelimiter", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -1458,19 +1458,19 @@ impl CSVOutputSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.field_delimiter {
-            write_characters_element(writer, "FieldDelimiter", &value.to_string())?;
+            write_characters_element(writer, "FieldDelimiter", &value)?;
         }
         if let Some(ref value) = obj.quote_character {
-            write_characters_element(writer, "QuoteCharacter", &value.to_string())?;
+            write_characters_element(writer, "QuoteCharacter", &value)?;
         }
         if let Some(ref value) = obj.quote_escape_character {
-            write_characters_element(writer, "QuoteEscapeCharacter", &value.to_string())?;
+            write_characters_element(writer, "QuoteEscapeCharacter", &value)?;
         }
         if let Some(ref value) = obj.quote_fields {
-            write_characters_element(writer, "QuoteFields", &value.to_string())?;
+            write_characters_element(writer, "QuoteFields", &value)?;
         }
         if let Some(ref value) = obj.record_delimiter {
-            write_characters_element(writer, "RecordDelimiter", &value.to_string())?;
+            write_characters_element(writer, "RecordDelimiter", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -1569,16 +1569,16 @@ impl CloudFunctionConfigurationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.cloud_function {
-            write_characters_element(writer, "CloudFunction", &value.to_string())?;
+            write_characters_element(writer, "CloudFunction", &value)?;
         }
         if let Some(ref value) = obj.events {
             &EventListSerializer::serialize(&mut writer, "Event", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "Id", &value.to_string())?;
+            write_characters_element(writer, "Id", &value)?;
         }
         if let Some(ref value) = obj.invocation_role {
-            write_characters_element(writer, "InvocationRole", &value.to_string())?;
+            write_characters_element(writer, "InvocationRole", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -1809,7 +1809,7 @@ impl CompletedPartSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.e_tag {
-            write_characters_element(writer, "ETag", &value.to_string())?;
+            write_characters_element(writer, "ETag", &value)?;
         }
         if let Some(ref value) = obj.part_number {
             write_characters_element(writer, "PartNumber", &value.to_string())?;
@@ -1905,10 +1905,10 @@ impl ConditionSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.http_error_code_returned_equals {
-            write_characters_element(writer, "HttpErrorCodeReturnedEquals", &value.to_string())?;
+            write_characters_element(writer, "HttpErrorCodeReturnedEquals", &value)?;
         }
         if let Some(ref value) = obj.key_prefix_equals {
-            write_characters_element(writer, "KeyPrefixEquals", &value.to_string())?;
+            write_characters_element(writer, "KeyPrefixEquals", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -2154,7 +2154,7 @@ impl CreateBucketConfigurationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.location_constraint {
-            write_characters_element(writer, "LocationConstraint", &value.to_string())?;
+            write_characters_element(writer, "LocationConstraint", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -2465,7 +2465,7 @@ impl DefaultRetentionSerializer {
             write_characters_element(writer, "Days", &value.to_string())?;
         }
         if let Some(ref value) = obj.mode {
-            write_characters_element(writer, "Mode", &value.to_string())?;
+            write_characters_element(writer, "Mode", &value)?;
         }
         if let Some(ref value) = obj.years {
             write_characters_element(writer, "Years", &value.to_string())?;
@@ -2736,7 +2736,7 @@ impl DeleteMarkerReplicationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.status {
-            write_characters_element(writer, "Status", &value.to_string())?;
+            write_characters_element(writer, "Status", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -3157,9 +3157,9 @@ impl DestinationSerializer {
             )?;
         }
         if let Some(ref value) = obj.account {
-            write_characters_element(writer, "Account", &value.to_string())?;
+            write_characters_element(writer, "Account", &value)?;
         }
-        write_characters_element(writer, "Bucket", &obj.bucket.to_string())?;
+        write_characters_element(writer, "Bucket", &obj.bucket)?;
         if let Some(ref value) = obj.encryption_configuration {
             &EncryptionConfigurationSerializer::serialize(
                 &mut writer,
@@ -3174,7 +3174,7 @@ impl DestinationSerializer {
             &ReplicationTimeSerializer::serialize(&mut writer, "ReplicationTime", value)?;
         }
         if let Some(ref value) = obj.storage_class {
-            write_characters_element(writer, "StorageClass", &value.to_string())?;
+            write_characters_element(writer, "StorageClass", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -3315,12 +3315,12 @@ impl EncryptionSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "EncryptionType", &obj.encryption_type.to_string())?;
+        write_characters_element(writer, "EncryptionType", &obj.encryption_type)?;
         if let Some(ref value) = obj.kms_context {
-            write_characters_element(writer, "KMSContext", &value.to_string())?;
+            write_characters_element(writer, "KMSContext", &value)?;
         }
         if let Some(ref value) = obj.kms_key_id {
-            write_characters_element(writer, "KMSKeyId", &value.to_string())?;
+            write_characters_element(writer, "KMSKeyId", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -3375,7 +3375,7 @@ impl EncryptionConfigurationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.replica_kms_key_id {
-            write_characters_element(writer, "ReplicaKmsKeyID", &value.to_string())?;
+            write_characters_element(writer, "ReplicaKmsKeyID", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -3504,7 +3504,7 @@ impl ErrorDocumentSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Key", &obj.key.to_string())?;
+        write_characters_element(writer, "Key", &obj.key)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -3655,7 +3655,7 @@ impl ExistingObjectReplicationSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Status", &obj.status)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -3925,10 +3925,10 @@ impl FilterRuleSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.name {
-            write_characters_element(writer, "Name", &value.to_string())?;
+            write_characters_element(writer, "Name", &value)?;
         }
         if let Some(ref value) = obj.value {
-            write_characters_element(writer, "Value", &value.to_string())?;
+            write_characters_element(writer, "Value", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -5166,7 +5166,7 @@ impl GlacierJobParametersSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Tier", &obj.tier.to_string())?;
+        write_characters_element(writer, "Tier", &obj.tier)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -5219,7 +5219,7 @@ impl GrantSerializer {
             &GranteeSerializer::serialize(&mut writer, "Grantee", value)?;
         }
         if let Some(ref value) = obj.permission {
-            write_characters_element(writer, "Permission", &value.to_string())?;
+            write_characters_element(writer, "Permission", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -5291,17 +5291,17 @@ impl GranteeSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.display_name {
-            write_characters_element(writer, "DisplayName", &value.to_string())?;
+            write_characters_element(writer, "DisplayName", &value)?;
         }
         if let Some(ref value) = obj.email_address {
-            write_characters_element(writer, "EmailAddress", &value.to_string())?;
+            write_characters_element(writer, "EmailAddress", &value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "ID", &value.to_string())?;
+            write_characters_element(writer, "ID", &value)?;
         }
-        write_characters_element(writer, "xsi:type", &obj.type_.to_string())?;
+        write_characters_element(writer, "xsi:type", &obj.type_)?;
         if let Some(ref value) = obj.uri {
-            write_characters_element(writer, "URI", &value.to_string())?;
+            write_characters_element(writer, "URI", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -5605,7 +5605,7 @@ impl IndexDocumentSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Suffix", &obj.suffix.to_string())?;
+        write_characters_element(writer, "Suffix", &obj.suffix)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -5681,7 +5681,7 @@ impl InputSerializationSerializer {
             &CSVInputSerializer::serialize(&mut writer, "CSV", value)?;
         }
         if let Some(ref value) = obj.compression_type {
-            write_characters_element(writer, "CompressionType", &value.to_string())?;
+            write_characters_element(writer, "CompressionType", &value)?;
         }
         if let Some(ref value) = obj.json {
             &JSONInputSerializer::serialize(&mut writer, "JSON", value)?;
@@ -5770,7 +5770,7 @@ impl IntelligentTieringAndOperatorSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tags {
             &TagSetSerializer::serialize(&mut writer, "Tag", value)?;
@@ -5846,8 +5846,8 @@ impl IntelligentTieringConfigurationSerializer {
         if let Some(ref value) = obj.filter {
             &IntelligentTieringFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
-        write_characters_element(writer, "Id", &obj.id.to_string())?;
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Id", &obj.id)?;
+        write_characters_element(writer, "Status", &obj.status)?;
         TieringListSerializer::serialize(&mut writer, "Tiering", &obj.tierings)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -5967,7 +5967,7 @@ impl IntelligentTieringFilterSerializer {
             &IntelligentTieringAndOperatorSerializer::serialize(&mut writer, "And", value)?;
         }
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tag {
             &TagSerializer::serialize(&mut writer, "Tag", value)?;
@@ -6106,11 +6106,11 @@ impl InventoryConfigurationSerializer {
         if let Some(ref value) = obj.filter {
             &InventoryFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
-        write_characters_element(writer, "Id", &obj.id.to_string())?;
+        write_characters_element(writer, "Id", &obj.id)?;
         write_characters_element(
             writer,
             "IncludedObjectVersions",
-            &obj.included_object_versions.to_string(),
+            &obj.included_object_versions,
         )?;
         write_characters_element(writer, "IsEnabled", &obj.is_enabled.to_string())?;
         if let Some(ref value) = obj.optional_fields {
@@ -6302,7 +6302,7 @@ impl InventoryFilterSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Prefix", &obj.prefix.to_string())?;
+        write_characters_element(writer, "Prefix", &obj.prefix)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -6538,15 +6538,15 @@ impl InventoryS3BucketDestinationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.account_id {
-            write_characters_element(writer, "AccountId", &value.to_string())?;
+            write_characters_element(writer, "AccountId", &value)?;
         }
-        write_characters_element(writer, "Bucket", &obj.bucket.to_string())?;
+        write_characters_element(writer, "Bucket", &obj.bucket)?;
         if let Some(ref value) = obj.encryption {
             &InventoryEncryptionSerializer::serialize(&mut writer, "Encryption", value)?;
         }
-        write_characters_element(writer, "Format", &obj.format.to_string())?;
+        write_characters_element(writer, "Format", &obj.format)?;
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -6594,7 +6594,7 @@ impl InventoryScheduleSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Frequency", &obj.frequency.to_string())?;
+        write_characters_element(writer, "Frequency", &obj.frequency)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -6668,7 +6668,7 @@ impl JSONInputSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.type_ {
-            write_characters_element(writer, "Type", &value.to_string())?;
+            write_characters_element(writer, "Type", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -6695,7 +6695,7 @@ impl JSONOutputSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.record_delimiter {
-            write_characters_element(writer, "RecordDelimiter", &value.to_string())?;
+            write_characters_element(writer, "RecordDelimiter", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -6879,13 +6879,9 @@ impl LambdaFunctionConfigurationSerializer {
             &NotificationConfigurationFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "Id", &value.to_string())?;
+            write_characters_element(writer, "Id", &value)?;
         }
-        write_characters_element(
-            writer,
-            "CloudFunction",
-            &obj.lambda_function_arn.to_string(),
-        )?;
+        write_characters_element(writer, "CloudFunction", &obj.lambda_function_arn)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -7147,7 +7143,7 @@ impl LifecycleRuleSerializer {
             &LifecycleRuleFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "ID", &value.to_string())?;
+            write_characters_element(writer, "ID", &value)?;
         }
         if let Some(ref value) = obj.noncurrent_version_expiration {
             &NoncurrentVersionExpirationSerializer::serialize(
@@ -7163,7 +7159,7 @@ impl LifecycleRuleSerializer {
                 value,
             )?;
         }
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Status", &obj.status)?;
         if let Some(ref value) = obj.transitions {
             &TransitionListSerializer::serialize(&mut writer, "Transition", value)?;
         }
@@ -7224,7 +7220,7 @@ impl LifecycleRuleAndOperatorSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tags {
             &TagSetSerializer::serialize(&mut writer, "Tag", value)?;
@@ -7289,7 +7285,7 @@ impl LifecycleRuleFilterSerializer {
             &LifecycleRuleAndOperatorSerializer::serialize(&mut writer, "And", value)?;
         }
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tag {
             &TagSerializer::serialize(&mut writer, "Tag", value)?;
@@ -8312,11 +8308,11 @@ impl LoggingEnabledSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "TargetBucket", &obj.target_bucket.to_string())?;
+        write_characters_element(writer, "TargetBucket", &obj.target_bucket)?;
         if let Some(ref value) = obj.target_grants {
             &TargetGrantsSerializer::serialize(&mut writer, "TargetGrants", value)?;
         }
-        write_characters_element(writer, "TargetPrefix", &obj.target_prefix.to_string())?;
+        write_characters_element(writer, "TargetPrefix", &obj.target_prefix)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -8495,10 +8491,10 @@ impl MetadataEntrySerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.name {
-            write_characters_element(writer, "Name", &value.to_string())?;
+            write_characters_element(writer, "Name", &value)?;
         }
         if let Some(ref value) = obj.value {
-            write_characters_element(writer, "Value", &value.to_string())?;
+            write_characters_element(writer, "Value", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -8586,7 +8582,7 @@ impl MetricsSerializer {
         if let Some(ref value) = obj.event_threshold {
             &ReplicationTimeValueSerializer::serialize(&mut writer, "EventThreshold", value)?;
         }
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Status", &obj.status)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -8640,7 +8636,7 @@ impl MetricsAndOperatorSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tags {
             &TagSetSerializer::serialize(&mut writer, "Tag", value)?;
@@ -8698,7 +8694,7 @@ impl MetricsConfigurationSerializer {
         if let Some(ref value) = obj.filter {
             &MetricsFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
-        write_characters_element(writer, "Id", &obj.id.to_string())?;
+        write_characters_element(writer, "Id", &obj.id)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -8788,7 +8784,7 @@ impl MetricsFilterSerializer {
             &MetricsAndOperatorSerializer::serialize(&mut writer, "And", value)?;
         }
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tag {
             &TagSerializer::serialize(&mut writer, "Tag", value)?;
@@ -9137,7 +9133,7 @@ impl NoncurrentVersionTransitionSerializer {
             write_characters_element(writer, "NoncurrentDays", &value.to_string())?;
         }
         if let Some(ref value) = obj.storage_class {
-            write_characters_element(writer, "StorageClass", &value.to_string())?;
+            write_characters_element(writer, "StorageClass", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -9538,9 +9534,9 @@ impl ObjectIdentifierSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Key", &obj.key.to_string())?;
+        write_characters_element(writer, "Key", &obj.key)?;
         if let Some(ref value) = obj.version_id {
-            write_characters_element(writer, "VersionId", &value.to_string())?;
+            write_characters_element(writer, "VersionId", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -9670,7 +9666,7 @@ impl ObjectLockConfigurationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.object_lock_enabled {
-            write_characters_element(writer, "ObjectLockEnabled", &value.to_string())?;
+            write_characters_element(writer, "ObjectLockEnabled", &value)?;
         }
         if let Some(ref value) = obj.rule {
             &ObjectLockRuleSerializer::serialize(&mut writer, "Rule", value)?;
@@ -9747,7 +9743,7 @@ impl ObjectLockLegalHoldSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.status {
-            write_characters_element(writer, "Status", &value.to_string())?;
+            write_characters_element(writer, "Status", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -9827,7 +9823,7 @@ impl ObjectLockRetentionSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.mode {
-            write_characters_element(writer, "Mode", &value.to_string())?;
+            write_characters_element(writer, "Mode", &value)?;
         }
         if let Some(ref value) = obj.retain_until_date {
             write_characters_element(writer, "RetainUntilDate", &value.to_string())?;
@@ -10178,10 +10174,10 @@ impl OwnerSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.display_name {
-            write_characters_element(writer, "DisplayName", &value.to_string())?;
+            write_characters_element(writer, "DisplayName", &value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "ID", &value.to_string())?;
+            write_characters_element(writer, "ID", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -10301,7 +10297,7 @@ impl OwnershipControlsRuleSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "ObjectOwnership", &obj.object_ownership.to_string())?;
+        write_characters_element(writer, "ObjectOwnership", &obj.object_ownership)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -11490,9 +11486,9 @@ impl QueueConfigurationSerializer {
             &NotificationConfigurationFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "Id", &value.to_string())?;
+            write_characters_element(writer, "Id", &value)?;
         }
-        write_characters_element(writer, "Queue", &obj.queue_arn.to_string())?;
+        write_characters_element(writer, "Queue", &obj.queue_arn)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -11557,10 +11553,10 @@ impl QueueConfigurationDeprecatedSerializer {
             &EventListSerializer::serialize(&mut writer, "Event", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "Id", &value.to_string())?;
+            write_characters_element(writer, "Id", &value)?;
         }
         if let Some(ref value) = obj.queue {
-            write_characters_element(writer, "Queue", &value.to_string())?;
+            write_characters_element(writer, "Queue", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -11789,19 +11785,19 @@ impl RedirectSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.host_name {
-            write_characters_element(writer, "HostName", &value.to_string())?;
+            write_characters_element(writer, "HostName", &value)?;
         }
         if let Some(ref value) = obj.http_redirect_code {
-            write_characters_element(writer, "HttpRedirectCode", &value.to_string())?;
+            write_characters_element(writer, "HttpRedirectCode", &value)?;
         }
         if let Some(ref value) = obj.protocol {
-            write_characters_element(writer, "Protocol", &value.to_string())?;
+            write_characters_element(writer, "Protocol", &value)?;
         }
         if let Some(ref value) = obj.replace_key_prefix_with {
-            write_characters_element(writer, "ReplaceKeyPrefixWith", &value.to_string())?;
+            write_characters_element(writer, "ReplaceKeyPrefixWith", &value)?;
         }
         if let Some(ref value) = obj.replace_key_with {
-            write_characters_element(writer, "ReplaceKeyWith", &value.to_string())?;
+            write_characters_element(writer, "ReplaceKeyWith", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -11853,9 +11849,9 @@ impl RedirectAllRequestsToSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "HostName", &obj.host_name.to_string())?;
+        write_characters_element(writer, "HostName", &obj.host_name)?;
         if let Some(ref value) = obj.protocol {
-            write_characters_element(writer, "Protocol", &value.to_string())?;
+            write_characters_element(writer, "Protocol", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -11975,7 +11971,7 @@ impl ReplicaModificationsSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Status", &obj.status)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -12055,7 +12051,7 @@ impl ReplicationConfigurationSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Role", &obj.role.to_string())?;
+        write_characters_element(writer, "Role", &obj.role)?;
         ReplicationRulesSerializer::serialize(&mut writer, "Rule", &obj.rules)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -12168,7 +12164,7 @@ impl ReplicationRuleSerializer {
             &ReplicationRuleFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "ID", &value.to_string())?;
+            write_characters_element(writer, "ID", &value)?;
         }
         if let Some(ref value) = obj.priority {
             write_characters_element(writer, "Priority", &value.to_string())?;
@@ -12180,7 +12176,7 @@ impl ReplicationRuleSerializer {
                 value,
             )?;
         }
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Status", &obj.status)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -12238,7 +12234,7 @@ impl ReplicationRuleAndOperatorSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tags {
             &TagSetSerializer::serialize(&mut writer, "Tag", value)?;
@@ -12304,7 +12300,7 @@ impl ReplicationRuleFilterSerializer {
             &ReplicationRuleAndOperatorSerializer::serialize(&mut writer, "And", value)?;
         }
         if let Some(ref value) = obj.prefix {
-            write_characters_element(writer, "Prefix", &value.to_string())?;
+            write_characters_element(writer, "Prefix", &value)?;
         }
         if let Some(ref value) = obj.tag {
             &TagSerializer::serialize(&mut writer, "Tag", value)?;
@@ -12430,7 +12426,7 @@ impl ReplicationTimeSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Status", &obj.status)?;
         ReplicationTimeValueSerializer::serialize(&mut writer, "Time", &obj.time)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -12528,7 +12524,7 @@ impl RequestPaymentConfigurationSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Payer", &obj.payer.to_string())?;
+        write_characters_element(writer, "Payer", &obj.payer)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -12726,7 +12722,7 @@ impl RestoreRequestSerializer {
             write_characters_element(writer, "Days", &value.to_string())?;
         }
         if let Some(ref value) = obj.description {
-            write_characters_element(writer, "Description", &value.to_string())?;
+            write_characters_element(writer, "Description", &value)?;
         }
         if let Some(ref value) = obj.glacier_job_parameters {
             &GlacierJobParametersSerializer::serialize(&mut writer, "GlacierJobParameters", value)?;
@@ -12738,10 +12734,10 @@ impl RestoreRequestSerializer {
             &SelectParametersSerializer::serialize(&mut writer, "SelectParameters", value)?;
         }
         if let Some(ref value) = obj.tier {
-            write_characters_element(writer, "Tier", &value.to_string())?;
+            write_characters_element(writer, "Tier", &value)?;
         }
         if let Some(ref value) = obj.type_ {
-            write_characters_element(writer, "Type", &value.to_string())?;
+            write_characters_element(writer, "Type", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -12976,7 +12972,7 @@ impl RuleSerializer {
             &LifecycleExpirationSerializer::serialize(&mut writer, "Expiration", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "ID", &value.to_string())?;
+            write_characters_element(writer, "ID", &value)?;
         }
         if let Some(ref value) = obj.noncurrent_version_expiration {
             &NoncurrentVersionExpirationSerializer::serialize(
@@ -12992,8 +12988,8 @@ impl RuleSerializer {
                 value,
             )?;
         }
-        write_characters_element(writer, "Prefix", &obj.prefix.to_string())?;
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Prefix", &obj.prefix)?;
+        write_characters_element(writer, "Status", &obj.status)?;
         if let Some(ref value) = obj.transition {
             &TransitionSerializer::serialize(&mut writer, "Transition", value)?;
         }
@@ -13133,16 +13129,16 @@ impl S3LocationSerializer {
         if let Some(ref value) = obj.access_control_list {
             &GrantsSerializer::serialize(&mut writer, "AccessControlList", value)?;
         }
-        write_characters_element(writer, "BucketName", &obj.bucket_name.to_string())?;
+        write_characters_element(writer, "BucketName", &obj.bucket_name)?;
         if let Some(ref value) = obj.canned_acl {
-            write_characters_element(writer, "CannedACL", &value.to_string())?;
+            write_characters_element(writer, "CannedACL", &value)?;
         }
         if let Some(ref value) = obj.encryption {
             &EncryptionSerializer::serialize(&mut writer, "Encryption", value)?;
         }
-        write_characters_element(writer, "Prefix", &obj.prefix.to_string())?;
+        write_characters_element(writer, "Prefix", &obj.prefix)?;
         if let Some(ref value) = obj.storage_class {
-            write_characters_element(writer, "StorageClass", &value.to_string())?;
+            write_characters_element(writer, "StorageClass", &value)?;
         }
         if let Some(ref value) = obj.tagging {
             &TaggingSerializer::serialize(&mut writer, "Tagging", value)?;
@@ -13192,7 +13188,7 @@ impl SSEKMSSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "KeyId", &obj.key_id.to_string())?;
+        write_characters_element(writer, "KeyId", &obj.key_id)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -13407,8 +13403,8 @@ impl SelectParametersSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Expression", &obj.expression.to_string())?;
-        write_characters_element(writer, "ExpressionType", &obj.expression_type.to_string())?;
+        write_characters_element(writer, "Expression", &obj.expression)?;
+        write_characters_element(writer, "ExpressionType", &obj.expression_type)?;
         InputSerializationSerializer::serialize(
             &mut writer,
             "InputSerialization",
@@ -13502,9 +13498,9 @@ impl ServerSideEncryptionByDefaultSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.kms_master_key_id {
-            write_characters_element(writer, "KMSMasterKeyID", &value.to_string())?;
+            write_characters_element(writer, "KMSMasterKeyID", &value)?;
         }
-        write_characters_element(writer, "SSEAlgorithm", &obj.sse_algorithm.to_string())?;
+        write_characters_element(writer, "SSEAlgorithm", &obj.sse_algorithm)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -13828,7 +13824,7 @@ impl SseKmsEncryptedObjectsSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Status", &obj.status.to_string())?;
+        write_characters_element(writer, "Status", &obj.status)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -14104,11 +14100,7 @@ impl StorageClassAnalysisDataExportSerializer {
             "Destination",
             &obj.destination,
         )?;
-        write_characters_element(
-            writer,
-            "OutputSchemaVersion",
-            &obj.output_schema_version.to_string(),
-        )?;
+        write_characters_element(writer, "OutputSchemaVersion", &obj.output_schema_version)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -14204,8 +14196,8 @@ impl TagSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "Key", &obj.key.to_string())?;
-        write_characters_element(writer, "Value", &obj.value.to_string())?;
+        write_characters_element(writer, "Key", &obj.key)?;
+        write_characters_element(writer, "Value", &obj.value)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -14351,7 +14343,7 @@ impl TargetGrantSerializer {
             &GranteeSerializer::serialize(&mut writer, "Grantee", value)?;
         }
         if let Some(ref value) = obj.permission {
-            write_characters_element(writer, "Permission", &value.to_string())?;
+            write_characters_element(writer, "Permission", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -14482,7 +14474,7 @@ impl TieringSerializer {
         W: Write,
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
-        write_characters_element(writer, "AccessTier", &obj.access_tier.to_string())?;
+        write_characters_element(writer, "AccessTier", &obj.access_tier)?;
         write_characters_element(writer, "Days", &obj.days.to_string())?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -14645,9 +14637,9 @@ impl TopicConfigurationSerializer {
             &NotificationConfigurationFilterSerializer::serialize(&mut writer, "Filter", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "Id", &value.to_string())?;
+            write_characters_element(writer, "Id", &value)?;
         }
-        write_characters_element(writer, "Topic", &obj.topic_arn.to_string())?;
+        write_characters_element(writer, "Topic", &obj.topic_arn)?;
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
@@ -14712,10 +14704,10 @@ impl TopicConfigurationDeprecatedSerializer {
             &EventListSerializer::serialize(&mut writer, "Event", value)?;
         }
         if let Some(ref value) = obj.id {
-            write_characters_element(writer, "Id", &value.to_string())?;
+            write_characters_element(writer, "Id", &value)?;
         }
         if let Some(ref value) = obj.topic {
-            write_characters_element(writer, "Topic", &value.to_string())?;
+            write_characters_element(writer, "Topic", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -14831,7 +14823,7 @@ impl TransitionSerializer {
             write_characters_element(writer, "Days", &value.to_string())?;
         }
         if let Some(ref value) = obj.storage_class {
-            write_characters_element(writer, "StorageClass", &value.to_string())?;
+            write_characters_element(writer, "StorageClass", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }
@@ -15212,10 +15204,10 @@ impl VersioningConfigurationSerializer {
     {
         writer.write(xml::writer::XmlEvent::start_element(name))?;
         if let Some(ref value) = obj.mfa_delete {
-            write_characters_element(writer, "MfaDelete", &value.to_string())?;
+            write_characters_element(writer, "MfaDelete", &value)?;
         }
         if let Some(ref value) = obj.status {
-            write_characters_element(writer, "Status", &value.to_string())?;
+            write_characters_element(writer, "Status", &value)?;
         }
         writer.write(xml::writer::XmlEvent::end_element())
     }

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -398,7 +398,7 @@ fn generate_struct_serializer(shape: &Shape, service: &Service<'_>) -> String {
             _ => {
                 serializer += &generate_primitive_struct_field_serializer(
                     shape,
-                    &member_shape.shape_type,
+                    member_shape.shape_type,
                     location_name,
                     member_name,
                 );
@@ -430,7 +430,7 @@ fn generate_primitive_struct_field_serializer(
     } else {
         format!(
             "if let Some(ref value) = obj.{field_name} {{
-                write_characters_element(writer, \"{location_name}\", &value.to_string())?;
+                write_characters_element(writer, \"{location_name}\", &value{to_string})?;
             }}",
             field_name = generate_field_name(member_name),
             location_name = location_name,

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -396,8 +396,12 @@ fn generate_struct_serializer(shape: &Shape, service: &Service<'_>) -> String {
                 );
             }
             _ => {
-                serializer +=
-                    &generate_primitive_struct_field_serializer(shape, location_name, member_name);
+                serializer += &generate_primitive_struct_field_serializer(
+                    shape,
+                    &member_shape.shape_type,
+                    location_name,
+                    member_name,
+                );
             }
         }
     }
@@ -408,14 +412,20 @@ fn generate_struct_serializer(shape: &Shape, service: &Service<'_>) -> String {
 
 fn generate_primitive_struct_field_serializer(
     shape: &Shape,
+    member_type: ShapeType,
     location_name: &str,
     member_name: &str,
 ) -> String {
+    let field_to_string = match member_type {
+        ShapeType::String => "",
+        _ => ".to_string()",
+    };
     if shape.required(member_name) {
         format!(
-            "write_characters_element(writer, \"{location_name}\", &obj.{field_name}.to_string())?;",
+            "write_characters_element(writer, \"{location_name}\", &obj.{field_name}{to_string})?;",
             field_name = generate_field_name(member_name),
             location_name = location_name,
+            to_string = field_to_string,
         )
     } else {
         format!(
@@ -424,6 +434,7 @@ fn generate_primitive_struct_field_serializer(
             }}",
             field_name = generate_field_name(member_name),
             location_name = location_name,
+            to_string = field_to_string,
         )
     }
 }


### PR DESCRIPTION
Rusoto generates a lot of code for each of its services which is noticable in its long compile time. These few commits follows the same ideas as in #1773 . Commonly generated code are extracted into helper functions that can be reused and wherever possible this are written in a manner to not have any type parameters so the code is only instantiated once.