### PR TITLE
Fix signature::canonical_uri to produce invalid uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Please put changes here.)
+- Fix `signature::canonical_uri` to produce invalid uri when `Region::Custom::endpoint` has `/` as path (eg. `localhost:5555/`).
 
 ## [0.48.0] - 2022-04-24
 

--- a/rusoto/signature/src/signature.rs
+++ b/rusoto/signature/src/signature.rs
@@ -688,10 +688,10 @@ fn canonical_uri(path: &str, region: &Region) -> String {
         _ => None,
     };
     match (endpoint_path, path) {
+        (Some(prefix), _) if prefix != "/" => encode_uri_path(&(prefix.to_owned() + path)),
         (Some(prefix), "") => prefix.to_string(),
         (None, "") => "/".to_string(),
-        (Some(prefix), _) => encode_uri_path(&(prefix.to_owned() + path)),
-        _ => encode_uri_path(path),
+        (Some(_) | None, _) => encode_uri_path(path),
     }
 }
 
@@ -1055,6 +1055,16 @@ mod tests {
                 &Region::Custom {
                     name: Region::UsEast1.name().into(),
                     endpoint: "http://localhost:8000".into()
+                }
+            ),
+            "/foo"
+        );
+        assert_eq!(
+            super::canonical_uri(
+                "/foo",
+                &Region::Custom {
+                    name: Region::UsEast1.name().into(),
+                    endpoint: "http://localhost:8000/".into()
                 }
             ),
             "/foo"


### PR DESCRIPTION
Fixes #1700 

CHANGELOG:
- Fix `signature::canonical_uri` to produce invalid uri when `Region::Custom::endpoint` has `/` as path (eg. `localhost:5555/`).