### PR TITLE
Add Clone derived trait to TlsError

### DIFF
--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -475,7 +475,7 @@ fn build_user_agent(prepend: &Option<String>, append: &Option<String>) -> Header
     agent.unwrap_or_else(|_| DEFAULT_USER_AGENT.parse().unwrap())
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 /// An error produced when the user has an invalid TLS client
 pub struct TlsError {
     message: String,


### PR DESCRIPTION
Hey, i'm pretty sure most Error types implement Clone? I think TlsError should too, as it's simply a String.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Add Clone derived trait to TlsError