### PR TITLE
Refactor the parsing of configuration and credentials files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   match `rusoto_credential`
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
+- Refactor the parsing of configuration and credentials files
 
 ## [0.46.0] - 2021-01-05
 

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 dirs-next = "2.0.0"
 futures = "0.3"
 hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
+rust-ini = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shlex = "0.1"

--- a/rusoto/credential/src/config/config_file.rs
+++ b/rusoto/credential/src/config/config_file.rs
@@ -1,0 +1,117 @@
+use std::path::Path;
+
+use ini::{Ini, Properties};
+
+use crate::CredentialsError;
+
+use super::{default_config_location, default_profile_name, try_parse_ini};
+
+pub struct ConfigFile {
+    ini: Ini,
+}
+
+fn try_parse_config_ini<L>(location: L) -> Result<Ini, CredentialsError>
+where
+    L: AsRef<Path>,
+{
+    try_parse_ini(location).map_err(|e| {
+        CredentialsError::new(format!("An error occurred parsing the config file: {}", e))
+    })
+}
+
+impl ConfigFile {
+    pub fn new<L>(location: L) -> Result<Self, CredentialsError>
+    where
+        L: AsRef<Path>,
+    {
+        let ini = try_parse_config_ini(location)?;
+        Ok(ConfigFile { ini })
+    }
+
+    pub fn new_default() -> Result<Self, CredentialsError> {
+        let location = default_config_location()?;
+        Self::new(&location)
+    }
+
+    pub fn profile(&self, profile_name: &str) -> Option<ConfigProfile<'_>> {
+        self.ini
+            .section(Some(profile_name))
+            .or_else(|| self.ini.section(Some(&format!("profile {}", profile_name))))
+            .map(ConfigProfile::from)
+    }
+
+    pub fn default_profile(&self) -> Option<ConfigProfile<'_>> {
+        self.profile(&default_profile_name())
+    }
+}
+
+pub struct ConfigProfile<'a> {
+    properties: &'a Properties,
+}
+
+impl<'a> From<&'a Properties> for ConfigProfile<'a> {
+    fn from(properties: &'a Properties) -> Self {
+        ConfigProfile { properties }
+    }
+}
+
+impl<'a> ConfigProfile<'a> {
+    pub fn region(&self) -> Option<&'a str> {
+        self.properties.get("region")
+    }
+
+    pub fn credential_process(&self) -> Option<&'a str> {
+        self.properties.get("credential_process")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn parse_config_file_default_profile() {
+        let result = ConfigFile::new(Path::new("tests/sample-data/default_config"));
+        assert!(result.is_ok());
+        let config = result.unwrap();
+        let default_profile = config
+            .default_profile()
+            .expect("No Default profile in default_profile_credentials");
+        assert_eq!(default_profile.region(), Some("us-east-2"));
+    }
+
+    #[test]
+    fn parse_config_file_multiple_profiles() {
+        let result = ConfigFile::new(Path::new("tests/sample-data/multiple_profile_config"));
+        assert!(result.is_ok());
+
+        let config = result.unwrap();
+
+        let foo_profile = config
+            .profile("foo")
+            .expect("No foo profile in multiple_profile_credentials");
+        assert_eq!(foo_profile.region(), Some("us-east-3"));
+
+        let bar_profile = config
+            .profile("bar")
+            .expect("No bar profile in multiple_profile_credentials");
+        assert_eq!(bar_profile.region(), Some("us-east-4"));
+    }
+
+    #[test]
+    fn parse_config_file_credential_process() {
+        let result = ConfigFile::new(Path::new("tests/sample-data/credential_process_config"));
+        assert!(result.is_ok());
+        let config = result.unwrap();
+        let default_profile = config
+            .default_profile()
+            .expect("No Default profile in default_profile_credentials");
+        assert_eq!(default_profile.region(), Some("us-east-2"));
+        assert_eq!(
+            default_profile.credential_process(),
+            Some("cat tests/sample-data/credential_process_sample_response")
+        );
+    }
+}

