### PR TITLE
Update shlex version to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swap the non-RustCrypto `md5` crate for the RustCrypto `md-5` crate, to match
   usage of RustCrypto `sha2` crate
 - Remove `Sync` constraint on `ByteStream`-related functions.
+- Update to `shlex` 1.0
+
 ## [0.46.0] - 2021-01-05
 
 - Display `rusoto_core::Client` in docs

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shlex = "0.1"
+shlex = "1"
 tokio = { version = "1.0", features = ["process", "sync", "time"] }
 zeroize = "1"
 


### PR DESCRIPTION
One more issue with 0.1/0.1.1 versions is that they [didn't include](https://docs.rs/crate/shlex/0.1.1/source/src/) any license files.