### PR TITLE
Upgrade hyper-rustls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Please put changes here.)
+- Update `hyper-rustls` to `0.23`
 
 ## [0.47.0] - 2021-06-29
 

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -28,7 +28,7 @@ crc32fast = "1.2"
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.22", optional = true, default-dependencies = false }
+hyper-rustls = { version = "0.23", optional = true, default-dependencies = false, features = [ "http2" ] }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = "1.4"
 log = "0.4"

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -223,11 +223,17 @@ impl HttpClient {
         #[cfg(feature = "native-tls")]
         let connector = HttpsConnector::new();
 
-        #[cfg(all(feature = "rustls", not(feature = "rustls-webpki")))]
-        let connector = HttpsConnector::with_native_roots();
+        #[cfg(feature = "rustls")]
+        let connector = {
+            let builder = crate::tls::HttpsConnectorBuilder::new();
 
-        #[cfg(feature = "rustls-webpki")]
-        let connector = HttpsConnector::with_webpki_roots();
+            #[cfg(not(feature = "rustls-webpki"))]
+            let builder = builder.with_native_roots();
+            #[cfg(feature = "rustls-webpki")]
+            let builder = builder.with_webpki_roots();
+
+            builder.https_only().enable_http2().build()
+        };
 
         Ok(Self::from_connector(connector))
     }
@@ -237,11 +243,17 @@ impl HttpClient {
         #[cfg(feature = "native-tls")]
         let connector = HttpsConnector::new();
 
-        #[cfg(all(feature = "rustls", not(feature = "rustls-webpki")))]
-        let connector = HttpsConnector::with_native_roots();
+        #[cfg(feature = "rustls")]
+        let connector = {
+            let builder = crate::tls::HttpsConnectorBuilder::new();
 
-        #[cfg(feature = "rustls-webpki")]
-        let connector = HttpsConnector::with_webpki_roots();
+            #[cfg(not(feature = "rustls-webpki"))]
+            let builder = builder.with_native_roots();
+            #[cfg(feature = "rustls-webpki")]
+            let builder = builder.with_webpki_roots();
+
+            builder.https_only().enable_http2().build()
+        };
 
         Ok(Self::from_connector_with_config(connector, config))
     }


### PR DESCRIPTION
I am not sure what the current status of the project is and whether PRs are still accepted.

We are currently still using rusoto in production, and would prefer to not compile `hyper-rustls` twice. For now we will keep this branch alive, and if this PR is accepted and a new release is made, we might migrate to that instead.