### PR TITLE
Update hyper rustls dependency

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -28,7 +28,7 @@ crc32fast = "1.2"
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.23", optional = true, default-features = false, features = [ "http1", "http2", "tls12", "logging" ] }
+hyper-rustls = { version = "0.24", optional = true, default-features = false, features = [ "http1", "http2", "tls12", "logging" ] }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = "1.4"
 log = "0.4"

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -21,7 +21,7 @@ rustc_version = "0.4"
 
 [dependencies]
 bytes = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { version = "=0.4.22", default-features = false, features = ["clock"] }
 digest = "0.9.0"
 futures = "0.3"
 hmac = "0.11"


### PR DESCRIPTION
### Update hyper-rustls to address [RUSTSEC-2023-0052](https://rustsec.org/advisories/RUSTSEC-2023-0052)
