### PR TITLE
Upgrade to shlex 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Update to `serde_urlencoded` 0.7
+- Update to `shlex` 1.0
 - Update to `rustc_version` 0.3
 - Replace `time`-related types in `rusoto_signature` with `chrono` types, to
   match `rusoto_credential`

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shlex = "0.1"
+shlex = "1"
 tokio = { version = "1.0", features = ["process", "sync", "time"] }
 zeroize = "1"
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Update to `shlex` 1.0

The breaking change in shlex 1 is a fix for [a correctness bug](https://github.com/comex/rust-shlex/issues/6). I haven't looked closely at how shlex is used in rusoto_credential so it should probably be made sure that this doesn't break anything that relied on the incorrect behavior.