--- a/rusoto/credential/src/config/credentials_file.rs
+++ b/rusoto/credential/src/config/credentials_file.rs
@@ -1,0 +1,164 @@
+use std::path::Path;
+
+use ini::{Ini, Properties};
+
+use crate::CredentialsError;
+
+use super::try_parse_ini;
+
+fn try_parse_credentials_ini<L>(location: L) -> Result<Ini, CredentialsError>
+where
+    L: AsRef<Path>,
+{
+    try_parse_ini(location).map_err(|e| {
+        CredentialsError::new(format!(
+            "An error occurred while parsing the credentials file: {}",
+            e
+        ))
+    })
+}
+
+pub struct CredentialsFile {
+    ini: Ini,
+}
+
+impl CredentialsFile {
+    pub fn new<L>(location: L) -> Result<Self, CredentialsError>
+    where
+        L: AsRef<Path>,
+    {
+        let ini = try_parse_credentials_ini(location)?;
+        Ok(CredentialsFile { ini })
+    }
+
+    pub fn profile(&self, profile_name: &str) -> Option<CredentialsProfile<'_>> {
+        self.ini
+            .section(Some(profile_name))
+            .map(CredentialsProfile::from)
+    }
+}
+
+pub struct CredentialsProfile<'a> {
+    properties: &'a Properties,
+}
+
+impl<'a> From<&'a Properties> for CredentialsProfile<'a> {
+    fn from(properties: &'a Properties) -> Self {
+        CredentialsProfile { properties }
+    }
+}
+
+impl<'a> CredentialsProfile<'a> {
+    pub fn region(&self) -> Option<&'a str> {
+        self.properties.get("region")
+    }
+
+    pub fn aws_access_key_id(&self) -> Option<&'a str> {
+        self.properties.get("aws_access_key_id")
+    }
+
+    pub fn aws_secret_access_key(&self) -> Option<&'a str> {
+        self.properties.get("aws_secret_access_key")
+    }
+
+    pub fn aws_session_token(&self) -> Option<&'a str> {
+        self.properties.get("aws_session_token")
+    }
+
+    pub fn aws_security_token(&self) -> Option<&'a str> {
+        self.properties.get("aws_security_token")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::{config::default_profile_name, CredentialsError};
+
+    #[test]
+    fn parse_credentials_file_default_profile() {
+        let result =
+            CredentialsFile::new(Path::new("tests/sample-data/default_profile_credentials"));
+        assert!(result.is_ok());
+
+        let credentials = result.ok().unwrap();
+
+        let default_profile = credentials
+            .profile(&default_profile_name())
+            .expect("No Default profile in default_profile_credentials");
+        assert_eq!(default_profile.aws_access_key_id(), Some("foo"));
+        assert_eq!(default_profile.aws_secret_access_key(), Some("bar"));
+    }
+
+    #[test]
+    fn parse_credentials_file_multiple_profiles() {
+        let result =
+            CredentialsFile::new(Path::new("tests/sample-data/multiple_profile_credentials"));
+        assert!(result.is_ok());
+
+        let credentials = result.ok().unwrap();
+
+        let foo_profile = credentials
+            .profile("foo")
+            .expect("No foo profile in multiple_profile_credentials");
+        assert_eq!(foo_profile.aws_access_key_id(), Some("foo_access_key"));
+        assert_eq!(foo_profile.aws_secret_access_key(), Some("foo_secret_key"));
+
+        let bar_profile = credentials
+            .profile("bar")
+            .expect("No bar profile in multiple_profile_credentials");
+        assert_eq!(bar_profile.aws_access_key_id(), Some("bar_access_key"));
+        assert_eq!(bar_profile.aws_secret_access_key(), Some("bar_secret_key"));
+    }
+
+    #[test]
+    fn parse_all_values_credentials_file() {
+        let result = CredentialsFile::new(Path::new("tests/sample-data/full_profile_credentials"));
+        assert!(result.is_ok());
+
+        let credentials = result.ok().unwrap();
+
+        let default_profile = credentials
+            .profile(&default_profile_name())
+            .expect("No default profile in full_profile_credentials");
+        assert_eq!(default_profile.aws_access_key_id(), Some("foo"));
+        assert_eq!(default_profile.aws_secret_access_key(), Some("bar"));
+    }
+
+    #[test]
+    fn parse_credentials_bad_path() {
+        let result = CredentialsFile::new(Path::new("/bad/file/path"));
+        assert!(
+            result.err().unwrap().to_string().starts_with("An error occurred while parsing the credentials file: Couldn\'t stat file [ \"/bad/file/path\" ]: "),
+        );
+    }
+
+    #[test]
+    fn parse_credentials_directory_path() {
+        let result = CredentialsFile::new(Path::new("tests/"));
+        assert_eq!(
+            result.err(),
+            Some(CredentialsError::new(
+                "An error occurred while parsing the credentials file: [ \"tests/\" ] is not a file.",
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_credentials_unrecognized_field() {
+        let result = CredentialsFile::new(Path::new(
+            "tests/sample-data/unrecognized_field_profile_credentials",
+        ));
+        assert!(result.is_ok());
+
+        let credentials = result.ok().unwrap();
+
+        let default_profile = credentials
+            .profile(&default_profile_name())
+            .expect("No default profile in full_profile_credentials");
+        assert_eq!(default_profile.aws_access_key_id(), Some("foo"));
+        assert_eq!(default_profile.aws_secret_access_key(), Some("bar"));
+    }
+}

--- a/rusoto/credential/src/config/credentials_file.rs
+++ b/rusoto/credential/src/config/credentials_file.rs
@@ -18,11 +18,16 @@ where
     })
 }
 
