### PR TITLE
Prevent infinite loop in xml deserialize_elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Please put changes here.)
+- Prevent infinite loop in XML deserializer.
 
 ## [0.48.0] - 2022-04-24
 

--- a/rusoto/core/src/proto/xml/util.rs
+++ b/rusoto/core/src/proto/xml/util.rs
@@ -242,7 +242,7 @@ where
 
     loop {
         match stack.peek() {
-            Some(&Ok(XmlEvent::EndElement { .. })) => break,
+            Some(&Ok(XmlEvent::EndElement { .. })) | None => break,
             Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
                 let local_name = name.local_name.to_owned();
                 handle_element(&local_name, stack, &mut obj)?;


### PR DESCRIPTION
We have observed infinite loops when the input XML was invalid. rusoto
would keep looking for an end-element even if it had already reached
EOF.