### PR TITLE
Cloneable http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Please put changes here.)
+- Make `rusoto_core::request::HttpClient` clonable
 
 ## [0.48.0] - 2022-04-24
 

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -210,6 +210,7 @@ impl<D: DispatchSignedRequest> DispatchSignedRequest for Arc<D> {
     }
 }
 
+#[derive(Clone)]
 /// Http client for use with AWS services.
 pub struct HttpClient<C = HttpsConnector<HttpConnector>> {
     inner: HyperClient<C, Body>,


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
- Make `rusoto_core::request::HttpClient` clonable.

`rusoto_core::request::HttpClient` internally use hyper Client. For performance reasons, it may be useful to reuse the connection pool.

According to hyper Client documentation [https://docs.rs/hyper/latest/hyper/client/struct.Client.html]:
> `Client` is cheap to clone and cloning is the recommended way to share a `Client`. The underlying connection pool will be reused.