+/// The AWS [credentials] file. Located at `~/.aws/credentials` by default, its location can be overriden with the
+/// `AWS_SHARED_CREDENTIALS_FILE` environment variable.
+///
+/// [credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 pub struct CredentialsFile {
     ini: Ini,
 }
 
 impl CredentialsFile {
+    /// Parses the credentials file at the given location.
     pub fn new<L>(location: L) -> Result<Self, CredentialsError>
     where
         L: AsRef<Path>,
@@ -31,6 +36,7 @@ impl CredentialsFile {
         Ok(CredentialsFile { ini })
     }
 
+    /// Returns the profile with the given name.
     pub fn profile(&self, profile_name: &str) -> Option<CredentialsProfile<'_>> {
         self.ini
             .section(Some(profile_name))
@@ -38,6 +44,7 @@ impl CredentialsFile {
     }
 }
 
+/// A profile defined in the AWS [credentials] file.
 pub struct CredentialsProfile<'a> {
     properties: &'a Properties,
 }
@@ -49,22 +56,27 @@ impl<'a> From<&'a Properties> for CredentialsProfile<'a> {
 }
 
 impl<'a> CredentialsProfile<'a> {
+    /// Returns the region property of this profile.
     pub fn region(&self) -> Option<&'a str> {
         self.properties.get("region")
     }
 
+    /// Returns the aws_access_key_id property of this profile.
     pub fn aws_access_key_id(&self) -> Option<&'a str> {
         self.properties.get("aws_access_key_id")
     }
 
+    /// Returns the aws_secret_access_key property of this profile.
     pub fn aws_secret_access_key(&self) -> Option<&'a str> {
         self.properties.get("aws_secret_access_key")
     }
 
+    /// Returns the aws_session_token property of this profile.
     pub fn aws_session_token(&self) -> Option<&'a str> {
         self.properties.get("aws_session_token")
     }
 
+    /// Returns the aws_security_token property of this profile.
     pub fn aws_security_token(&self) -> Option<&'a str> {
         self.properties.get("aws_security_token")
     }

--- a/rusoto/credential/src/config/mod.rs
+++ b/rusoto/credential/src/config/mod.rs
@@ -90,40 +90,12 @@ where
 }
 
 #[cfg(test)]
