### PR TITLE
Fix google cloud storage with rustls + http2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Please put changes here.)
+- Remove host HTTP header when using rustls 
 
 ## [0.48.0] - 2022-04-24
 

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -444,6 +444,10 @@ where
         message: format!("error building request: {}", err),
     })?;
 
+    // we use HTTP/2 with rustls, the host header is required to sign the request
+    // Google cloud storage rejects HTTP/2 payloads containing a host header
+    #[cfg(any(feature = "rustls", feature = "rustls-webpki"))]
+    hyper_headers.remove("host");
     *http_request.headers_mut() = hyper_headers;
 
     let f = client.request(http_request);


### PR DESCRIPTION
Remove host http header when using rustls in order for storage.googleapis.com to function with rustls

Hi! 
We ran into a error using Rusoto with rustls enabled (https://github.com/quickwit-oss/quickwit/issues/1584). It turns out Google rejects the http2 payload if it contains a host header. This fix feels a little hacky given that google seems to be the only provider to act this way. I can close this PR and open an issue if you prefer :) 

Sample code which errors on the current main branch:
```rust
use rusoto_core::Region;
use rusoto_s3::{S3Client, S3};

#[tokio::main]
async fn main() {
    let region = Region::Custom {
        name: "gcs".to_string(),
        endpoint: "https://storage.googleapis.com".to_string(),
    };
    let client = S3Client::new(region);
    println!("{:?}", client.list_buckets().await);
}
```

outputs `Err(HttpDispatch(HttpDispatchError { message: "Error obtaining body: Error obtaining chunk: error reading a body from connection: stream error received: unspecific protocol error detected" }))`

with this branch: `Ok(ListBucketsOutput { buckets: Some([Bucket { creation_date: Some("2022-06-05T18:03:45.929Z"), name: Some("qw-region") }]), owner: None })`

It's possible to use rusoto with rustls and GCP using a http1 client (https://github.com/quickwit-oss/quickwit/pull/1612)
