### PR TITLE
Support building rustls without native certs, to eliminate openssl-probe

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -28,7 +28,7 @@ crc32fast = "1.2"
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.22", optional = true }
+hyper-rustls = { version = "0.22", optional = true, default-dependencies = false }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = "1.4"
 log = "0.4"
@@ -59,7 +59,7 @@ default = ["native-tls"]
 encoding = ["flate2"]
 nightly-testing = ["rusoto_credential/nightly-testing"]
 native-tls = ["hyper-tls"]
-rustls = ["hyper-rustls"]
+rustls = ["hyper-rustls/native-tokio"]
 rustls-webpki = ["hyper-rustls/webpki-tokio"]
 unstable = []
 

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -19,7 +19,7 @@
 //! Rusoto is an [AWS](https://aws.amazon.com/) SDK for Rust.
 //! A high level overview is available in `README.md` at <https://github.com/rusoto/rusoto>.
 
-#[cfg(feature = "rustls")]
+#[cfg(any(feature = "rustls", feature = "rustls-webpki"))]
 use hyper_rustls as tls;
 #[cfg(feature = "native-tls")]
 use hyper_tls as tls;


### PR DESCRIPTION
Allow the user to choose between rustls and rustls-webpki, and make only the former depend on native cert support.