-pub mod test_utils {
-    use super::{AWS_CONFIG_FILE, AWS_PROFILE, AWS_SHARED_CREDENTIALS_FILE};
-    use std::env;
+pub mod test_utils {}
 
-    #[derive(Debug)]
-    pub struct VarGuard {
-        variable: String,
-        previous_value: Option<String>,
-    }
-
-    impl VarGuard {
-        fn new(variable: String, value: Option<String>) -> VarGuard {
-            let previous_value = env::var(&variable).map(Some).unwrap_or(None);
-            if let Some(value) = value {
-                env::set_var(&variable, value);
-            } else {
-                env::remove_var(&variable);
-            }
-            VarGuard {
-                variable,
-                previous_value,
-            }
-        }
-    }
-
-    impl Drop for VarGuard {
-        fn drop(&mut self) {
-            if let Some(value) = self.previous_value.take() {
-                env::set_var(&self.variable, value);
-            } else {
-                env::remove_var(&self.variable)
-            }
-        }
-    }
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::test_utils::{lock_env, VarGuard};
 
     pub fn with_env_profile(value: Option<&str>) -> VarGuard {
         VarGuard::new(AWS_PROFILE.to_string(), value.map(ToString::to_string))
@@ -139,13 +111,6 @@ pub mod test_utils {
             value.map(ToString::to_string),
         )
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_utils::lock_env;
-    use test_utils::{with_env_profile, with_env_shared_credentials_file};
 
     #[test]
     fn default_profile_name_from_env_var() {

--- a/rusoto/credential/src/config/mod.rs
+++ b/rusoto/credential/src/config/mod.rs
@@ -1,0 +1,197 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use dirs_next::home_dir;
+use ini::Ini;
+
+use crate::{non_empty_env_var, CredentialsError};
+
+mod config_file;
+mod credentials_file;
+
+pub use config_file::{ConfigFile, ConfigProfile};
+pub use credentials_file::{CredentialsFile, CredentialsProfile};
+
+const AWS_PROFILE: &str = "AWS_PROFILE";
+const AWS_CONFIG_FILE: &str = "AWS_CONFIG_FILE";
+const AWS_SHARED_CREDENTIALS_FILE: &str = "AWS_SHARED_CREDENTIALS_FILE";
+const DEFAULT_PROFILE: &str = "default";
+
+/// Default config file location:
+/// 1: if set and not empty, use the value from environment variable ```AWS_CONFIG_FILE```
+/// 2. otherwise return `~/.aws/config` (Linux/Mac) resp. `%USERPROFILE%\.aws\config` (Windows)
+pub fn default_config_location() -> Result<PathBuf, CredentialsError> {
+    let env = non_empty_env_var(AWS_CONFIG_FILE);
+    match env {
+        Some(path) => Ok(PathBuf::from(path)),
+        None => hardcoded_location("config"),
+    }
+}
+
+/// Default credentials file location:
+/// 1. if set and not empty, use value from environment variable ```AWS_SHARED_CREDENTIALS_FILE```
+/// 2. otherwise return `~/.aws/credentials` (Linux/Mac) resp. `%USERPROFILE%\.aws\credentials` (Windows)
+pub fn default_credentials_location() -> Result<PathBuf, CredentialsError> {
+    let env = non_empty_env_var(AWS_SHARED_CREDENTIALS_FILE);
+    match env {
+        Some(path) => Ok(PathBuf::from(path)),
+        None => hardcoded_location("credentials"),
+    }
+}
+
+fn hardcoded_location(filename: &str) -> Result<PathBuf, CredentialsError> {
+    match home_dir() {
+        Some(mut home_path) => {
+            home_path.push(".aws");
+            home_path.push(filename);
+            Ok(home_path)
+        }
+        None => Err(CredentialsError::new("Failed to determine home directory.")),
+    }
+}
+
+/// Get the default profile name:
+/// 1. if set and not empty, use value from environment variable ```AWS_PROFILE```
+/// 2. otherwise return ```"default"```
+/// see https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html.
+pub fn default_profile_name() -> String {
+    non_empty_env_var(AWS_PROFILE).unwrap_or_else(|| DEFAULT_PROFILE.into())
+}
+
+pub(self) fn try_parse_ini<L>(location: L) -> Result<Ini, CredentialsError>
+where
+    L: AsRef<Path>,
+{
+    match fs::metadata(location.as_ref()) {
+        Err(err) => {
+            return Err(CredentialsError::new(format!(
+                "Couldn't stat file [ {:?} ]: {}",
+                location.as_ref(),
+                err
+            )));
+        }
+        Ok(metadata) => {
+            if !metadata.is_file() {
+                return Err(CredentialsError::new(format!(
+                    "[ {:?} ] is not a file.",
+                    location.as_ref()
+                )));
+            }
+        }
+    };
+
+    let ini = Ini::load_from_file(location).map_err(|err| {
+        CredentialsError::new(format!("An error occurred while parsing the file: {}", err))
+    })?;
+
+    Ok(ini)
+}
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::{AWS_CONFIG_FILE, AWS_PROFILE, AWS_SHARED_CREDENTIALS_FILE};
+    use std::env;
+
+    #[derive(Debug)]
+    pub struct VarGuard {
+        variable: String,
+        previous_value: Option<String>,
+    }
+
+    impl VarGuard {
+        fn new(variable: String, value: Option<String>) -> VarGuard {
+            let previous_value = env::var(&variable).map(Some).unwrap_or(None);
+            if let Some(value) = value {
+                env::set_var(&variable, value);
+            } else {
+                env::remove_var(&variable);
+            }
+            VarGuard {
+                variable,
+                previous_value,
+            }
+        }
+    }
+
+    impl Drop for VarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.previous_value.take() {
+                env::set_var(&self.variable, value);
+            } else {
+                env::remove_var(&self.variable)
+            }
+        }
+    }
+
+    pub fn with_env_profile(value: Option<&str>) -> VarGuard {
+        VarGuard::new(AWS_PROFILE.to_string(), value.map(ToString::to_string))
+    }
+
+    pub fn with_env_config_file(value: Option<&str>) -> VarGuard {
+        VarGuard::new(AWS_CONFIG_FILE.to_string(), value.map(ToString::to_string))
+    }
+
+    pub fn with_env_shared_credentials_file(value: Option<&str>) -> VarGuard {
+        VarGuard::new(
+            AWS_SHARED_CREDENTIALS_FILE.to_string(),
+            value.map(ToString::to_string),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::lock_env;
+    use test_utils::{with_env_profile, with_env_shared_credentials_file};
+
+    #[test]
+    fn default_profile_name_from_env_var() {
+        let _guard = lock_env();
+        let _profile_guard = with_env_profile(Some("bar"));
+        assert_eq!("bar", default_profile_name());
+    }
+
+    #[test]
+    fn default_profile_name_from_empty_env_var() {
+        let _guard = lock_env();
+        let _profile_guard = with_env_profile(Some(""));
+        assert_eq!(DEFAULT_PROFILE, default_profile_name());
+    }
+
+    #[test]
+    fn default_profile_name_with_no_env_var() {
+        let _guard = lock_env();
+        let _profile_guard = with_env_profile(None);
+        assert_eq!(DEFAULT_PROFILE, default_profile_name());
+    }
+
+    #[test]
+    fn default_profile_location_from_env_var() {
+        let _guard = lock_env();
+        let _credentials_guard = with_env_shared_credentials_file(Some("bar"));
+        assert_eq!(Ok(PathBuf::from("bar")), default_credentials_location());
+    }
+
+    #[test]
+    fn default_profile_location_from_empty_env_var() {
+        let _guard = lock_env();
+        let _credentials_guard = with_env_shared_credentials_file(Some(""));
+        assert_eq!(
+            hardcoded_location("credentials"),
+            default_credentials_location()
+        );
+    }
+
+    #[test]
+    fn default_profile_location_with_no_env_var() {
+        let _guard = lock_env();
+        let _credentials_guard = with_env_shared_credentials_file(None);
+        assert_eq!(
+            hardcoded_location("credentials"),
+            default_credentials_location()
+        );
+    }
+}

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::static_provider::StaticProvider;
 pub use crate::variable::Variable;
 
 pub mod claims;
+mod config;
 mod container;
 mod environment;
 mod instance_metadata;

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -127,8 +127,10 @@ impl ProfileProvider {
 #[async_trait]
 impl ProvideAwsCredentials for ProfileProvider {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        match ConfigFile::new_default()?
-            .default_profile()
+        let config_file = ConfigFile::new_default().ok();
+        match config_file
+            .as_ref()
+            .and_then(|config_file| config_file.default_profile())
             .and_then(|profile| profile.credential_process())
             .map(std::borrow::ToOwned::to_owned)
         {
@@ -215,9 +217,7 @@ mod tests {
     use crate::{
         config::{
             default_profile_name,
-            test_utils::{
-                with_env_config_file, with_env_profile, with_env_shared_credentials_file,
-            },
+            tests::{with_env_config_file, with_env_profile, with_env_shared_credentials_file},
         },
         test_utils::lock_env,
         CredentialsError, ProvideAwsCredentials,

--- a/rusoto/credential/src/test_utils.rs
+++ b/rusoto/credential/src/test_utils.rs
@@ -48,3 +48,35 @@ pub fn lock_env() -> MutexGuard<'static, ()> {
         }
     }
 }
+
+/// Temporarily sets or removes an environment variable.
+#[derive(Debug)]
+pub struct VarGuard {
+    name: String,
+    previous_value: Option<String>,
+}
+
+impl VarGuard {
+    pub fn new(name: String, value: Option<String>) -> VarGuard {
+        let previous_value = std::env::var(&name).map(Some).unwrap_or(None);
+        if let Some(value) = value {
+            std::env::set_var(&name, value);
+        } else {
+            std::env::remove_var(&name);
+        }
+        VarGuard {
+            name,
+            previous_value,
+        }
+    }
+}
+
+impl Drop for VarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = self.previous_value.take() {
+            std::env::set_var(&self.name, value);
+        } else {
+            std::env::remove_var(&self.name)
+        }
+    }
+}

--- a/rusoto/credential/tests/sample-data/multiple_profile_credentials
+++ b/rusoto/credential/tests/sample-data/multiple_profile_credentials
@@ -1,7 +1,9 @@
 [foo]
 aws_access_key_id = foo_access_key
 aws_secret_access_key = foo_secret_key
+region = us-east-3
 
 [bar]
 aws_access_key_id = bar_access_key
 aws_secret_access_key = bar_secret_key
+region = us-east-4


### PR DESCRIPTION
As mentioned on Discord, I'm currently working on adding an [AWS SSO](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html) provider for issue #1810. While working on it, I noticed that the way rusoto parses and validates the config and credentials file had a few issues:

* We roll out our own INI parsing logic. While this cuts down on dependencies, it also means that we don't necessarily handle all edge cases of the format. It also makes it unnecessarily hard to parse new properties correctly. `botocore` uses Python's `configparser` module, so I think it makes sense for us to bring the `ini` crate for this purpose.
* We had two different methods for parsing INI files (`parse_config_file` and `parse_credentials_file`), whose behaviors differed in subtle ways (e.g. regarding error handling)
* It improperly parses profile names in the credentials file. `[profile named_profile]` is only valid in the config file, as noted on https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html.

There were a couple more issues with the tests:

* I reworked the way we set/unset environment variables to use the guard pattern.
* `region_from_profile` and `region_from_profile_missing_profile` used the wrong type of file (`config` instead of `credentials`) to initialize a `ProfileProvider`.

I asked this question on Discord, but I didn't get an answer, so I'm asking it again here: Are breaking changes frowned upon at this point in Rusoto's existence? I feel like the current ProfileProvider API isn't ideal and that there are a few method signatures that could be improved. For instance, I think `ProfileProvider` should be able to be parameterized both with the `config` and `credentials` files location (right now it can only be parameterized with the `credentials` file location). I also think that it should parse both `credentials` and `config` files on initialization so it may re-use the results in later method calls. However, this would alter some method's signature to remove a few error cases, and modify the arguments of a couple methods.

For now, I only slightly reworked the wording/messages of some errors. I don't know if that could be considered a breaking change, considering we only have one error type for all credentials-related issues.