### PR TITLE
Add support for the eu-central-2 (Zurich) and me-central-1 (UAE) regions.

### DIFF
--- a/rusoto/signature/src/region.rs
+++ b/rusoto/signature/src/region.rs
@@ -58,7 +58,7 @@ pub enum Region {
 
     /// Region that covers the South-Eastern part of Asia Pacific
     ApSoutheast2,
-    
+
     /// Region that covers the South-Eastern part of Asia Pacific
     ApSoutheast3,
 
@@ -67,6 +67,9 @@ pub enum Region {
 
     /// Region that covers Central Europe
     EuCentral1,
+
+    /// Region that covers Central Europe
+    EuCentral2,
 
     /// Region that covers Western Europe
     EuWest1,
@@ -82,6 +85,9 @@ pub enum Region {
 
     /// Region that covers Southern Europe
     EuSouth1,
+
+    /// UAE, Middle East Central
+    MeCentral1,
 
     /// Bahrain, Middle East South
     MeSouth1,
@@ -150,11 +156,13 @@ impl Region {
             Region::ApSoutheast3 => "ap-southeast-3",
             Region::CaCentral1 => "ca-central-1",
             Region::EuCentral1 => "eu-central-1",
+            Region::EuCentral2 => "eu-central-2",
             Region::EuWest1 => "eu-west-1",
             Region::EuWest2 => "eu-west-2",
             Region::EuWest3 => "eu-west-3",
             Region::EuNorth1 => "eu-north-1",
             Region::EuSouth1 => "eu-south-1",
+            Region::MeCentral1 => "me-central-1",
             Region::MeSouth1 => "me-south-1",
             Region::SaEast1 => "sa-east-1",
             Region::UsEast1 => "us-east-1",
@@ -251,11 +259,13 @@ impl FromStr for Region {
             "ap-southeast-3" | "apsoutheast3" => Ok(Region::ApSoutheast3),
             "ca-central-1" | "cacentral1" => Ok(Region::CaCentral1),
             "eu-central-1" | "eucentral1" => Ok(Region::EuCentral1),
+            "eu-central-2" | "eucentral2" => Ok(Region::EuCentral2),
             "eu-west-1" | "euwest1" => Ok(Region::EuWest1),
             "eu-west-2" | "euwest2" => Ok(Region::EuWest2),
             "eu-west-3" | "euwest3" => Ok(Region::EuWest3),
             "eu-north-1" | "eunorth1" => Ok(Region::EuNorth1),
             "eu-south-1" | "eusouth1" => Ok(Region::EuSouth1),
+            "me-central-1" | "mecentral1" => Ok(Region::MeCentral1),
             "me-south-1" | "mesouth1" => Ok(Region::MeSouth1),
             "sa-east-1" | "saeast1" => Ok(Region::SaEast1),
             "us-east-1" | "useast1" => Ok(Region::UsEast1),
@@ -327,11 +337,13 @@ mod tests {
         assert_eq!("ap-southeast-3".parse(), Ok(Region::ApSoutheast3));
         assert_eq!("ca-central-1".parse(), Ok(Region::CaCentral1));
         assert_eq!("eu-central-1".parse(), Ok(Region::EuCentral1));
+        assert_eq!("eu-central-2".parse(), Ok(Region::EuCentral2));
         assert_eq!("eu-west-1".parse(), Ok(Region::EuWest1));
         assert_eq!("eu-west-2".parse(), Ok(Region::EuWest2));
         assert_eq!("eu-west-3".parse(), Ok(Region::EuWest3));
         assert_eq!("eu-north-1".parse(), Ok(Region::EuNorth1));
         assert_eq!("eu-south-1".parse(), Ok(Region::EuSouth1));
+        assert_eq!("me-central-1".parse(), Ok(Region::MeCentral1));
         assert_eq!("me-south-1".parse(), Ok(Region::MeSouth1));
         assert_eq!("sa-east-1".parse(), Ok(Region::SaEast1));
         assert_eq!("us-east-1".parse(), Ok(Region::UsEast1));
@@ -357,11 +369,13 @@ mod tests {
         assert_tokens(&Region::ApSoutheast3, &tokens_for_region("ap-southeast-3"));
         assert_tokens(&Region::CaCentral1, &tokens_for_region("ca-central-1"));
         assert_tokens(&Region::EuCentral1, &tokens_for_region("eu-central-1"));
+        assert_tokens(&Region::EuCentral2, &tokens_for_region("eu-central-2"));
         assert_tokens(&Region::EuWest1, &tokens_for_region("eu-west-1"));
         assert_tokens(&Region::EuWest2, &tokens_for_region("eu-west-2"));
         assert_tokens(&Region::EuWest3, &tokens_for_region("eu-west-3"));
         assert_tokens(&Region::EuNorth1, &tokens_for_region("eu-north-1"));
         assert_tokens(&Region::EuSouth1, &tokens_for_region("eu-south-1"));
+        assert_tokens(&Region::MeCentral1, &tokens_for_region("me-central-1"));
         assert_tokens(&Region::MeSouth1, &tokens_for_region("me-south-1"));
         assert_tokens(&Region::SaEast1, &tokens_for_region("sa-east-1"));
         assert_tokens(&Region::UsEast1, &tokens_for_region("us-east-1"));

--- a/rusoto/signature/src/signature.rs
+++ b/rusoto/signature/src/signature.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use base64;
 use bytes::Bytes;
-use chrono::{DateTime, Utc, NaiveDate};
+use chrono::{DateTime, NaiveDate, Utc};
 use digest::Digest;
 use hex;
 use hmac::{Hmac, Mac, NewMac};
@@ -218,8 +218,12 @@ impl SignedRequest {
             "organizations" => {
                 // Matches https://docs.aws.amazon.com/general/latest/gr/ao.html
                 match self.region {
-                    Region::CnNorth1 | Region::CnNorthwest1 => Region::CnNorthwest1.name().to_string(),
-                    Region::UsGovEast1 | Region::UsGovWest1 => Region::UsGovWest1.name().to_string(),
+                    Region::CnNorth1 | Region::CnNorthwest1 => {
+                        Region::CnNorthwest1.name().to_string()
+                    }
+                    Region::UsGovEast1 | Region::UsGovWest1 => {
+                        Region::UsGovWest1.name().to_string()
+                    }
                     _ => Region::UsEast1.name().to_string(),
                 }
             }
@@ -388,7 +392,7 @@ impl SignedRequest {
         let signature = sign_string(
             &string_to_sign,
             creds.aws_secret_access_key(),
-            current_time.date().naive_utc(),
+            current_time.date_naive(),
             &self.region.name(),
             &self.service,
         );
@@ -493,7 +497,7 @@ impl SignedRequest {
         let signature = sign_string(
             &string_to_sign,
             creds.aws_secret_access_key(),
-            date.date().naive_utc(),
+            date.date_naive(),
             &self.region_for_service(),
             &self.service,
         );
@@ -793,8 +797,12 @@ fn build_hostname(service: &str, region: &Region) -> String {
         "organizations" => match *region {
             // organizations is routed specially: see https://docs.aws.amazon.com/organizations/latest/APIReference/Welcome.html and https://docs.aws.amazon.com/general/latest/gr/ao.html
             Region::Custom { ref endpoint, .. } => extract_hostname(endpoint).to_owned(),
-            Region::CnNorth1 | Region::CnNorthwest1 => "organizations.cn-northwest-1.amazonaws.com.cn".to_owned(),
-            Region::UsGovEast1 | Region::UsGovWest1 => "organizations.us-gov-west-1.amazonaws.com".to_owned(),
+            Region::CnNorth1 | Region::CnNorthwest1 => {
+                "organizations.cn-northwest-1.amazonaws.com.cn".to_owned()
+            }
+            Region::UsGovEast1 | Region::UsGovWest1 => {
+                "organizations.us-gov-west-1.amazonaws.com".to_owned()
+            }
             _ => "organizations.us-east-1.amazonaws.com".to_owned(),
         },
         "iam" => match *region {


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Add support for the eu-central-2 (Zurich) and me-central-1 (UAE) regions.

Also no longer using deprecated chrono method in `rusoto_signature`.