### PR TITLE
Use ring crypto for 10-20% CPU utlilization gain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
 - Remove `Sync` constraint on `ByteStream`-related functions.
+- Use `ring` for the signature computation bringing 10-20% CPU utlilization
+  eduction.
+
 ## [0.46.0] - 2021-01-05
 
 - Display `rusoto_core::Client` in docs

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -24,7 +24,6 @@ bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 digest = "0.9.0"
 futures = "0.3"
-hmac = "0.10"
 http = "0.2"
 hyper = { version = "0.14", features = ["stream"] }
 log = "0.4.1"
@@ -32,9 +31,9 @@ md-5 = "0.9"
 base64 = "0.13"
 hex = "0.4"
 serde = "1"
-sha2 = "0.9"
 percent-encoding = "2"
 pin-project-lite = "0.2"
+ring = "0.16"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [dependencies.rusoto_credential]


### PR DESCRIPTION
Computing SigV4 signatures uses SHA2 for the derivation. The Sha2 crate
does not have architeture optimizations. By using Ring, we now have them
and also they are selected at runtime. This manifests in 10-20% reduction
of CPU utlilization for production workloads.

A lot of `rusoto` users already have transitive dependency on `ring`
through `rustls`, so this removes one more dependency for them.
