### PR TITLE
Enable hyper's http2 feature

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -27,7 +27,7 @@ bytes = "1.0"
 crc32fast = "1.2"
 futures = "0.3"
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.22", optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = "1.4"


### PR DESCRIPTION
Calls to the Lambda API fail in rusoto 0.46.0 because HTTP/2 is negotiated but the corresponding hyper `http2` feature is not enabled.

Example error:

```
[2021-01-28T00:00:36Z DEBUG rustls::client::hs] No cached session for DNSNameRef("lambda.us-west-2.amazonaws.com")
[2021-01-28T00:00:36Z DEBUG rustls::client::hs] Not resuming any session
[2021-01-28T00:00:36Z DEBUG rustls::client::hs] ALPN protocol is Some(b"h2")
[2021-01-28T00:00:36Z DEBUG rustls::client::hs] Using ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
[2021-01-28T00:00:36Z DEBUG rustls::client::hs] Server supports tickets
[2021-01-28T00:00:36Z DEBUG rustls::client::tls12] ECDHE curve is ECParameters { curve_type: NamedCurve, named_group: secp256r1 }
[2021-01-28T00:00:36Z DEBUG rustls::client::tls12] Server DNS name is DNSName("lambda.us-west-2.amazonaws.com")
[2021-01-28T00:00:37Z DEBUG rustls::client::tls12] Session saved
[2021-01-28T00:00:37Z DEBUG hyper::proto::h1::conn] received unexpected 40 bytes on an idle connection
[2021-01-28T00:00:37Z DEBUG hyper::client::client] client connection error: received unexpected message from connection
```

hyper-rustls [adds `h2` to the ALPN protocol list by default](https://github.com/ctz/hyper-rustls/blob/3f16ac4c36d1133883073b7d6eacf8c09339e87f/src/connector.rs#L64)