### PR TITLE
Disable the futures/executor feature to remove futures-executor from the dep tree

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -653,7 +653,7 @@ path = "../rusoto/services/ram"
 async-trait = "0.1.31"
 env_logger = "0.7"
 bytes = "1.0"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 log = "0.4"
 rand = "0.7"
 time = "0.2"

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 chrono = "0.4"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 http = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -25,7 +25,7 @@ rustc_version = "0.3"
 async-trait = "0.1"
 bytes = "1.0"
 crc32fast = "1.2"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
 hyper-rustls = { version = "0.22", optional = true }

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 dirs-next = "2.0.0"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rusoto/services/accessanalyzer/Cargo.toml
+++ b/rusoto/services/accessanalyzer/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0.2"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/appconfig/Cargo.toml
+++ b/rusoto/services/appconfig/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/application-insights/Cargo.toml
+++ b/rusoto/services/application-insights/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/appmesh/Cargo.toml
+++ b/rusoto/services/appmesh/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/backup/Cargo.toml
+++ b/rusoto/services/backup/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -23,6 +23,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0.2"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codeguru-reviewer/Cargo.toml
+++ b/rusoto/services/codeguru-reviewer/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codeguruprofiler/Cargo.toml
+++ b/rusoto/services/codeguruprofiler/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codestar-connections/Cargo.toml
+++ b/rusoto/services/codestar-connections/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codestar-notifications/Cargo.toml
+++ b/rusoto/services/codestar-notifications/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -27,6 +27,8 @@ default-features = false
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/compute-optimizer/Cargo.toml
+++ b/rusoto/services/compute-optimizer/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/connectparticipant/Cargo.toml
+++ b/rusoto/services/connectparticipant/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/dataexchange/Cargo.toml
+++ b/rusoto/services/dataexchange/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/datasync/Cargo.toml
+++ b/rusoto/services/datasync/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/detective/Cargo.toml
+++ b/rusoto/services/detective/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/dlm/Cargo.toml
+++ b/rusoto/services/dlm/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ebs/Cargo.toml
+++ b/rusoto/services/ebs/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ec2-instance-connect/Cargo.toml
+++ b/rusoto/services/ec2-instance-connect/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/elastic-inference/Cargo.toml
+++ b/rusoto/services/elastic-inference/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/es/Cargo.toml
+++ b/rusoto/services/es/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/forecast/Cargo.toml
+++ b/rusoto/services/forecast/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/forecastquery/Cargo.toml
+++ b/rusoto/services/forecastquery/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/frauddetector/Cargo.toml
+++ b/rusoto/services/frauddetector/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/globalaccelerator/Cargo.toml
+++ b/rusoto/services/globalaccelerator/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/groundstation/Cargo.toml
+++ b/rusoto/services/groundstation/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/imagebuilder/Cargo.toml
+++ b/rusoto/services/imagebuilder/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0.2"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iotevents-data/Cargo.toml
+++ b/rusoto/services/iotevents-data/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iotevents/Cargo.toml
+++ b/rusoto/services/iotevents/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iotsecuretunneling/Cargo.toml
+++ b/rusoto/services/iotsecuretunneling/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/iotthingsgraph/Cargo.toml
+++ b/rusoto/services/iotthingsgraph/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kendra/Cargo.toml
+++ b/rusoto/services/kendra/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kinesis-video-signaling/Cargo.toml
+++ b/rusoto/services/kinesis-video-signaling/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kinesisanalyticsv2/Cargo.toml
+++ b/rusoto/services/kinesisanalyticsv2/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/lakeformation/Cargo.toml
+++ b/rusoto/services/lakeformation/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/managedblockchain/Cargo.toml
+++ b/rusoto/services/managedblockchain/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/marketplace-catalog/Cargo.toml
+++ b/rusoto/services/marketplace-catalog/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mediaconnect/Cargo.toml
+++ b/rusoto/services/mediaconnect/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mediapackage-vod/Cargo.toml
+++ b/rusoto/services/mediapackage-vod/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/migrationhub-config/Cargo.toml
+++ b/rusoto/services/migrationhub-config/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0.2"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/networkmanager/Cargo.toml
+++ b/rusoto/services/networkmanager/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/outposts/Cargo.toml
+++ b/rusoto/services/outposts/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/personalize-events/Cargo.toml
+++ b/rusoto/services/personalize-events/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/personalize-runtime/Cargo.toml
+++ b/rusoto/services/personalize-runtime/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/personalize/Cargo.toml
+++ b/rusoto/services/personalize/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/pinpoint-email/Cargo.toml
+++ b/rusoto/services/pinpoint-email/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/pinpoint-sms-voice/Cargo.toml
+++ b/rusoto/services/pinpoint-sms-voice/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/qldb-session/Cargo.toml
+++ b/rusoto/services/qldb-session/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/qldb/Cargo.toml
+++ b/rusoto/services/qldb/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/quicksight/Cargo.toml
+++ b/rusoto/services/quicksight/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/robomaker/Cargo.toml
+++ b/rusoto/services/robomaker/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -23,6 +23,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/route53resolver/Cargo.toml
+++ b/rusoto/services/route53resolver/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -23,6 +23,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-a2i-runtime/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0.2"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/savingsplans/Cargo.toml
+++ b/rusoto/services/savingsplans/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/schemas/Cargo.toml
+++ b/rusoto/services/schemas/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/securityhub/Cargo.toml
+++ b/rusoto/services/securityhub/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/service-quotas/Cargo.toml
+++ b/rusoto/services/service-quotas/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sesv2/Cargo.toml
+++ b/rusoto/services/sesv2/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/signer/Cargo.toml
+++ b/rusoto/services/signer/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sms-voice/Cargo.toml
+++ b/rusoto/services/sms-voice/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -24,6 +24,8 @@ xml-rs = "0.8"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sso-oidc/Cargo.toml
+++ b/rusoto/services/sso-oidc/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sso/Cargo.toml
+++ b/rusoto/services/sso/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0.2"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -28,6 +28,8 @@ default-features = false
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/textract/Cargo.toml
+++ b/rusoto/services/textract/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/transfer/Cargo.toml
+++ b/rusoto/services/transfer/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/workmailmessageflow/Cargo.toml
+++ b/rusoto/services/workmailmessageflow/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0.2"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -23,6 +23,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -25,6 +25,8 @@ serde_json = "1.0"
 
 [dependencies.futures]
 version = "0.3"
+default-features = false
+features = ["std", "async-await"]
 
 [dependencies.rusoto_core]
 version = "0.46.0"

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -23,7 +23,7 @@ rustc_version = "0.3"
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 digest = "0.9.0"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 hmac = "0.10"
 http = "0.2"
 hyper = { version = "0.14", features = ["stream"] }

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -131,8 +131,8 @@ impl<'b> Service<'b> {
                 path: None,
                 version: Some("0.3".to_owned()),
                 optional: None,
-                default_features: None,
-                features: None,
+                default_features: Some(false),
+                features: Some(vec!["std".to_owned(), "async-await".to_owned()]),
             },
         );
         dependencies.insert(


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
