### PR TITLE
Remove unnecessary Sync constraint on ByteStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   match `rusoto_credential`
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
-
+- Remove `Sync` constraint on `ByteStream`-related functions.
 ## [0.46.0] - 2021-01-05
 
 - Display `rusoto_core::Client` in docs


### PR DESCRIPTION
Whole package seems to compile without it. Closes #1896.

This should allow to create ByteStreams from streams that are !Sync.
