### PR TITLE
Added function to create a mock response using bytes

### DIFF
--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -130,6 +130,13 @@ impl MockRequestDispatcher {
         self
     }
 
+    /// Mocks the service response body that would be
+    /// returned from AWS
+    pub fn with_bytes_body(mut self, body: &[u8]) -> MockRequestDispatcher {
+        self.body = body.to_vec();
+        self
+    }
+
     /// Mocks the json serialized response body what would be
     /// returned from AWS
     pub fn with_json_body<B>(mut self, body: B) -> MockRequestDispatcher


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Added the ability to create a `MockRequestDispatcher` with body of bytes.

This is useful when we're serializing/deserializing stuff using `bincode`.