### PR TITLE
Fix dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
 - Remove `Sync` constraint on `ByteStream`-related functions.
+- Update minimum versions of async-trait, percent-encoding, and serde.
 ## [0.46.0] - 2021-01-05
 
 - Display `rusoto_core::Client` in docs

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 rustc_version = "0.3"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = "0.1.9"
 bytes = "1.0"
 crc32fast = "1.2"
 futures = "0.3"

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -16,12 +16,12 @@ exclude = ["tests/sample-data/*"]
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = "0.1.9"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 dirs-next = "2.0.0"
 futures = "0.3"
 hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 shlex = "0.1"
 tokio = { version = "1.0", features = ["process", "sync", "time"] }

--- a/rusoto/services/accessanalyzer/Cargo.toml
+++ b/rusoto/services/accessanalyzer/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/appconfig/Cargo.toml
+++ b/rusoto/services/appconfig/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/appmesh/Cargo.toml
+++ b/rusoto/services/appmesh/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/backup/Cargo.toml
+++ b/rusoto/services/backup/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/codeguru-reviewer/Cargo.toml
+++ b/rusoto/services/codeguru-reviewer/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/codeguruprofiler/Cargo.toml
+++ b/rusoto/services/codeguruprofiler/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/codestar-notifications/Cargo.toml
+++ b/rusoto/services/codestar-notifications/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/connectparticipant/Cargo.toml
+++ b/rusoto/services/connectparticipant/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/dataexchange/Cargo.toml
+++ b/rusoto/services/dataexchange/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/detective/Cargo.toml
+++ b/rusoto/services/detective/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/dlm/Cargo.toml
+++ b/rusoto/services/dlm/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/ebs/Cargo.toml
+++ b/rusoto/services/ebs/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/elastic-inference/Cargo.toml
+++ b/rusoto/services/elastic-inference/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/es/Cargo.toml
+++ b/rusoto/services/es/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/groundstation/Cargo.toml
+++ b/rusoto/services/groundstation/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/imagebuilder/Cargo.toml
+++ b/rusoto/services/imagebuilder/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/iotevents-data/Cargo.toml
+++ b/rusoto/services/iotevents-data/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/iotevents/Cargo.toml
+++ b/rusoto/services/iotevents/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/kinesis-video-signaling/Cargo.toml
+++ b/rusoto/services/kinesis-video-signaling/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/managedblockchain/Cargo.toml
+++ b/rusoto/services/managedblockchain/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/marketplace-catalog/Cargo.toml
+++ b/rusoto/services/marketplace-catalog/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/mediaconnect/Cargo.toml
+++ b/rusoto/services/mediaconnect/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/mediapackage-vod/Cargo.toml
+++ b/rusoto/services/mediapackage-vod/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/networkmanager/Cargo.toml
+++ b/rusoto/services/networkmanager/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/outposts/Cargo.toml
+++ b/rusoto/services/outposts/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/personalize-events/Cargo.toml
+++ b/rusoto/services/personalize-events/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/personalize-runtime/Cargo.toml
+++ b/rusoto/services/personalize-runtime/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/pinpoint-email/Cargo.toml
+++ b/rusoto/services/pinpoint-email/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/pinpoint-sms-voice/Cargo.toml
+++ b/rusoto/services/pinpoint-sms-voice/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/qldb/Cargo.toml
+++ b/rusoto/services/qldb/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/quicksight/Cargo.toml
+++ b/rusoto/services/quicksight/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/robomaker/Cargo.toml
+++ b/rusoto/services/robomaker/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/savingsplans/Cargo.toml
+++ b/rusoto/services/savingsplans/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/schemas/Cargo.toml
+++ b/rusoto/services/schemas/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/securityhub/Cargo.toml
+++ b/rusoto/services/securityhub/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/sesv2/Cargo.toml
+++ b/rusoto/services/sesv2/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/signer/Cargo.toml
+++ b/rusoto/services/signer/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/sms-voice/Cargo.toml
+++ b/rusoto/services/sms-voice/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/sso-oidc/Cargo.toml
+++ b/rusoto/services/sso-oidc/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/sso/Cargo.toml
+++ b/rusoto/services/sso/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/services/workmailmessageflow/Cargo.toml
+++ b/rusoto/services/workmailmessageflow/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 
 [dependencies.futures]
 version = "0.3"

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -19,8 +19,8 @@ targets = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
+serde = "1.0.103"
+serde_derive = "1.0.103"
 serde_json = "1.0"
 
 [dependencies.futures]

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -33,7 +33,7 @@ base64 = "0.13"
 hex = "0.4"
 serde = "1"
 sha2 = "0.9"
-percent-encoding = "2"
+percent-encoding = "2.1.0"
 pin-project-lite = "0.2"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -216,11 +216,11 @@ impl<'b> Service<'b> {
             "rest-json" => {
                 dependencies.insert(
                     "serde".to_owned(),
-                    cargo::Dependency::Simple("1.0.2".into()),
+                    cargo::Dependency::Simple("1.0.103".into()),
                 );
                 dependencies.insert(
                     "serde_derive".to_owned(),
-                    cargo::Dependency::Simple("1.0.2".into()),
+                    cargo::Dependency::Simple("1.0.103".into()),
                 );
                 // some rest-json services don't use the `serde_json` crate:
                 if self.needs_serde_json_crate() {


### PR DESCRIPTION
Some dependency versions are not specified properly. For example, `rusoto_signature` requires `percent_encoding = "2"` although it uses `percent_encoding::AsciiSet::remove` that was added in 2.1.0.